### PR TITLE
Order artist urls on artist page

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -192,7 +192,7 @@ class Artist < ApplicationRecord
     end
 
     def sorted_urls
-      urls.sort {|a, b| a.priority <=> b.priority}
+      urls.sort {|a, b| b.priority <=> a.priority}
     end
 
     def url_array

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -166,13 +166,15 @@ class Artist < ApplicationRecord
         %r!\Ahttps?://(?:[a-zA-Z0-9_-]+\.)*#{domain}/\z!i
       end)
 
+      # Looks at the url and goes one directory down if no results are found.
+      # Should the domain of the url match one of the domains in the site blacklist stop immediately
+      # http://www.explame.com/cool/page/ => http://www.explame.com/cool/ => http://www.explame.com/
+      # This was presumably made so you only get specific matches for user pages and not some unrelated
+      # results when that specific user doesn't exist
       def find_artists(url)
         url = ArtistUrl.normalize(url)
         artists = []
-
-        # return [] unless Sources::Strategies.find(url).normalized_for_artist_finder?
-
-        while artists.empty? && url.size > 10
+        while artists.empty? && url.length > 10
           u = url.sub(/\/+$/, "") + "/"
           u = u.to_escaped_for_sql_like.gsub(/\*/, '%') + '%'
           artists += Artist.joins(:urls).where(["artists.is_active = TRUE AND artist_urls.normalized_url LIKE ? ESCAPE E'\\\\'", u]).limit(10).order("artists.name").all

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -87,22 +87,57 @@ class ArtistUrl < ApplicationRecord
     end
   end
 
+  # sites apearing at the start have higher priority than those below
+  SITES_PRIORITY_ORDER = [
+    "furaffinity.net",
+    "deviantart.com",
+    "twitter.com",
+    "pixiv.net",
+    "inkbunny.net",
+    "sofurry.com",
+    "weasyl.com",
+    "furrynetwork.com",
+    "tumblr.com",
+    "newgrounds.com",
+    "hentai-foundry.com",
+    "artstation.com",
+    "baraag.net",
+    "pawoo.net",
+    "pillowfort.social",
+    "reddit.com",
+    "youtube.com",
+    "instagram.com",
+    "vk.com",
+    "facebook.com",
+    # livestreams
+    "picarto.tv",
+    "piczel.tv",
+    "twitch.tv",
+    # support the artist
+    "patreon.com",
+    "subscribestar.adult",
+    "ko-fi.com",
+    "commishes.com",
+    "fanbox.cc",
+    "gumroad.com",
+    "redbubble.com",
+    # misc
+    "discord.gg",
+    "trello.com",
+    "curiouscat.me",
+    "toyhou.se",
+    "linktr.ee",
+    "carrd.co",
+  ].reverse!
+
+  # higher priority will apear higher in the artist url list
+  # inactive urls will be pushed to the bottom
   def priority
-    if normalized_url =~ /pixiv\.net\/member\.php/
-      10
-
-    elsif normalized_url =~ /seiga\.nicovideo\.jp\/user\/illust/
-      10
-
-    elsif normalized_url =~ /twitter\.com/ && normalized_url !~ /status/
-      15
-
-    elsif normalized_url =~ /tumblr|patreon|deviantart|artstation/
-      20
-
-    else
-      100
-    end
+    prio = 0
+    prio -= 1000 unless is_active
+    host = Addressable::URI.parse(url).domain
+    prio += SITES_PRIORITY_ORDER.index(host).to_i
+    prio
   end
 
   def normalize

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -27,7 +27,7 @@
     <% if artist.urls.present? %>
       <li><strong>URLs</strong></li>
       <ul>
-        <% artist.urls.each do |url| %>
+        <% artist.sorted_urls.each do |url| %>
           <li>
             <% if url.is_active? %>
               <%= link_to h(url.to_s), h(url) %>


### PR DESCRIPTION
Currently artist urls are displayed as users add them. I myself try to group them somewhat together, but only if I have a link to add.
If an artist has especially many urls they'll be pretty much mixed with inactive urls sprinkled in. Instead order them after a fixed pattern:
* Put urls with actual uploadable content to the top, like furaffinity/twitter etc.
* Put livestream/donation after that
* End with a few miscellaneous domains like linktr/trello
* Alwasy put inactive urls below active ones

Obviously I didn't put in every domain but this should catch the large majority. Unknown domains will simply be put at the end of active urls, right before the inactive ones.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/14981592/122097815-62f5b300-ce10-11eb-8f99-984ac06a8df8.png) | ![image](https://user-images.githubusercontent.com/14981592/122097868-7143cf00-ce10-11eb-9a22-ef9e31821e8c.png) 
| ![image](https://user-images.githubusercontent.com/14981592/122098249-e6af9f80-ce10-11eb-90bf-f6b441504834.png) | ![image](https://user-images.githubusercontent.com/14981592/122098274-f0d19e00-ce10-11eb-90d5-055d39379c58.png) 

Looks much cleaner in my opinion and the links which I'm actually interested in are at predictable locations.