### PR TITLE
Don't queue nil tag category update jobs

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -192,7 +192,7 @@ class Tag < ApplicationRecord
 
     def update_category
       update_category_cache
-      update_category_post_counts
+      update_category_post_counts unless new_record?
       write_category_change_entry unless new_record?
     end
 


### PR DESCRIPTION
Tag category updates don't need to run for new tags, and attempting
to run them results in an exception because the tag does not have
a tag id at that point.

The tag counts for the post are still correct as the tag has been
saved and is in the transaction by the time the post system asks
for tag counts for each category, negating the need for the job.

Closes #71 