### PR TITLE
Update some help links

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -11,7 +11,6 @@ class UploadsController < ApplicationController
       return access_denied("You can not upload during your first week.")
     end
     @source = Sources::Strategies.find(params[:url], params[:ref]) if params[:url].present?
-    @upload_notice_wiki = WikiPage.titled(Danbooru.config.upload_notice_wiki_page).first
     @upload = Upload.new
     respond_with(@upload)
   end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -16,13 +16,6 @@ module TagsHelper
       html << " (#{link_to "learn more", wiki_pages_path(title: "e621:tag_aliases")}).</p>"
     end
 
-    automatic_tags = TagImplication.automatic_tags_for([tag.name])
-    if automatic_tags.present?
-      html << "<p class='hint'>This tag automatically adds "
-      html << raw(automatic_tags.map {|x| link_to(x, show_or_new_wiki_pages_path(:title => x))}.join(", "))
-      html << " (#{link_to "learn more", wiki_pages_path(title: "help:autotags")}).</p>"
-    end
-
     if tag.antecedent_implications.present?
       html << "<p class='hint'>This tag implicates "
       html << raw(tag.antecedent_implications.map {|x| link_to(x.consequent_name, show_or_new_wiki_pages_path(:title => x.consequent_name))}.join(", "))

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -7,13 +7,13 @@ module TagsHelper
     if tag.antecedent_alias
       html << "<p class='hint'>This tag has been aliased to "
       html << link_to(tag.antecedent_alias.consequent_name, show_or_new_wiki_pages_path(:title => tag.antecedent_alias.consequent_name))
-      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_aliases")}).</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "e621:tag_aliases")}).</p>"
     end
 
     if tag.consequent_aliases.present?
       html << "<p class='hint'>The following tags are aliased to this tag: "
       html << raw(tag.consequent_aliases.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
-      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_aliases")}).</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "e621:tag_aliases")}).</p>"
     end
 
     automatic_tags = TagImplication.automatic_tags_for([tag.name])
@@ -26,13 +26,13 @@ module TagsHelper
     if tag.antecedent_implications.present?
       html << "<p class='hint'>This tag implicates "
       html << raw(tag.antecedent_implications.map {|x| link_to(x.consequent_name, show_or_new_wiki_pages_path(:title => x.consequent_name))}.join(", "))
-      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_implications")}).</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "e621:tag_implications")}).</p>"
     end
 
     if tag.consequent_implications.present?
       html << "<p class='hint'>The following tags implicate this tag: "
       html << raw(tag.consequent_implications.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
-      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_implications")}).</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "e621:tag_implications")}).</p>"
     end
 
     html.html_safe

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -419,7 +419,7 @@ let Note = {
       $dialog.data("uiDialog")._title = function(title) {
         title.html(this.options.title); // Allow unescaped html in dialog title
       }
-      $dialog.dialog("option", "title", 'Edit note #' + id + ' (<a href="/wiki_pages/help:notes">view help</a>)');
+      $dialog.dialog("option", "title", 'Edit note #' + id + ' (<a href="/wiki_pages/e621:notes">view help</a>)');
 
       $dialog.on("dialogclose.danbooru", function() {
         Note.editing = false;
@@ -828,4 +828,3 @@ $(function() {
 });
 
 export default Note
-

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -860,7 +860,6 @@ class Post < ApplicationRecord
       normalized_tags = apply_locked_tags(normalized_tags, @locked_to_add, @locked_to_remove)
       normalized_tags = %w(tagme) if normalized_tags.empty?
       normalized_tags = add_automatic_tags(normalized_tags)
-      # normalized_tags = normalized_tags + Tag.create_for_list(TagImplication.automatic_tags_for(normalized_tags))
       normalized_tags = TagImplication.with_descendants(normalized_tags)
       enforce_dnp_tags(normalized_tags)
       normalized_tags -= @locked_to_remove if @locked_to_remove # Prevent adding locked tags through implications or aliases.

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -28,12 +28,6 @@ class TagImplication < TagRelationship
       def descendants_with_originals(names)
         active.where(antecedent_name: names).map { |x| [x.antecedent_name, x.descendant_names] }.uniq
       end
-
-      def automatic_tags_for(names)
-        # TODO: Remove this?
-        tags = []
-        tags.uniq
-      end
     end
 
     def descendants

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -86,7 +86,7 @@
       <ul>
         <li><h1>Blips</h1></li>
         <li><%= link_to("Listing", blips_path) %></li>
-        <li><%= link_to("Help", wiki_pages_path(title: "help:blips")) %></li>
+        <li><%= link_to("Help", wiki_pages_path(title: "e621:blips")) %></li>
       </ul>
     </section>
     <section>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -660,10 +660,6 @@ fart'
       nil
     end
 
-    def upload_notice_wiki_page
-      "help:upload_notice"
-    end
-
     def flag_notice_wiki_page
       "help:flag_notice"
     end


### PR DESCRIPTION
Some pages link to wiki pages with the help prefix but their only content was a link to a wiki page with e621 as the prefix.
Also removes something related to autotagging which isn't used anymore, I just removed it because of the wiki link.

`help:home` and `help:flag_notice` actually exist, `help:appeal_notice` and `help:replacement_notice` don't but theres also no e621 entry for them