### PR TITLE
Prevent viewing deleted or banned posts

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -462,7 +462,8 @@ module Danbooru
     end
 
     def can_user_see_post?(user, post)
-     if is_user_restricted?(user) && is_post_restricted?(post)
+      return false if (post.is_deleted? || post.is_banned?) && !user.is_moderator?
+      if is_user_restricted?(user) && is_post_restricted?(post)
         false
       else
         true


### PR DESCRIPTION
This fixes an exploit where you can view deleted and banned posts
through the atom service regardless of user level.

Closes #13 