### PR TITLE
[Vagrant] Don't explicitly set RAILS_ENV

### DIFF
--- a/vagrant/install.sh
+++ b/vagrant/install.sh
@@ -113,8 +113,6 @@ if ! type ruby-install >/dev/null 2>&1; then
     cd ruby-install-0.8.1/
     sudo make install >/dev/null
     rm /usr/local/src/ruby-install-0.8.1.tar.gz
-
-    echo "export RAILS_ENV=development" > /etc/profile.d/rails_env.sh
 fi
 
 if [ -f "$CHRUBY_PATH" ]; then


### PR DESCRIPTION
See #274 where I lamented a bit about this. After further testing in seems that `Rails.env` equals `development` when not specified otherwise or some other place correctly sets it to `development`.

This keeps the main application running as usual and enables executing `rake test` inside the vm without needed to specifify `RAILS_ENV=test`