### PR TITLE
Improve tag search with artist page

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1111,9 +1111,9 @@ class Tag < ApplicationRecord
       end
 
       if params[:has_artist].to_s.truthy?
-        q = q.joins("INNER JOIN artists ON tags.name = artists.name").where("artists.is_active = true")
+        q = q.joins("INNER JOIN artists ON tags.name = artists.name")
       elsif params[:has_artist].to_s.falsy?
-        q = q.joins("LEFT JOIN artists ON tags.name = artists.name").where("artists.name IS NULL OR artists.is_active = false")
+        q = q.joins("LEFT JOIN artists ON tags.name = artists.name").where("artists.name IS NULL")
       end
 
       q = q.attribute_matches(:is_locked, params[:is_locked])

--- a/app/models/tag_type_version.rb
+++ b/app/models/tag_type_version.rb
@@ -8,20 +8,19 @@ class TagTypeVersion < ApplicationRecord
 
       if params[:tag].present?
         tag = Tag.find_by_normalized_name(params[:tag])
-        q = q.where(tag_id: tag.id) if tag
+        q = q.where(tag: tag)
       end
 
       if params[:user_id].present?
-        q = q.where('creator_id = ?', params[:user_id])
+        user = User.find_by_id(params[:user_id])
+        q = q.where(creator: user)
       end
       if params[:user_name].present?
-        name = User.find_by_name(params[:user_name])
-        q = q.where('creator_id = ? ', name.id) if id
+        user = User.find_by_name(params[:user_name])
+        q = q.where(creator: user)
       end
 
-      q = q.order(id: :desc)
-
-      q
+      q.order(id: :desc)
     end
   end
 

--- a/app/views/tag_type_versions/index.html.erb
+++ b/app/views/tag_type_versions/index.html.erb
@@ -18,9 +18,7 @@
         <% @tag_versions.each do |change| %>
           <tr id="r<%= change.id %>">
             <td><%= link_to change.tag.name, edit_tag_path(change.tag) %></td>
-            <td>
-              <span title='<%= change.created_at.strftime("%b %d, %Y %I:%M %p") %>'><%= change.created_at.strftime("%b %d") %></span>
-            </td>
+            <td><%= compact_time change.created_at %></td>
             <td><%= link_to_user change.creator %></td>
 
             <td><a class="<%= "tag-type-#{change.old_type}" %>"><%= Tag.category_for_value(change.old_type) %></a></td>
@@ -33,7 +31,7 @@
     </div>
 
     <div id="paginator">
-      <%= sequential_paginator(@tag_versions) %>
+      <%= numbered_paginator(@tag_versions) %>
     </div>
   </div>
 </div>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -14,7 +14,11 @@
           <tr>
             <td><%= tag.post_count %></td>
             <td class="category-<%= tag.category %>">
-              <%= link_to("?", show_or_new_wiki_pages_path(:title => tag.name)) %>
+              <% if tag.category == Tag.categories.artist %>
+                <%= link_to("?",  show_or_new_artists_path(:name => tag.name)) %>
+              <% else %>
+                <%= link_to("?", show_or_new_wiki_pages_path(:title => tag.name)) %>
+              <% end %>
               <%= link_to(tag.name, posts_path(:tags => tag.name)) %>
             </td>
             <td>


### PR DESCRIPTION
This changed the behaviour on https://e621.net/tags when searching for tags with or without artist pages.


|         | With Artist Page           | Without Artist Page  |
| ------------- |:-------------:| -----:|
| Current      | Tags with artist pages AND the artist is active  | Tags without an artist page OR the artist page is not active |
| New     | Tags with artist pages      |   Tags without artist pages |

[I wanted to search for tags in need of an artist page](https://e621.net/tags?commit=Search&search%5Bcategory%5D=1&search%5Bhas_artist%5D=no&search%5Bhide_empty%5D=yes&search%5Border%5D=count) but most of those are just marked as inactive which makes it a pain to pick out those that actually need attention. I would argue that even a tag with a deleted/inactive artist still has an artist.

Speaking of pain: Opening a artist via `?` just opened the wiki page. Now it directs you to the artist page if the tag is actually an artist. This makes it much easier to create artists from there. Going from the wiki page to creating/edititing the artist was a few clicks more. Artist pages also allow for  creating/editing the resppective wiki page which is a plus.

To me it looks like `is_active` is more of a `is_locked` but theres already `is_locked` so theres probably some more difference between them. Doesn't make it easier to understand that the the actual UI text refers to it as delete.

While playing with that I also noticed that TagTypeVersion searching by username was broken, so I fixed it. I also ~~simplified the search form, added autocomplete for users,~~ display dates better and use a numered paginator (like the rest on e6)

EDIT: I removed the better search form from here for now since I'm doing something else which would probably give me some merge conflics down the line.