### PR TITLE
Add replacement tracking for uploader

### DIFF
--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -25,7 +25,7 @@ class PostReplacementsController < ApplicationController
 
   def approve
     @post_replacement = PostReplacement.find(params[:id])
-    @post_replacement.approve!
+    @post_replacement.approve!(penalize_current_uploader: params[:penalize_current_uploader])
 
     respond_with(@post_replacement, location: post_path(@post_replacement.post))
   end

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -1,7 +1,7 @@
 class PostReplacementsController < ApplicationController
   respond_to :html
   before_action :moderator_only, only: [:destroy]
-  before_action :janitor_only, only: [:create, :new, :approve, :reject, :promote]
+  before_action :janitor_only, only: [:create, :new, :approve, :reject, :promote, :toggle_penalize]
   content_security_policy only: [:new] do |p|
     p.img_src :self, :data, "*"
   end
@@ -28,6 +28,13 @@ class PostReplacementsController < ApplicationController
     @post_replacement.approve!(penalize_current_uploader: params[:penalize_current_uploader])
 
     respond_with(@post_replacement, location: post_path(@post_replacement.post))
+  end
+
+  def toggle_penalize
+    @post_replacement = PostReplacement.find(params[:id])
+    @post_replacement.toggle_penalize!
+    flash[:notice] = "Updated user upload limit"
+    respond_with(@post_replacement)
   end
 
   def reject

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -27,7 +27,7 @@ class PostReplacementsController < ApplicationController
     @post_replacement = PostReplacement.find(params[:id])
     @post_replacement.approve!(penalize_current_uploader: params[:penalize_current_uploader])
 
-    respond_with(@post_replacement)
+    respond_with(@post_replacement, location: post_path(@post_replacement.post))
   end
 
   def toggle_penalize
@@ -48,7 +48,7 @@ class PostReplacementsController < ApplicationController
     @post_replacement = PostReplacement.find(params[:id])
     @post_replacement.destroy
 
-    respond_with(@post_replacement)
+    respond_with(@post_replacement, location: post_path(@post_replacement.post))
   end
 
   def promote
@@ -59,7 +59,7 @@ class PostReplacementsController < ApplicationController
     elsif @upload.errors.any?
       respond_with(@upload)
     else
-      respond_with(@upload)
+      respond_with(@upload.post)
     end
   end
 

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -56,7 +56,7 @@ class PostReplacementsController < ApplicationController
 
   def index
     params[:search][:post_id] = params.delete(:post_id) if params.has_key?(:post_id)
-    @post_replacements = PostReplacement.visible(CurrentUser.user).search(search_params).paginate(params[:page], limit: params[:limit])
+    @post_replacements = PostReplacement.includes(:post).visible(CurrentUser.user).search(search_params).paginate(params[:page], limit: params[:limit])
 
     respond_with(@post_replacements)
   end

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -1,5 +1,5 @@
 class PostReplacementsController < ApplicationController
-  respond_to :html
+  respond_to :html, :json
   before_action :moderator_only, only: [:destroy]
   before_action :janitor_only, only: [:create, :new, :approve, :reject, :promote, :toggle_penalize]
   content_security_policy only: [:new] do |p|
@@ -26,22 +26,14 @@ class PostReplacementsController < ApplicationController
   def approve
     @post_replacement = PostReplacement.find(params[:id])
     @post_replacement.approve!(penalize_current_uploader: params[:penalize_current_uploader])
-    if @post_replacement.errors.any?
-      flash[:notice] = @post_replacement.errors.full_messages.join("; ")
-    else
-      flash[:notice] = "Post replacement accepted"
-    end
-    respond_with(@post_replacement, location: post_path(@post_replacement.post))
+
+    respond_with(@post_replacement)
   end
 
   def toggle_penalize
     @post_replacement = PostReplacement.find(params[:id])
     @post_replacement.toggle_penalize!
-    if @post_replacement.errors.any?
-      flash[:notice] = @post_replacement.errors.full_messages.join("; ")
-    else
-      flash[:notice] = "Updated user upload limit"
-    end
+
     respond_with(@post_replacement)
   end
 
@@ -49,13 +41,7 @@ class PostReplacementsController < ApplicationController
     @post_replacement = PostReplacement.find(params[:id])
     @post_replacement.reject!
 
-    if @post_replacement.errors.any?
-      flash[:notice] = @post_replacement.errors.full_messages.join("; ")
-    else
-      flash[:notice] = "Post replacement rejected"
-    end
-
-    respond_with(@post_replacement)
+    respond_with(@post_replacement, location: post_path(@post_replacement.post))
   end
 
   def destroy
@@ -68,16 +54,12 @@ class PostReplacementsController < ApplicationController
   def promote
     @post_replacement = PostReplacement.find(params[:id])
     @upload = @post_replacement.promote!
-
     if @post_replacement.errors.any?
-      flash[:notice] = @post_replacement.errors.full_messages.join("; ")
-      respond_with(@upload)
+      respond_with(@post_replacement)
     elsif @upload.errors.any?
-      flash[:notice] = @upload.errors.full_messages.join("; ")
       respond_with(@upload)
     else
-      flash[:notice] = "Post replacement promoted to post ##{@upload.post.id}"
-      respond_with(@upload.post)
+      respond_with(@upload)
     end
   end
 

--- a/app/helpers/post_replacement_helper.rb
+++ b/app/helpers/post_replacement_helper.rb
@@ -1,6 +1,10 @@
 module PostReplacementHelper
   def replacement_thumbnail(replacement)
     return tag.a(image_tag(replacement.replacement_thumb_url), href: replacement.replacement_file_url) if replacement.file_visible_to?(CurrentUser.user)
-    image_tag(replacement.replacement_thumb_url)
+    if replacement.post.deleteblocked?
+      image_tag(Danbooru.config.deleted_preview_url)
+    else
+      image_tag(replacement.replacement_thumb_url)
+    end
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -37,6 +37,7 @@ export { default as Note } from '../src/javascripts/notes.js';
 export { default as Post } from '../src/javascripts/posts.js';
 export { default as PostDeletion } from "../src/javascripts/post_delete.js";
 export { default as PostModeMenu } from '../src/javascripts/post_mode_menu.js';
+export { default as PostReplacement } from '../src/javascripts/post_replacement.js';
 export { default as PostVersions } from '../src/javascripts/post_versions.js';
 export { default as RelatedTag } from '../src/javascripts/related_tag.js';
 export { default as Shortcuts } from '../src/javascripts/shortcuts.js';

--- a/app/javascript/src/javascripts/post_replacement.js
+++ b/app/javascript/src/javascripts/post_replacement.js
@@ -55,8 +55,7 @@ PostReplacement.promote = function (id) {
     url: `/post_replacements/${id}/promote.json`,
     dataType: 'json'
   }).done(function (data) {
-    console.log(data);
-    Utility.notice(`Replacement promoted to post #${data.post_id}`)
+    Utility.notice(`Replacement promoted to post #${data.post.id}`)
   }).fail(function (data, status, xhr) {
     Utility.error(data.responseText);
   });

--- a/app/javascript/src/javascripts/post_replacement.js
+++ b/app/javascript/src/javascripts/post_replacement.js
@@ -1,0 +1,83 @@
+import Utility from './utility'
+
+let PostReplacement = {};
+
+PostReplacement.initialize_all = function () {
+  $(".replacement-approve-action").on("click", e => {
+    const target = $(e.target);
+    e.preventDefault();
+    PostReplacement.approve(target.data("replacement-id"), target.data("penalize"));
+  });
+  $(".replacement-reject-action").on("click", e => {
+    e.preventDefault();
+    PostReplacement.reject($(e.target).data("replacement-id"));
+  });
+  $(".replacement-promote-action").on("click", e => {
+    e.preventDefault();
+    PostReplacement.promote($(e.target).data("replacement-id"));
+  });
+  $(".replacement-toggle-penalize-action").on("click", e => {
+    e.preventDefault();
+    PostReplacement.toggle_penalize($(e.target).data("replacement-id"));
+  });
+};
+
+PostReplacement.approve = function (id, penalize_current_uploader) {
+  $.ajax({
+    type: "PUT",
+    url: `/post_replacements/${id}/approve.json`,
+    data: {
+      penalize_current_uploader: penalize_current_uploader
+    },
+    dataType: 'json'
+  }).done(function () {
+    Utility.notice("Post Replacement accepted");
+  }).fail(function (data, status, xhr) {
+    Utility.error(data.responseText);
+  });
+};
+
+PostReplacement.reject = function (id) {
+  $.ajax({
+    type: "PUT",
+    url: `/post_replacements/${id}/reject.json`,
+    dataType: 'json'
+  }).done(function () {
+    Utility.notice("Post Replacement rejected");
+  }).fail(function (data, status, xhr) {
+    Utility.error(data.responseText);
+  });
+}
+
+PostReplacement.promote = function (id) {
+  $.ajax({
+    type: "POST",
+    url: `/post_replacements/${id}/promote.json`,
+    dataType: 'json'
+  }).done(function (data) {
+    console.log(data);
+    Utility.notice(`Replacement promoted to post #${data.post_id}`)
+  }).fail(function (data, status, xhr) {
+    Utility.error(data.responseText);
+  });
+}
+
+PostReplacement.toggle_penalize = function (id) {
+  $.ajax({
+    type: "PUT",
+    url: `/post_replacements/${id}/toggle_penalize.json`,
+    dataType: 'json'
+  }).done(function (data) {
+    Utility.notice("User upload limit updated");
+  }).fail(function (data, status, xhr) {
+    Utility.error(data.responseText);
+  });
+}
+
+$(function () {
+  if ($("#c-post-replacements").length)
+    PostReplacement.initialize_all();
+});
+
+
+export default PostReplacement

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -296,6 +296,18 @@ class PostReplacement < ApplicationRecord
         where(creator_id: id.to_i)
       end
 
+      def for_uploader_on_approve(id)
+        where(uploader_id_on_approve: id.to_i)
+      end
+
+      def penalized
+        where(penalize_uploader_on_approve: true)
+      end
+
+      def not_penalized
+        where(penalize_uploader_on_approve: false)
+      end
+
       def visible(user)
         return where('status != ?', 'rejected') if user.is_anonymous?
         return all if user.is_janitor?

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -173,11 +173,11 @@ class PostReplacement < ApplicationRecord
   end
 
   module ProcessingMethods
-    def approve!
+    def approve!(penalize_current_uploader:)
       transaction do
         ModAction.log(:post_replacement_accept, {post_id: post.id, replacement_id: self.id, old_md5: post.md5, new_md5: self.md5})
         processor = UploadService::Replacer.new(post: post, replacement: self)
-        processor.process!
+        processor.process!(penalize_current_uploader: penalize_current_uploader)
       end
       post.update_index
     end
@@ -195,6 +195,7 @@ class PostReplacement < ApplicationRecord
     def reject!
       ModAction.log(:post_replacement_reject, {post_id: post.id, replacement_id: self.id})
       update_attribute(:status, 'rejected')
+      UserStatus.for_user(creator_id).update_all("post_replacement_rejected_count = post_replacement_rejected_count + 1")
       post.update_index
     end
   end
@@ -231,6 +232,14 @@ class PostReplacement < ApplicationRecord
 
         if params[:creator_name].present?
           q = q.where(creator_id: User.name_to_id(params[:creator_name]))
+        end
+
+        if params[:uploader_id_on_approve].present?
+          q = q.where(uploader_id_on_approve: params[:uploader_id_on_approve].split(",").map(&:to_i))
+        end
+
+        if params[:uploader_name_on_approve].present?
+          q = q.where(uploader_id_on_approve: User.name_to_id(params[:uploader_name_on_approve]))
         end
 
         if params[:post_id].present?

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -169,7 +169,7 @@ class PostReplacement < ApplicationRecord
 
   module ApiMethods
     def hidden_attributes
-      super + [:storage_id]
+      super + %i[storage_id protected uploader_id_on_approve penalize_uploader_on_approve]
     end
   end
 

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -257,23 +257,23 @@ class PostReplacement < ApplicationRecord
         q = q.attribute_exact_matches(:status, params[:status])
 
         if params[:creator_id].present?
-          q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
+          q = q.where("creator_id in (?)", params[:creator_id].split(",").first(100).map(&:to_i))
         end
 
         if params[:creator_name].present?
-          q = q.where(creator_id: User.name_to_id(params[:creator_name]))
+          q = q.where("creator_id = ?", User.name_to_id(params[:creator_name]))
         end
 
         if params[:uploader_id_on_approve].present?
-          q = q.where(uploader_id_on_approve: params[:uploader_id_on_approve].split(",").map(&:to_i))
+          q = q.where("uploader_id_on_approve in (?)", params[:uploader_id_on_approve].split(",").first(100).map(&:to_i))
         end
 
         if params[:uploader_name_on_approve].present?
-          q = q.where(uploader_id_on_approve: User.name_to_id(params[:uploader_name_on_approve]))
+          q = q.where("uploader_id_on_approve = ?", User.name_to_id(params[:uploader_name_on_approve]))
         end
 
         if params[:post_id].present?
-          q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
+          q = q.where("post_id in (?)", params[:post_id].split(",").first(100).map(&:to_i))
         end
 
 

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -3,6 +3,7 @@ class PostReplacement < ApplicationRecord
   belongs_to :post
   belongs_to :creator, class_name: "User"
   belongs_to :approver, class_name: "User", optional: true
+  belongs_to :uploader_on_approve, class_name: "User", foreign_key: :uploader_id_on_approve, optional: true
   attr_accessor :replacement_file, :replacement_url, :final_source, :tags, :is_backup
 
   validate :user_is_not_limited, on: :create
@@ -180,6 +181,15 @@ class PostReplacement < ApplicationRecord
         processor.process!(penalize_current_uploader: penalize_current_uploader)
       end
       post.update_index
+    end
+
+    def toggle_penalize!
+      if penalize_uploader_on_approve
+        UserStatus.for_user(uploader_on_approve).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count - 1")
+      else
+        UserStatus.for_user(uploader_on_approve).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count + 1")
+      end
+      update_attribute(:penalize_uploader_on_approve, !penalize_uploader_on_approve)
     end
 
     def promote!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -579,7 +579,8 @@ class User < ApplicationRecord
 
     def upload_limit_pieces
       deleted_count = Post.deleted.for_user(id).count
-      rejected_replacement_count = PostReplacement.rejected.for_user(id).count
+      rejected_replacement_count = post_replacement_rejected_count
+      replaced_penalize_count = own_post_replaced_penalize_count
       unapproved_count = Post.pending_or_flagged.for_user(id).count
       unapproved_replacements_count = PostReplacement.pending.for_user(id).count
       approved_count = Post.for_user(id).where('is_flagged = false AND is_deleted = false AND is_pending = false').count
@@ -751,6 +752,18 @@ class User < ApplicationRecord
 
     def negative_feedback_count
       feedback.negative.count
+    end
+
+    def post_replacement_rejected_count
+      user_status.post_replacement_rejected_count
+    end
+
+    def own_post_replaced_count
+      user_status.own_post_replaced_count
+    end
+
+    def own_post_replaced_penalize_count
+      user_status.own_post_replaced_penalize_count
     end
 
     def refresh_counts!

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -78,6 +78,10 @@ class UserPresenter
     template.link_to(user.post_deleted_count, template.deleted_posts_path(user_id: user.id))
   end
 
+  def replaced_upload_count(template)
+    template.link_to(user.own_post_replaced_count, template.post_replacements_path(search: {uploader_name_on_approve: user.name}))
+  end
+
   def favorite_count(template)
     template.link_to(user.favorite_count, template.favorites_path(:user_id => user.id))
   end

--- a/app/views/post_replacements/_search.html.erb
+++ b/app/views/post_replacements/_search.html.erb
@@ -2,6 +2,7 @@
   <%= f.input :md5, label: "MD5", input_html: { value: params.dig(:search, :md5) } %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name) } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :post_id) } %>
+  <%= f.input :uploader_name_on_approve, label: "Uploader on Approve", input_html: { value: params.dig(:search, :uploader_name_on_approve) } %>
   <%= f.input :status, label: "status", collection: ["pending", "rejected", "approved", "promoted"], include_blank: true, selected: params.dig(:search, :status) %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -75,7 +75,7 @@
                     <%= link_to_user post_replacement.uploader_on_approve %>,
                     penalized: <%= post_replacement.penalize_uploader_on_approve ? "yes" : "no" %>
                     <% if CurrentUser.is_janitor? %>
-                      <%= link_to "toggle", toggle_penalize_post_replacement_path(post_replacement), method: :PUT %>
+                      <%= link_to "toggle", "#toggle", class: "replacement-toggle-penalize-action", data: { replacement_id: post_replacement.id} %><br>
                     <% end %>
                   </dd>
                   <dt>Approver</dt>
@@ -93,13 +93,13 @@
             <td>
               <% if CurrentUser.is_janitor? %>
                 <% if post_replacement.status == "pending"%>
-                  <%= link_to "Approve And Penalize Current Uploader", approve_post_replacement_path(post_replacement, penalize_current_uploader: true), method: :PUT %><br>
-                  <%= link_to "Approve", approve_post_replacement_path(post_replacement, penalize_current_uploader: false), method: :PUT %><br>
-                  <%= link_to "Reject", reject_post_replacement_path(post_replacement), method: :PUT %><br>
-                  <%= link_to "As New Post", promote_post_replacement_path(post_replacement), method: :PUT %><br>
+                  <%= link_to "Approve And Penalize Current Uploader", "#approve", class: "replacement-approve-action", data: { replacement_id: post_replacement.id, penalize: true} %><br>
+                  <%= link_to "Approve", "#approve", class: "replacement-approve-action", data: { replacement_id: post_replacement.id, penalize: false} %><br>
+                  <%= link_to "Reject", "#reject", class: "replacement-reject-action", data: { replacement_id: post_replacement.id} %><br>
+                  <%= link_to "As New Post", "#promote", class: "replacement-promote-action", data: { replacement_id: post_replacement.id} %><br>
                 <% end %>
                 <% if post_replacement.status == "original" %>
-                  <%= link_to "Reset To", approve_post_replacement_path(post_replacement, penalize_current_uploader: false), method: :PUT %><br>
+                  <%= link_to "Reset To", "#approve", class: "replacement-approve-action", data: { replacement_id: post_replacement.id, penalize: false} %><br>
                 <% end %>
               <% end %>
               <% if CurrentUser.is_moderator? %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -72,9 +72,9 @@
                 <% if post_replacement.status == 'approved' %>
                   <dt>Original Uploader</dt>
                   <dd>
-                    <%= link_to_user post_replacement.uploader_on_approve %>,
-                    penalized: <%= post_replacement.penalize_uploader_on_approve ? "yes" : "no" %>
+                    <%= link_to_user post_replacement.uploader_on_approve %>
                     <% if CurrentUser.is_janitor? %>
+                      | penalized: <%= post_replacement.penalize_uploader_on_approve ? "yes" : "no" %>
                       <%= link_to "toggle", "#toggle", class: "replacement-toggle-penalize-action", data: { replacement_id: post_replacement.id} %><br>
                     <% end %>
                   </dd>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -92,10 +92,15 @@
 
             <td>
               <% if CurrentUser.is_janitor? %>
-                <%= link_to "Approve and penalize uploader", approve_post_replacement_path(post_replacement, penalize_current_uploader: true), method: :PUT %><br>
-                <%= link_to "Approve", approve_post_replacement_path(post_replacement, penalize_current_uploader: false), method: :PUT %><br>
-                <%= link_to "Reject", reject_post_replacement_path(post_replacement), method: :PUT %><br>
-                <%= link_to "As New Post", promote_post_replacement_path(post_replacement), method: :PUT %><br>
+                <% if post_replacement.status == "pending"%>
+                  <%= link_to "Approve And Penalize Current Uploader", approve_post_replacement_path(post_replacement, penalize_current_uploader: true), method: :PUT %><br>
+                  <%= link_to "Approve", approve_post_replacement_path(post_replacement, penalize_current_uploader: false), method: :PUT %><br>
+                  <%= link_to "Reject", reject_post_replacement_path(post_replacement), method: :PUT %><br>
+                  <%= link_to "As New Post", promote_post_replacement_path(post_replacement), method: :PUT %><br>
+                <% end %>
+                <% if post_replacement.status == "original" %>
+                  <%= link_to "Reset To", approve_post_replacement_path(post_replacement, penalize_current_uploader: false), method: :PUT %><br>
+                <% end %>
               <% end %>
               <% if CurrentUser.is_moderator? %>
                 <%= link_to "Destroy", post_replacement_path(post_replacement), method: :DELETE, 'data-confirm': 'Are you sure you want to destroy this replacement?' %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -84,7 +84,8 @@
 
             <td>
               <% if CurrentUser.is_janitor? %>
-                <%= link_to "Approve", approve_post_replacement_path(post_replacement), method: :PUT %><br>
+                <%= link_to "Approve and penalize uploader", approve_post_replacement_path(post_replacement, penalize_current_uploader: true), method: :PUT %><br>
+                <%= link_to "Approve", approve_post_replacement_path(post_replacement, penalize_current_uploader: false), method: :PUT %><br>
                 <%= link_to "Reject", reject_post_replacement_path(post_replacement), method: :PUT %><br>
                 <%= link_to "As New Post", promote_post_replacement_path(post_replacement), method: :PUT %><br>
               <% end %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -70,6 +70,14 @@
                 <dt>Reason</dt>
                 <dd><%= post_replacement.reason %></dd>
                 <% if post_replacement.status == 'approved' %>
+                  <dt>Original Uploader</dt>
+                  <dd>
+                    <%= link_to_user post_replacement.uploader_on_approve %>,
+                    penalized: <%= post_replacement.penalize_uploader_on_approve ? "yes" : "no" %>
+                    <% if CurrentUser.is_janitor? %>
+                      <%= link_to "toggle", toggle_penalize_post_replacement_path(post_replacement), method: :PUT %>
+                    <% end %>
+                  </dd>
                   <dt>Approver</dt>
                   <dd><%= link_to_user post_replacement.approver %></dd>
                 <% end %>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -51,12 +51,13 @@
       </tr>
 
       <tr>
-        <th>Deleted Posts</th>
+        <th>Deleted/Replaced Posts</th>
         <td>
           <%= presenter.deleted_upload_count(self) %>
           <% if CurrentUser.is_moderator? %>
             [<%= link_to "sample", posts_path(:tags => "user:#{user.name} order:random limit:300 status:deleted") %>]
           <% end %>
+          / <%= presenter.replaced_upload_count(self) %>
         </td>
         <th>Post Changes</th>
         <td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -250,7 +250,7 @@ Rails.application.routes.draw do
     member do
       put :approve
       put :reject
-      put :promote
+      post :promote
       put :toggle_penalize
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,6 +251,7 @@ Rails.application.routes.draw do
       put :approve
       put :reject
       put :promote
+      put :toggle_penalize
     end
   end
   resources :deleted_posts, only: [:index]

--- a/db/migrate/20210625155528_add_replacement_audit_stats.rb
+++ b/db/migrate/20210625155528_add_replacement_audit_stats.rb
@@ -1,0 +1,18 @@
+class AddReplacementAuditStats < ActiveRecord::Migration[6.1]
+  def up
+    add_column :post_replacements2, :uploader_id_on_approve, :int
+    add_column :post_replacements2, :penalize_uploader_on_approve, :boolean
+    add_column :user_statuses, :own_post_replaced_count, :int, nil: false, default: 0
+    add_column :user_statuses, :own_post_replaced_penalize_count, :int, nil: false, default: 0
+    add_column :user_statuses, :post_replacement_rejected_count, :int, nil: false, default: 0
+
+  end
+
+  def down
+    drop_column :post_replacements2, :uploader_id_on_approve
+    drop_column :post_replacements2, :penalize_uploader_on_approve
+    drop_column :user_statuses, :own_post_replaced_count
+    drop_column :user_statuses, :own_post_replaced_penalize_count
+    drop_column :user_statuses, :post_replacement_rejected_count
+  end
+end

--- a/db/migrate/20210625155528_add_replacement_audit_stats.rb
+++ b/db/migrate/20210625155528_add_replacement_audit_stats.rb
@@ -1,18 +1,9 @@
 class AddReplacementAuditStats < ActiveRecord::Migration[6.1]
-  def up
+  def change
     add_column :post_replacements2, :uploader_id_on_approve, :int
     add_column :post_replacements2, :penalize_uploader_on_approve, :boolean
     add_column :user_statuses, :own_post_replaced_count, :int, nil: false, default: 0
     add_column :user_statuses, :own_post_replaced_penalize_count, :int, nil: false, default: 0
     add_column :user_statuses, :post_replacement_rejected_count, :int, nil: false, default: 0
-
-  end
-
-  def down
-    drop_column :post_replacements2, :uploader_id_on_approve
-    drop_column :post_replacements2, :penalize_uploader_on_approve
-    drop_column :user_statuses, :own_post_replaced_count
-    drop_column :user_statuses, :own_post_replaced_penalize_count
-    drop_column :user_statuses, :post_replacement_rejected_count
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1638,7 +1638,9 @@ CREATE TABLE public.post_replacements2 (
     storage_id character varying NOT NULL,
     status character varying DEFAULT 'pending'::character varying NOT NULL,
     reason character varying NOT NULL,
-    protected boolean DEFAULT false NOT NULL
+    protected boolean DEFAULT false NOT NULL,
+    uploader_id_on_approve integer,
+    penalize_uploader_on_approve boolean
 );
 
 
@@ -2588,7 +2590,10 @@ CREATE TABLE public.user_statuses (
     pool_edit_count integer DEFAULT 0 NOT NULL,
     blip_count integer DEFAULT 0 NOT NULL,
     set_count integer DEFAULT 0 NOT NULL,
-    artist_edit_count integer DEFAULT 0 NOT NULL
+    artist_edit_count integer DEFAULT 0 NOT NULL,
+    own_post_replaced_count integer DEFAULT 0,
+    own_post_replaced_penalize_count integer DEFAULT 0,
+    post_replacement_rejected_count integer DEFAULT 0
 );
 
 
@@ -5263,6 +5268,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210426025625'),
 ('20210430201028'),
 ('20210506235640'),
-('20210718172512');
-
+('20210718172512'),
+('20210625155528');
 

--- a/script/fixes/103_fill_new_post_replacement_fields.rb
+++ b/script/fixes/103_fill_new_post_replacement_fields.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment'))
+
+UserStatus.find_each do |user_status|
+  user_status.update_column(:post_replacement_rejected_count, PostReplacement.rejected.for_user(user_status.user.id).count)
+end
+
+# post ids who have two replacements, one approved, one original
+PostReplacement.select(:post_id).where(status: ["approved", "original"]).group(:post_id)
+               .having("count(post_id) = 2").map(&:post_id).each do |post_id|
+  replacements = PostReplacement.where(post_id: post_id).order(:status)
+  
+  approved = replacements[0]
+  original = replacements[1]
+
+  approved.uploader_id_on_approve = original.creator_id
+  approved.penalize_uploader_on_approve = true
+  approved.save!
+
+  user_status = UserStatus.for_user(original.creator_id)
+  user_status.update_all("own_post_replaced_count = own_post_replaced_count + 1")
+  user_status.update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count + 1")
+end

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -77,7 +77,7 @@ class PostReplacementTest < ActiveSupport::TestCase
     end
 
     should "affect user upload limit" do
-      assert_difference("PostReplacement.pending.for_user(@user.id).count", 1) do
+      assert_difference(->{PostReplacement.pending.for_user(@user.id).count}, 1) do
         @replacement = @post.replacements.create(FactoryBot.attributes_for(:png_replacement).merge(creator: @user, creator_ip_addr: '127.0.0.1'))
       end
     end
@@ -109,9 +109,25 @@ class PostReplacementTest < ActiveSupport::TestCase
     end
 
     should "give user back their upload slot" do
-      assert_difference("PostReplacement.pending.for_user(@user.id).count", -1) do
+      assert_difference(->{PostReplacement.pending.for_user(@user.id).count}, -1) do
         @replacement.reject!
       end
+    end
+
+    should "increment the users rejected replacements count" do
+      assert_difference(->{@user.post_replacement_rejected_count}, 1) do
+        assert_difference(->{PostReplacement.rejected.for_user(@user.id).count}, 1) do
+          @replacement.reject!
+          @user.reload
+        end
+      end
+    end
+
+    should "work only once for pending replacements" do
+      @replacement.reject!
+      assert_equal [], @replacement.errors.full_messages
+      @replacement.reject!
+      assert_equal ["Status must be pending to reject"], @replacement.errors.full_messages
     end
   end
 
@@ -124,20 +140,21 @@ class PostReplacementTest < ActiveSupport::TestCase
 
     should "create a mod action" do
       assert_difference("ModAction.count") do
-        @replacement.approve!
+        @replacement.approve! penalize_current_uploader: true
       end
     end
 
     should "fail if post cannot be backed up" do
       @post.md5 = "123" # Breaks file path, should force backup to fail.
       assert_raise(ProcessingError) do
-        @replacement.approve!
+        @replacement.approve! penalize_current_uploader: true
       end
     end
 
+
     should "update post with new image" do
       old_md5 = @post.md5
-      @replacement.approve!
+      @replacement.approve! penalize_current_uploader: true
       @post.reload
       assert_not_equal @post.md5, old_md5
       assert_equal @replacement.image_width, @post.image_width
@@ -151,25 +168,25 @@ class PostReplacementTest < ActiveSupport::TestCase
     should "generate videos samples if replacement is video" do
       @replacement = FactoryBot.create(:webm_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: @post)
       @post.expects(:generate_video_samples).times(1)
-      @replacement.approve!
+      @replacement.approve! penalize_current_uploader: true
     end
 
     should "delete original files immediately" do
       sm = Danbooru.config.storage_manager
       old_md5 = @post.md5
       old_ext = @post.file_ext
-      @replacement.approve!
+      @replacement.approve! penalize_current_uploader: true
       @post.reload
-      assert_not File.exists?(sm.file_path(old_md5, old_ext, :original))
-      assert_not File.exists?(sm.file_path(old_md5, old_ext, :preview))
-      assert_not File.exists?(sm.file_path(old_md5, old_ext, :large))
-      assert_not File.exists?(sm.file_path(old_md5, old_ext, :original, protected=true))
+      assert_not File.exist?(sm.file_path(old_md5, old_ext, :original))
+      assert_not File.exist?(sm.file_path(old_md5, old_ext, :preview))
+      assert_not File.exist?(sm.file_path(old_md5, old_ext, :large))
+      assert_not File.exist?(sm.file_path(old_md5, old_ext, :original, protected=true))
     end
 
     should "not be able to approve on deleted post" do
       @post.update_column(:is_deleted, true)
       assert_raise ProcessingError do
-        @replacement.approve!
+        @replacement.approve! penalize_current_uploader: true
       end
     end
 
@@ -177,7 +194,7 @@ class PostReplacementTest < ActiveSupport::TestCase
       old_md5 = @post.md5
       old_source = @post.source
       assert_difference("@post.replacements.size", 1) do
-        @replacement.approve!
+        @replacement.approve! penalize_current_uploader: true
       end
       new_replacement = @post.replacements.last
       assert_equal 'original', new_replacement.status
@@ -187,20 +204,77 @@ class PostReplacementTest < ActiveSupport::TestCase
     end
 
     should "update users upload counts" do
-      assert_difference("Post.for_user(@mod_user.id).where('is_flagged = false AND is_deleted = false AND is_pending = false').count", -1) do
-        assert_difference("Post.for_user(@user.id).where('is_flagged = false AND is_deleted = false AND is_pending = false').count", 1) do
-          @replacement.approve!
+      assert_difference(->{Post.for_user(@mod_user.id).where('is_flagged = false AND is_deleted = false AND is_pending = false').count}, -1) do
+        assert_difference(->{Post.for_user(@user.id).where('is_flagged = false AND is_deleted = false AND is_pending = false').count}, 1) do
+          @replacement.approve! penalize_current_uploader: true
+        end
+      end
+    end
+
+    should "update the original users upload limit if penalized" do
+      assert_difference(->{@mod_user.own_post_replaced_count}, 1) do
+        assert_difference(->{@mod_user.own_post_replaced_penalize_count}, 1) do
+          assert_difference(->{PostReplacement.penalized.for_uploader_on_approve(@mod_user.id).count}, 1) do
+            @replacement.approve! penalize_current_uploader: true
+            @mod_user.reload
+          end
+        end
+      end
+    end
+
+    should "not update the original users upload limit if not penalizing" do
+      assert_difference(-> {@mod_user.own_post_replaced_count}, 1) do
+        assert_difference(->{@mod_user.own_post_replaced_penalize_count}, 0) do
+          assert_difference(->{PostReplacement.not_penalized.for_uploader_on_approve(@mod_user.id).count}, 1) do
+            @replacement.approve! penalize_current_uploader: false
+            @mod_user.reload
+          end
         end
       end
     end
 
     should "correctly resize the posts notes" do
-      @replacement.approve!
+      @replacement.approve! penalize_current_uploader: true
       @note.reload
       assert_equal 153, @note.x
       assert_equal 611, @note.y
       assert_equal 153, @note.width
       assert_equal 152, @note.height
+    end
+
+    should "only work on pending or original replacements" do
+      @replacement.reject!
+      @replacement.approve! penalize_current_uploader: false
+      assert_equal(["Status must be pending or original to approve"], @replacement.errors.full_messages)
+    end
+
+    should "only work once" do
+      @replacement.approve! penalize_current_uploader: false
+      assert_equal [], @replacement.errors.full_messages
+      @replacement.approve! penalize_current_uploader: false
+      assert_equal ["Status must be pending or original to approve"], @replacement.errors.full_messages
+    end
+  end
+
+  context "Toggle:" do
+    setup do
+      @replacement = FactoryBot.create(:png_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: @post)
+      assert @replacement
+    end
+
+    should "change the users upload limit" do
+      @replacement.approve! penalize_current_uploader: false
+      assert_difference(->{@mod_user.own_post_replaced_penalize_count}, 1) do
+        assert_difference(->{PostReplacement.penalized.for_uploader_on_approve(@mod_user.id).count}, 1) do
+          @replacement.toggle_penalize!
+          @mod_user.reload
+        end
+      end
+    end
+
+    should "only work on appoved replacements" do
+      @replacement.toggle_penalize!
+      assert_equal(["Status must be approved to penalize"], @replacement.errors.full_messages)
     end
   end
 
@@ -226,14 +300,20 @@ class PostReplacementTest < ActiveSupport::TestCase
     end
 
     should "credit replacer with new post" do
-      assert_difference("Post.for_user(@mod_user.id).where('is_flagged = false AND is_deleted = false AND is_pending = false').count", 0) do
-        assert_difference("Post.for_user(@user.id).where('is_flagged = false AND is_deleted = false').count", 1) do
+      assert_difference(->{Post.for_user(@mod_user.id).where('is_flagged = false AND is_deleted = false AND is_pending = false').count}, 0) do
+        assert_difference(->{Post.for_user(@user.id).where('is_flagged = false AND is_deleted = false').count}, 1) do
           post = @replacement.promote!
           assert post
           assert_equal [], post.errors.full_messages
           assert_equal [], post.post.errors.full_messages
         end
       end
+    end
+
+    should "only work on pending replacements" do
+      @replacement.approve! penalize_current_uploader: false
+      @replacement.promote!
+      assert_equal(["Status must be pending to promote"], @replacement.errors.full_messages)
     end
   end
 end


### PR DESCRIPTION
Adds the possibility for users to see which of their posts got replaced. For a given replacement the uploader at the time of approval gets saved which can later on be used to filter for specific users. I also added the option of penalizing the original user for the upload which can be toggled later on. When a replacement gets accepted you can choose if it should affect the users upload limit or not. I made the actions use ajax which feels better in my opinion. Getting thrown of the page doesn't feel that great in my opinion.

Another thing I noticed was that replacements don't hide their thumbnails when the post is deleted because they don't behave like post thumbnails. I checked if the post is currently deleted and if it is display the deleted thumbnail. There are still other problems like that the thumbnails don't listen to other things like the blacklist or safeblock but to fix that things would need to change a bit more.

I created a fixer script which tries to fill the newly added fields from the currently available data, but if a post has more than two replacements it's not really possible. I imagine the most only got replaced once though.