### PR TITLE
Remove references to banblocked? on posts

### DIFF
--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -94,16 +94,12 @@ module PostSets
       posts.select { |p| !p.visible? }
     end
 
-    def banned_posts
-      posts.select { |p| p.banblocked? }
-    end
-
     def censored_posts
-      posts.select { |p| p.levelblocked? && !p.banblocked? }
+      posts.select { |p| p.levelblocked? }
     end
 
     def safe_posts
-      posts.select { |p| p.safeblocked? && !p.levelblocked? && !p.banblocked? }
+      posts.select { |p| p.safeblocked? && !p.levelblocked? }
     end
 
     def per_page

--- a/app/views/posts/partials/index/_posts.html.erb
+++ b/app/views/posts/partials/index/_posts.html.erb
@@ -5,10 +5,6 @@
 
   <% if post_set.hidden_posts.present? %>
     <div class="tn hidden-posts-notice">
-      <% if post_set.banned_posts.present? %>
-        <%= post_set.banned_posts.size %> post(s) were removed from this page at the artist's request (<%= link_to "learn more", wiki_pages_path(title: "banned_artist") %>).<br>
-      <% end %>
-
       <% if post_set.censored_posts.present? %>
         <%= post_set.censored_posts.size %> post(s) on this page require a <%= link_to "Gold account", new_user_upgrade_path %> to view (<%= link_to "learn more", wiki_pages_path(title: "help:censored_tags") %>).<br>
       <% end %>

--- a/app/views/posts/partials/show/_embedded.html.erb
+++ b/app/views/posts/partials/show/_embedded.html.erb
@@ -1,7 +1,5 @@
-<% if post.banblocked? -%>
-  <p>The artist requested removal of this image.</p>
-<% elsif post.levelblocked? -%>
-  <p><%= link_to("You need a gold account to see this image", new_user_upgrade_path) %>.</p>
+<% if post.levelblocked? -%>
+  <p>You can not view this image.</p>
 <% elsif post.safeblocked? -%>
   <p>This image is unavailable on safe mode (<%= Danbooru.config.app_name %>). Go to <%= link_to("Danbooru", "https://danbooru.donmai.us") %> or disable safe mode to view (<%= link_to("learn more", wiki_pages_path(title: "help:user_settings")) -%>).</p>
 <% elsif post.is_flash? -%>


### PR DESCRIPTION
Unfortunately this only seems to be referenced by views and in
a few special functions for the post search system, so it went
unnoticed in the first commit.