### PR TITLE
[UI] Fix multiple static navbar entries being active

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -266,6 +266,9 @@ module ApplicationHelper
 
 protected
   def nav_link_match(controller, url)
+    # Static routes must match completely
+    return url == request.path if controller == "static"
+
     url =~ case controller
     when "sessions", "users", "maintenance/user/login_reminders", "maintenance/user/password_resets", "admin/users", "dmails"
       /^\/(session|users)/
@@ -309,8 +312,9 @@ protected
     when "help"
       /^\/help/
 
+    # If there is no match activate the site map only
     else
-      /^\/static/
+      /^#{site_map_path}/
     end
   end
 end


### PR DESCRIPTION
Previously the controller was used exclusivley to check if a route
was active. Because static entries all use the same controller it was
possible for multiple navbar entries to be active at the same time
if you were on a static page.

This fixes that by first checking for route equality and ignoring the
static controller later on.

Before: 
![image](https://user-images.githubusercontent.com/14981592/112042823-4404bf00-8b48-11eb-9eb0-a1c6ef25184d.png)
After:
![image](https://user-images.githubusercontent.com/14981592/112042870-51ba4480-8b48-11eb-9d28-305a417f66de.png)
![image](https://user-images.githubusercontent.com/14981592/112042888-57b02580-8b48-11eb-8237-e50073c9e3f5.png)
