### PR TITLE
[CORS] Allow authorization header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   class APIThrottled < Exception; end
 
-  skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? }
+  skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? || request.options? }
   before_action :reset_current_user
   before_action :set_current_user
   before_action :normalize_search
@@ -23,16 +23,17 @@ class ApplicationController < ActionController::Base
   # here, so calling `rescue_exception` would cause a double render error.
   rescue_from ActionController::InvalidCrossOriginRequest, with: -> {}
 
+  def enable_cors
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Headers"] = "Authorization"
+  end
+
   protected
 
   def self.rescue_with(*klasses, status: 500)
     rescue_from *klasses do |exception|
       render_error_page(status, exception)
     end
-  end
-
-  def enable_cors
-    response.headers["Access-Control-Allow-Origin"] = "*"
   end
 
   def api_check

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -407,6 +407,8 @@ Rails.application.routes.draw do
     end
   end
 
+  options "*all", to: "application#enable_cors"
+
   # aliases
   resources :wpages, :controller => "wiki_pages"
   resources :ftopics, :controller => "forum_topics"


### PR DESCRIPTION
Fixes #270. There was no route for options which is why the preflight check failed. Headers need to be whitelisted to be used which was also missing.

The api wiki page mentions basic auth working, which I would expect to hold true for cors requests as well. We talked about this and you're not a fan of changing anything in that regard but since I already had something working I'll put it up anyways. I'll put up a mention regarding the status of cors in the wiki when this is merged/rejected.

POST requests also work against expectations since they are able to be made without triggering a preflight check. See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests for more infos on that.