### PR TITLE
[Replacements] Fix broken state when rescaling notes

### DIFF
--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -86,12 +86,12 @@ class UploadService
       # Reset ownership information on post.
       post.uploader_id = replacement.creator_id
       post.uploader_ip_addr = replacement.creator_ip_addr
+      post.save!
 
       rescale_notes(post)
       update_ugoira_frame_data(post, upload)
 
       replacement.update({status: 'approved', approver_id: CurrentUser.id})
-      post.save!
 
       if post.is_video?
         post.generate_video_samples(later: true)
@@ -101,8 +101,8 @@ class UploadService
     end
 
     def rescale_notes(post)
-      x_scale = post.image_width.to_f / post.image_width_was.to_f
-      y_scale = post.image_height.to_f / post.image_height_was.to_f
+      x_scale = post.image_width.to_f / post.image_width_before_last_save.to_f
+      y_scale = post.image_height.to_f / post.image_height_before_last_save.to_f
 
       post.notes.each do |note|
         note.rescale!(x_scale, y_scale)

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -117,6 +117,7 @@ class PostReplacementTest < ActiveSupport::TestCase
 
   context "Approve:" do
     setup do
+      @note = FactoryBot.create(:note, post: @post, x: 100, y: 200, width: 100, height: 50)
       @replacement = FactoryBot.create(:png_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: @post)
       assert @replacement
     end
@@ -191,6 +192,15 @@ class PostReplacementTest < ActiveSupport::TestCase
           @replacement.approve!
         end
       end
+    end
+
+    should "correctly resize the posts notes" do
+      @replacement.approve!
+      @note.reload
+      assert_equal 153, @note.x
+      assert_equal 611, @note.y
+      assert_equal 153, @note.width
+      assert_equal 152, @note.height
     end
   end
 


### PR DESCRIPTION
After the note will be saved it reloaded the post, throwing the
previous changes like new md5, size etc. away