### PR TITLE
[Vagrant] Expose postgres server to host

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ By the time you get back the install will surely have completed.<sup>1</sup>
 
 <sub><sup>1</sup> If the install did not finish by the time an activity is complete please select another activity to avoid crippling boredom.</sub>
 
+#### Development Database
+
+The postgres server accepts outside connections which you can use to connect with a local client. Use `192.168.64.78:5432` to connect to a database named `danbooru2` with the user `danbooru`. Leave the password blank, anything will work.
+
 #### VirtualBox Troubleshooting
 
 In case the VM doesn't start with the error `VT-x not available` and the error description `WHvCapabilityCodeHypervisorPresent is FALSE!` the the following solution should resolve the issue:

--- a/vagrant/install.sh
+++ b/vagrant/install.sh
@@ -88,7 +88,14 @@ systemctl enable elasticsearch 2>/dev/null
 service elasticsearch start
 
 script_log "Setting up postgres..."
+# allow connections from the host machine
+if ! grep -q "192" "/etc/postgresql/12/main/pg_hba.conf"; then
+  echo "host danbooru2,danbooru2_test danbooru 192.168.64.1/32 trust" >> /etc/postgresql/12/main/pg_hba.conf
+fi
+# do not require passwords for authentication
 sed -i -e 's/md5/trust/' /etc/postgresql/12/main/pg_hba.conf
+# listen for outside connections
+echo "listen_addresses = '*'" > /etc/postgresql/12/main/conf.d/listen_addresses.conf
 
 if [ ! -f /usr/lib/postgresql/12/lib/test_parser.so ]; then
     script_log "Building test_parser..."


### PR DESCRIPTION
This is something I added manually everytime I after I destroyed the image. Since this could probably be usefull to others I though why not add it to the setup script.

Should the port already be occupied it will simply not map, informing the user during `vagrant up` and continue on with the setup.