### PR TITLE
Added own_vote to post serializer

### DIFF
--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -92,7 +92,11 @@ class PostSerializer < ActiveModel::Serializer
     object.is_favorited?
   end
 
+  def own_vote
+    object.own_vote&.score || 0
+  end
+
   attributes :id, :created_at, :updated_at, :file, :preview, :sample, :score, :tags, :locked_tags, :change_seq, :flags,
              :rating, :fav_count, :sources, :pools, :relationships, :approver_id, :uploader_id, :description,
-             :comment_count, :is_favorited
+             :comment_count, :is_favorited, :own_vote
 end


### PR DESCRIPTION
Adds an `own_vote` key to the API response to show whether the user has voted on a post or not, and which way. Possible values are `1` for an upvoted post, `-1` for downvoted, or `0` for post not yet voted for.

Ends up being always `0` for logged out users since the CurrentUser.user is checked in [models/post.rb](https://github.com/zwagoth/e621ng/blob/7a1f10b977434981b92fbb55d7f60bf98231a768/app/models/post.rb#L1220).