### PR TITLE
[PostVersions] Fix display for parent/rating

### DIFF
--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -215,12 +215,12 @@ class PostArchive < ApplicationRecord
     if post.nil?
       latest_tags = tag_array
     else
-      latest_tags = post.tag_array
+      latest_tags = post.tag_array + parent_rating_tags(post)
     end
 
-    new_tags = tag_array
+    new_tags = tag_array + parent_rating_tags(self)
 
-    old_tags = version.present? ? version.tag_array : []
+    old_tags = version.present? ? version.tag_array + parent_rating_tags(version) : []
 
     added_tags = new_tags - old_tags
     removed_tags = old_tags - new_tags
@@ -230,16 +230,6 @@ class PostArchive < ApplicationRecord
 
     added_locked = new_locked - old_locked
     removed_locked = old_locked - new_locked
-
-    if rating_changed
-      added_tags << "rating:#{rating}"
-      removed_tags << "rating:#{version.rating}" if version.present?
-    end
-
-    if parent_changed
-      added_tags << "parent:#{parent_id}"
-      removed_tags << "parent:#{version.parent_id}" if version.present?
-    end
 
     return {
         added_tags: added_tags,
@@ -251,6 +241,12 @@ class PostArchive < ApplicationRecord
         removed_locked_tags: removed_locked,
         unchanged_locked_tags: new_locked & old_locked
     }
+  end
+
+  def parent_rating_tags(post)
+    result = ["rating:#{post.rating}"]
+    result << "parent:#{post.parent_id}" unless post.parent_id.nil?
+    result
   end
 
   def changes


### PR DESCRIPTION
The diff algorithm has trouble with parent/rating values. Rating and parent changes are always strikethrough, if no parent is present on upload it will simply show `parent:`. This aims to fix that. A sideeffect of this change is that parent/rating will also be displayed when it didn't change from the previous version but I believe that should be fine since they will be appended at the end of the list anyways.

Old              |  New
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/14981592/120711560-d23ddf80-c4bf-11eb-8891-0881bdf5c7fe.png)  |  ![image](https://user-images.githubusercontent.com/14981592/120711502-c2be9680-c4bf-11eb-9c84-cf20894d6aef.png)

This has no effect on undoing versions. Undoing happens in `changes` while `diff` is only responsible for visualizing it.
