### PR TITLE
Add list of post favorites to seperate route 

### DIFF
--- a/app/controllers/post_favorites_controller.rb
+++ b/app/controllers/post_favorites_controller.rb
@@ -1,0 +1,8 @@
+class PostFavoritesController < ApplicationController
+  before_action :member_only
+  respond_to :html
+
+  def index
+    @users = ::Post.find(params[:post_id]).favorited_users
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -285,7 +285,7 @@ protected
     when "notes", "note_versions"
       /^\/notes/
 
-    when "posts", "uploads", "post_versions", "explore/posts", "moderator/post/dashboards", "favorites"
+    when "posts", "uploads", "post_versions", "explore/posts", "moderator/post/dashboards", "favorites", "post_favorites"
       /^\/posts/
 
     when "artists", "artist_versions"

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -44,10 +44,6 @@ module PostsHelper
     end
   end
 
-  def post_favlist(post)
-    post.favorited_users.reverse_each.map {|user| link_to_user(user)}.join(", ").html_safe
-  end
-
   def has_parent_message(post, parent_post_set)
     html = ""
 

--- a/app/javascript/src/javascripts/posts.js.erb
+++ b/app/javascript/src/javascripts/posts.js.erb
@@ -24,7 +24,6 @@ Post.initialize_all = function() {
   if ($("#c-posts").length && $("#a-show").length) {
     this.initialize_links();
     this.initialize_post_relationship_previews();
-    this.initialize_favlist();
     this.initialize_post_sections();
     this.initialize_resize();
     this.initialize_similar();
@@ -441,13 +440,6 @@ Post.toggle_relationship_preview = function(preview, preview_link) {
   } else {
     preview_link.html("show &raquo;");
   }
-}
-
-Post.initialize_favlist = function() {
-  $("#show-favlist-link, #hide-favlist-link").on("click.danbooru", function(e) {
-    $("#favlist, #show-favlist-link, #hide-favlist-link").toggle();
-    e.preventDefault();
-  });
 }
 
 Post.currentPost = function() {

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -456,11 +456,6 @@ div#c-posts {
       }
     }
 
-    #favlist {
-      margin-left: 1em;
-      word-wrap: break-word;
-    }
-
     .search-seq-nav + .pool-nav, .search-seq-nav + .set-nav, .pool-nav + .set-nav {
       margin-top: 0.5em;
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ApplicationRecord
   has_many :forum_posts, -> {order("forum_posts.created_at, forum_posts.id")}, :foreign_key => "creator_id"
   has_many :user_name_change_requests, -> {visible.order("user_name_change_requests.id desc")}
   has_many :post_sets, -> {order(name: :asc)}, foreign_key: :creator_id
-  has_many :favorites, ->(rec) {where("user_id = ?", rec.id).order("id desc")}
+  has_many :favorites, -> {order(id: :desc)}
   belongs_to :avatar, class_name: 'Post', optional: true
   accepts_nested_attributes_for :dmail_filter
 

--- a/app/views/post_favorites/index.html.erb
+++ b/app/views/post_favorites/index.html.erb
@@ -1,11 +1,12 @@
-<div id="c-users">
+<div id="c-post-favorites">
   <div id="a-index">
     <h1>Post Favorites</h1>
-
+    <%= PostPresenter.preview(@post) %>
     <table width="100%" class="striped">
       <thead>
         <tr>
-          <th>Name</th>
+          <th>Favorited by</th>
+          <th>Other Favorites</th>
         </tr>
       </thead>
       <tbody>
@@ -14,10 +15,14 @@
             <td>
               <%= link_to_user user %>
             </td>
+            <td>
+              <%= link_to(user.favorite_count, favorites_path(:user_id => user.id)) %>
+            </td>
           </tr>
         <% end %>
       </tbody>
     </table>
+    <%= numbered_paginator(@users) %>
   </div>
 </div>
 

--- a/app/views/post_favorites/index.html.erb
+++ b/app/views/post_favorites/index.html.erb
@@ -1,0 +1,28 @@
+<div id="c-users">
+  <div id="a-index">
+    <h1>Post Favorites</h1>
+
+    <table width="100%" class="striped">
+      <thead>
+        <tr>
+          <th>Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @users.each do |user| %>
+          <tr>
+            <td>
+              <%= link_to_user user %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%= render "posts/partials/common/secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Post Favorites - #<%= params[:post_id] %>
+<% end %>

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -41,9 +41,5 @@
     <% end %>
   </li>
   <li>Favorites: <span id="favcount-for-post-<%= post.id %>"><%= post.fav_count %></span>
-  <% if CurrentUser.is_privileged? %>
-    <%= link_to "Show »", "#", id: "show-favlist-link", style: ("display: none;" if post.fav_count == 0) %>
-    <%= link_to "« Hide", "#", id: "hide-favlist-link", style: "display: none;" %>
-    <div id="favlist" style="display: none;"><%= post_favlist(post) %></div>
-  <% end %></li>
+  <%= link_to "Show", post_favorites_path(post.id), style: ("display: none;" if post.fav_count == 0) %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,7 @@ Rails.application.routes.draw do
     resources :replacements, :only => [:index, :new, :create], :controller => "post_replacements"
     resource :votes, :controller => "post_votes", :only => [:create, :destroy]
     resource :flag, controller: 'post_flags', only: [:destroy]
+    resources :favorites, :controller => "post_favorites", :only => [:index]
     collection do
       get :random
     end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -56,6 +56,7 @@ Disallow: /posts*?*pool_id*
 Disallow: /posts*?*post_set_id*
 Disallow: /posts.json
 Disallow: /posts.xml
+Disallow: /posts/*/favorites
 Disallow: /reports
 Disallow: /session
 Disallow: /sources


### PR DESCRIPTION
Well, here goes nothing. 

![image](https://user-images.githubusercontent.com/14981592/112284465-913c7a00-8c89-11eb-8065-088225fdc0c0.png)

![image](https://user-images.githubusercontent.com/14981592/112286562-ba5e0a00-8c8b-11eb-970b-f6414324911c.png)

I added pagination simply by slicing the post favorites and using PaginatedArray. Only for the slice the user records will be loaded which also means that pages will probably have a different number of entries, depending on how many user have privacy mode turned on.

EDIT: Disregard the above paragraph, fetching the users happens by joining favorites to user now

I also added the Other Favorites column because it just looked plain bad when only one column was present. I don't know the performance implications of that but I imagine it won't be that high because I include `:user_status` when fetching users.


It's interesting how the favorites are stored in the `fav_string` of the post. Storing them that way instead of having to join a table with literally 100s of million entries comes in handy now. I'm pretty sure it's only purpose is to go from one post to who favorited it without joining. Pretty usefull for `fav:` queries.

Side note: I changed the test where the original method was called but the test fails before that. Generally a whole bunch of tests fail and I was wondering if I'm doing something wrong or if it is just the way it is