### PR TITLE
Modaction fixes

### DIFF
--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -46,11 +46,7 @@ class ModActionDecorator < ApplicationDecorator
     when "artist_unban"
       "Marked artist ##{vals['artist_id']} as no longer DNP"
     when "artist_page_rename"
-      if vals['old_name'].nil?
-        "Created artist page \"#{vals['new_name']}\":/artists/show_or_new?name=#{vals['new_name']}"
-      else
-        "Renamed artist page (\"#{vals['old_name']}\":/artists/show_or_new?name=#{vals['old_name']} -> \"#{vals['new_name']}\":/artists/show_or_new?name=#{vals['new_name']})"
-      end
+      "Renamed artist page (\"#{vals['old_name']}\":/artists/show_or_new?name=#{vals['old_name']} -> \"#{vals['new_name']}\":/artists/show_or_new?name=#{vals['new_name']})"
     when "artist_page_lock"
       "Locked artist page artist ##{vals['artist_page']}"
     when "artist_page_unlock"
@@ -307,11 +303,7 @@ class ModActionDecorator < ApplicationDecorator
     when "wiki_page_unlock"
       "Unlocked wiki page [[#{vals['wiki_page']}]]"
     when "wiki_page_rename"
-      if vals['old_title'].nil?
-        "Created wiki page [[#{vals['new_title']}]]"
-      else
-        "Renamed wiki page ([[#{vals['old_title']}]] → [[#{vals['new_title']}]])"
-      end
+      "Renamed wiki page ([[#{vals['old_title']}]] → [[#{vals['new_title']}]])"
 
     when "bulk_revert"
       "Processed bulk revert for #{vals['constraints']} by #{user}"

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -295,7 +295,11 @@ class ModActionDecorator < ApplicationDecorator
     when "wiki_page_unlock"
       "Unlocked wiki page [[#{vals['wiki_page']}]]"
     when "wiki_page_rename"
-      "Renamed wiki page ([[#{vals['old_title']}]] → [[#{vals['new_title']}]])"
+      if vals['old_title'].nil?
+        "Created wiki page [[#{vals['new_title']}]]"
+      else
+        "Renamed wiki page ([[#{vals['old_title']}]] → [[#{vals['new_title']}]])"
+      end
 
     when "bulk_revert"
       "Processed bulk revert for #{vals['constraints']} by #{user}"

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -18,9 +18,9 @@ class ModActionDecorator < ApplicationDecorator
     case object.action
       ### Pools ###
     when "pool_delete"
-      "Deleted pool ##{vals['pool_id']}(named #{vals['pool_name']}) by #{user}"
+      "Deleted pool ##{vals['pool_id']} (named #{vals['pool_name']}) by #{user}"
     when "pool_undelete"
-      "Undeleted pool ##{vals['pool_id']}(named #{vals['pool_name']}) by #{user}"
+      "Undeleted pool ##{vals['pool_id']} (named #{vals['pool_name']}) by #{user}"
 
       ### Takedowns ###
     when "takedown_process"
@@ -29,7 +29,7 @@ class ModActionDecorator < ApplicationDecorator
       ### IP Ban ###
     when "ip_ban_create"
       "Created ip ban"
-    when "ip_ban_deleted"
+    when "ip_ban_delete"
       "Removed ip ban"
 
       ### Ticket ###
@@ -67,12 +67,12 @@ class ModActionDecorator < ApplicationDecorator
       "Changed #{user} flags. Added: #{vals['added'].join(', ')}. Removed: #{vals['removed'].join(', ')}"
     when "edited_user"
       "Edited #{user}"
-    when "changed_user_blacklist"
+    when "user_blacklist_changed"
       "Edited blacklist of #{user}"
     when "changed_user_text"
       "Changed profile text of #{user}"
     when "user_name_change"
-      "Changed named of #{user} from #{vals['old_name']} to #{vals['new_naame']}"
+      "Changed name of #{user} from #{vals['old_name']} to #{vals['new_name']}"
 
       ### User Record ###
 
@@ -155,11 +155,11 @@ class ModActionDecorator < ApplicationDecorator
 
       ### Forum Category ###
 
-    when "created_forum_category"
+    when "forum_category_create"
       "Created forum category ##{vals['forum_category_id']}"
-    when "edited_forum_category"
+    when "forum_category_update"
       "Edited forum category ##{vals['forum_category_id']}"
-    when "deleted_forum_category"
+    when "forum_category_delete"
       "Deleted forum category ##{vals['forum_category_id']}"
 
       ### Blip ###

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -51,8 +51,8 @@ class ModActionDecorator < ApplicationDecorator
     when "user_delete"
       "Deleted user #{user}"
     when "user_ban"
-      if vals['duration'] == "permanent"
-        "Permanently banned #{user}"
+      if vals['duration'].is_a?(Numeric) && vals['duration'] < 0
+        "Banned #{user} permanently"
       elsif vals['duration']
         "Banned #{user} for #{vals['duration']} #{vals['duration'] == 1 ? "day" : "days"}"
       else

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -45,6 +45,16 @@ class ModActionDecorator < ApplicationDecorator
       "Marked artist ##{vals['artist_id']} as DNP"
     when "artist_unban"
       "Marked artist ##{vals['artist_id']} as no longer DNP"
+    when "artist_page_rename"
+      if vals['old_name'].nil?
+        "Created artist page \"#{vals['new_name']}\":/artists/show_or_new?name=#{vals['new_name']}"
+      else
+        "Renamed artist page (\"#{vals['old_name']}\":/artists/show_or_new?name=#{vals['old_name']} -> \"#{vals['new_name']}\":/artists/show_or_new?name=#{vals['new_name']})"
+      end
+    when "artist_page_lock"
+      "Locked artist page artist ##{vals['artist_page']}"
+    when "artist_page_unlock"
+      "Unlocked artist page artist ##{vals['artist_page']}"
 
       ### User ###
 
@@ -102,6 +112,8 @@ class ModActionDecorator < ApplicationDecorator
       "Destroyed post ##{vals['post_id']}"
     when "post_rating_lock"
       "Post rating was #{vals['locked'] ? 'locked' : 'unlocked'} on post ##{vals['post_id']}"
+    when "post_unapprove"
+      "Unapproved post ##{vals['post_id']}"
 
       ### Set ###
 

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -64,7 +64,7 @@ class ModActionDecorator < ApplicationDecorator
     when "user_level_change"
       "Changed #{user} level from #{vals['level_was']} to #{vals['level']}"
     when "user_flags_change"
-      "Changed #{user} flags. Added: #{vals['added'].join(', ')}. Removed: #{vals['removed'].join(', ')}"
+      "Changed #{user} flags. Added: [#{vals['added'].join(', ')}] Removed: [#{vals['removed'].join(', ')}]"
     when "edited_user"
       "Edited #{user}"
     when "user_blacklist_changed"

--- a/app/logical/user_promotion.rb
+++ b/app/logical/user_promotion.rb
@@ -63,7 +63,7 @@ private
     flag_check(added, removed, "no_flagging", "flag ban")
     flag_check(added, removed, "no_feedback", "feedback_ban")
 
-    if !added.empty? || !removed.empty?
+    unless added.empty? && removed.empty?
       ModAction.log(:user_flags_change, {user_id: user.id, added: added, removed: removed})
     end
 

--- a/app/logical/user_promotion.rb
+++ b/app/logical/user_promotion.rb
@@ -63,7 +63,7 @@ private
     flag_check(added, removed, "no_flagging", "flag ban")
     flag_check(added, removed, "no_feedback", "feedback_ban")
 
-    if added || removed
+    if !added.empty? || !removed.empty?
       ModAction.log(:user_flags_change, {user_id: user.id, added: added, removed: removed})
     end
 

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -35,7 +35,7 @@ class Artist < ApplicationRecord
   scope :unbanned, -> { where(is_banned: false) }
 
   def log_changes
-    if name_changed?
+    if name_changed? && !new_record?
       ModAction.log(:artist_page_rename, {new_name: name, old_name: name_was})
     end
     if is_locked_changed?

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -26,6 +26,12 @@ class ForumPost < ApplicationRecord
   after_update(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
     ModAction.log(:forum_post_update, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
   end
+  after_update(:if => ->(rec) {rec.is_hidden? && rec.saved_change_to_is_hidden?}) do |rec|
+    ModAction.log(:forum_post_hide, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+  end
+  after_update(:if => ->(rec) {!rec.is_hidden? && rec.saved_change_to_is_hidden?}) do |rec|
+    ModAction.log(:forum_post_unhide, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+  end
   after_destroy(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
     ModAction.log(:forum_post_delete, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
   end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -26,11 +26,8 @@ class ForumPost < ApplicationRecord
   after_update(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
     ModAction.log(:forum_post_update, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
   end
-  after_update(:if => ->(rec) {rec.is_hidden? && rec.saved_change_to_is_hidden?}) do |rec|
-    ModAction.log(:forum_post_hide, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
-  end
-  after_update(:if => ->(rec) {!rec.is_hidden? && rec.saved_change_to_is_hidden?}) do |rec|
-    ModAction.log(:forum_post_unhide, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+  after_update(:if => ->(rec) {rec.saved_change_to_is_hidden?}) do |rec|
+    ModAction.log(rec.is_hidden ? :forum_post_hide : :forum_post_unhide, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
   end
   after_destroy(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
     ModAction.log(:forum_post_delete, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -21,17 +21,11 @@ class ForumTopic < ApplicationRecord
   accepts_nested_attributes_for :original_post
   before_destroy :create_mod_action_for_delete
   after_update :update_original_post
-  after_save(:if => ->(rec) {rec.is_locked? && rec.saved_change_to_is_locked?}) do |rec|
-    ModAction.log(:forum_topic_lock, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
+  after_save(:if => ->(rec) {rec.saved_change_to_is_locked?}) do |rec|
+    ModAction.log(rec.is_locked ? :forum_topic_lock : :forum_topic_unlock, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
   end
-  after_save(:if => ->(rec) {!rec.is_locked? && rec.saved_change_to_is_locked?}) do |rec|
-    ModAction.log(:forum_topic_unlock, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
-  end
-  after_save(:if => ->(rec) {rec.is_sticky? && rec.saved_change_to_is_sticky?}) do |rec|
-    ModAction.log(:forum_topic_stick, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
-  end
-  after_save(:if => ->(rec) {!rec.is_sticky? && rec.saved_change_to_is_sticky?}) do |rec|
-    ModAction.log(:forum_topic_unstick, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
+  after_save(:if => ->(rec) {rec.saved_change_to_is_sticky?}) do |rec|
+    ModAction.log(rec.is_sticky ? :forum_topic_stick : :forum_topic_unstick, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
   end
 
   module CategoryMethods

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -27,6 +27,12 @@ class ForumTopic < ApplicationRecord
   after_save(:if => ->(rec) {!rec.is_locked? && rec.saved_change_to_is_locked?}) do |rec|
     ModAction.log(:forum_topic_unlock, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
   end
+  after_save(:if => ->(rec) {rec.is_sticky? && rec.saved_change_to_is_sticky?}) do |rec|
+    ModAction.log(:forum_topic_stick, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
+  end
+  after_save(:if => ->(rec) {!rec.is_sticky? && rec.saved_change_to_is_sticky?}) do |rec|
+    ModAction.log(:forum_topic_unstick, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
+  end
 
   module CategoryMethods
     extend ActiveSupport::Concern

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -58,6 +58,9 @@ class ModAction < ApplicationRecord
   KnownActions = [
       :artist_ban,
       :artist_unban,
+      :artist_page_rename,
+      :artist_page_lock,
+      :artist_page_unlock,
       :blip_delete,
       :blip_hide,
       :blip_unhide,
@@ -90,6 +93,7 @@ class ModAction < ApplicationRecord
       :post_destroy,
       :post_delete,
       :post_undelete,
+      :post_unapprove,
       :post_rating_lock,
       :report_reason_create,
       :report_reason_delete,

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -29,7 +29,7 @@ class WikiPage < ApplicationRecord
   end
 
   def log_changes
-    if title_changed?
+    if title_changed? && !new_record?
       ModAction.log(:wiki_page_rename, {new_title: title, old_title: title_was})
     end
     if is_deleted_changed?


### PR DESCRIPTION
This MR does a few things:

- Fixes a bunch of modactions like post_unapprove which weren't present in the decorator/dropdown menu
- Fix for logging empty user flag changes and display of negative user ban durations
- Renames a few modactions in the decorator which had their name changed for logging purposes but not in the decorator itself
- Adds logging to forum post hide/unhide and forum topic sticky/unsticky which were already in the decorator but not logged
- Seperate presentation for wiki page creation and wiki page renaming (old_title is null on creation)

This is the first time I'm doing anything ruby/rails, hopefully the code is good enough or something.
If the extra logging of the post/topic isn't wanted I can simply remove it. I just thought that it wouldn't hurt to add.
I tested the changes on my local copy of e6 and eveything seemed to work fine.