### PR TITLE
Password migration/upgrade

### DIFF
--- a/app/controllers/maintenance/user/deletions_controller.rb
+++ b/app/controllers/maintenance/user/deletions_controller.rb
@@ -8,8 +8,6 @@ module Maintenance
         deletion = UserDeletion.new(CurrentUser.user, params[:password])
         deletion.delete!
         session.delete(:user_id)
-        cookies.delete(:cookie_password_hash)
-        cookies.delete(:user_name)
         redirect_to(posts_path, :notice => "You are now logged out")
       end
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,8 +16,6 @@ class SessionsController < ApplicationController
 
   def destroy
     session.delete(:user_id)
-    cookies.delete(:user_name)
-    cookies.delete(:password_hash)
     redirect_to(posts_path, :notice => "You are now logged out.")
   end
 

--- a/app/logical/pbkdf2.rb
+++ b/app/logical/pbkdf2.rb
@@ -1,0 +1,80 @@
+# Password Hashing With PBKDF2 (http://crackstation.net/hashing-security.htm).
+# Copyright (c) 2013, Taylor Hornby
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+require 'securerandom'
+require 'openssl'
+require 'base64'
+
+module PBKDF2
+
+  PBKDF2_ITERATIONS = 20000
+  SALT_BYTE_SIZE = 24
+  HASH_BYTE_SIZE = 24
+
+  HASH_SECTIONS = 4
+  SECTION_DELIMITER = ':'
+  ITERATIONS_INDEX = 1
+  SALT_INDEX = 2
+  HASH_INDEX = 3
+
+  def self.create_hash( password )
+    salt = SecureRandom.base64( SALT_BYTE_SIZE )
+    pbkdf2 = OpenSSL::PKCS5::pbkdf2_hmac_sha1(
+        password,
+        salt,
+        PBKDF2_ITERATIONS,
+        HASH_BYTE_SIZE
+    )
+    return ["sha1", PBKDF2_ITERATIONS, salt, Base64.encode64( pbkdf2 )].join( SECTION_DELIMITER )
+  end
+
+  def self.validate_password( password, correctHash )
+    params = correctHash.split( SECTION_DELIMITER )
+    return false if params.length != HASH_SECTIONS
+
+    pbkdf2 = Base64.decode64( params[HASH_INDEX] )
+    testHash = OpenSSL::PKCS5::pbkdf2_hmac_sha1(
+        password,
+        params[SALT_INDEX],
+        params[ITERATIONS_INDEX].to_i,
+        pbkdf2.length
+    )
+
+    return pbkdf2 == testHash
+  end
+
+  def self.needs_upgrade( hash )
+    params = hash.split( SECTION_DELIMITER )
+    if params.length != HASH_SECTIONS
+      return true
+    end
+    if params[ITERATIONS_INDEX] != PBKDF2_ITERATIONS.to_s
+      return true
+    end
+    return false
+  end
+
+end

--- a/app/logical/session_creator.rb
+++ b/app/logical/session_creator.rb
@@ -15,19 +15,6 @@ class SessionCreator
     if User.authenticate(name, password)
       user = User.find_by_name(name)
 
-      if remember.present?
-        cookies.permanent.signed[:user_name] = {
-          :value => user.name,
-          :secure => secure,
-          :httponly => true
-        }
-        cookies.permanent[:password_hash] = {
-          :value => user.bcrypt_cookie_password_hash,
-          :secure => secure,
-          :httponly => true
-        }
-      end
-
       session[:user_id] = user.id
       user.update_column(:last_ip_addr, ip_addr)
       return true

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
       "user#{n}"
     end
     password "password"
-    password_hash {User.sha1("password")}
+    password_hash {PasswordHash.create_hash("password")}
     email {FFaker::Internet.email}
     default_image_size "large"
     base_upload_limit 10

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -56,18 +56,6 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
           assert_response 401
         end
       end
-      
-      context "using the password_hash parameter" do
-        should "succeed for password matches" do
-          get posts_path, params: {:format => "json", :login => @user.name, :password_hash => User.sha1("password")}
-          assert_response :success
-        end
-        
-        # should "fail for password mismatches" do
-        #   get posts_path, {:format => "json", :login => @user.name, :password_hash => "bad"}
-        #   assert_response 403
-        # end
-      end
     end
 
     context "index action" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -192,15 +192,6 @@ class UserTest < ActiveSupport::TestCase
     end
 
     context "password" do
-      should "match the cookie hash" do
-        @user = FactoryBot.create(:user)
-        @user.password = "zugzug5"
-        @user.password_confirmation = "zugzug5"
-        @user.save
-        @user.reload
-        assert(User.authenticate_cookie_hash(@user.name, @user.bcrypt_cookie_password_hash))
-      end
-
       should "match the confirmation" do
         @user = FactoryBot.create(:user)
         @user.old_password = "password"


### PR DESCRIPTION
NOTE: All existing passwords in development no longer work after
this change! Change your users password using the rails console.

Automatically convert and ugrade old passwords to using bcrypt
Removed the seemingly pointless transformation and hashing on top
of the actual password with a static salt.
Disabled logging in using password hashes, because that's just not
secure in any way, and negates cracking passwords at all.
Disabled sending the password hash to the client as a cookie, even
if it was signed.
Disabled legacy API logins.

Closes #15 