### PR TITLE
A bunch of stuff

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,6 +88,8 @@ class ApplicationController < ActionController::Base
       render_error_page(501, exception, message: "This feature isn't available: #{exception.message}")
     when PG::ConnectionBad
       render_error_page(503, exception, message: "The database is unavailable. Try again later.")
+    when ActionController::ParameterMissing
+      render_expected_error(400, exception.message)
     else
       render_error_page(500, exception)
     end

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -111,6 +111,15 @@ class ModActionDecorator < ApplicationDecorator
     when "post_unapprove"
       "Unapproved post ##{vals['post_id']}"
 
+      ### Post Replacements ###
+
+    when "post_replacement_accept"
+      "Post replacement for post ##{vals['post_id']} was accepted"
+    when "post_replacement_reject"
+      "Post replacement for post ##{vals['post_id']} was rejected"
+    when "post_replacement_delete"
+      "Post replacement for post ##{vals['post_id']} was deleted"
+
       ### Set ###
 
     when "set_mark_private"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,12 +76,9 @@ module ApplicationHelper
     raw %{<a href="#{h(url)}" #{attributes}>#{text}</a>}
   end
 
-  def search_show_link
-    tag.a "Show Search Options", href: '#', id: 'search-form-show-link'
-  end
-
-  def search_hide_link
-    tag.a "Hide Search Options", href: '#', id: 'search-form-hide-link'
+  def hideable_form_search(path:, always_display: false, &block)
+    show_on_load = !params[:search].empty? || always_display
+    render "application/hideable_form_search", path: path, show_on_load: show_on_load, block: block
   end
 
   def format_text(text, **options)

--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -8,11 +8,13 @@ function initSearch() {
   const $searchHide = $("#search-form-hide-link");
   if ($searchForm.length) {
     $searchShow.on('click', e => {
+      e.preventDefault();
       $searchForm.fadeIn('fast');
       $searchShow.hide();
       $searchHide.show();
     });
     $searchHide.on('click', e => {
+      e.preventDefault();
       $searchForm.fadeOut('fast');
       $searchShow.show();
       $searchHide.hide();

--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -17,16 +17,6 @@ function initSearch() {
       $searchShow.show();
       $searchHide.hide();
     });
-    const urlSearch = new URLSearchParams(window.location.search);
-    if (Array.from(urlSearch.keys()).filter(e => e.startsWith("search")).length) {
-      $searchForm.show('fast');
-      $searchShow.hide();
-      $searchHide.show();
-    } else {
-      $searchForm.hide('fast');
-      $searchShow.show();
-      $searchHide.hide();
-    }
   }
 }
 

--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -3,21 +3,29 @@ import LS from './local_storage'
 import Utility from './utility'
 
 function initSearch() {
-  const $s = $("#searchform");
-  const $sh = $("#searchform_hide");
-  if ($s.length) {
-    $("#search-form-show-link").on('click', e => {
-      $s.fadeIn('fast');
-      $sh.hide();
+  const $searchForm = $("#searchform");
+  const $searchShow = $("#search-form-show-link");
+  const $searchHide = $("#search-form-hide-link");
+  if ($searchForm.length) {
+    $searchShow.on('click', e => {
+      $searchForm.fadeIn('fast');
+      $searchShow.hide();
+      $searchHide.show();
     });
-    $("#search-form-hide-link").on('click', e => {
-      $s.fadeOut('fast');
-      $sh.show();
+    $searchHide.on('click', e => {
+      $searchForm.fadeOut('fast');
+      $searchShow.show();
+      $searchHide.hide();
     });
     const urlSearch = new URLSearchParams(window.location.search);
     if (Array.from(urlSearch.keys()).filter(e => e.startsWith("search")).length) {
-      $s.show();
-      $sh.hide();
+      $searchForm.show('fast');
+      $searchShow.hide();
+      $searchHide.show();
+    } else {
+      $searchForm.hide('fast');
+      $searchShow.show();
+      $searchHide.hide();
     }
   }
 }

--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -214,12 +214,6 @@ $widget-background: $section-background;
 $widget-header-background: $main-background;
 $widget-header-color: $text-color;
 
-// Bans
-$ban-expired-background: $state-success-color;
-$ban-expired-hover-background: darken($state-success-color, 5%);
-$ban-background: $state-error-color;
-$ban-hover-background: darken($state-error-color, 5%);
-
 // Artists
 $artist-new-artist-color: #A00;
 

--- a/app/javascript/src/styles/specific/bans.scss
+++ b/app/javascript/src/styles/specific/bans.scss
@@ -1,19 +1,17 @@
-
-
 #c-bans #a-index {
   tr[data-expired="true"] {
-    background-color: $ban-expired-background !important;
+    background-color: $positive-record-background;
 
     &:hover {
-      background-color: $ban-expired-hover-background !important;
+      background-color: darken($positive-record-background, 5%);
     }
   }
 
   tr[data-expired="false"] {
-    background-color: $ban-background !important;
+    background-color: $negative-record-background;
 
     &:hover {
-      background-color: $ban-hover-background !important;
+      background-color: darken($negative-record-background, 5%);
     }
   }
 }

--- a/app/javascript/src/styles/specific/comments.scss
+++ b/app/javascript/src/styles/specific/comments.scss
@@ -83,6 +83,7 @@ div#c-comments {
       padding-left: $padding-050;
       padding-bottom: $padding-025;
       margin-bottom: $padding-100;
+      word-wrap: break-word;
 
       .comments {
         margin-left: 2rem;

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -14,6 +14,7 @@ class ForumTopic < ApplicationRecord
   before_validation :initialize_is_hidden, :on => :create
   validates :title, :creator_id, presence: true
   validates_associated :original_post
+  validates_presence_of :original_post
   validates_associated :category
   validates :min_level, inclusion: { :in => MIN_LEVELS.values }
   validates :title, :length => {:maximum => 250}

--- a/app/views/admin/exceptions/index.html.erb
+++ b/app/views/admin/exceptions/index.html.erb
@@ -25,6 +25,10 @@
   </tbody>
 </table>
 
+<% content_for(:page_title) do %>
+  Exceptions
+<% end %>
+
 <div id="paginator">
   <%= numbered_paginator(@exception_logs) %>
 </div>

--- a/app/views/admin/exceptions/show.html.erb
+++ b/app/views/admin/exceptions/show.html.erb
@@ -16,3 +16,7 @@
   <strong>Raw Stacktrace:</strong>
   <pre class="box-section"><%= @exception_log.trace %></pre>
 </div>
+
+<% content_for(:page_title) do %>
+  Exceptions - <%= @exception_log.code %>
+<% end %>

--- a/app/views/admin/staff_notes/_search.html.erb
+++ b/app/views/admin/staff_notes/_search.html.erb
@@ -1,13 +1,10 @@
-<div id='searchform_hide'>
-  <%= search_show_link %>
-</div>
-<div class='section' id='searchform' style='width:400px;<% unless params[:show] %>display:none;
-  <% end %>'>
+<%= search_show_link %>
+<%= search_hide_link %>
+<div class='section' id='searchform' style='width:400px;'>
   <%= simple_form_for(:search, :method => :get, url: admin_staff_notes_path, defaults: {required: false}, html: {class: "inline-form"}) do |f| %>
     <%= f.input :creator_name, label: "Creator Name", input_html: {data: {autocomplete: "user"}} %>
     <%= f.input :user_name, label: "User Name", input_html: {data: {autocomplete: "user"}} %>
     <%= f.input :body_matches, label: "Body" %>
     <%= f.submit "Search" %>
   <% end %>
-  <%= search_hide_link %>
 </div>

--- a/app/views/admin/staff_notes/_search.html.erb
+++ b/app/views/admin/staff_notes/_search.html.erb
@@ -1,10 +1,6 @@
-<%= search_show_link %>
-<%= search_hide_link %>
-<div class='section' id='searchform' style='width:400px;'>
-  <%= simple_form_for(:search, :method => :get, url: admin_staff_notes_path, defaults: {required: false}, html: {class: "inline-form"}) do |f| %>
-    <%= f.input :creator_name, label: "Creator Name", input_html: {data: {autocomplete: "user"}} %>
-    <%= f.input :user_name, label: "User Name", input_html: {data: {autocomplete: "user"}} %>
-    <%= f.input :body_matches, label: "Body" %>
-    <%= f.submit "Search" %>
-  <% end %>
-</div>
+<%= hideable_form_search path: admin_staff_notes_path, always_display: true do |f| %>
+  <%= f.input :creator_name, label: "Creator Name", input_html: {data: {autocomplete: "user"}} %>
+  <%= f.input :user_name, label: "User Name", input_html: {data: {autocomplete: "user"}} %>
+  <%= f.input :body_matches, label: "Body" %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/application/_hideable_form_search.erb
+++ b/app/views/application/_hideable_form_search.erb
@@ -1,0 +1,5 @@
+<a href="#" id="search-form-show-link" <% if show_on_load %>style="display:none;"<% end %>>Show Search Options</a>
+<a href="#" id="search-form-hide-link" <% unless show_on_load %>style="display:none;"<% end %>>Hide Search Options</a>
+<div class="section" id="searchform" <% unless show_on_load %>style="display:none;"<% end %>>
+  <%= simple_form_for(:search, :method => :get, url: path, defaults: {required: false}, html: {class: "inline-form"}, &block) %>
+</div>

--- a/app/views/blips/_search.html.erb
+++ b/app/views/blips/_search.html.erb
@@ -1,11 +1,7 @@
-<%= search_show_link %>
-<%= search_hide_link %>
-<div class='section' id='searchform' style='width:400px;'>
-  <%= simple_form_for(:search, :method => :get, url: blips_path, defaults: {required: false}, html: {class: "inline-form"}) do |f| %>
-    <%= f.input :creator_name, label: "Blipper", input_html: {data: {autocomplete: "user"}} %>
-    <%= f.input :body_matches, label: "Body" %>
-    <%= f.input :response_to, label: "Parent Blip #" %>
-    <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc)] %>
-    <%= f.submit "Search" %>
-  <% end %>
-</div>
+<%= hideable_form_search path: blips_path do |f| %>
+  <%= f.input :creator_name, label: "Blipper", input_html: {data: {autocomplete: "user"}} %>
+  <%= f.input :body_matches, label: "Body" %>
+  <%= f.input :response_to, label: "Parent Blip #" %>
+  <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc)] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/blips/_search.html.erb
+++ b/app/views/blips/_search.html.erb
@@ -1,8 +1,6 @@
-<div id='searchform_hide'>
-  <%= search_show_link %>
-</div>
-<div class='section' id='searchform' style='width:400px;<% unless params[:show] %>display:none;
-  <% end %>'>
+<%= search_show_link %>
+<%= search_hide_link %>
+<div class='section' id='searchform' style='width:400px;'>
   <%= simple_form_for(:search, :method => :get, url: blips_path, defaults: {required: false}, html: {class: "inline-form"}) do |f| %>
     <%= f.input :creator_name, label: "Blipper", input_html: {data: {autocomplete: "user"}} %>
     <%= f.input :body_matches, label: "Body" %>
@@ -10,5 +8,4 @@
     <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc)] %>
     <%= f.submit "Search" %>
   <% end %>
-  <%= search_hide_link %>
 </div>

--- a/app/views/post_sets/_search.html.erb
+++ b/app/views/post_sets/_search.html.erb
@@ -1,7 +1,6 @@
-<% unless params[:show] %>
-  <div id='searchform_hide'><%= search_show_link %></div>
-<% end %>
-<div class='section' id='searchform' style='width:400px;<% unless params[:show] %>display:none;<% end %>'>
+<%= search_show_link %>
+<%= search_hide_link %>
+<div class='section' id='searchform' style='width:400px;'>
   <%= simple_form_for(:search, url: post_sets_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
     <%= f.input :name, label: "Name", input_html: { value: params.dig(:search, :name) } %>
     <%= f.input :shortname, label: "Short Name", input_html: {value: params.dig(:search, :shortname)} %>
@@ -9,5 +8,4 @@
     <%= f.input :order, collection: [%w[Name name], ['Short Name', 'shortname'], ['Post Count', 'postcount'], %w[Created created_at], %w[Updated update]], include_blank: false, selected: params.dig(:search, :order) %>
     <%= f.submit "Search" %>
   <% end %>
-  <% unless params[:show] %><%= search_hide_link %><% end %>
 </div>

--- a/app/views/post_sets/_search.html.erb
+++ b/app/views/post_sets/_search.html.erb
@@ -1,11 +1,7 @@
-<%= search_show_link %>
-<%= search_hide_link %>
-<div class='section' id='searchform' style='width:400px;'>
-  <%= simple_form_for(:search, url: post_sets_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-    <%= f.input :name, label: "Name", input_html: { value: params.dig(:search, :name) } %>
-    <%= f.input :shortname, label: "Short Name", input_html: {value: params.dig(:search, :shortname)} %>
-    <%= f.input :creator_name, label: "Username", input_html: {value: params.dig(:search, :creator_name), data: {autocomplete: 'users'}} %>
-    <%= f.input :order, collection: [%w[Name name], ['Short Name', 'shortname'], ['Post Count', 'postcount'], %w[Created created_at], %w[Updated update]], include_blank: false, selected: params.dig(:search, :order) %>
-    <%= f.submit "Search" %>
-  <% end %>
-</div>
+<%= hideable_form_search path: post_sets_path do |f| %>
+  <%= f.input :name, label: "Name", input_html: { value: params.dig(:search, :name) } %>
+  <%= f.input :shortname, label: "Short Name", input_html: {value: params.dig(:search, :shortname)} %>
+  <%= f.input :creator_name, label: "Username", input_html: {value: params.dig(:search, :creator_name), data: {autocomplete: 'users'}} %>
+  <%= f.input :order, collection: [%w[Name name], ['Short Name', 'shortname'], ['Post Count', 'postcount'], %w[Created created_at], %w[Updated update]], include_blank: false, selected: params.dig(:search, :order) %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/post_versions/_search.html.erb
+++ b/app/views/post_versions/_search.html.erb
@@ -1,8 +1,6 @@
-<div id='searchform_hide'>
-  <%= search_show_link %>
-</div>
-<div class='section' id='searchform' style='width:400px;<% unless params[:show] %>display:none;
-  <% end %>'>
+<%= search_show_link %>
+<%= search_hide_link %>
+<div class='section' id='searchform' style='width:400px;'>
   <%= simple_form_for(:search, :method => :get, url: post_versions_path, defaults: {required: false}, html: {class: "inline-form"}) do |f| %>
     <%= f.input :updater_name, label: "User", input_html: {value: params.dig(:search, :updater_name), data: {autocomplete: "user"}} %>
     <%= f.input :updater_id, label: "User ID", input_html: {value: params.dig(:search, :updater_id)} %>
@@ -32,5 +30,4 @@
     <%= f.input :source, label: "Source", input_html: {value: params.dig(:search, :source)} %>
     <%= f.submit "Search" %>
   <% end %>
-  <%= search_hide_link %>
 </div>

--- a/app/views/post_versions/_search.html.erb
+++ b/app/views/post_versions/_search.html.erb
@@ -1,33 +1,29 @@
-<%= search_show_link %>
-<%= search_hide_link %>
-<div class='section' id='searchform' style='width:400px;'>
-  <%= simple_form_for(:search, :method => :get, url: post_versions_path, defaults: {required: false}, html: {class: "inline-form"}) do |f| %>
-    <%= f.input :updater_name, label: "User", input_html: {value: params.dig(:search, :updater_name), data: {autocomplete: "user"}} %>
-    <%= f.input :updater_id, label: "User ID", input_html: {value: params.dig(:search, :updater_id)} %>
-    <%= f.input :post_id, label: "Post #", input_html: {value: params.dig(:search, :post_id)} %>
-    <%= f.input :reason, label: "Reason", input_html: {value: params.dig(:search, :reason)} %>
-    <%= f.input :description, label: "Description", input_html: {value: params.dig(:search, :description)} %>
-    <%= f.input :rating_changed, label: "Rating Changed To", collection: [
-      ["", ""],
-      ["Safe", "s"],
-      ["Questionable", "q"],
-      ["Explicit", "e"]
-    ], selected: params.dig(:search, :rating_changed) %>
-    <%= f.input :rating, label: "Final Rating", collection: [
-      ["", ""],
-      ["Safe", "s"],
-      ["Questionable", "q"],
-      ["Explicit", "e"]
-    ], selected: params.dig(:search, :rating) %>
-    <%= f.input :parent_id, label: "Parent ID", input_html: {value: params.dig(:search, :parent_id)} %>
-    <%= f.input :parent_id_changed, label: "Parent Changed To", input_html: {value: params.dig(:search, :parent_id_changed)} %>
-    <%= f.input :tags, label: "Final Tags", input_html: {value: params.dig(:search, :tags)} %>
-    <%= f.input :tags_added, label: "Added Tags", input_html: {value: params.dig(:search, :tags_added)} %>
-    <%= f.input :tags_removed, label: "Removed Tags", input_html: {value: params.dig(:search, :tags_removed)} %>
-    <%= f.input :locked_tags, label: "Final Locked Tags", input_html: {value: params.dig(:search, :locked_tags)} %>
-    <%= f.input :locked_tags_added, label: "Added Locked Tags", input_html: {value: params.dig(:search, :locked_tags_added)} %>
-    <%= f.input :locked_tags_removed, label: "Removed Locked Tags", input_html: {value: params.dig(:search, :locked_tags_removed)} %>
-    <%= f.input :source, label: "Source", input_html: {value: params.dig(:search, :source)} %>
-    <%= f.submit "Search" %>
-  <% end %>
-</div>
+<%= hideable_form_search path: post_versions_path do |f| %>
+  <%= f.input :updater_name, label: "User", input_html: {value: params.dig(:search, :updater_name), data: {autocomplete: "user"}} %>
+  <%= f.input :updater_id, label: "User ID", input_html: {value: params.dig(:search, :updater_id)} %>
+  <%= f.input :post_id, label: "Post #", input_html: {value: params.dig(:search, :post_id)} %>
+  <%= f.input :reason, label: "Reason", input_html: {value: params.dig(:search, :reason)} %>
+  <%= f.input :description, label: "Description", input_html: {value: params.dig(:search, :description)} %>
+  <%= f.input :rating_changed, label: "Rating Changed To", collection: [
+    ["", ""],
+    ["Safe", "s"],
+    ["Questionable", "q"],
+    ["Explicit", "e"]
+  ], selected: params.dig(:search, :rating_changed) %>
+  <%= f.input :rating, label: "Final Rating", collection: [
+    ["", ""],
+    ["Safe", "s"],
+    ["Questionable", "q"],
+    ["Explicit", "e"]
+  ], selected: params.dig(:search, :rating) %>
+  <%= f.input :parent_id, label: "Parent ID", input_html: {value: params.dig(:search, :parent_id)} %>
+  <%= f.input :parent_id_changed, label: "Parent Changed To", input_html: {value: params.dig(:search, :parent_id_changed)} %>
+  <%= f.input :tags, label: "Final Tags", input_html: {value: params.dig(:search, :tags)} %>
+  <%= f.input :tags_added, label: "Added Tags", input_html: {value: params.dig(:search, :tags_added)} %>
+  <%= f.input :tags_removed, label: "Removed Tags", input_html: {value: params.dig(:search, :tags_removed)} %>
+  <%= f.input :locked_tags, label: "Final Locked Tags", input_html: {value: params.dig(:search, :locked_tags)} %>
+  <%= f.input :locked_tags_added, label: "Added Locked Tags", input_html: {value: params.dig(:search, :locked_tags_added)} %>
+  <%= f.input :locked_tags_removed, label: "Removed Locked Tags", input_html: {value: params.dig(:search, :locked_tags_removed)} %>
+  <%= f.input :source, label: "Source", input_html: {value: params.dig(:search, :source)} %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/post_versions/index.html.erb
+++ b/app/views/post_versions/index.html.erb
@@ -4,8 +4,6 @@
 
     <h1>Changes</h1>
 
-    <p>Recent updates may not have been processed yet. The most recently processed version was <%= time_ago_in_words_tagged(PostArchive.maximum(:updated_at) || 0) %>.</p>
-
     <% if CurrentUser.is_admin? %>
       <div class="inline-form">
         <div class="input">

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -86,7 +86,7 @@
       <ul>
         <li><h1>Blips</h1></li>
         <li><%= link_to("Listing", blips_path) %></li>
-        <li><%= link_to("Help", wiki_pages_path(title: "e621:blips")) %></li>
+        <li><%= link_to("Help", help_page_path(id: "blips")) %></li>
       </ul>
     </section>
     <section>
@@ -95,17 +95,18 @@
         <% if CurrentUser.is_moderator? %>
           <li><%= link_to("Dashboard", moderator_dashboard_path) %></li>
         <% end %>
-        <li><%= link_to("Bans", bans_path) %></li>
         <li><%= link_to("Listing", users_path) %></li>
-        <% unless CurrentUser.is_anonymous? %>
+        <li><%= link_to("Bans", bans_path) %></li>
+        <% if CurrentUser.is_anonymous? %>
+          <li><%= link_to("Signup", new_user_path) %></li>
+        <% else %>
           <li><%= link_to("Profile", user_path(CurrentUser.user)) %></li>
           <li><%= link_to("Settings", edit_user_path(CurrentUser.user)) %></li>
+          <li><%= link_to("Refresh counts", new_maintenance_user_count_fixes_path) %>
         <% end %>
         <li><%= link_to("Feedback", user_feedbacks_path) %></li>
-        <li><%= link_to("Signup", new_user_path) %></li>
         <li><%= link_to("Terms of Service", terms_of_service_path) %></li>
-        <li><%= link_to("Refresh counts", new_maintenance_user_count_fixes_path) %>
-        <li><%= link_to("Help", help_page_path(id: "users")) %></li>
+        <li><%= link_to("Help", help_page_path(id: "accounts")) %></li>
       </ul>
       <ul>
         <li><h1>Admin</h1></li>

--- a/app/views/tag_type_versions/_search.html.erb
+++ b/app/views/tag_type_versions/_search.html.erb
@@ -1,26 +1,6 @@
-<%= search_show_link %>
-<%= search_hide_link %>
-<div class='section' id='searchform' style='width:400px;'>
-  <%= form_tag({action: "index"}, method: :get) do %>
-    <table class='search'>
-      <tr>
-        <td><label for="tag">Tag</label></td>
-        <td><%= text_field_tag "search[tag]", params[:search][:tag] %></td>
-      </tr>
-      <tr>
-        <td><label for="name">Username</label></td>
-        <td><%= text_field_tag "search[user_name]", params[:search][:user_name], style: "width:195px" %></td>
-      </tr>
-      <tr>
-        <td><label for="user_id">User ID</label></td>
-        <td><%= text_field_tag "search[user_id]", params[:search][:user_id], style: "width:195px" %></td>
-      </tr>
-      <tr>
-        <td colspan="2"><%= submit_tag "Search" %></td>
-      </tr>
-    </table>
-    <% if params[:show] %>
-      <input type='hidden' name='show' value='1'/>
-    <% end %>
-  <% end %>
-</div>
+<%= hideable_form_search path: tag_type_versions_path do |f| %>
+  <%= f.input :tag, label: "Tag", input_html: { value: params.dig(:search, :tag) } %>
+  <%= f.input :user_name, label: "Username", input_html: {value: params.dig(:search, :user_name), data: {autocomplete: "user"}} %>
+  <%= f.input :user_id, label: "User ID", input_html: {value: params.dig(:search, :user_id)} %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/tag_type_versions/_search.html.erb
+++ b/app/views/tag_type_versions/_search.html.erb
@@ -1,8 +1,6 @@
-<% unless params[:show] %>
-  <div id='searchform_hide'><%= search_show_link %></div>
-<% end %>
-<div class='section' id='searchform' style='width:400px;<% unless params[:show] %>display:none;
-  <% end %>'>
+<%= search_show_link %>
+<%= search_hide_link %>
+<div class='section' id='searchform' style='width:400px;'>
   <%= form_tag({action: "index"}, method: :get) do %>
     <table class='search'>
       <tr>
@@ -25,5 +23,4 @@
       <input type='hidden' name='show' value='1'/>
     <% end %>
   <% end %>
-  <% unless params[:show] %><%= search_hide_link %><% end %>
 </div>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -1,6 +1,6 @@
 <div id="c-tags">
   <div id="a-edit">
-    <h1>Tag: <%= @tag.name %></h1>
+    <h1>Tag: <%= link_to @tag.name, posts_path(:tags => @tag.name), :class => "tag-type-#{@tag.category}" %></h1>
 
     <%= simple_form_for(@tag) do |f| %>
       <% if @tag.is_locked? %>

--- a/app/views/takedowns/_search.html.erb
+++ b/app/views/takedowns/_search.html.erb
@@ -4,10 +4,15 @@
 
 <div class='section' style='width:400px;<%= 'display:none;' unless params[:search][:show] %>' id='searchform'>
   <%= simple_form_for(:search, url: path, method: :get, defaults: {required: false}, html: {class: 'inline-form'}) do |f| %>
-    <%= f.input :source, label: 'Source', input_html: {value: params[:search][:source]} %>
-    <%= f.input :reason, label: 'Reason', input_html: {value: params[:search][:reason]} %>
-    <%= f.input :notes, label: 'Admin Response', input_html: {value: params[:search][:notes]} %>
+    <%= f.input :status, label: "Status", collection: [["Pending", "pending"],
+                                                       ["Inactive", "inactive"],
+                                                       ["Denied", "denied"],
+                                                       ["Partially Approved", "partial"],
+                                                       ["Approved", "approved"]], include_blank: true, selected: params[:search][:status] %>
     <% if CurrentUser.is_admin? %>
+      <%= f.input :source, label: 'Source', input_html: {value: params[:search][:source]} %>
+      <%= f.input :reason, label: 'Reason', input_html: {value: params[:search][:reason]} %>
+      <%= f.input :notes, label: 'Admin Response', input_html: {value: params[:search][:notes]} %>
       <%= f.input :reason_hidden, label: 'Reason hidden?', collection: [
         ["Yes", true],
         ["No", false],
@@ -17,19 +22,14 @@
       <%= f.input :email, label: "Email", input_html: {value: params[:search][:email]} %>
       <%= f.input :ip_addr, label: "IP Address", input_html: {value: params[:search][:ip_addr]} %>
       <%= f.input :vericode, label: "Vericode", input_html: {value: params[:search][:vericode]} %>
-    <% end %>
 
-    <%= f.input :status, label: "Status", collection: [["Pending", "pending"],
-                                                       ["Inactive", "inactive"],
-                                                       ["Denied", "denied"],
-                                                       ["Partially Approved", "partial"],
-                                                       ["Approved", "approved"]], include_blank: true, selected: params[:search][:status] %>
-    <%= f.input :order, label: 'Order', collection: [["Date", "date"],
-                                                     ["Source", "source"],
-                                                     ["Email", "email"],
-                                                     ["IP Address", "ip_addr"],
-                                                     ["Status", "status"],
-                                                     ["Post count", "post_count"]], selected: params[:search][:order] %>
+      <%= f.input :order, label: 'Order', collection: [["Date", "date"],
+                                                       ["Source", "source"],
+                                                       ["Email", "email"],
+                                                       ["IP Address", "ip_addr"],
+                                                       ["Status", "status"],
+                                                       ["Post count", "post_count"]], selected: params[:search][:order] %>
+    <% end %>
 
     <%= f.input :show, as: :hidden, value: '1' %>
     <%= f.submit "Submit" %>

--- a/app/views/takedowns/_search.html.erb
+++ b/app/views/takedowns/_search.html.erb
@@ -1,8 +1,6 @@
-<% unless params[:search][:show] %>
-  <div id='searchform_hide'><%= search_show_link %></div>
-<% end %>
-
-<div class='section' style='width:400px;<%= 'display:none;' unless params[:search][:show] %>' id='searchform'>
+<%= search_show_link %>
+<%= search_hide_link %>
+<div class='section' style='width:400px;' id='searchform'>
   <%= simple_form_for(:search, url: path, method: :get, defaults: {required: false}, html: {class: 'inline-form'}) do |f| %>
     <%= f.input :status, label: "Status", collection: [["Pending", "pending"],
                                                        ["Inactive", "inactive"],
@@ -33,7 +31,5 @@
 
     <%= f.input :show, as: :hidden, value: '1' %>
     <%= f.submit "Submit" %>
-  <% end %>
-  <% unless params[:search][:show] %><%= search_hide_link %>
   <% end %>
 </div>

--- a/app/views/takedowns/_search.html.erb
+++ b/app/views/takedowns/_search.html.erb
@@ -1,35 +1,29 @@
-<%= search_show_link %>
-<%= search_hide_link %>
-<div class='section' style='width:400px;' id='searchform'>
-  <%= simple_form_for(:search, url: path, method: :get, defaults: {required: false}, html: {class: 'inline-form'}) do |f| %>
-    <%= f.input :status, label: "Status", collection: [["Pending", "pending"],
-                                                       ["Inactive", "inactive"],
-                                                       ["Denied", "denied"],
-                                                       ["Partially Approved", "partial"],
-                                                       ["Approved", "approved"]], include_blank: true, selected: params[:search][:status] %>
-    <% if CurrentUser.is_admin? %>
-      <%= f.input :source, label: 'Source', input_html: {value: params[:search][:source]} %>
-      <%= f.input :reason, label: 'Reason', input_html: {value: params[:search][:reason]} %>
-      <%= f.input :notes, label: 'Admin Response', input_html: {value: params[:search][:notes]} %>
-      <%= f.input :reason_hidden, label: 'Reason hidden?', collection: [
-        ["Yes", true],
-        ["No", false],
-      ], include_blank: true, selected: params[:search][:reason_hidden] %>
-      <%= f.input :instructions, label: "Instructions", input_html: {value: params[:search][:instructions]} %>
-      <%= f.input :post_id, label: "Post ID", input_html: {value: params[:search][:post_id]} %>
-      <%= f.input :email, label: "Email", input_html: {value: params[:search][:email]} %>
-      <%= f.input :ip_addr, label: "IP Address", input_html: {value: params[:search][:ip_addr]} %>
-      <%= f.input :vericode, label: "Vericode", input_html: {value: params[:search][:vericode]} %>
+<%= hideable_form_search path: path do |f| %>
+  <%= f.input :status, label: "Status", collection: [["Pending", "pending"],
+                                                      ["Inactive", "inactive"],
+                                                      ["Denied", "denied"],
+                                                      ["Partially Approved", "partial"],
+                                                      ["Approved", "approved"]], include_blank: true, selected: params[:search][:status] %>
+  <% if CurrentUser.is_admin? %>
+    <%= f.input :source, label: 'Source', input_html: {value: params[:search][:source]} %>
+    <%= f.input :reason, label: 'Reason', input_html: {value: params[:search][:reason]} %>
+    <%= f.input :notes, label: 'Admin Response', input_html: {value: params[:search][:notes]} %>
+    <%= f.input :reason_hidden, label: 'Reason hidden?', collection: [
+      ["Yes", true],
+      ["No", false],
+    ], include_blank: true, selected: params[:search][:reason_hidden] %>
+    <%= f.input :instructions, label: "Instructions", input_html: {value: params[:search][:instructions]} %>
+    <%= f.input :post_id, label: "Post ID", input_html: {value: params[:search][:post_id]} %>
+    <%= f.input :email, label: "Email", input_html: {value: params[:search][:email]} %>
+    <%= f.input :ip_addr, label: "IP Address", input_html: {value: params[:search][:ip_addr]} %>
+    <%= f.input :vericode, label: "Vericode", input_html: {value: params[:search][:vericode]} %>
 
-      <%= f.input :order, label: 'Order', collection: [["Date", "date"],
-                                                       ["Source", "source"],
-                                                       ["Email", "email"],
-                                                       ["IP Address", "ip_addr"],
-                                                       ["Status", "status"],
-                                                       ["Post count", "post_count"]], selected: params[:search][:order] %>
-    <% end %>
-
-    <%= f.input :show, as: :hidden, value: '1' %>
-    <%= f.submit "Submit" %>
+    <%= f.input :order, label: 'Order', collection: [["Date", "date"],
+                                                      ["Source", "source"],
+                                                      ["Email", "email"],
+                                                      ["IP Address", "ip_addr"],
+                                                      ["Status", "status"],
+                                                      ["Post count", "post_count"]], selected: params[:search][:order] %>
   <% end %>
-</div>
+  <%= f.submit "Submit" %>
+<% end %>

--- a/app/views/takedowns/index.html.erb
+++ b/app/views/takedowns/index.html.erb
@@ -13,7 +13,9 @@
         <th>Status</th>
         <th>Post count</th>
         <th>Date</th>
-        <th width="5%"></th>
+        <% if CurrentUser.is_admin? %>
+          <th width="5%"></th>
+        <% end %>
       </tr>
       </thead>
       <tbody>

--- a/app/views/takedowns/new.html.erb
+++ b/app/views/takedowns/new.html.erb
@@ -11,9 +11,9 @@
 
         <p class='nomargin'>Example:</p>
         <ul>
-          <li>http://www.furaffinity.net/user/your_name</li>
-          <li>http://your_name.deviantart.com</li>
-          <li>http://mywebsite.com</li>
+          <li>https://www.furaffinity.net/user/your_name</li>
+          <li>https://www.deviantart.com/your_name</li>
+          <li>https://mywebsite.com</li>
         </ul>
         <p class='nomargin'>In the next step, you will send a private message from the gallery account you specify, or an e-mail from your website's address/domain.</p>
         <%= f.input :source, as: :string, required: true %>
@@ -28,7 +28,7 @@
 
       <div class='section' style='width:600px;'>
         <label for="takedown_post_list">IDs or URLs of the offending images</label>
-        <p class='nomargin'>A list of either image IDs (like 75512) or URLs (like http://<%= Danbooru.config.server_host %>/post/show/75512), one per line.</p>
+        <p class='nomargin'>A list of either image IDs (like 75512) or URLs (like <%= post_url 75512 %>), one per line.</p>
         <%= f.input :post_ids, as: :text, label: 'Posts' %>
 
         <div class='takedown-instructions-header'>OR</div>

--- a/app/views/tickets/_search.html.erb
+++ b/app/views/tickets/_search.html.erb
@@ -1,6 +1,4 @@
-<%= search_show_link %>
-<%= search_hide_link %>
-<%= simple_form_for(:search, method: :get, defaults: {required: false}, html: {id: 'searchform', class: "inline-form"}) do |f| %>
+<%= hideable_form_search path: tickets_path do |f| %>
   <% if CurrentUser.is_admin? %>
     <%= f.input :creator_name, label: "Reporter", input_html: {value: params.dig(:search, :creator_name)} %>
     <%= f.input :creator_id, label: "Reporter ID", input_html: {value: params.dig(:search, :creator_id)} %>

--- a/app/views/tickets/_search.html.erb
+++ b/app/views/tickets/_search.html.erb
@@ -1,6 +1,5 @@
-<div id='searchform_hide'>
-  <%= search_show_link %>
-</div>
+<%= search_show_link %>
+<%= search_hide_link %>
 <%= simple_form_for(:search, method: :get, defaults: {required: false}, html: {id: 'searchform', class: "inline-form"}) do |f| %>
   <% if CurrentUser.is_admin? %>
     <%= f.input :creator_name, label: "Reporter", input_html: {value: params.dig(:search, :creator_name)} %>
@@ -30,6 +29,4 @@
       ["Denied", "denied"]
   ], selected: params.dig(:search, :status) %>
   <%= f.submit "Search" %>
-  <%= search_hide_link %>
 <% end %>
-

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -40,7 +40,13 @@
           <% end %>
         </td>
         <th>Upload Limit</th>
-        <td><%= presenter.upload_limit(self) %> (<%= link_to "help", wiki_page_path(id: "upload_limit") %>)
+        <td>
+          <%= presenter.upload_limit(self) %>
+          <% if CurrentUser.user.id == user.id  %>
+            (<%= link_to "help", upload_limit_users_path %>)
+          <% else %>
+            (<%= link_to "help", wiki_page_path(id: "upload_limit") %>)
+          <% end %>
         </td>
       </tr>
 

--- a/app/views/users/home.html.erb
+++ b/app/views/users/home.html.erb
@@ -155,4 +155,8 @@
   </div>
 <% end %>
 
+<% content_for(:page_title) do %>
+  Home
+<% end %>
+
 <%= render 'secondary_links' %>

--- a/app/views/users/upload_limit.html.erb
+++ b/app/views/users/upload_limit.html.erb
@@ -42,3 +42,7 @@
     </p>
   <% end %>
 </div>
+
+<% content_for(:page_title) do %>
+  Upload Limit
+<% end %>


### PR DESCRIPTION
This does a few unrelated things, I'm fine with dropping some if they are not wanted.

1. Hide some actions you can only do when logged in/out on the site map. Also fixes a broken link to `users` help which is now called `accounts`. Move Listing to the top like on the other sections
2. Use positive/negative feedback colors for user bans. The current colors are too bright in my opinion and since there are already colors associated with bans it makes sense to use them here too
![image](https://user-images.githubusercontent.com/14981592/123266243-230f8980-d4fc-11eb-8ec6-8d4aa626f7e7.png)
3. Colorize the tag name when editing the tag. Currently it's all white which normaly means that it is a metatag. Also makes the tag clickable to start a quick tag search 
![image](https://user-images.githubusercontent.com/14981592/123266790-9fa26800-d4fc-11eb-9500-e3aa196b5bc4.png)
4. Add some more missing page titles I missed in my other pr 
5. Disallow creating a forum topic without an original post. Stuff breaks when there is none, starting with displaying it
6. Remove recent update notice from PostVersions. If I understand correctly this was previously delegated (or just some leftover from the site update) to a remote service which could produce some delays. But since the data was migrated into the main db this isn't the case anymore
7. Hide delete header from takedowns when you're not an admin. Fixes borked table layout
8. Link to /users/upload_limit when clicking on upload limit help on your own profile. This goes into more detail than the currently linked wiki page can and I find the displayed information nice to look at. This only makes sense on your own profile, putting it on everyones would probably just create confusion
9. Fix word breaking issues for long username on /comments?group_by=comment. Grouping by post already handles this correctly, all other places I can think of like viewing an individual comment and on posts itself also work
![image](https://user-images.githubusercontent.com/14981592/123267845-bdbc9800-d4fd-11eb-95fe-53f58ed606b4.png)
10. Hide disallowed takedown search parameters for normal users. Since order is restricted and always selected you can't start a search over the ui without manually editing the url. Don't know if takedown searches for users are even that useful, but this way it's better than before
11. Put "Hide Search Options" at the same location as "Show Search Options". Currently the action for hiding the form is inside the form itself which results in them not being at the same spot. I also made a function for creating one of those since they all do the same thing but some were build slightly differently. This also fixes the search form fading in instead of being visible immediately when you loaded a search url because it's not reliant on js anymore. See /takedowns?search[status]=pending
![Peek 2021-06-24 15-13](https://user-images.githubusercontent.com/14981592/123269113-f610a600-d4fe-11eb-8584-cd2435edb946.gif)
12. Again with the forms. Clicking on showing/hiding the form results in a link being pushed to the browser history since the default is not prevented.
13. Add missing ModAction descriptions for post replacements
14. Show correct post url example on takedowns. The url currently uses the old format (post/show/:id) and the hostname (e621ng-app[1..4].e621.net). Also updates the gallery examples to use https and convert to new format for deviantart.
15. Fixes the issue described in #209. Anticipate that this exception might be thrown and render an expected error instead.