### PR TITLE
Add user profile info

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -83,7 +83,7 @@ class UsersController < ApplicationController
 
   def user_params(context)
     permitted_params = %i[
-      password old_password password_confirmation email
+      password old_password password_confirmation
       comment_threshold default_image_size favorite_tags blacklisted_tags
       time_zone per_page custom_style
 
@@ -97,7 +97,8 @@ class UsersController < ApplicationController
     ]
 
     permitted_params += [dmail_filter_attributes: %i[id words]]
-    permitted_params << :name if context == :create
+    permitted_params += [:profile_about, :profile_artinfo, :email] if CurrentUser.is_member? # Prevent editing when blocked
+    permitted_params += [:name, :email] if context == :create
     permitted_params << :level if CurrentUser.is_admin?
 
     params.require(:user).permit(permitted_params)

--- a/app/javascript/src/styles/specific/users.scss
+++ b/app/javascript/src/styles/specific/users.scss
@@ -2,6 +2,14 @@
 
 div#c-users {
   div#a-show {
+    .about-section {
+      display: flex;
+      .about-piece {
+        flex-grow: 1;
+        margin: 0 1em;
+      }
+    }
+
     div.box {
       h2, h3 {
         color: #333;

--- a/app/views/users/_about.html.erb
+++ b/app/views/users/_about.html.erb
@@ -1,0 +1,14 @@
+<div class="about-section">
+  <% if user.profile_about.present? %>
+    <div class="box-section about-piece" id="about-info">
+      <h3>About:</h3>
+      <div class="content"><%= format_text(user.profile_about) %></div>
+    </div>
+  <% end %>
+  <% if user.profile_artinfo.present? %>
+    <div class="box-section about-piece" id="about-artinfo">
+      <h3>Artist Information:</h3>
+      <div class="content"><%= format_text(user.profile_artinfo) %></div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -36,6 +36,10 @@
           </p>
         </div>
 
+        <%= f.input :profile_about, label: "About Me" %>
+
+        <%= f.input :profile_artinfo, label: "Commission Info" %>
+
         <%= f.input :time_zone, :include_blank => false %>
 
         <%= f.input :receive_email_notifications, :as => :select, :include_blank => false, :collection => [["Yes", "true"], ["No", "false"]] %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,7 @@
     <h1><%= link_to_user @user %></h1>
 
     <%= render "statistics", :presenter => @presenter, :user => @user %>
+    <%= render "about", presenter: @presenter, user: @user %>
 
     <% if !CurrentUser.is_admin? && !@user.enable_privacy_mode? || CurrentUser.id == @user.id %>
       <%= render "posts/partials/common/inline_blacklist" %>

--- a/db/migrate/20190428132152_add_profile_info.rb
+++ b/db/migrate/20190428132152_add_profile_info.rb
@@ -1,0 +1,6 @@
+class AddProfileInfo < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :profile_about, :text
+    add_column :users, :profile_artinfo, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2460,7 +2460,9 @@ furry -rating:s'::text,
     bit_prefs bigint DEFAULT 0 NOT NULL,
     last_ip_addr inet,
     unread_dmail_count integer DEFAULT 0 NOT NULL,
-    set_count integer DEFAULT 0 NOT NULL
+    set_count integer DEFAULT 0 NOT NULL,
+    profile_about text,
+    profile_artinfo text
 );
 
 
@@ -4880,6 +4882,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190413055451'),
 ('20190418093745'),
 ('20190427163107'),
-('20190427181805');
+('20190427181805'),
+('20190428132152');
 
 


### PR DESCRIPTION
Possible improvements:
 - Lock commission information to users linked to artists.
   (Currently not implemented.)

Closes #25 