### PR TITLE
Add a bunch of missing html titles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? }
   before_action :reset_current_user
   before_action :set_current_user
-  before_action :set_title
   before_action :normalize_search
   before_action :api_check
   before_action :set_variant
@@ -12,6 +11,7 @@ class ApplicationController < ActionController::Base
   after_action :reset_current_user
   layout "default"
 
+  include TitleHelper
   include DeferredPosts
   helper_method :deferred_post_ids, :deferred_posts
 
@@ -189,10 +189,6 @@ class ApplicationController < ActionController::Base
     if CurrentUser.is_anonymous?
       access_denied("Must be logged in")
     end
-  end
-
-  def set_title
-    @page_title = Danbooru.config.app_name + "/#{params[:controller]}"
   end
 
   # Remove blank `search` params from the url.

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -10,7 +10,7 @@ class StaticController < ApplicationController
   end
 
   def not_found
-    render plain: "not found", status: :not_found
+    render "static/404", formats: [:html], status: 404
   end
 
   def error

--- a/app/helpers/title_helper.rb
+++ b/app/helpers/title_helper.rb
@@ -1,0 +1,6 @@
+module TitleHelper
+  def get_title
+    return Danbooru.config.app_name if current_page? root_path
+    return content_for(:page_title) + " - " + Danbooru.config.app_name if content_for? :page_title
+  end
+end

--- a/app/views/admin/alias_and_implication_imports/new.html.erb
+++ b/app/views/admin/alias_and_implication_imports/new.html.erb
@@ -40,5 +40,5 @@ mass update aaa -> bbb
 </div>
 
 <% content_for(:page_title) do %>
-  Alias &amp; Implication Import - <%= Danbooru.config.app_name %>
+  Alias &amp; Implication Import
 <% end %>

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -25,5 +25,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Admin Dashboard - <%= Danbooru.config.app_name %>
+  Admin Dashboard
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -73,5 +73,5 @@
 <%= render "users/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit User - <%= Danbooru.config.app_name %>
+  Edit User
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -73,5 +73,5 @@
 <%= render "users/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit User
+  Edit User - <%= @user.name %>
 <% end %>

--- a/app/views/admin/users/edit_blacklist.html.erb
+++ b/app/views/admin/users/edit_blacklist.html.erb
@@ -7,3 +7,7 @@
     <% end %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Edit Blacklist - <%= @user.name %>
+<% end %>

--- a/app/views/admin/users/password_reset.html.erb
+++ b/app/views/admin/users/password_reset.html.erb
@@ -10,3 +10,7 @@
     Their password reset URL is: <a href='<%= edit_maintenance_user_password_reset_url(:host => Danbooru.config.hostname, :only_path => false, :key => @reset_key.key, :uid => @reset_key.user_id) %>'><%= edit_maintenance_user_password_reset_url(:host => Danbooru.config.hostname, :only_path => false, :key => @reset_key.key, :uid => @reset_key.user_id) %></a></p>
   <% end %>
 </div>
+
+<% content_for(:page_title) do %>
+  Reset Password - <%= @user.name %>
+<% end %>

--- a/app/views/admin/users/request_password_reset.html.erb
+++ b/app/views/admin/users/request_password_reset.html.erb
@@ -19,3 +19,7 @@
     <% end %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Reset Password - <%= @user.name %>
+<% end %>

--- a/app/views/artist_commentaries/index.html.erb
+++ b/app/views/artist_commentaries/index.html.erb
@@ -40,5 +40,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist Commentary - <%= Danbooru.config.app_name %>
+  Artist Commentary
 <% end %>

--- a/app/views/artist_commentaries/search.html.erb
+++ b/app/views/artist_commentaries/search.html.erb
@@ -16,5 +16,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Artist Commentary - <%= Danbooru.config.app_name %>
+  Search Artist Commentary
 <% end %>

--- a/app/views/artist_commentary_versions/index.html.erb
+++ b/app/views/artist_commentary_versions/index.html.erb
@@ -18,5 +18,5 @@
 <%= render "artist_commentaries/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist Commentary Versions - <%= Danbooru.config.app_name %>
+  Artist Commentary Versions
 <% end %>

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -45,5 +45,5 @@
 <%= render "artists/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist URLs - <%= Danbooru.config.app_name %>
+  Artist URLs
 <% end %>

--- a/app/views/artist_versions/index.html.erb
+++ b/app/views/artist_versions/index.html.erb
@@ -10,5 +10,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist Versions - <%= Danbooru.config.app_name %>
+  Artist Versions
 <% end %>

--- a/app/views/artist_versions/search.html.erb
+++ b/app/views/artist_versions/search.html.erb
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Artist Changes - <%= Danbooru.config.app_name %>
+  Search Artist Changes
 <% end %>

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -27,5 +27,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artist - <%= @artist.name %> - <%= Danbooru.config.app_name %>
+  Artist - <%= @artist.name %>
 <% end %>

--- a/app/views/artists/banned.html.erb
+++ b/app/views/artists/banned.html.erb
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Avoid Posting - <%= Danbooru.config.app_name %>
+  Avoid Posting
 <% end %>

--- a/app/views/artists/edit.html.erb
+++ b/app/views/artists/edit.html.erb
@@ -18,5 +18,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Artist
+  Edit Artist - <%= @artist.name %>
 <% end %>

--- a/app/views/artists/edit.html.erb
+++ b/app/views/artists/edit.html.erb
@@ -18,5 +18,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Artist - <%= Danbooru.config.app_name %>
+  Edit Artist
 <% end %>

--- a/app/views/artists/index.html.erb
+++ b/app/views/artists/index.html.erb
@@ -34,5 +34,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Artists - <%= Danbooru.config.app_name %>
+  Artists
 <% end %>

--- a/app/views/artists/new.html.erb
+++ b/app/views/artists/new.html.erb
@@ -11,5 +11,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Artist - <%= Danbooru.config.app_name %>
+  New Artist
 <% end %>

--- a/app/views/bans/edit.html.erb
+++ b/app/views/bans/edit.html.erb
@@ -16,5 +16,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Ban - <%= Danbooru.config.app_name %>
+  Edit Ban
 <% end %>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -49,5 +49,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Bans - <%= Danbooru.config.app_name %>
+  Bans
 <% end %>

--- a/app/views/bans/new.html.erb
+++ b/app/views/bans/new.html.erb
@@ -8,5 +8,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Ban - <%= Danbooru.config.app_name %>
+  New Ban
 <% end %>

--- a/app/views/bans/show.html.erb
+++ b/app/views/bans/show.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Ban - <%= @ban.user.name %> - <%= Danbooru.config.app_name %>
+  Ban - <%= @ban.user.name %>
 <% end %>

--- a/app/views/blips/edit.html.erb
+++ b/app/views/blips/edit.html.erb
@@ -5,3 +5,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Edit Blip #<%= @blip.id %>
+<% end %>

--- a/app/views/blips/index.html.erb
+++ b/app/views/blips/index.html.erb
@@ -32,3 +32,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Blips
+<% end %>

--- a/app/views/blips/new.html.erb
+++ b/app/views/blips/new.html.erb
@@ -7,3 +7,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  New Blip
+<% end %>

--- a/app/views/blips/show.html.erb
+++ b/app/views/blips/show.html.erb
@@ -28,3 +28,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Blip #<%= @blip.id %>
+<% end %>

--- a/app/views/bulk_update_requests/edit.html.erb
+++ b/app/views/bulk_update_requests/edit.html.erb
@@ -8,5 +8,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Bulk Update Request - <%= Danbooru.config.app_name %>
+  Edit Bulk Update Request
 <% end %>

--- a/app/views/bulk_update_requests/index.html.erb
+++ b/app/views/bulk_update_requests/index.html.erb
@@ -12,5 +12,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Bulk Update Requests - <%= Danbooru.config.app_name %>
+  Bulk Update Requests
 <% end %>

--- a/app/views/bulk_update_requests/new.html.erb
+++ b/app/views/bulk_update_requests/new.html.erb
@@ -9,5 +9,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Bulk Update Request - <%= Danbooru.config.app_name %>
+  New Bulk Update Request
 <% end %>

--- a/app/views/bulk_update_requests/show.html.erb
+++ b/app/views/bulk_update_requests/show.html.erb
@@ -24,5 +24,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Bulk Update Request - <%= Danbooru.config.app_name %>
+  Bulk Update Request
 <% end %>

--- a/app/views/comment_votes/index.html.erb
+++ b/app/views/comment_votes/index.html.erb
@@ -68,3 +68,6 @@
   </div>
 </div>
 
+<% content_for(:page_title) do %>
+  Comment Votes
+<% end %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -9,5 +9,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Comment - <%= Danbooru.config.app_name %>
+  Edit Comment
 <% end %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Comments - <%= Danbooru.config.app_name %>
+  Comments
 <% end %>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -9,5 +9,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Comment - <%= Danbooru.config.app_name %>
+  New Comment
 <% end %>

--- a/app/views/comments/search.html.erb
+++ b/app/views/comments/search.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Comments - <%= Danbooru.config.app_name %>
+  Search Comments
 <% end %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -18,5 +18,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Comment - <%= Danbooru.config.app_name %>
+  Comment
 <% end %>

--- a/app/views/deleted_posts/index.html.erb
+++ b/app/views/deleted_posts/index.html.erb
@@ -25,3 +25,7 @@
 <div id="paginator">
   <%= numbered_paginator(@posts) %>
 </div>
+
+<% content_for(:page_title) do %>
+  Deleted Posts
+<% end %>

--- a/app/views/dmails/index.html.erb
+++ b/app/views/dmails/index.html.erb
@@ -54,5 +54,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Messages - <%= Danbooru.config.app_name %>
+  Messages
 <% end %>

--- a/app/views/dmails/new.html.erb
+++ b/app/views/dmails/new.html.erb
@@ -8,5 +8,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Message - <%= Danbooru.config.app_name %>
+  New Message
 <% end %>

--- a/app/views/dmails/show.html.erb
+++ b/app/views/dmails/show.html.erb
@@ -39,5 +39,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Message - <%= @dmail.title %> - <%= Danbooru.config.app_name %>
+  Message - <%= @dmail.title %>
 <% end %>

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -35,3 +35,7 @@
     </div>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Edit Histories
+<% end %>

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -24,3 +24,7 @@
     </div>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Edit History
+<% end %>

--- a/app/views/email_blacklists/index.html.erb
+++ b/app/views/email_blacklists/index.html.erb
@@ -31,5 +31,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Email Blacklists - <%= Danbooru.config.app_name %>
+  Email Blacklists
 <% end %>

--- a/app/views/email_blacklists/new.html.erb
+++ b/app/views/email_blacklists/new.html.erb
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Email Blacklist - <%= Danbooru.config.app_name %>
+  New Email Blacklist
 <% end %>

--- a/app/views/explore/posts/intro.html.erb
+++ b/app/views/explore/posts/intro.html.erb
@@ -22,10 +22,10 @@
       <% end %>
     <% end %>
   </div>
-</div> 
+</div>
 
 <%= render "static/footer" %>
 
 <% content_for(:page_title) do %>
-  <%= Danbooru.config.app_name %>
+  Explore
 <% end %>

--- a/app/views/explore/posts/missed_searches.html.erb
+++ b/app/views/explore/posts/missed_searches.html.erb
@@ -31,5 +31,5 @@
 <%= render "posts/partials/common/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Missed Searches - <%= Danbooru.config.app_name %>
+  Missed Searches
 <% end %>

--- a/app/views/explore/posts/popular.html.erb
+++ b/app/views/explore/posts/popular.html.erb
@@ -17,7 +17,7 @@
 <%= render "posts/partials/common/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Popular - <%= Danbooru.config.app_name %>
+  Popular
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/explore/posts/searches.html.erb
+++ b/app/views/explore/posts/searches.html.erb
@@ -31,5 +31,5 @@
 <%= render "posts/partials/common/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Popular Searches - <%= Danbooru.config.app_name %>
+  Popular Searches
 <% end %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -32,5 +32,5 @@
 <%= render "posts/partials/common/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Favorites - <%= @user.pretty_name %> - <%= Danbooru.config.app_name %>
+  Favorites - <%= @user.pretty_name %>
 <% end %>

--- a/app/views/forum_categories/index.html.erb
+++ b/app/views/forum_categories/index.html.erb
@@ -42,3 +42,7 @@
     <%= subnav_link_to "Help", help_page_path(id: 'forum') %>
   </menu>
 <% end %>
+
+<% content_for(:page_title) do %>
+  Forum Categories
+<% end %>

--- a/app/views/forum_posts/edit.html.erb
+++ b/app/views/forum_posts/edit.html.erb
@@ -9,5 +9,5 @@
 <%= render "forum_topics/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Forum Post - <%= Danbooru.config.app_name %>
+  Edit Forum Post
 <% end %>

--- a/app/views/forum_posts/index.html.erb
+++ b/app/views/forum_posts/index.html.erb
@@ -32,5 +32,5 @@
 <%= render "forum_topics/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Forum Posts - <%= Danbooru.config.app_name %>
+  Forum Posts
 <% end %>

--- a/app/views/forum_posts/new.html.erb
+++ b/app/views/forum_posts/new.html.erb
@@ -13,5 +13,5 @@
 <%= render "forum_topics/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Forum Post - <%= Danbooru.config.app_name %>
+  New Forum Post
 <% end %>

--- a/app/views/forum_posts/search.html.erb
+++ b/app/views/forum_posts/search.html.erb
@@ -17,5 +17,5 @@
 <%= render "forum_topics/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Forum Posts - <%= Danbooru.config.app_name %>
+  Search Forum Posts
 <% end %>

--- a/app/views/forum_posts/show.html.erb
+++ b/app/views/forum_posts/show.html.erb
@@ -8,5 +8,5 @@
 <%= render "forum_topics/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Forum Post - <%= Danbooru.config.app_name %>
+  Forum Post
 <% end %>

--- a/app/views/forum_topics/edit.html.erb
+++ b/app/views/forum_topics/edit.html.erb
@@ -7,5 +7,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Edit Forum Topic - <%= Danbooru.config.app_name %>
+  Edit Forum Topic
 <% end %>

--- a/app/views/forum_topics/edit.html.erb
+++ b/app/views/forum_topics/edit.html.erb
@@ -7,5 +7,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Edit Forum Topic
+  Edit Forum Topic - <%= @forum_topic.title %>
 <% end %>

--- a/app/views/forum_topics/index.html.erb
+++ b/app/views/forum_topics/index.html.erb
@@ -20,7 +20,7 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Forum - <%= Danbooru.config.app_name %>
+  Forum
 <% end %>
 
 <% content_for(:html_header, auto_discovery_link_tag(:atom, forum_topics_url(:atom), title: "Forum Topics")) %>

--- a/app/views/forum_topics/new.html.erb
+++ b/app/views/forum_topics/new.html.erb
@@ -9,5 +9,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Forum Topic - <%= Danbooru.config.app_name %>
+  New Forum Topic
 <% end %>

--- a/app/views/forum_topics/new_merge.html.erb
+++ b/app/views/forum_topics/new_merge.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Merge Forum Topic - <%= Danbooru.config.app_name %>
+  Merge Forum Topic
 <% end %>

--- a/app/views/forum_topics/show.html.erb
+++ b/app/views/forum_topics/show.html.erb
@@ -41,7 +41,7 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Forum - <%= @forum_topic.title %> - <%= Danbooru.config.app_name %>
+  Forum - <%= @forum_topic.title %>
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/help/edit.html.erb
+++ b/app/views/help/edit.html.erb
@@ -9,3 +9,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Edit Help Entry - <%= @help.title %>
+<% end %>

--- a/app/views/help/index.html.erb
+++ b/app/views/help/index.html.erb
@@ -44,3 +44,7 @@
     <% end %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Help Index
+<% end %>

--- a/app/views/help/new.html.erb
+++ b/app/views/help/new.html.erb
@@ -8,3 +8,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  New Help Entry
+<% end %>

--- a/app/views/help/show.html.erb
+++ b/app/views/help/show.html.erb
@@ -13,3 +13,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Help: <%= HelpPage.title(@help.name) %>
+<% end %>

--- a/app/views/ip_bans/index.html.erb
+++ b/app/views/ip_bans/index.html.erb
@@ -30,5 +30,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  IP Bans - <%= Danbooru.config.app_name %>
+  IP Bans
 <% end %>

--- a/app/views/ip_bans/new.html.erb
+++ b/app/views/ip_bans/new.html.erb
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New IP Ban - <%= Danbooru.config.app_name %>
+  New IP Ban
 <% end %>

--- a/app/views/iqdb_queries/show.html.erb
+++ b/app/views/iqdb_queries/show.html.erb
@@ -23,6 +23,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Similar Images Search - <%= Danbooru.config.app_name %>
+  Similar Images Search
 <% end %>
-

--- a/app/views/janitor_trials/index.html.erb
+++ b/app/views/janitor_trials/index.html.erb
@@ -29,5 +29,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Janitor Trials - <%= Danbooru.config.app_name %>
+  Janitor Trials
 <% end %>

--- a/app/views/janitor_trials/new.html.erb
+++ b/app/views/janitor_trials/new.html.erb
@@ -16,5 +16,5 @@
 
 <%= render "secondary_links" %>
 <% content_for(:page_title) do %>
-  New Janitor - <%= Danbooru.config.app_name %>
+  New Janitor
 <% end %>

--- a/app/views/layouts/blank.html.erb
+++ b/app/views/layouts/blank.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-  <title><%= yield :page_title %></title>
+  <title><%= get_title %></title>
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
   <link rel="top" title="<%= Danbooru.config.app_name %>" href="/">
   <%= csrf_meta_tag %>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-  <title><%= yield :page_title %></title>
+  <title><%= get_title %></title>
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/app/views/maintenance/user/api_keys/show.html.erb
+++ b/app/views/maintenance/user/api_keys/show.html.erb
@@ -11,5 +11,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  API Key - <%= Danbooru.config.app_name %>
+  API Key
 <% end %>

--- a/app/views/maintenance/user/api_keys/view.html.erb
+++ b/app/views/maintenance/user/api_keys/view.html.erb
@@ -28,5 +28,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  API Key - <%= Danbooru.config.app_name %>
+  API Key
 <% end %>

--- a/app/views/maintenance/user/count_fixes/new.html.erb
+++ b/app/views/maintenance/user/count_fixes/new.html.erb
@@ -11,5 +11,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Refresh Counts - <%= Danbooru.config.app_name %>
+  Refresh Counts
 <% end %>

--- a/app/views/maintenance/user/deletions/show.html.erb
+++ b/app/views/maintenance/user/deletions/show.html.erb
@@ -35,5 +35,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Delete Account - <%= Danbooru.config.app_name %>
+  Delete Account
 <% end %>

--- a/app/views/maintenance/user/dmail_filters/edit.html.erb
+++ b/app/views/maintenance/user/dmail_filters/edit.html.erb
@@ -33,5 +33,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Edit Message Filters - <%= Danbooru.config.app_name %>
+  Edit Message Filters
 <% end %>

--- a/app/views/maintenance/user/email_changes/new.html.erb
+++ b/app/views/maintenance/user/email_changes/new.html.erb
@@ -25,3 +25,7 @@
     <% end %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Change Email
+<% end %>

--- a/app/views/maintenance/user/login_reminders/new.html.erb
+++ b/app/views/maintenance/user/login_reminders/new.html.erb
@@ -20,5 +20,5 @@
 <%= render "sessions/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Login Reminder - <%= Danbooru.config.app_name %>
+  Login Reminder
 <% end %>

--- a/app/views/maintenance/user/password_resets/edit.html.erb
+++ b/app/views/maintenance/user/password_resets/edit.html.erb
@@ -25,5 +25,5 @@
 <%= render "sessions/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Reset Password - <%= Danbooru.config.app_name %>
+  Reset Password
 <% end %>

--- a/app/views/maintenance/user/password_resets/new.html.erb
+++ b/app/views/maintenance/user/password_resets/new.html.erb
@@ -19,5 +19,5 @@
 <%= render "sessions/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Reset Password - <%= Danbooru.config.app_name %>
+  Reset Password
 <% end %>

--- a/app/views/maintenance/user/passwords/edit.html.erb
+++ b/app/views/maintenance/user/passwords/edit.html.erb
@@ -12,5 +12,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Change Password - <%= Danbooru.config.app_name %>
+  Change Password
 <% end %>

--- a/app/views/meta_searches/tags.html.erb
+++ b/app/views/meta_searches/tags.html.erb
@@ -118,5 +118,5 @@
 <%= render "tags/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  MetaSearch - Tags - <%= Danbooru.config.app_name %>
+  MetaSearch - Tags
 <% end %>

--- a/app/views/mod_actions/index.html.erb
+++ b/app/views/mod_actions/index.html.erb
@@ -28,5 +28,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Mod Actions - <%= Danbooru.config.app_name %>
+  Mod Actions
 <% end %>

--- a/app/views/moderator/dashboards/show.html.erb
+++ b/app/views/moderator/dashboards/show.html.erb
@@ -23,5 +23,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Mod Dashboard - <%= Danbooru.config.app_name %>
+  Mod Dashboard
 <% end %>

--- a/app/views/moderator/ip_addrs/index.html.erb
+++ b/app/views/moderator/ip_addrs/index.html.erb
@@ -19,5 +19,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  IP Addresses - <%= Danbooru.config.app_name %>
+  IP Addresses
 <% end %>

--- a/app/views/moderator/ip_addrs/search.html.erb
+++ b/app/views/moderator/ip_addrs/search.html.erb
@@ -11,5 +11,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Search IP Addresses - <%= Danbooru.config.app_name %>
+  Search IP Addresses
 <% end %>

--- a/app/views/moderator/post/disapprovals/index.html.erb
+++ b/app/views/moderator/post/disapprovals/index.html.erb
@@ -50,5 +50,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Post Disapprovals - <%= Danbooru.config.app_name %>
+  Post Disapprovals
 <% end %>

--- a/app/views/moderator/post/posts/confirm_delete.html.erb
+++ b/app/views/moderator/post/posts/confirm_delete.html.erb
@@ -31,3 +31,7 @@
   <%= submit_tag "Delete" %>
   <%= submit_tag "Cancel" %>
 <% end %>
+
+<% content_for(:page_title) do %>
+  Delete Post - #<%= @post.id %>
+<% end %>

--- a/app/views/moderator/post/posts/confirm_move_favorites.html.erb
+++ b/app/views/moderator/post/posts/confirm_move_favorites.html.erb
@@ -10,3 +10,7 @@
   <%= submit_tag "Submit" %>
   <%= submit_tag "Cancel" %>
 <% end %>
+
+<% content_for(:page_title) do %>
+  Move Favorites - #<%= @post.id %>
+<% end %>

--- a/app/views/moderator/post/queues/random.html.erb
+++ b/app/views/moderator/post/queues/random.html.erb
@@ -25,7 +25,7 @@
 <%= render "posts/partials/common/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Mod Queue - <%= Danbooru.config.app_name %>
+  Mod Queue
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/moderator/post/queues/show.html.erb
+++ b/app/views/moderator/post/queues/show.html.erb
@@ -40,5 +40,5 @@
 <%= render "posts/partials/common/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Mod Queue - <%= Danbooru.config.app_name %>
+  Mod Queue
 <% end %>

--- a/app/views/moderator/tags/edit.html.erb
+++ b/app/views/moderator/tags/edit.html.erb
@@ -21,5 +21,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Mass Edit - <%= Danbooru.config.app_name %>
+  Mass Edit
 <% end %>

--- a/app/views/news_updates/edit.html.erb
+++ b/app/views/news_updates/edit.html.erb
@@ -12,5 +12,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Update - <%= Danbooru.config.app_name %>
+  Edit Update
 <% end %>

--- a/app/views/news_updates/index.html.erb
+++ b/app/views/news_updates/index.html.erb
@@ -30,5 +30,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  News Updates - <%= Danbooru.config.app_name %>
+  News Updates
 <% end %>

--- a/app/views/news_updates/new.html.erb
+++ b/app/views/news_updates/new.html.erb
@@ -12,5 +12,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Update - <%= Danbooru.config.app_name %>
+  New Update
 <% end %>

--- a/app/views/note_versions/index.html.erb
+++ b/app/views/note_versions/index.html.erb
@@ -15,5 +15,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Note Versions - <%= Danbooru.config.app_name %>
+  Note Versions
 <% end %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -40,5 +40,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Notes - <%= Danbooru.config.app_name %>
+  Notes
 <% end %>

--- a/app/views/notes/search.html.erb
+++ b/app/views/notes/search.html.erb
@@ -16,5 +16,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Notes - <%= Danbooru.config.app_name %>
+  Search Notes
 <% end %>

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -22,5 +22,5 @@
 <%= render "pools/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Order Pool - <%= Danbooru.config.app_name %>
+  Order Pool
 <% end %>

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -22,5 +22,5 @@
 <%= render "pools/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Order Pool
+  Order Pool - <%= @pool.pretty_name %>
 <% end %>

--- a/app/views/pool_versions/diff.html.erb
+++ b/app/views/pool_versions/diff.html.erb
@@ -15,5 +15,5 @@
 <%= render "pools/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Pool Version Comparison - <%= @pool_version.name %> - <%= Danbooru.config.app_name %>
+  Pool Version Comparison
 <% end %>

--- a/app/views/pool_versions/index.html.erb
+++ b/app/views/pool_versions/index.html.erb
@@ -15,5 +15,5 @@
 <%= render "pools/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Pool Versions - <%= Danbooru.config.app_name %>
+  Pool Versions
 <% end %>

--- a/app/views/pools/edit.html.erb
+++ b/app/views/pools/edit.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Pool
+  Edit Pool - <%= @pool.pretty_name %>
 <% end %>

--- a/app/views/pools/edit.html.erb
+++ b/app/views/pools/edit.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Pool - <%= Danbooru.config.app_name %>
+  Edit Pool
 <% end %>

--- a/app/views/pools/gallery.html.erb
+++ b/app/views/pools/gallery.html.erb
@@ -15,5 +15,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Pool Gallery - <%= Danbooru.config.app_name %>
+  Pool Gallery
 <% end %>

--- a/app/views/pools/index.html.erb
+++ b/app/views/pools/index.html.erb
@@ -40,7 +40,7 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Pools - <%= Danbooru.config.app_name %>
+  Pools
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/pools/new.html.erb
+++ b/app/views/pools/new.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Pool - <%= Danbooru.config.app_name %>
+  New Pool
 <% end %>

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -27,7 +27,7 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Pool - <%= @pool.pretty_name %> - <%= Danbooru.config.app_name %>
+  Pool - <%= @pool.pretty_name %>
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/post_appeals/index.html.erb
+++ b/app/views/post_appeals/index.html.erb
@@ -55,5 +55,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Appeals - <%= Danbooru.config.app_name %>
+  Appeals
 <% end %>

--- a/app/views/post_appeals/new.html.erb
+++ b/app/views/post_appeals/new.html.erb
@@ -3,3 +3,7 @@
     <%= render "post_appeals/new", post_appeal: @post_appeal %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  New Appeal - #<%= @post_appeal.post_id %>
+<% end %>

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -38,5 +38,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Approvals - <%= Danbooru.config.app_name %>
+  Approvals
 <% end %>

--- a/app/views/post_events/index.html.erb
+++ b/app/views/post_events/index.html.erb
@@ -33,5 +33,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Events - <%= Danbooru.config.app_name %>
+  Events
 <% end %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -63,5 +63,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Flags - <%= Danbooru.config.app_name %>
+  Flags
 <% end %>

--- a/app/views/post_flags/new.html.erb
+++ b/app/views/post_flags/new.html.erb
@@ -3,3 +3,7 @@
     <%= render "post_flags/new", post_flag: @post_flag %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  New Flag - #<%= @post_flag.post_id %>
+<% end %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -84,5 +84,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Post Replacements - <%= Danbooru.config.app_name %>
+  Post Replacements
 <% end %>

--- a/app/views/post_replacements/new.html.erb
+++ b/app/views/post_replacements/new.html.erb
@@ -3,3 +3,7 @@
     <%= render "new", post_replacement: @post_replacement %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  New Post Replacement - #<%= @post_replacement.post_id %>
+<% end %>

--- a/app/views/post_report_reasons/edit.html.erb
+++ b/app/views/post_report_reasons/edit.html.erb
@@ -14,3 +14,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Edit Post Report Reason
+<% end %>

--- a/app/views/post_report_reasons/index.html.erb
+++ b/app/views/post_report_reasons/index.html.erb
@@ -28,3 +28,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Post Report Reasons
+<% end %>

--- a/app/views/post_report_reasons/new.html.erb
+++ b/app/views/post_report_reasons/new.html.erb
@@ -15,3 +15,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  New Post Report Reason
+<% end %>

--- a/app/views/post_set_maintainers/index.html.erb
+++ b/app/views/post_set_maintainers/index.html.erb
@@ -72,3 +72,7 @@
 </div>
 
 <%= render partial: "post_sets/secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Set Maintainers
+<% end %>

--- a/app/views/post_sets/destroy.html.erb
+++ b/app/views/post_sets/destroy.html.erb
@@ -14,3 +14,7 @@
 <% end -%>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Set Deleted
+<% end %>

--- a/app/views/post_sets/edit.html.erb
+++ b/app/views/post_sets/edit.html.erb
@@ -36,3 +36,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Edit Set - <%= @post_set.name %>
+<% end %>

--- a/app/views/post_sets/index.html.erb
+++ b/app/views/post_sets/index.html.erb
@@ -58,3 +58,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Sets
+<% end %>

--- a/app/views/post_sets/maintainers.html.erb
+++ b/app/views/post_sets/maintainers.html.erb
@@ -69,3 +69,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Set Maintainers - <%= @post_set.name %>
+<% end %>

--- a/app/views/post_sets/new.html.erb
+++ b/app/views/post_sets/new.html.erb
@@ -29,3 +29,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  New Set
+<% end %>

--- a/app/views/post_sets/post_list.erb
+++ b/app/views/post_sets/post_list.erb
@@ -10,3 +10,7 @@
 </div>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Set Post List - <%= @post_set.name %>
+<% end %>

--- a/app/views/post_sets/show.html.erb
+++ b/app/views/post_sets/show.html.erb
@@ -77,3 +77,7 @@
 <% end %>
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Set - <%= @post_set.name %>
+<% end %>

--- a/app/views/post_versions/index.html.erb
+++ b/app/views/post_versions/index.html.erb
@@ -42,5 +42,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Post Changes - <%= Danbooru.config.app_name %>
+  Post Changes
 <% end %>

--- a/app/views/post_votes/index.html.erb
+++ b/app/views/post_votes/index.html.erb
@@ -64,3 +64,7 @@
     </div>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Post Votes
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -53,9 +53,9 @@
 
 <% content_for(:page_title) do %>
   <% if @post_set.public_tag_string.present? %>
-    <%= @post_set.humanized_tag_string %> - <%= Danbooru.config.app_name %>
+    <%= @post_set.humanized_tag_string %>
   <% else %>
-    <%= Danbooru.config.app_name %>
+    Posts
   <% end %>
 <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -218,7 +218,7 @@
 </div>
 
 <% content_for(:page_title) do %>
-  #<%= @post.id %> - <%= Danbooru.config.app_name %>
+  #<%= @post.id %>
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/recommended_posts/show.html.erb
+++ b/app/views/recommended_posts/show.html.erb
@@ -5,12 +5,12 @@
     <p>Based on your favorites, you may enjoy these posts. Favorite more to get more accurate results. These recommendations update every hour.</p>
 
     <%= render "posts/partials/common/inline_blacklist" %>
-    <%= render partial: "show" %> 
+    <%= render partial: "show" %>
   </div>
 </div>
 
 <%= render "posts/partials/common/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Recommended Posts - <%= Danbooru.config.app_name %>
+  Recommended Posts
 <% end %>

--- a/app/views/related_tags/show.html.erb
+++ b/app/views/related_tags/show.html.erb
@@ -35,5 +35,5 @@
 <%= render "tags/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Related tags - <%= Danbooru.config.app_name %>
+  Related tags
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -35,7 +35,7 @@
 </div>
 
 <% content_for(:page_title) do %>
- Sign in - <%= Danbooru.config.app_name %>
+ Sign in
 <% end %>
 
 <%= render "secondary_links" %>

--- a/app/views/static/404.html.erb
+++ b/app/views/static/404.html.erb
@@ -1,1 +1,5 @@
 <p>Not found.</p>
+
+<% content_for(:page_title) do %>
+  Not Found
+<% end %>

--- a/app/views/static/access_denied.html.erb
+++ b/app/views/static/access_denied.html.erb
@@ -5,5 +5,5 @@
 <%= link_to "Go back", :back, :rel => "prev" %>
 
 <% content_for(:page_title) do %>
-  Access Denied - <%= Danbooru.config.app_name %>
+  Access Denied
 <% end %>

--- a/app/views/static/bookmarklet.html.erb
+++ b/app/views/static/bookmarklet.html.erb
@@ -26,5 +26,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Bookmarklet - <%= Danbooru.config.app_name %>
+  Bookmarklet
 <% end %>

--- a/app/views/static/contact.html.erb
+++ b/app/views/static/contact.html.erb
@@ -5,9 +5,9 @@
     <h2>Questions &amp; Comments</h2>
 
     <p>You can reach the administrator of this site at <%= mail_to Danbooru.config.contact_email, nil, :encode => :hex %>.</p>
-
-    <% content_for(:page_title) do %>
-      Contact - <%= Danbooru.config.app_name %>
-    <% end %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Contact
+<% end %>

--- a/app/views/static/discord.html.erb
+++ b/app/views/static/discord.html.erb
@@ -9,3 +9,7 @@
     <%= submit_tag 'Join the server.' %>
   <% end %>
 </div>
+
+<% content_for(:page_title) do %>
+  Discord Server
+<% end %>

--- a/app/views/static/error.html.erb
+++ b/app/views/static/error.html.erb
@@ -9,3 +9,7 @@
 <% else %>
   <p>An error happened but there are no details provided. That's pretty odd.</p>
 <% end %>
+
+<% content_for(:page_title) do %>
+  Unexpected Error
+<% end %>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -111,5 +111,3 @@
 <% content_for(:html_header) do -%>
   <meta name="enable-auto-complete" content="<%= CurrentUser.user.enable_auto_complete %>">
 <%- end %>
-
-<% content_for(:page_title) do %><%= Danbooru.config.app_name %><% end %>

--- a/app/views/static/keyboard_shortcuts.html.erb
+++ b/app/views/static/keyboard_shortcuts.html.erb
@@ -64,5 +64,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Keyboard Shortcuts - <%= Danbooru.config.app_name %>
+  Keyboard Shortcuts
 <% end %>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -128,5 +128,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Site Map - <%= Danbooru.config.app_name %>
+  Site Map
 <% end %>

--- a/app/views/static/takedown.html.erb
+++ b/app/views/static/takedown.html.erb
@@ -26,3 +26,7 @@
   <p>If you wish to file a fully fledged DMCA notice please have all relevant documents sent to takedowns at e621.net.</p>
 </div>
 <div class="Clear">&nbsp;</div>
+
+<% content_for(:page_title) do %>
+  Takedown Policy
+<% end %>

--- a/app/views/static/terms_of_service.html.erb
+++ b/app/views/static/terms_of_service.html.erb
@@ -12,5 +12,5 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Rules - <%= Danbooru.config.app_name %>
+  Rules
 <% end %>

--- a/app/views/static/theme.html.erb
+++ b/app/views/static/theme.html.erb
@@ -90,3 +90,7 @@
     });
   });
 <% end -%>
+
+<% content_for(:page_title) do %>
+  Themes
+<% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -595,3 +595,7 @@
     });
   });
 <% end -%>
+
+<% content_for(:page_title) do %>
+  Stats
+<% end %>

--- a/app/views/tag_alias_requests/new.html.erb
+++ b/app/views/tag_alias_requests/new.html.erb
@@ -42,5 +42,5 @@
 <%= render "tag_aliases/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tag Alias Request - <%= Danbooru.config.app_name %>
+  Tag Alias Request
 <% end %>

--- a/app/views/tag_aliases/edit.html.erb
+++ b/app/views/tag_aliases/edit.html.erb
@@ -16,5 +16,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Tag Alias - <%= Danbooru.config.app_name %>
+  Edit Tag Alias
 <% end %>

--- a/app/views/tag_aliases/index.html.erb
+++ b/app/views/tag_aliases/index.html.erb
@@ -13,5 +13,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tag Aliases - <%= Danbooru.config.app_name %>
+  Tag Aliases
 <% end %>

--- a/app/views/tag_aliases/show.html.erb
+++ b/app/views/tag_aliases/show.html.erb
@@ -45,5 +45,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tag Alias - <%= Danbooru.config.app_name %>
+  Tag Alias
 <% end %>

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -17,7 +17,7 @@
     <% end %>
 
     <% content_for(:page_title) do %>
-      Tag Correction - <%= Danbooru.config.app_name %>
+      Tag Correction
     <% end %>
   </div>
 </div>

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -15,9 +15,9 @@
       <%= submit_tag "Fix" %>
       <%= submit_tag "Cancel" %>
     <% end %>
-
-    <% content_for(:page_title) do %>
-      Tag Correction
-    <% end %>
   </div>
 </div>
+
+<% content_for(:page_title) do %>
+  Tag Correction
+<% end %>

--- a/app/views/tag_implication_requests/new.html.erb
+++ b/app/views/tag_implication_requests/new.html.erb
@@ -42,5 +42,5 @@
 <%= render "tag_implications/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tag Implication Request - <%= Danbooru.config.app_name %>
+  Tag Implication Request
 <% end %>

--- a/app/views/tag_implications/edit.html.erb
+++ b/app/views/tag_implications/edit.html.erb
@@ -16,5 +16,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Tag Implication - <%= Danbooru.config.app_name %>
+  Edit Tag Implication
 <% end %>

--- a/app/views/tag_implications/index.html.erb
+++ b/app/views/tag_implications/index.html.erb
@@ -10,5 +10,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tag Implications - <%= Danbooru.config.app_name %>
+  Tag Implications
 <% end %>

--- a/app/views/tag_implications/show.html.erb
+++ b/app/views/tag_implications/show.html.erb
@@ -33,5 +33,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tag Implication - <%= Danbooru.config.app_name %>
+  Tag Implication
 <% end %>

--- a/app/views/tag_type_versions/index.html.erb
+++ b/app/views/tag_type_versions/index.html.erb
@@ -38,3 +38,6 @@
   </div>
 </div>
 
+<% content_for(:page_title) do %>
+  Tag Type Versions
+<% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -21,5 +21,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Tag - <%= Danbooru.config.app_name %>
+  Edit Tag
 <% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -21,5 +21,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Tag
+  Edit Tag - <%= @tag.name %>
 <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -38,5 +38,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tags - <%= Danbooru.config.app_name %>
+  Tags
 <% end %>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -12,5 +12,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Tag - <%= @tag.name %> - <%= Danbooru.config.app_name %>
+  Tag - <%= @tag.name %>
 <% end %>

--- a/app/views/takedowns/index.html.erb
+++ b/app/views/takedowns/index.html.erb
@@ -58,5 +58,5 @@
 <%= render "takedowns/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Takedowns - <%= Danbooru.config.app_name %>
+  Takedowns
 <% end %>

--- a/app/views/takedowns/new.html.erb
+++ b/app/views/takedowns/new.html.erb
@@ -55,3 +55,7 @@
 </div>
 
 <%= render partial: 'secondary_links' %>
+
+<% content_for(:page_title) do %>
+  New Takedown
+<% end %>

--- a/app/views/takedowns/show.html.erb
+++ b/app/views/takedowns/show.html.erb
@@ -188,3 +188,7 @@
 
 
 <%= render partial: "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Takedown #<%= @takedown.id %>
+<% end %>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -60,3 +60,7 @@
 </div>
 
 <% render partial: 'secondary_links' %>
+
+<% content_for(:page_title) do %>
+  Tickets
+<% end %>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -64,3 +64,7 @@
 </div>
 
 <% render partial: 'secondary_links' %>
+
+<% content_for(:page_title) do %>
+  New Ticket
+<% end %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -141,3 +141,7 @@
 <% end %>
 
 <% render partial: 'secondary_links' %>
+
+<% content_for(:page_title) do %>
+  <%= @ticket.type_title %> Ticket
+<% end %>

--- a/app/views/upload_whitelists/edit.html.erb
+++ b/app/views/upload_whitelists/edit.html.erb
@@ -18,5 +18,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Upload Whitelist - <%= Danbooru.config.app_name %>
+  Edit Upload Whitelist
 <% end %>

--- a/app/views/upload_whitelists/index.html.erb
+++ b/app/views/upload_whitelists/index.html.erb
@@ -37,5 +37,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Upload Whitelists - <%= Danbooru.config.app_name %>
+  Upload Whitelists
 <% end %>

--- a/app/views/upload_whitelists/new.html.erb
+++ b/app/views/upload_whitelists/new.html.erb
@@ -18,5 +18,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Upload Whitelist - <%= Danbooru.config.app_name %>
+  New Upload Whitelist
 <% end %>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -80,5 +80,5 @@
 <%= render "uploads/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Uploads - <%= Danbooru.config.app_name %>
+  Uploads
 <% end %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -44,3 +44,7 @@
   Danbooru.Uploader.init();
 <% end -%>
 <%= render "posts/partials/common/secondary_links" %>
+
+<% content_for(:page_title) do %>
+  New Upload
+<% end %>

--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -46,7 +46,7 @@
 <%= render "uploads/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Upload - <%= Danbooru.config.app_name %>
+  Upload
 <% end %>
 
 <% if @upload.is_pending? || @upload.is_processing? || @upload.is_preprocessing? || @upload.is_preprocessed? %>

--- a/app/views/user_feedbacks/edit.html.erb
+++ b/app/views/user_feedbacks/edit.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Feedback - <%= Danbooru.config.app_name %>
+  Edit Feedback
 <% end %>

--- a/app/views/user_feedbacks/edit.html.erb
+++ b/app/views/user_feedbacks/edit.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Feedback
+  Edit Feedback - <%= @user_feedback.user.name %>
 <% end %>

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -42,5 +42,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Feedback - <%= Danbooru.config.app_name %>
+  Feedback
 <% end %>

--- a/app/views/user_feedbacks/new.html.erb
+++ b/app/views/user_feedbacks/new.html.erb
@@ -20,5 +20,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Feedback - <%= Danbooru.config.app_name %>
+  New Feedback
 <% end %>

--- a/app/views/user_feedbacks/search.html.erb
+++ b/app/views/user_feedbacks/search.html.erb
@@ -22,5 +22,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search User Feedbacks - <%= Danbooru.config.app_name %>
+  Search User Feedbacks
 <% end %>

--- a/app/views/user_feedbacks/show.html.erb
+++ b/app/views/user_feedbacks/show.html.erb
@@ -19,5 +19,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Feedback - <%= @user_feedback.user_name %> - <%= Danbooru.config.app_name %>
+  Feedback - <%= @user_feedback.user_name %>
 <% end %>

--- a/app/views/user_name_change_requests/index.html.erb
+++ b/app/views/user_name_change_requests/index.html.erb
@@ -46,3 +46,7 @@
 </div>
 
 <%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Name Change Requests
+<% end %>

--- a/app/views/user_name_change_requests/new.html.erb
+++ b/app/views/user_name_change_requests/new.html.erb
@@ -15,3 +15,7 @@
 </div>
 
 <%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Username Change Request
+<% end %>

--- a/app/views/user_name_change_requests/show.html.erb
+++ b/app/views/user_name_change_requests/show.html.erb
@@ -86,3 +86,7 @@
 </div>
 
 <%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Name Change Request - <%= @change_request.user.pretty_name %>
+<% end %>

--- a/app/views/user_reverts/new.html.erb
+++ b/app/views/user_reverts/new.html.erb
@@ -15,5 +15,5 @@
 <%= render "users/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  User Revert - <%= Danbooru.config.app_name %>
+  User Revert
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -115,7 +115,7 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Settings - <%= Danbooru.config.app_name %>
+  Settings
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -58,5 +58,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Users - <%= Danbooru.config.app_name %>
+  Users
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -33,5 +33,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Sign up - <%= Danbooru.config.app_name %>
+  Sign up
 <% end %>

--- a/app/views/users/search.html.erb
+++ b/app/views/users/search.html.erb
@@ -23,5 +23,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Users - <%= Danbooru.config.app_name %>
+  Search Users
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,7 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  User - <%= @presenter.name %> - <%= Danbooru.config.app_name %>
+  User - <%= @presenter.name %>
 <% end %>
 
 <% content_for(:html_header, auto_discovery_link_tag(:atom, comments_url(:atom, search: {post_tags_match: "user:#{@user.name}"}), title: "Comments on #{@user.name}'s uploads")) %>

--- a/app/views/wiki_page_versions/diff.html.erb
+++ b/app/views/wiki_page_versions/diff.html.erb
@@ -17,5 +17,5 @@
 <%= render "wiki_pages/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Wiki Page Versions Comparison - <%= @thispage.pretty_title %> - <%= Danbooru.config.app_name %>
+  Wiki Page Versions Comparison - <%= @thispage.pretty_title %>
 <% end %>

--- a/app/views/wiki_page_versions/index.html.erb
+++ b/app/views/wiki_page_versions/index.html.erb
@@ -19,5 +19,5 @@
 <%= render "wiki_pages/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Wiki Page Versions - <%= Danbooru.config.app_name %>
+  Wiki Page Versions
 <% end %>

--- a/app/views/wiki_page_versions/show.html.erb
+++ b/app/views/wiki_page_versions/show.html.erb
@@ -23,5 +23,5 @@
 <%= render "wiki_pages/secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Wiki Page Version - <%= Danbooru.config.app_name %>
+  Wiki Page Version
 <% end %>

--- a/app/views/wiki_pages/edit.html.erb
+++ b/app/views/wiki_pages/edit.html.erb
@@ -21,5 +21,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Wiki Page - <%= Danbooru.config.app_name %>
+  Edit Wiki Page
 <% end %>

--- a/app/views/wiki_pages/edit.html.erb
+++ b/app/views/wiki_pages/edit.html.erb
@@ -21,5 +21,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Edit Wiki Page
+  Edit Wiki Page - <%= @wiki_page.title %>
 <% end %>

--- a/app/views/wiki_pages/index.html.erb
+++ b/app/views/wiki_pages/index.html.erb
@@ -28,7 +28,7 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Wiki - <%= Danbooru.config.app_name %>
+  Wiki
 <% end %>
 
 <%= render "secondary_links" %>

--- a/app/views/wiki_pages/new.html.erb
+++ b/app/views/wiki_pages/new.html.erb
@@ -24,5 +24,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  New Wiki Page - <%= Danbooru.config.app_name %>
+  New Wiki Page
 <% end %>

--- a/app/views/wiki_pages/search.html.erb
+++ b/app/views/wiki_pages/search.html.erb
@@ -29,5 +29,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Search Wiki - <%= Danbooru.config.app_name %>
+  Search Wiki
 <% end %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -36,7 +36,7 @@
 </div>
 
 <% content_for(:page_title) do %>
-  Wiki - <%= @wiki_page.pretty_title %> - <%= Danbooru.config.app_name %>
+  Wiki - <%= @wiki_page.pretty_title %>
 <% end %>
 
 <% content_for(:html_header) do %>

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -24,5 +24,5 @@
 <%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
-  Wiki - <%= params[:title] %> - <%= Danbooru.config.app_name %>
+  Wiki - <%= @wiki_page.title %>
 <% end %>


### PR DESCRIPTION
Some pages I frequently use like uploading and sets were missing their titles. This adds them and a bunch of other missing ones as well. Some of them are deprecated or unused like Artist Commentaries but I added them anyways for completeness sake.

The first commit removes `app_name` from every `page_title` and instead adds it back later in a helper function. The only page which didn't have `app_name` at the end was the root page so I special cased that in the helper.
Overall this commit is not really nessesary but I thought it makes the code a bit cleaner.

The second commit adds the missing titles and adds useful information to a few existing ones, like the tag name when you are editing a tag. Most existing titles already had this kind of information.

The third commit doesn't really fit with the other two, I just added it here to not spam MR (tell me I should do that instead). It replaces the plain 404 error page with the already used one in `application_controller`. That way you don't get blinded by accidentally misstyping a url.
Not sure if it's important but I made it to only respond as html which keeps it in line that no valid json will be served, even if the request ends with `json`. You only get valid json if you are on an existing route.