### PR TITLE
Uploader enhancements

### DIFF
--- a/app/javascript/src/javascripts/uploader.vue
+++ b/app/javascript/src/javascripts/uploader.vue
@@ -757,6 +757,12 @@
       },
       findRelated(type) {
         const self = this;
+        if (self.loadingRelated)
+          return;
+        if (self.relatedTags.length > 0 && self.lastRelatedType === type) {
+          self.relatedTags = [];
+          return;
+        }
         const convertResponse = function (respData) {
           const sortedRelated = [];
           for (const key in respData) {
@@ -786,6 +792,7 @@
           params['category'] = type;
         $.getJSON("/related_tag/bulk.json", params, function (data) {
           self.relatedTags = convertResponse(data);
+          self.lastRelatedType = type;
         }).always(function () {
           self.loadingRelated = false;
         });

--- a/app/javascript/src/javascripts/uploader_preview.vue
+++ b/app/javascript/src/javascripts/uploader_preview.vue
@@ -19,22 +19,26 @@
     functional: true,
     props: ['tag'],
     render: function (h, ctx) {
+      function create_tag_link(name, tagType) {
+        return h('a', {
+            staticClass: 'tag-type-' + tagType,
+            attrs: { href: "/wiki_pages/show_or_new?name=" + name, target: "_blank" }
+          }, name);
+      }
       var tag = ctx.props.tag;
       switch (tag.type) {
         default:
         case 'tag':
-          return h('a', {
-            staticClass: 'tag-preview tag-type-' + tag.tagType
-          }, tag.a);
+          return h('span', {staticClass: 'tag-preview'}, [create_tag_link(tag.a, tag.tagType)]);
         case 'alias':
           return h('span', {staticClass: 'tag-preview tag-preview-alias'}, [
             h('del', undefined, [
-              h('a', {staticClass: 'tag-type-' + tag.tagType}, tag.a)
-            ]), ' → ', h('a', {staticClass: 'tag-type-' + tag.tagType}, tag.b)
+              create_tag_link(tag.a, tag.tagType)
+            ]), ' → ', create_tag_link(tag.b, tag.tagType)
           ]);
         case 'implication':
           return h('span', {staticClass: 'tag-preview tag-preview-implication'}, [
-            h('a', {staticClass: 'tag-type-' + tag.tagType}, tag.a), ' ⇐ ', h('a', {staticClass: 'tag-type-' + tag.tagType}, tag.b)
+            create_tag_link(tag.a, tag.tagType), ' ⇐ ', create_tag_link(tag.b, tag.tagType)
           ]);
       }
     }

--- a/app/javascript/src/javascripts/uploader_related.vue
+++ b/app/javascript/src/javascripts/uploader_related.vue
@@ -30,7 +30,7 @@
         this.$emit('tag-active', tag[0], !this.tagActive(tag));
       },
       tagLink: function (tag) {
-        return '/post/index?tags=' + encodeURIComponent(tag[0]);
+        return '/wiki_pages/show_or_new?name=' + encodeURIComponent(tag[0]);
       },
       tagActive: function (tag) {
         return this.tags.indexOf(tag[0]) !== -1;


### PR DESCRIPTION
A few small tweaks to the uploaders tagbox. Links the related and final tags to the wiki page instead of linking to a tag search and doing nothing.

Also makes it possible to hide related tags once opened when clicking on it again. Previously there was no way to close it which I  found annoying when I accidentaly opened it.