### PR TITLE
[Seeding] Fix system user not being promoted

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -100,7 +100,6 @@ class User < ApplicationRecord
   before_create :encrypt_password_on_create
   before_update :encrypt_password_on_update
   after_save :update_cache
-  before_create :promote_to_admin_if_first_user
   #after_create :notify_sock_puppets
   after_create :create_user_status
   has_many :feedback, :class_name => "UserFeedback", :dependent => :destroy
@@ -302,18 +301,6 @@ class User < ApplicationRecord
 
     def promote_to!(new_level, options = {})
       UserPromotion.new(self, CurrentUser.user, new_level, options).promote!
-    end
-
-    def promote_to_admin_if_first_user
-      return if Rails.env.test?
-
-      if User.admins.count == 0
-        self.level = Levels::ADMIN
-        self.can_approve_posts = true
-        self.can_upload_free = true
-      else
-        self.level = Levels::MEMBER
-      end
     end
 
     def role

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -58,7 +58,7 @@ module Danbooru
     #
     # Run `rake db:seed` to create this account if it doesn't already exist in your install.
     def system_user
-      "E621_Bot"
+      "auto_moderator"
     end
 
     def upload_feedback_topic

--- a/db/migrate/20210430201028_set_user_level_default.rb
+++ b/db/migrate/20210430201028_set_user_level_default.rb
@@ -1,0 +1,9 @@
+class SetUserLevelDefault < ActiveRecord::Migration[6.1]
+  def up
+    change_column :users, :level, :integer, default: 20
+  end
+
+  def down
+    change_column :users, :level, :integer, default: 0
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,6 +58,8 @@ unless Rails.env.test?
 
     md5 = Digest::MD5.hexdigest(data)
     service = UploadService.new({
+                                    uploader_id: CurrentUser.id,
+                                    uploader_ip_addr: CurrentUser.ip_addr,
                                     file: file,
                                     tag_string: post["tags"].values.flatten.join(" "),
                                     source: post["sources"].join("\n"),

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,7 +31,7 @@ User.find_or_create_by!(name: Danbooru.config.system_user) do |user|
   user.password_hash = ""
   user.email = "system@e621.net"
   user.can_upload_free = true
-  user.level = User::Levels::ADMIN
+  user.level = User::Levels::JANITOR
 end
 
 unless Rails.env.test?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,6 +22,7 @@ admin = User.find_or_create_by!(name: "admin") do |user|
   user.password_hash = ""
   user.email = "admin@e621.net"
   user.can_upload_free = true
+  user.can_approve_posts = true
   user.level = User::Levels::ADMIN
 end
 
@@ -31,6 +32,7 @@ User.find_or_create_by!(name: Danbooru.config.system_user) do |user|
   user.password_hash = ""
   user.email = "system@e621.net"
   user.can_upload_free = true
+  user.can_approve_posts = true
   user.level = User::Levels::JANITOR
 end
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2558,7 +2558,7 @@ CREATE TABLE public.users (
     password_hash character varying NOT NULL,
     email character varying,
     email_verification_key character varying,
-    level integer DEFAULT 0 NOT NULL,
+    level integer DEFAULT 20 NOT NULL,
     base_upload_limit integer DEFAULT 10 NOT NULL,
     last_logged_in_at timestamp without time zone,
     last_forum_read_at timestamp without time zone,
@@ -5127,6 +5127,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20201220190335'),
 ('20210117173030'),
 ('20210405040522'),
-('20210425020131');
+('20210425020131'),
+('20210430201028');
 
 


### PR DESCRIPTION
It's me again, this time with a fix for the initial setup of the databse.

Creating users with the level property set has no effect, it will be overwritten in the function `promote_to_admin_if_first_user` (at least thats how I understand it). This prevents some system user actions which require higher privileges.

I also changed the system user name and level to the values of `auto_moderator` on the live site because I think thats the system user there. Correct me if I'm wrong.