### PR TITLE
Move deleted posts to a protected folder

### DIFF
--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -21,7 +21,7 @@ module Moderator
 
       def undelete
         @post = ::Post.find(params[:id])
-        @post.approve!
+        @post.undelete!
       end
 
       def confirm_move_favorites

--- a/app/logical/storage_manager/local.rb
+++ b/app/logical/storage_manager/local.rb
@@ -1,5 +1,6 @@
 class StorageManager::Local < StorageManager
   DEFAULT_PERMISSIONS = 0644
+  IMAGE_TYPES = %i[preview large crop original]
 
   def store(io, dest_path)
     temp_path = dest_path + "-" + SecureRandom.uuid + ".tmp"
@@ -22,5 +23,31 @@ class StorageManager::Local < StorageManager
 
   def open(path)
     File.open(path, "r", binmode: true)
+  end
+
+  def move_file_delete(post)
+    IMAGE_TYPES.each do |type|
+      path = file_path(post, post.file_ext, type, false)
+      new_path = file_path(post, post.file_ext, type, true)
+      move_file(path, new_path)
+    end
+  end
+
+  def move_file_undelete(post)
+    IMAGE_TYPES.each do |type|
+      path = file_path(post, post.file_ext, type, true)
+      new_path = file_path(post, post.file_ext, type, false)
+      move_file(path, new_path)
+    end
+  end
+
+  private
+
+  def move_file(old_path, new_path)
+    if File.exists?(old_path)
+      FileUtils.mkdir_p(File.dirname(new_path))
+      FileUtils.mv(old_path, new_path)
+      FileUtils.chmod(DEFAULT_PERMISSIONS, new_path)
+    end
   end
 end

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -124,6 +124,14 @@ module Danbooru
       "sample-"
     end
 
+    def protected_path_prefix
+      "deleted"
+    end
+
+    def protected_file_secret
+      "abc123"
+    end
+
     # When calculating statistics based on the posts table, gather this many posts to sample from.
     def post_sample_size
       300


### PR DESCRIPTION
Set up support for moving deleted files to a protected location
and support for emitting urls with authorization parameters to
permit access to them.

This closes #14

Additionally, this also fixes a problem where deleted posts could not be undeleted because of an incomplete change to how undeletion works.