### PR TITLE
Unified sidebar's search and blacklist help links

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -133,7 +133,7 @@ Blacklist.update_sidebar = function () {
     link.attr("rel", "nofollow");
     link.on("click.danbooru", Blacklist.entryToggle);
     count.html(entry.hits);
-    count.addClass("count");
+    count.addClass("post-count");
     item.append(link);
     item.append(" ");
     item.append(count);

--- a/app/views/posts/partials/common/_search.html.erb
+++ b/app/views/posts/partials/common/_search.html.erb
@@ -1,7 +1,7 @@
 <%# path, tags %>
 
 <section id="search-box">
-  <h1>Search <span class="search-help"><%= link_to "(Search Help)", help_page_path(id: "cheatsheet") %></span></h1>
+  <h1>Search <span class="search-help"><%= link_to "(help)", help_page_path(id: "cheatsheet") %></span></h1>
   <%= form_tag(path, :method => "get") do %>
     <% if params[:raw] %>
       <%= hidden_field_tag :raw, params[:raw] %>

--- a/app/views/posts/partials/common/_search.html.erb
+++ b/app/views/posts/partials/common/_search.html.erb
@@ -1,7 +1,7 @@
 <%# path, tags %>
 
 <section id="search-box">
-  <h1>Search <span class="search-help"><%= link_to "(help)", help_page_path(id: "cheatsheet") %></span></h1>
+  <h1>Search <span class="search-help"><%= link_to "(search help)", help_page_path(id: "cheatsheet") %></span></h1>
   <%= form_tag(path, :method => "get") do %>
     <% if params[:raw] %>
       <%= hidden_field_tag :raw, params[:raw] %>

--- a/app/views/posts/partials/index/_blacklist.html.erb
+++ b/app/views/posts/partials/index/_blacklist.html.erb
@@ -1,5 +1,5 @@
 <section id="blacklist-box" class="sidebar-blacklist">
-  <h1>Blacklisted <span class="blacklist-help"><%= link_to "(help)", help_page_path(id: "blacklists") %></span></h1>
+  <h1>Blacklisted <span class="blacklist-help"><%= link_to "(blacklist help)", help_page_path(id: "blacklists") %></span></h1>
   <ul id="blacklist-list">
   </ul>
   <%= link_to "Disable all", "#", :id => "disable-all-blacklists", :style => "display: none;" %>

--- a/app/views/posts/partials/index/_blacklist.html.erb
+++ b/app/views/posts/partials/index/_blacklist.html.erb
@@ -1,7 +1,7 @@
-<div id="blacklist-box" class="sidebar-blacklist">
-  <h1>Blacklisted (<%= link_to "help", help_page_path(id: "blacklists") %>)</h1>
+<section id="blacklist-box" class="sidebar-blacklist">
+  <h1>Blacklisted <span class="blacklist-help"><%= link_to "(help)", help_page_path(id: "blacklists") %></span></h1>
   <ul id="blacklist-list">
   </ul>
   <%= link_to "Disable all", "#", :id => "disable-all-blacklists", :style => "display: none;" %>
   <%= link_to "Re-enable all", "#", :id => "re-enable-all-blacklists", :style => "display: none;" %>
-</div>
+</section>


### PR DESCRIPTION
* Made the blacklist section's help link's HTML similar to the one next to Search title for easier and more consistent CSS styling.
* Changed the Search help link's text to the shorter one.

I also added a basic editorconfig file that should match the coding style of the project.