### PR TITLE
 [Vagrant] Update image to ubuntu 20.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.configure('2') do |config|
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true
 
-  config.vm.box = 'generic/ubuntu1804'
+  config.vm.box = 'generic/ubuntu2004'
 
   config.vm.provider 'virtualbox' do |v|
     v.cpus = 2

--- a/vagrant/install.sh
+++ b/vagrant/install.sh
@@ -42,9 +42,9 @@ if ! package_installed elasticsearch; then
     script_log "Elasticsearch repository added"
 fi
 
-if ! package_installed postgresql-11; then
+if ! package_installed postgresql-12; then
     add_key https://www.postgresql.org/media/keys/ACCC4CF8.asc
-    echo "deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+    echo "deb https://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     script_log "PostgreSQL repository added"
 fi
 
@@ -81,6 +81,9 @@ fi
 
 script_log "Setting up elasticsearch..."
 sed -i -e 's/\(-Xm[sx]\)1g/\1256m/' /etc/elasticsearch/jvm.options
+if ! grep -Fq "xpack.security.enabled" /etc/elasticsearch/elasticsearch.yml; then
+    echo "xpack.security.enabled: false" >> /etc/elasticsearch/elasticsearch.yml
+fi
 systemctl enable elasticsearch 2>/dev/null
 service elasticsearch start
 


### PR DESCRIPTION
The readme mentions Ubuntu 20.04 as the installation target, let the vagrant script reflect that.

Also suppress an annoying message from elasticsearch, seems to have been added in a recent version.
The default was false anyways, it's just the message that now also shows up. See https://github.com/elastic/elasticsearch/pull/70114