### PR TITLE
Allow logged out users to view posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1914,7 +1914,7 @@ class Post < ApplicationRecord
   end
 
   def loginblocked?
-    CurrentUser.is_anonymous?
+    CurrentUser.is_anonymous? && hide_from_anonymous?
   end
 
   def visible?


### PR DESCRIPTION
Missed an important test condition when working on the initial feature. Now anonymous users can once again view posts.