### PR TITLE
Flip uploader height/width order

### DIFF
--- a/app/javascript/src/javascripts/uploader.vue
+++ b/app/javascript/src/javascripts/uploader.vue
@@ -901,7 +901,7 @@
       },
       previewDimensions() {
         if (this.previewWidth && this.previewHeight)
-          return this.previewHeight + '×' + this.previewWidth;
+          return this.previewWidth + '×' + this.previewHeight;
         return '';
       },
       directURLProblem: function () {


### PR DESCRIPTION
Change order of width and height on uploader to match the rest of site.
Previously HeightxWidth was used but Width x height is more common.