### PR TITLE
[Posts] Fix applying an aliased away tag when marking as translated 

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,7 +9,7 @@ class Post < ApplicationRecord
   class TimeoutError < Exception ; end
 
   # Tags to copy when copying notes.
-  NOTE_COPY_TAGS = %w[translated partially_translated check_translation translation_request reverse_translation]
+  NOTE_COPY_TAGS = %w[translated partially_translated translation_check translation_request]
 
   before_validation :initialize_uploader, :on => :create
   before_validation :merge_old_changes
@@ -2160,13 +2160,13 @@ class Post < ApplicationRecord
   end
 
   def mark_as_translated(params)
-    add_tag("check_translation") if params["check_translation"].to_s.truthy?
-    remove_tag("check_translation") if params["check_translation"].to_s.falsy?
+    add_tag("translation_check") if params["translation_check"].to_s.truthy?
+    remove_tag("translation_check") if params["translation_check"].to_s.falsy?
 
     add_tag("partially_translated") if params["partially_translated"].to_s.truthy?
     remove_tag("partially_translated") if params["partially_translated"].to_s.falsy?
 
-    if has_tag?("check_translation") || has_tag?("partially_translated")
+    if has_tag?("translation_check") || has_tag?("partially_translated")
       add_tag("translation_request")
       remove_tag("translated")
     else

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -121,8 +121,8 @@
           <%= hidden_field_tag :pool_id, params[:pool_id] %>
 
           <fieldset>
-            <label for="post_check_translation">
-              <%= check_box "post", "check_translation", :checked => @post.has_tag?("check_translation") %>
+            <label for="post_translation_check">
+              <%= check_box "post", "translation_check", :checked => @post.has_tag?("translation_check") %>
               Check translation
             </label>
 


### PR DESCRIPTION
Also remove reverse_translation which is not used.

Depending on what happens with https://e621.net/forum_topics/29883 this can either me rejected or merged