### PR TITLE
Improve initial vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure('2') do |config|
   # end
 
   VAGRANT_COMMAND = ARGV[0]
-  # config.ssh.username = 'danbooru' if VAGRANT_COMMAND == 'ssh'
+  config.ssh.username = 'danbooru' if VAGRANT_COMMAND == 'ssh'
 
   config.vm.define 'default' do |node|
     node.vm.hostname = 'e621.local'
@@ -34,4 +34,3 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision 'shell', path: 'vagrant/install.sh'
 end
-

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -557,15 +557,15 @@ class User < ApplicationRecord
     end
 
     def can_upload_with_reason
-      if hourly_upload_limit <= 0
+      if hourly_upload_limit <= 0 && !Danbooru.config.disable_throttles
         :REJ_UPLOAD_HOURLY
       elsif can_upload_free? || is_admin?
           true
-      elsif younger_than(7.days) && !Danbooru.config.disable_throttles
+      elsif younger_than(7.days)
         :REJ_UPLOAD_NEWBIE
-      elsif !is_privileged? && post_edit_limit <= 0
+      elsif !is_privileged? && post_edit_limit <= 0 && !Danbooru.config.disable_throttles
         :REJ_UPLOAD_EDIT
-      elsif upload_limit <= 0
+      elsif upload_limit <= 0 && !Danbooru.config.disable_throttles
         :REJ_UPLOAD_LIMIT
       else
         true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,10 +52,16 @@ unless Rails.env.test?
     file = Tempfile.new.binmode
     file.write data
 
+    post["tags"].each do |category, tags|
+      Tag.find_or_create_by_name_list(tags.map {|tag| category + ":" + tag})
+    end
+
     md5 = Digest::MD5.hexdigest(data)
     service = UploadService.new({
                                     file: file,
                                     tag_string: post["tags"].values.flatten.join(" "),
+                                    source: post["sources"].join("\n"),
+                                    description: post["description"],
                                     rating: post["rating"],
                                     md5: md5,
                                     md5_confirmation: md5

--- a/db/seeds.yml
+++ b/db/seeds.yml
@@ -1,446 +1,81 @@
-images:
-  - tags: zoodystopia 2016 anthro bandage black_nose brown_fur canine clothed clothing
-      collar disney fox fur gloves_(marking) green_eyes looking_at_viewer male mammal
-      markings multicolored_fur nick_wilde open_shirt orange_fur pantssad shirt shock_collar
-      simple_background solo standing turningtides_(artist) white_background zootopia
-    url: https://static1.e621.net/data/87/8f/878f64f8df553ce09218bc9b1083b4e3.png
-  - tags: 5:4 2016 3_toes anthro barefoot canine claws clothed clothing cuddling disney
-      duo fabienne_growley female flat_chested fox green_eyes ipoke judy_hopps lagomorph
-      male mammal nick_wilde peter_moosebridge phone purple_eyes rabbit sitting smile
-      sofa soles television toes zootopia
-    url: https://static1.e621.net/data/62/f1/62f197461e755a7d4bd5884dc8ff20d6.jpg
-  - tags: begging begging_pose blue_fur blue_tail canine chest_tuft dipstick_tail facial_markings
-      fan_character feral feralized fluffy fur looking_away male mammal markings mask_(marking)
-      multicolored_fur multicolored_tail nintendo pokémon pokémon_(species) portrait red_eyes
-      riolu simple_background smile solo tuft two_tone_fur two_tone_tail umpherio_(umpherio)
-      video_games white_background white_fur white_tail xnirox
-    url: https://static1.e621.net/data/97/38/973887346d669d97c7a75b7324855773.png
-  - tags: felid pantherine 2017 armor big_breasts black_lips blue_eyes blue_hair bodysuit
-      breasts clothed clothing f-r95 female fingerless_gloves fluffy fluffy_tail gloves
-      hair inner_ear_fluff inside knee_pads long_tail looking_away looking_outside mammal
-      pink_noseshoulder_pads sitting skinsuit snow_leopard solo space spots tight_clothing
-      toeless_footwear yuna_snowleopard
-    url: https://static1.e621.net/data/34/7f/347fec14942b176b074c1cad64c31ad2.png
-  - tags: back_muscles 2015 anthro ass_up bed bedroom black_fur black_stripes book bookshelf
-      butt crawling feline fireplace fur green_eyes hax_(artist) inside kenket lofi
-      lying male mammal morning multicolored_fur nude on_floor on_front one_eye_closed
-      orange_fur painting pawpads platerug shaded solo striped_body stripes table tiger
-      vase white_fur window
-    url: https://static1.e621.net/data/sample/6f/f4/6ff406e64fe870f43512d863a8fd119b.jpg
-  - tags: pink_eyes 2018 anthro canine clothed clothing cookie digital_media_(artwork)
-      dog female food fur hair looking_at_viewer mammal nana_(fadey) open_mouthsmile
-      solo standing tofu93
-    url: https://static1.e621.net/data/sample/0f/01/0f01bc5401835aa1a082b19e83a0e956.jpg
-  - tags: 2013 anthro beverage blue_fur blue_hair borny_(character) canine clothing
-      coffee digital_media_(artwork) food fox fur green_eyes hair hoodie male mammal
-      open_mouth phonesolo wolfy-nail
-    url: https://static1.e621.net/data/sample/ac/9f/ac9f231b988d4b6f43b66e89e1d5578e.jpg
-  - tags: clothed detailed_background fully_clothed holding_object menacing outside
-      standing yellow_sclera 2015 anthro cheetah clothing feline female flashlight gun
-      handgun mammal muscular muscular_female pistol police ranged_weaponsolo street_lamp
-      sunrise tirrel uniform weapon
-    url: https://static1.e621.net/data/sample/d3/ae/d3aee9d4de485f2be935e84ebbd971b7.jpg
-  - tags: 2015 ambiguous_gender anthro blue_eyes clothing cosplay costume day detailed_background
-      dragon dreamworks falvie fudge_the_otter how_to_train_your_dragon kigurumi mammal
-      membranous_wings mustelid night_fury open_mouth otter outsidesitting sky smile
-      solo star starry_sky sunset toothless wings
-    url: https://static1.e621.net/data/sample/0f/d1/0fd1d92190633265fb32a800d65c82d7.jpg
-  - tags: holding_object food ambiguous_gender beverage black_fur blue_fur blush canine
-      chigiri clothing coffee cup first_person_view fur happy long_ears lucario mammal
-      nintendo one_eye_closed pokémon red_eyes sitting smile solo steam video_games wink
-    url: https://static1.e621.net/data/5a/c6/5ac6787ce0216184bb1737ffc97972e7.png
-  - tags: android animatronic anthro canine clothed clothing exposed_endoskeleton eye_patch
-      eyewear five_nights_at_freddy's fox foxy_(fnaf) fur hook hook_hand machine male
-      mammal naoren piratered_fur robot simple_background solo topless video_games white_background
-      yellow_eyes
-    url: https://static1.e621.net/data/17/0a/170ad0093d771d4b99c59f9626712578.png
-  - tags: 2015 finger_claws 5_fingers <3 anthro blush boss_monster breasts caprine claws
-      clothed clothing eyebrows eyelashes female fur gastropod goat hi-biki hi_res horn
-      long_ears looking_at_viewer mammal poserobe simple_background smile snail solo
-      toriel undertale video_games white_fur wide_hips
-    url: https://static1.e621.net/data/sample/31/16/31162bd0709f5c79726eb55a05997237.jpg
-  - tags: 2017 4_toes anthro arnou barefoot black_fur black_nose blue_eyes canine clothed
-      clothing cuddling day detailed_background digitigrade duo fur hoodie koul male
-      male/male mammal outside red_eyes smile toes tree wolf wulfcole
-    url: https://static1.e621.net/data/sample/e2/4e/e24e60d0e2604a1e18de6ec698462e75.jpg
-  - tags: 2014 anthro black_nose blue_eyes blush brown_fur clothed clothing collar countershade_face
-      countershading female flower flower_in_hair fur headshot_portrait kiki looking_away
-      mammal markings multicolored_fur mustelid open_mouth otter plant portrait rarakiesimple_background
-      solo spots teeth tongue two_tone_fur whiskers white_fur
-    url: https://static1.e621.net/data/8d/8e/8d8ec834c0b6bd02181510e3bc3f7e4d.png
-  - tags: pretending anthro antlers brown_fur cellphone cervine cloud deer duo feline
-      fur green_eyes hi_res horn humor imminent_death lion male mammal nbowa outside
-      phone predator/preyselfie sky tirrel tirrel_(character) tongue tongue_out tree
-    url: https://static1.e621.net/data/sample/d9/0e/d90ea5d58bbb37f6c08d054946a478f9.jpg
-  - tags: "... ambiguous_gender anthro black_fur blue_fur blush canine close-up crossed_arms
-    fur icon jia looking_at_viewer lucario mammal nintendo pokémon pokémon_(species) red_eyes
-    simple_background solo tan_fur video_games white_background"
-    url: https://static1.e621.net/data/sample/db/b6/dbb6db28e0514bb981f417edf6479c9a.jpg
-  - tags: winged_arms wings ... absurd_res anthro avian beak bird blush breath_of_the_wild
-      clothed clothing dialogue english_text feathers hi_res kass_(zelda) male muscular
-      muscular_male nintendo outsiderito sketch solo tacklebox text the_legend_of_zelda
-      video_games
-    url: https://static1.e621.net/data/sample/c6/a3/c6a32022972d9807cfaae5000f45b2c4.jpg
-  - tags: too_early_for_this 2014 5_fingers annoyed anthro beverage big_eyebrows black_eyebrows
-      black_eyes black_fur black_hair black_nose black_shirt blue_fur bust_portrait
-      canine clothed clothing coffee coffee_mug countertop crossed_arms cup dialogue
-      digital_media_(artwork) ear_piercing english_text eyebrows facial_hair facial_piercing
-      food fur gauged_ear goatee grumpy hair holding_cup holding_object hot_drink lip_piercing
-      lol_comments looking_at_viewer male mammal multicolored_fur multicolored_hair
-      nose_piercing nose_ring open_mouth piercing portrait profanityreaction_image restricted_palette
-      shirt signature simple_background sitting sky3 skye_blue solo speech_bubble steam
-      striped_ears table teeth text thick_eyebrows two_tone_fur two_tone_hair white_background
-      white_fur white_hair wolf
-    url: https://static1.e621.net/data/sample/16/61/1661025f6995846607e709c6da99e123.jpg
-  - tags: 2013 ambiguous_gender black_eyes cloud cloudscape colorful detailed_background
-      feral fish happy lol_comments marine open_mouth outside rainbow rainbow_archreaction_image
-      shark sky solo sparkles spunky_(artist) super_gay teeth
-    url: https://static1.e621.net/data/e5/03/e503e7d3465337448b715cfd6457edd0.jpg
-  - tags: 2017 anthro belly big_breasts breasts brown_hair canine chinese_clothing chinese_dress
-      cleavage cleavage_cutout clothed clothing dress female food fox gradient_background
-      hair hairclip hi_res kemono long_hair looking_at_viewer mammal purple_eyessetouchi_kurage
-      simple_background slightly_chubby solo voluptuous waiter wide_hips
-    url: https://static1.e621.net/data/sample/b1/0d/b10d8740126b4fb20d4b21920d131c8f.jpg
-  - tags: brown_hair orange_hair sitting striped_body striped_fur striped_tail 2018
-      <3 anthro black_topwear blue_eyes blue_topwear breasts clothed clothing collaboration
-      countershade_legs countershade_torso countershading day deymos digital_media_(artwork)
-      dipstick_tail domestic_cat felid feline felis female fingerless_(marking) flower
-      fully_clothed fur hair inside iskra legwear looking_aside mammal multicolored_body
-      multicolored_fur multicolored_tail orange_body orange_fur panties pink_nose plantshaded
-      shirt solo stripes sunflower tan_body tan_fur thigh_highs underwear url vera_(iskra)
-      white_legwear window
-    url: https://static1.e621.net/data/sample/80/8d/808d424fd5c3ccbaddac9fc5b92f028a.jpg
-  - tags: 2016 anthro blush buckteeth canine disney duo embarrassed english_text female
-      fireworks fox freedomthai fur green_eyes grey_fur half-closed_eyes hand_on_head
-      hi_res holding_object judy_hopps lagomorph larger_male long_ears male male/female
-      mammal nick_wilde night open_mouth orange_fur outside pen predator/prey purple_eyes
-      rabbitromantic_ambiance size_difference smaller_female smile smirk tears teeth
-      text zootopia
-    url: https://static1.e621.net/data/sample/c6/32/c6321f137f68f99f2bee51dba3bf1de5.jpg
-  - tags: ambiguous_gender capcom cub dragon horn kneeling kosian looking_at_viewer
-      membranous_wings monster_hunter red_eyes rukodiora scalie simple_background solo
-      video_games white_background wings young
-    url: https://static1.e621.net/data/sample/da/92/da922cd07342972262e98de824595cd1.jpg
-  - tags: 2014 anthro beach bikini bikini_top blue_eyes bottomless clothed clothing
-      cloud detailed_background digital_media_(artwork) ear_piercing falvie fangs female
-      grin hair looking_at_viewer mammal markings mustelid neck_tuft otter outside piercingsand
-      seaside short_hair sky smile solo swimsuit tuft water white_hair
-    url: https://static1.e621.net/data/sample/aa/3f/aa3f6074e6c14ff78b40ff51f109869b.jpg
-  - tags: casual_nudity day eyebrows eyelashes grey_hair half-closed_eyes looking_aside
-      multicolored_fur multicolored_hair partially_submerged skinny_dipping slim snout
-      sunlight swimming tan_fur thick_tail 2015 anthro back_muscles blonde_hair brown_eyes
-      brown_fur brown_hair brown_nose butt digital_media_(artwork) eyewear fangs female
-      feral fish fur goggles hair hi_res high-angle_view mammal marine mikhaila mouth_hold
-      mustelid nude otter patreonshort_hair solo teeth tsampikos water wet wide_hips
-    url: https://static1.e621.net/data/sample/82/ab/82abacf96b5e3bde9d92ef6e5e0197eb.jpg
-  - tags: 5_fingers anthro_on_anthro black_nose blush brown_fur brown_nose brown_stripes
-      brown_tail canid cheek_tuft chest_tuft embrace eyebrows felid fluffy fluffy_tail
-      gloves_(marking) glowing_ears glowing_fur glowing_spots green_fur green_spots
-      holding_object holding_plush humanoid_hands interspecies markings orange_tail
-      pantherine romantic_couple snout spots spotted_fur striped_fur striped_tail tan_belly
-      tan_fur tuft white_belly white_tail anthro bed bed_sheet bedding bioluminescence
-      brown_hair canine cuddling digital_media_(artwork) duo eyes_closed fox fur gabe_(mytigertail)
-      glowing hair hug inside lan lying male male/male mammal multicolored_fur mytigertail
-      nude on_bed on_side open_mouth orange_fur orange_stripes pillow plushie rating:q
-      sleeping smile spooning stripes tiger two_tone_fur white_fur zeta-haru
-    url: https://static1.e621.net/data/sample/b8/89/b889bbc7002cc1152ed7f1c8e3a14670.jpg
-  - tags: 2014 3:2 afternoon alien big_ears black_scales blue_eyes blue_fur blue_nose
-      claws clothed clothing cosplay costume crossover daww disney dragon dreamworks
-      duo experiment_(species) feral fish food fur grasp green_sclera hat head_tuft
-      headgear holding_food holding_object how_to_train_your_dragon inside lilo_and_stitch
-      long_ears looking_down looking_up lying male marine membranous_wings night_fury
-      no_sclera offering_(disambiguation) offering_food offering_to_another on_front
-      on_ground outstretched_arms raised_arm scales scalie scarf sharp_teeth size_difference
-      smile standing stitch sunlight teeth toe_claws toothless tsaoshin wings
-    url: https://static1.e621.net/data/50/cc/50cc1f4f731dca8cb66fdb9fd42bc57d.png
-  - tags: 2017 ambiguous_form ambiguous_gender big_ears brown_eyes canid canine derp_eyes
-      dipstick_ears ears_down english_text fangs felisrandomis fennec fox frown fur
-      headshot_portrait humor inner_ear_fluff lol_comments mammal multiple_poses open_mouth
-      open_smile portrait pose screaming simple_background smile solo tan_fur teeth
-      text the_truth tongue weasyl
-    url: https://static1.e621.net/data/79/d7/79d74e8154dcea5339ff51f77fd3c98b.png
-  - tags: 2018 anthro black_hair blue_eyes blush canid canine canis clothing domestic_dog
-      faceless_male female hair human male mammal on_lap sally_(povinne10) talilly tongue
-      tongue_out
-    url: https://static1.e621.net/data/08/1e/081e279f730cccb5948853e8d1ea6a9f.jpg
-  - tags: 2018 <3 ambiguous_gender blush coal_(rakkuguy) eyes_closed happy human kobold
-      mammal motion_lines one_eye_closed open_mouth petting rakkuguy scalie simple_background
-      smile tailwag tongue tongue_out white_background
-    url: https://static1.e621.net/data/48/5d/485d385d6bb518ee12c78747054e827c.jpg
-  - tags: 2018 <3 3_toes ambiguous/ambiguous ambiguous_gender anthro anthro_on_anthro
-      blue_fur butt canid canine cewljoke chest_tuft cute_fangs duo evolutionary_family
-      eyes_closed fur hindpaw hi_res hug kneeling level_difference lucario mammal nintendo
-      nude pawpads paws pink_pawpads pokémon pokémon_(species) red_eyes riolu signature
-      simple_background smile spikes toes tuft video_games white_background wholesome
-    url: https://static1.e621.net/data/69/14/6914390405ab241003e48b4cfeeea5f3.png
-  - tags: 2017 absurd_res ambiguous_gender anatomy black_background blep canid canine
-      cross-eyed diagram english_text feral fox fur hi_res humor mammal meme red_fox
-      riot_the_red_fox simple_background sitting solo text tongue tongue_out whiskers
-      zillion_ross
-    url: https://static1.e621.net/data/8b/a7/8ba7610b0a2b91d91aebf4a55e131aa7.png
-  - tags: 2018 4_toes anatomy black_background black_fur black_hair black_nose blue_fur
-      blue_hair blue_tongue canid canine claws diagram ear_piercing english_text feral
-      fox fur fur_markings gloves_(marking) hair hi_res humor industrial_piercing male
-      mammal markings meme mostly_nude multicolored_fur multicolored_hair open_mouth
-      original_character_do_not_steal owo owo_whats_this paws piercing quadruped restricted_palette
-      scarf simple_background socks_(marking) solo teeth text the_truth toe_claws toes
-      tongue two_tone_hair white_fur zillion_ross
-    url: https://static1.e621.net/data/63/3b/633bbadd77a49e662768428ffc026491.png
-  - tags: 2017 <3 alcohol avian beak beer beverage bird black_feathers bottle corvid
-      crow deep_throat digital_media_(artwork) english_text feathers feral hi_res humor
-      lol_comments oral oral_penetration penetration solo swish talons text wings
-    url: https://static1.e621.net/data/7c/d9/7cd90352fa57ddaeb3f422de355e727c.jpg
-  - tags: 2017 5_fingers alternate_form anthro canid canine clothed clothing cup cups_on_ears
-      cute_fangs dagger detailed_background dialogue digital_media_(artwork) dutch_angle
-      english_text fox fur gregg_(nitw) happy inside jacket knife koul looking_at_viewer
-      male mammal melee_weapon night_in_the_woods open_mouth orange_fur smile solo speech_bubble
-      text video_games weapon
-    url: https://static1.e621.net/data/4f/be/4fbe36ed49bf8d501edb8509a554837d.jpg
-  - tags: ambiguous_gender canid canine conditional_dnp daww derp_eyes digital_media_(artwork)
-      digital_painting_(artwork) ears_back eyes_closed feral flexible fluffy fox full-length_portrait
-      fur humor lol_comments mammal markings oops orange_fur paws playing portrait red_fox
-      side_view simple_background snow socks_(marking) solo trunchbull upside_down whiskers
-      white_background white_fur
-    url: https://static1.e621.net/data/94/d1/94d108d2e4ed476a113f93e7768accce.jpg
-  - tags: anthro canid canine clothed clothing english_text fangs female fur hair image_macro
-      impact_(font) jurassic_park mammal meme nasusbot open_mouth parody profanity reaction_image
-      skrillex smile solo teeth text
-    url: https://static1.e621.net/data/cb/a4/cba428d3227dd7358dbf63787c759e8d.png
-  - tags: "<3 3_toes ambiguous_gender anthro barefoot biped black_fur black_markings
-    blue_fur blue_tail blush canid canine cel_shading cheek_tuft collar digital_media_(artwork)
-    digitigrade facial_markings feet fur fur_tuft gloves_(marking) gradient_background
-    kneeling leash leash_in_mouth lucario mammal markings mouth_hold multicolored_fur
-    neck_tuft nintendo nude object_in_mouth paws pink_background pokémon pokémon_(species)
-    pseudo_clothing rakkuguy red_eyes shaded side_view simple_background smile snout
-    solo spikes submissive toes tuft video_games white_background yellow_fur"
-    url: https://static1.e621.net/data/a1/1e/a11e49bd7c556049770b3e905e9528ef.png
-  - tags: 2013 4_fingers anthro barefoot beverage black_fur black_nose canid canine
-      clothed clothing coffee coffee_mug cup dipstick_ears dipstick_tail english_text
-      eyes_closed fennec fingerless_(marking) fluffy fluffy_tail food fox fully_clothed
-      fur gloves_(marking) hair hi_res inner_ear_fluff lying male mammal markings multicolored_tail
-      orange_fur orange_hair pants reaching shirt side_view simple_background sleeping
-      socks_(marking) solo sound_effects text thanshuhai tired toeless_(marking) tongue
-      tongue_out white_background white_fur zzz
-    url: https://static1.e621.net/data/8d/eb/8deb2ae9fe81f9f6383a24c591bdd3be.png
-  - tags: 2016 alolan_vulpix altered_reflection ambiguous_gender black_nose brown_eyes
-      brown_hair canid canine contrast digital_media_(artwork) duality feral fur grey_nose
-      hair hindpaw hi_res inner_ear_fluff looking_at_viewer mammal multi_tail nintendo
-      paws pokémon pokémon_(species) realistic reflection regional_variant solo split_screen
-      standing symmetry tamberella tan_fur video_games vulpix white_fur
-    url: https://static1.e621.net/data/7e/11/7e11e929a5c5b58078d600d3aa23cf21.jpg
-  - tags: anthro canid canine clothed clothing disney edit english_text fox fully_clothed
-      gradient_background lyrics male mammal michael_jackson music nick_wilde simple_background
-      smile smooth_criminal solo song sound text zootopia 羽默空_(artist)
-    url: https://static1.e621.net/data/fc/09/fc090f0332c2ae9e91bb6953179bceaf.jpg
-  - tags: anthro antlers brown_fur cellphone cervid cloud duo felid fur green_eyes hi_res
-      horn humor imminent_death lion male mammal nbowa outside pantherine phone predator/prey
-      pretending selfie sky tirrel tirrel_(character) tongue tongue_out tree
-    url: https://static1.e621.net/data/d9/0e/d90ea5d58bbb37f6c08d054946a478f9.jpg
-  - tags: 2016 anthro black_fur black_hair black_nose blizzard_entertainment bound breasts
-      canid canine cheek_tuft conditional_dnp crying digital_media_(artwork) domestic_cat
-      dream_eater duo e621 english_text eyelashes fan_character felid feline felis female
-      feral floof flora_fauna fluffy food food_creature fruit fur green_eyes hair hi_res
-      horn humor impact_(font) kingdom_hearts lol_comments looking_up mammal melon meloncat
-      melonyan meme meow_wow meta nude paralee_(character) plant poof profanity rainbow
-      ratte sad square_enix tardar_sauce tears technicolor_yawn text tuft video_games
-      vomit wall_of_text warcraft watermelon were werecanid werecanine werewolf worgen
-    url: https://static1.e621.net/data/42/2a/422aaf2c210d6e0e48480ce419b06896.png
-  - tags: 2016 <3 4_fingers abstract_background anthro asriel_dreemurr big_eyes black_background
-      blush boss_monster bovid braeburned brown_background caprine cheek_tuft clothing
-      cute_fangs digital_media_(artwork) fangs feels fur gesture goat gradient_background
-      green_clothing green_topwear hair half-length_portrait hand_heart head_tuft hi_res
-      long_ears looking_at_viewer love male mammal multicolored_clothing open_mouth
-      pink_tongue portrait sharp_teeth signature simple_background smile solo sweater
-      teeth tongue tuft undertale video_games white_fur yellow_bottomwear yellow_clothing
-      young
-    url: https://static1.e621.net/data/14/e7/14e7eff45c61ba29e02f4f59846dc6bc.png
-  - tags: "... <3 absurd_res ambiguous_gender beady_eyes blep dialogue english_text
-    feral forked_tongue hi_res iron_and_whine python reptile scalie simple_background
-    snake solo text tongue tongue_out traditional_media_(artwork) white_background"
-    url: https://static1.e621.net/data/7f/6a/7f6af5deef179238510cfa1d606ef81f.jpg
-  - tags: 2016 alantka anthro canid canine cuddling detailed_background disney duo embrace
-      eyes_closed female forest fox fur gloves_(marking) green_eyes grey_fur judy_hopps
-      lagomorph long_ears looking_down male mammal markings nick_wilde orange_fur outside
-      predator/prey rabbit romantic_couple size_difference smile style_parody tree zootopia
-    url: https://static1.e621.net/data/e1/28/e128617350d9e02bf816f0d4d529c210.jpg
-  - tags: 2016 absurd_res anthro barefoot bed bedroom bracelet buckteeth canid canine
-      choker dancing dennyvixen dipstick_tail disney duo earbuds eyes_closed female
-      fox fur gloves_(marking) good_morning grey_fur happy headphones hi_res inner_ear_fluff
-      inside ipod ipod_nano jewelry judy_hopps lagomorph long_ears male mammal markings
-      multicolored_tail nick_wilde on_bed open_mouth orange_fur pawpads portable_music_player
-      predator/prey rabbit smile teeth two_tone_tail upscale zootopia
-    url: https://static1.e621.net/data/2e/d4/2ed4a63c7105f9e6ca099033403b242a.png
-  - tags: ">.< :< :> :| •≠• :3 ambiguous_gender black_eyes :d d: expressions food_creature
-    frown group humor looking_at_viewer low_res mint not_furry :o o3o open_mouth plastic
-    real smile tic_tac tongue tongue_out w4nw4n x_x"
-    url: https://static1.e621.net/data/e5/1e/e51edfb8ec608817cca55d9bf7579c47.jpg
-  - tags: absurd_res anthro bed bouquet canid canine canis clothing duo eyes_closed
-      female flower_bouquet hair hi_res human larger_anthro larger_female male mammal
-      size_difference sleeping smaller_human smaller_male spooning vanchamarl were werecanid
-      werecanine werewolf wholesome wolf zephra
-    url: https://static1.e621.net/data/14/b5/14b5352ee09a0dee5a565f5c0e6bfb3c.png
-  - tags: 2016 anthro blue_eyes boss_monster bovid caprine cellphone crossover disney
-      english_text female fur goat holding_object horn image_macro long_ears mammal
-      meme monsters_inc open_mouth parody phone pixar reaction_image solo sulley taken_(movie)
-      text toriel undertale video_games white_fur wolfjedisamuel
-    url: https://static1.e621.net/data/fb/52/fb52b8b36ecb85eaf155855a23e70f24.png
-  - tags: animated anthro asriel_dreemurr blush boss_monster bovid caprine clothing
-      computer edit empty_eyes english_text floppy_ears goat happy hyperactive lol_comments
-      male mammal o_o simple_background smile solo text undertale undertale-tales video_games
-    url: https://static1.e621.net/data/bf/3c/bf3ce93ea4f3e7e3719c59b6557343b0.gif
-  - tags: 2016 angry anthro antlers bell cervid collar computer furry_problems green_eyes
-      horn laptop lol_comments male mammal reaction_image solo tirrel tirrel_(character)
-    url: https://static1.e621.net/data/9c/39/9c39de16aa06ea3afbc0ca4cd3137960.jpg
-  - tags: anthro big_breasts black_fur black_nose blue_eyes breasts claws clothed clothing
-      english_text female fur giant_panda gillpanda gillpanda_(character) looking_at_viewer
-      mammal morbidly_obese motivational_poster multicolored_fur obese overweight overweight_female
-      pawpads pen sharp_teeth simple_background smile solo teeth text thumbs_up two_tone_fur
-      ursid white_background white_fur
-    url: https://static1.e621.net/data/fa/67/fa67485134b0ee19fdaa49a68161f4f5.jpg
-  - tags: 2015 anthro asriel_dreemurr big_eyes boss_monster bovid caprine clothed clothing
-      fangs fatz_geronimo goat hoodie horn long_ears male mammal purple_background reaction_image
-      simple_background solo undertale video_games wide_eyed
-    url: https://static1.e621.net/data/f1/8d/f18db1184cf4c62d7afbdf8fd28f39f7.png
-  - tags: 2015 anatomy anthro asriel_dreemurr boss_monster bovid bukoya-star caprine
-      chart child clothed clothing cub english_text flower fur goat green_eyes grey_background
-      hi_res long_ears looking_at_viewer male mammal open_mouth plant simple_background
-      solo text undertale video_games white_fur young
-    url: https://static1.e621.net/data/b6/33/b633e381a700c619f7ea22666cf6b93d.jpg
-  - tags: 2015 <3 anthro asriel_dreemurr_(god_form) blue_background boss_monster bovid
-      caprine clothed clothing digital_media_(artwork) eating fluffy_hair fur gem goat
-      hair horn looking_at_viewer male mammal pocky red_eyes robe saturnspace simple_background
-      solo undertale video_games white_fur white_hair
-    url: https://static1.e621.net/data/8b/80/8b8000f1845841e50515eb0aa224abfb.png
-  - tags: 2015 ambiguous_gender baseball_cap beady_eyes black_eyes digital_media_(artwork)
-      feral forked_tongue grey_tongue half-length_portrait hat lol_comments meme mostly_nude
-      portrait purple_headwear python reptile scalie simple_background smile snake solo
-      tongue tongue_out unknown_artist white_background
-    url: https://static1.e621.net/data/bf/f6/bff630817262325b514eee7ff197802e.png
-  - tags: 2015 ambiguous_gender avian beak bird bread cere_(feature) columbid common_pigeon
-      crumbs cryptid-creations derp_eyes doing_it_wrong feathers feral flour folded_wings
-      food humor in_bread lol_comments meme pigeon red_eyes simple_background solo watermark
-      what white_background
-    url: https://static1.e621.net/data/f9/1f/f91f92ac563c3bbe4e569d68a46dfafe.png
-  - tags: 2015 ambiguous_gender anthro blue_eyes clothing cosplay costume day detailed_background
-      dragon dreamworks falvie fudge_the_otter how_to_train_your_dragon kigurumi mammal
-      membranous_wings mustelid night_fury open_mouth otter outside sitting sky smile
-      solo star starry_sky sunset toothless wings
-    url: https://static1.e621.net/data/0f/d1/0fd1d92190633265fb32a800d65c82d7.png
-  - tags: 2015 5_fingers ambiguous_gender anthro black_lips black_nose canid canine
-      canis controller domestic_cat duo eye_contact felid feline felis fluffy fluffy_tail
-      fur grey_fur handpaw hax_(artist) inside jackal kenket lamp lofi long_mouth looking_at_another
-      looking_down looking_up lying mammal no_sclera nude on_back orange_eyes pawpads
-      paws pink_nose reaching remote_control romantic_couple shaded side_view slice_of_life
-      smile snout sofa table tv_remote whiskers white_fur yellow_eyes
-    url: https://static1.e621.net/data/0c/09/0c09080148c52ed89f16fe8fbc731dcf.jpg
-  - tags: 2012 anthro beverage black_fur building cafe camera_view canid canine car
-      chair cheek_tuft clothed clothing coffee coffee_mug coffee_shop cup detailed_background
-      digital_media_(artwork) eyebrows fog food fox fur green_eyes hair half-length_portrait
-      high-angle_view inside looking_at_viewer male mammal multicolored_fur orange_fur
-      orange_hair portrait red_fox selfie sitting slice_of_life smile solo table thanshuhai
-      tuft vehicle white_fur
-    url: https://static1.e621.net/data/a0/47/a0476a240b0b780b926d831a3e6426ea.png
-  - tags: angry blue_body blue_eyes blue_hair blush dialogue english_text equine eyelashes
-      eyes_closed female friendship_is_magic hair horn horse humor long_hair mammal
-      my_little_pony open_mouth orange_background pink_tongue princess_luna_(mlp) profanity
-      reaction_image simple_background solo sweat teeth text the_truth tongue unknown_artist
-      winged_unicorn wings
-    url: https://static1.e621.net/data/ef/e5/efe507d244c5841d8496ce52f4f706a6.png
-  - tags: "... ambiguous_gender bed bedding black_fur blanket checkered_background domestic_cat
-    english_text felid feline felis female fur garfield_(series) lying mae_(nitw)
-    mammal night_in_the_woods on_bed on_front pattern_background reaction_image simple_background
-    solo speech_bubble text under_covers unknown_artist video_games"
-    url: https://static1.e621.net/data/19/43/194344f13372ea3e80ef007dd56463c2.png
-  - tags: 2015 anthro cheetah clothed clothing detailed_background felid feline female
-      flashlight fully_clothed gun handgun holding_object mammal menacing muscular muscular_female
-      outside pistol police ranged_weapon solo standing street_lamp sunrise tirrel uniform
-      weapon yellow_sclera
-    url: https://static1.e621.net/data/d3/ae/d3aee9d4de485f2be935e84ebbd971b7.jpg
-  - tags: 2015 anthro antlers bell blue_eyes brown_hair canid canine car cervid cheetah
-      clothed clothing collar comic dialogue driver driving duo english_text felid feline
-      female green_eyes hair hat headlight hi_res horn humor inside_car male mammal
-      outside police profanity running text tirrel tirrel_(character) uniform vehicle
-    url: https://static1.e621.net/data/ed/e7/ede74f19c7adc6115fb751d729eceaf8.jpg
-  - tags: 2013 ambiguous_gender angry brown_fur canid canine chibi dipstick_tail english_text
-      feral fox fur humor mammal markings multicolored_fur multicolored_tail orange_fur
-      profanity running serious simple_background socks_(marking) solo technicolorpie
-      technicolor_pie text two_tone_tail white_background white_fur yellow_fur
-    url: https://static1.e621.net/data/44/53/4453fcdd6d4ce1cf6d6da88c9a35bafc.png
-  - tags: 2013 abstract_background ambiguous_gender anthro arm_support blonde_hair bow_tie
-      bust_portrait clothed clothing coat cosplay digital_media_(artwork) felid fur
-      gene_wilder hair half-closed_eyes hat humor inner_ear_fluff leaning_on_elbow lol_comments
-      long_hair low_res mammal meme pantherine parody portrait reaction_image smile
-      solo tassy tiger top_hat willy_wonka willy_wonka_and_the_chocolate_factory yellow_eyes
-      yellow_fur
-    url: https://static1.e621.net/data/d1/bb/d1bbf569513c5acf13b1be36d1d64bff.png
-  - tags: begging begging_pose blue_fur blue_tail canid canine chest_tuft conditional_dnp
-      dipstick_tail facial_markings fan_character feral feralized fluffy fur looking_away
-      male mammal markings mask_(marking) multicolored_fur multicolored_tail nintendo
-      pokémon pokémon_(species) portrait red_eyes riolu simple_background smile solo
-      tuft two_tone_fur two_tone_tail umpherio_(umpherio) video_games white_background
-      white_fur white_tail xnirox
-    url: https://static1.e621.net/data/97/38/973887346d669d97c7a75b7324855773.png
-  - tags: 2014 <3 anthro avian beak bird black_eyes black_nose blue_body blue_feathers
-      blue_jay blush brown_fur cartoon_network chest_tuft comic corvid dialogue duo
-      english_text eyes_closed fangs feathers fur grey_beak hi_res kissing kissing_cheek
-      love male male/male mammal markings mordecai_(regular_show) open_beak open_mouth
-      procyonid raccoon regular_show rigby_(regular_show) romantic_couple simple_background
-      stripes surprise tan_fur teeth text tongue tuft white_background white_body white_feathers
-      wholesome xiamtheferret
-    url: https://static1.e621.net/data/ca/c9/cac98850f5b5b48440c100ad800caac1.png
-  - tags: anthro blonde_hair blue_eyes bone_necklace breasts carnivore clothed clothing
-      digital_media_(artwork) domestic_cat eating eyebrows felid feline felis female
-      food front_view hair half-length_portrait holding_food holding_object inuki inuki_(character)
-      jewelry mammal meat melloque necklace pink_nose ponytail portrait shirt shirt_logo
-      signature simple_background smile solo steak teeth
-    url: https://static1.e621.net/data/63/43/63433706609c428f2027986940547834.png
-  - tags: 2015 applejack_(mlp) blonde_hair cutie_mark earth_pony equine face_paint feathers
-      female feral friendship_is_magic green_eyes hair headdress hi_res horse jewelry
-      looking_at_viewer mammal my_little_pony native_american necklace pony portrait
-      santagiera solo teeth
-    url: https://static1.e621.net/data/ac/85/ac85e5ea07ae712946bb897bff734d59.jpg
-  - tags: 2015 animatronic anthro avian beak beverage bird blue_eyes blush bonnie_(fnaf)
-      canid canine cellphone chica_(fnaf) chicken eye_patch eyewear five_nights_at_freddy's
-      food fox foxy_(fnaf) freddy_(fnaf) group happy hat humor kissing lagomorph laugh
-      looking_away machine male male/male mammal phone purple_eyes rabbit robot smile
-      spin_the_bottle ursid video_games xiamtheferret yellow_eyes
-    url: https://static1.e621.net/data/be/55/be5581393bcf2451ca90c16ba48c694c.png
-  - tags: 2014 anthro antiander blue_eyes canid canine clothed clothing dress feathered_wings
-      feathers female fox gloves hair heterochromia hi_res holly_(plant) long_hair mammal
-      plant solo source_request white_hair wings
-    url: https://static1.e621.net/data/7c/8a/7c8a07df68f6b8c93d425158396df811.png
-  - tags: 2012 ambiguous_gender black_fur black_nose eeveelution fadingsky feral fire
-      fur markings nintendo pink_background pokémon pokémon_(species) red_eyes simple_background
-      smoke solo umbreon video_games yellow_markings
-    url: https://static1.e621.net/data/d8/2f/d82fc9c3bfa78c17db4d117950063124.png
-  - tags: 2014 ass_up avian beak blue_eyes blue_fur braeburned digital_media_(artwork)
-      earth_pony equine feathered_wings feathers female feral friendship_is_magic fur
-      gilda_(mlp) group gryphon hair horse laser laser_pointer mammal multicolored_hair
-      my_little_pony pegasus pink_fur pink_hair pinkie_pie_(mlp) pony purple_eyes rainbow_dash_(mlp)
-      rainbow_hair tongue tongue_out wings yellow_eyes
-    url: https://static1.e621.net/data/8c/08/8c08e77a944dd6df29eb3e908f5bd93f.png
-  - tags: ambiguous_gender anthro bust_portrait canid canine canis close-up darkwingo
-      dingo eye_reflection fluffy green_background green_eyes head_tilt hi_res hybrid
-      jewelry mammal markings necklace portrait scar simple_background smile solo thanshuhai
-      wolf
-    url: https://static1.e621.net/data/d7/10/d710ff227b96e59a655d152ac2fcc9f7.jpg
-  - tags: 2014 <3 anthro beverage beverage_can black_hair blue_hair blue_highlights
-      clothing collar digital_media_(artwork) domestic_cat fangs felid feline felis
-      female food gradient_hair green_eyes hair highlights jacket looking_at_viewer
-      mammal smile solo tentacletongue wolfy-nail young
-    url: https://static1.e621.net/data/86/94/86942ce7f5be8ba952fef914c5593d2e.jpg
-  - tags: 2012 ambiguous_gender bed bedding blanket blue_eyes eeveelution feral hi_res
-      looking_at_viewer lying nintendo on_bed on_front open_mouth pawpads pokémon pokémon_(species)
-      shadow solo tartii under_covers vaporeon video_games watermark
-    url: https://static1.e621.net/data/c0/d4/c0d4964ebc0fb0eeddb61bc03cbc6a2b.jpg
-  - tags: 2014 5:4 anthro atryl avian beak black_feathers brown_feathers cloud digital_media_(artwork)
-      duo eye_contact feathered_wings feathers female friendship_is_magic genevieve_(mlp)
-      grass greta_(mlp) grey_eyes gryphon hug my_little_pony one_eye_closed outside
-      sky smile white_feathers wings wink
-    url: https://static1.e621.net/data/67/c9/67c952de260ede67d0fe507bb99d3a6e.png
-  - tags: 2014 3_toes ambiguous_gender animated anthro ass_up black_scales butt digitigrade
-      dragon felid feral group hindpaw humor inside_train lamp loop low_res male mammal
-      membranous_wings metro multicolored_scales paws pushing rubble scales scalie size_difference
-      solo_focus subway tirrel toes train tunnel two_tone_scales vehicle white_scales
-      wings
-    url: https://static1.e621.net/data/7d/0d/7d0de8443bad63b6bd56a24ca0d0fb98.gif
+post_ids:
+  - 864982
+  - 831434
+  - 604569
+  - 1384351
+  - 713232
+  - 2058923
+  - 348854
+  - 677272
+  - 721020
+  - 783617
+  - 524011
+  - 738084
+  - 1324650
+  - 447317
+  - 902353
+  - 608312
+  - 1196171
+  - 539888
+  - 426556
+  - 1158932
+  - 1787376
+  - 844336
+  - 133831
+  - 543720
+  - 675477
+  - 468397
+  - 480698
+  - 1201721
+  - 2104542
+  - 1910123
+  - 1162821
+  - 1559520
+  - 1559522
+  - 1337331
+  - 1289163
+  - 1124466
+  - 922038
+  - 1051272
+  - 1014268
+  - 972377
+  - 891419
+  - 902353
+  - 896454
+  - 882158
+  - 864033
+  - 854142
+  - 853653
+  - 818700
+  - 830459
+  - 818006
+  - 818294
+  - 802009
+  - 810790
+  - 799347
+  - 1401572
+  - 766674
+  - 735523
+  - 722531
+  - 721020
+  - 2038195
+  - 701921
+  - 692610
+  - 687969
+  - 677272
+  - 672692
+  - 668603
+  - 664515
+  - 604569
+  - 605113
+  - 589740
+  - 586160
+  - 584859
+  - 577089
+  - 559155
+  - 494915
+  - 492433
+  - 464910
+  - 444992
+  - 429880
+  - 437103

--- a/vagrant/ruby-setup.sh
+++ b/vagrant/ruby-setup.sh
@@ -32,12 +32,12 @@ gem install bundler:2.0.1 >/dev/null
 bundler config github.https true
 
 script_log "Dropping existing databases (if any)..."
-dropdb danbooru2
-dropdb danbooru2_test
+dropdb --if-exists danbooru2
+dropdb --if-exists danbooru2_test
 
 script_log "Creating config files..."
 sed -s "s/url: <%= .* %>/host: localhost/g" script/install/database.yml.templ > config/database.yml
-cp script/install/danbooru_local_config.rb.templ config/danbooru_local_config.rb
+cp -n script/install/danbooru_local_config.rb.templ config/danbooru_local_config.rb
 mkdir -p ~/.danbooru/
 openssl rand -hex 32 > ~/.danbooru/secret_token
 openssl rand -hex 32 > ~/.danbooru/session_secret_key


### PR DESCRIPTION
This does a few things:

- Set the default user for ssh back to `danbooru`. This was uncommented a while ago but I don't know why, there probably was a reason. Because ruby-installs are local to a user the vagrant user does not have the correct ruby version to chroot to. This might be fixable by doing a system wide install but this seemed like the easier approach
- Don't copy over the local config if it already exists
- Seed the posts with data from the live site. Instead of putting everything in the yaml just use the api to fetch the info. This also gives access to a few things which were previously not seeded like sources, description and tag types. I also replaced a few deleted posts while I was at it
- Fix `can_upload_with_reason` not accounting for `disable_throttles`. Noticable when seeding because only 30 posts where uploaded. This worked previously but at some point the hourly upload limit was enforced on all users, including admins. This still means that during seeding `disable_throttles` must be set to true. Not sure what the best solution is here