### PR TITLE
Fix regression in JS linking

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -30,8 +30,19 @@ importAll(require.context('../src/javascripts', true, /\.js(\.erb)?$/));
 importAll(require.context('../src/styles/common', true, /\.scss(?:\.erb)?$/));
 importAll(require.context('../src/styles/specific', true, /\.scss(?:\.erb)?$/));
 
-import Takedown from '../src/javascripts/takedowns.js';
-window.Takedown = Takedown;
-
-import Blip from '../src/javascripts/blips.js';
-window.Blip = Blip;
+export { default as Autocomplete } from '../src/javascripts/autocomplete.js.erb';
+export { default as Blacklist } from '../src/javascripts/blacklists.js';
+export { default as Blip } from '../src/javascripts/blips.js';
+export { default as Comment } from '../src/javascripts/comments.js';
+export { default as Dtext } from '../src/javascripts/dtext.js';
+export { default as Note } from '../src/javascripts/notes.js';
+export { default as Post } from '../src/javascripts/posts.js.erb';
+export { default as PostModeMenu } from '../src/javascripts/post_mode_menu.js';
+export { default as PostTooltip } from '../src/javascripts/post_tooltips.js';
+export { default as RelatedTag } from '../src/javascripts/related_tag.js';
+export { default as Shortcuts } from '../src/javascripts/shortcuts.js';
+export { default as Upload } from '../src/javascripts/uploads.js';
+export { default as Utility } from '../src/javascripts/utility.js';
+export { default as Ugoira } from '../src/javascripts/ugoira.js';
+export { default as Takedown } from '../src/javascripts/takedowns.js';
+export { default as Thumbnails } from '../src/javascripts/thumbnails.js';

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -23,11 +23,11 @@
       </div>
 
       <menu>
-        <li><%= tag.a "Respond", href: '#', onclick: "Blip.quote(#{blip.id})" %></li>
+        <li><%= tag.a "Respond", href: '#', onclick: "Danbooru.Blip.quote(#{blip.id})" %></li>
         <% if blip.can_edit?(CurrentUser.user) %>
           <li><%= link_to "Edit", edit_blip_path(blip) %></li>
         <% end %>
-        <li><%= tag.a "@", href: '#', onclick: "Blip.atme(#{blip.id})" %></li>
+        <li><%= tag.a "@", href: '#', onclick: "Danbooru.Blip.atme(#{blip.id})" %></li>
 
         <% if !blip.is_hidden %>
           <% if blip.can_hide?(CurrentUser.user) %>

--- a/app/views/takedowns/edit.html.erb
+++ b/app/views/takedowns/edit.html.erb
@@ -130,15 +130,15 @@
 
         <label for="takedown-add-posts-tags">Add posts with tags:</label><br>
         <%= text_field_tag "takedown-add-posts-tags", "", size: 40 %>
-        <%= button_tag "Add", onclick: "Takedown.add_posts_by_tags_preview(#{@takedown.id});", id: "takedown-add-posts-tags-preview", type: :button, disabled: true %>
-        <%= button_tag "Confirm", onclick: "Takedown.add_posts_by_tags(#{@takedown.id});", id: "takedown-add-posts-tags-confirm", type: :button %>
-        <%= button_tag "Cancel", onclick: "Takedown.add_posts_by_tags_cancel();", id: "takedown-add-posts-tags-cancel", type: :button %>
+        <%= button_tag "Add", onclick: "Danbooru.Takedown.add_posts_by_tags_preview(#{@takedown.id});", id: "takedown-add-posts-tags-preview", type: :button, disabled: true %>
+        <%= button_tag "Confirm", onclick: "Danbooru.Takedown.add_posts_by_tags(#{@takedown.id});", id: "takedown-add-posts-tags-confirm", type: :button %>
+        <%= button_tag "Cancel", onclick: "Danbooru.Takedown.add_posts_by_tags_cancel();", id: "takedown-add-posts-tags-cancel", type: :button %>
         <div id="takedown-add-posts-tags-warning"></div>
         <br><br>
 
         <label for="takedown-add-posts-ids">Add post IDs to takedown (space-separated):</label><br>
         <%= text_field_tag "takedown-add-posts-ids", "", size: 40 %>
-        <%= button_tag "Add", onclick: "Takedown.add_posts_by_ids(#{@takedown.id})", id: "takedown-add-posts-ids-submit", disabled: true %>
+        <%= button_tag "Add", onclick: "Danbooru.Takedown.add_posts_by_ids(#{@takedown.id})", id: "takedown-add-posts-ids-submit", disabled: true %>
       </div>
 
       <h2>Update</h2>
@@ -216,7 +216,7 @@
 
         // Remove post
         $("body").on("click", ".takedown-post-remove", function () {
-            Takedown.remove_post(<%= @takedown.id %>, $(this).parent().data("post-id"));
+            Danbooru.Takedown.remove_post(<%= @takedown.id %>, $(this).parent().data("post-id"));
         });
 
         // Enable/disable add-post input submit buttons if input is filled/blank


### PR DESCRIPTION
This fixes a regression introduced in PR #75 where I mistakenly
removed the exports from the application pack. These were being
placed into the Danbooru namespace object as a library and referenced
by various items across the site.

This brings them back and converts the takedown and blip services
to use the namespace.