### PR TITLE
Add readonly mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   class APIThrottled < Exception; end
+  class ReadOnlyException < Exception; end
 
   skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? }
   before_action :reset_current_user
@@ -8,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :api_check
   before_action :set_variant
   before_action :enable_cors
+  before_action :enforce_readonly
   after_action :reset_current_user
   layout "default"
 
@@ -89,6 +91,8 @@ class ApplicationController < ActionController::Base
     when PG::ConnectionBad
       render_error_page(503, exception, message: "The database is unavailable. Try again later.")
     when ActionController::ParameterMissing
+      render_expected_error(400, exception.message)
+    when ReadOnlyException
       render_expected_error(400, exception.message)
     else
       render_error_page(500, exception)
@@ -227,5 +231,14 @@ class ApplicationController < ActionController::Base
 
   def search_params
     params.fetch(:search, {}).permit!
+  end
+
+  def enforce_readonly
+    return unless Danbooru.config.readonly_mode
+    raise ReadOnlyException.new "The site is in readonly mode" unless allowed_readonly_actions.include? action_name
+  end
+
+  def allowed_readonly_actions
+    %w[index show search]
   end
 end

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -27,7 +27,7 @@ class DmailsController < ApplicationController
   def show
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
-    @dmail.mark_as_read!
+    @dmail.mark_as_read! unless Danbooru.config.readonly_mode
     respond_with(@dmail)
   end
 

--- a/app/controllers/explore/posts_controller.rb
+++ b/app/controllers/explore/posts_controller.rb
@@ -22,9 +22,14 @@ module Explore
       render :layout => "blank"
     end
 
-  private
+    private
+
     def set_date
       @date = params[:date] ? Date.parse(params[:date]) : Date.today
+    end
+
+    def allowed_readonly_actions
+      super + ["popular"]
     end
   end
 end

--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -40,7 +40,7 @@ class ForumTopicsController < ApplicationController
   end
 
   def show
-    if request.format == Mime::Type.lookup("text/html")
+    if request.format == Mime::Type.lookup("text/html") && !Danbooru.config.readonly_mode
       @forum_topic.mark_as_read!(CurrentUser.user)
     end
     @forum_posts = ForumPost.includes(topic: [:category]).search(:topic_id => @forum_topic.id).reorder("forum_posts.id").paginate(params[:page])

--- a/app/controllers/pool_elements_controller.rb
+++ b/app/controllers/pool_elements_controller.rb
@@ -27,12 +27,6 @@ class PoolElementsController < ApplicationController
     respond_with(@pool, :location => post_path(@post))
   end
 
-  def all_select
-    @pools = Pool.undeleted.where("is_active = true").order("name").select("id, name")
-    @pools.each # hack to force rails to eager load
-    @pools
-  end
-
   private
 
   def append_pool_to_session(pool)

--- a/app/controllers/pool_elements_controller.rb
+++ b/app/controllers/pool_elements_controller.rb
@@ -33,7 +33,8 @@ class PoolElementsController < ApplicationController
     @pools
   end
 
-private
+  private
+
   def append_pool_to_session(pool)
     recent_pool_ids = session[:recent_pool_ids].to_s.scan(/\d+/)
     recent_pool_ids << pool.id.to_s

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -109,4 +109,8 @@ class PoolsController < ApplicationController
     permitted_params = %i[name description category is_active post_ids post_ids_string]
     params.require(:pool).permit(*permitted_params, post_ids: [])
   end
+
+  def allowed_readonly_actions
+    super + ["gallery"]
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -109,7 +109,7 @@ class PostsController < ApplicationController
     respond_with_post_after_update(@post)
   end
 
-private
+  private
 
   def tag_query
     params[:tags] || (params[:post] && params[:post][:tags])
@@ -176,5 +176,9 @@ private
     permitted_params += %i[is_status_locked locked_tags hide_from_anonymous hide_from_search_engines] if CurrentUser.is_admin?
 
     params.require(:post).permit(permitted_params)
+  end
+
+  def allowed_readonly_actions
+    super + %w[random show_seq]
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,6 +21,12 @@ class SessionsController < ApplicationController
   end
 
   def sign_out
-    destroy()
+    destroy
+  end
+
+  private
+
+  def allowed_readonly_actions
+    super + %w[destroy sign_out]
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -30,7 +30,7 @@ class StaticController < ApplicationController
   end
 
   def disable_mobile_mode
-    if CurrentUser.is_member?
+    if CurrentUser.is_member? && !Danbooru.config.readonly_mode
       user = CurrentUser.user
       user.disable_responsive_mode = !user.disable_responsive_mode
       user.save
@@ -58,5 +58,8 @@ class StaticController < ApplicationController
 
       redirect_to(Danbooru.config.discord_site + user_hash)
     end
+  end
+
+  def enforce_readonly
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -51,7 +51,8 @@ class TagsController < ApplicationController
     respond_with(@tag)
   end
 
-private
+  private
+
   def check_privilege(tag)
     raise User::PrivilegeError unless tag.category_editable_by?(CurrentUser.user)
   end
@@ -61,5 +62,9 @@ private
     permitted_params << :is_locked if CurrentUser.is_moderator?
 
     params.require(:tag).permit(permitted_params)
+  end
+
+  def allowed_readonly_actions
+    super + %w[autocomplete]
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -142,4 +142,8 @@ class UsersController < ApplicationController
     permitted_params += [:email_matches] if CurrentUser.is_admin?
     params.fetch(:search, {}).permit(permitted_params)
   end
+
+  def allowed_readonly_actions
+    super + %w[home upload_limit]
+  end
 end

--- a/app/javascript/src/styles/common/main_layout.scss
+++ b/app/javascript/src/styles/common/main_layout.scss
@@ -126,3 +126,9 @@ div.clearfix {
   float: right;
   font-size: 70%;
 }
+
+div#readonly-notice  {
+  background: $news-background;
+  border-radius: $border-radius-full;
+  text-align: center;
+}

--- a/app/logical/maintenance.rb
+++ b/app/logical/maintenance.rb
@@ -2,6 +2,8 @@ module Maintenance
   module_function
 
   def daily
+    return if Danbooru.config.readonly_mode
+
     ignoring_exceptions { PostPruner.new.prune! }
     ignoring_exceptions { Upload.where('created_at < ?', 1.week.ago).delete_all }
     #ignoring_exceptions { ApiCacheGenerator.new.generate_tag_cache }
@@ -18,6 +20,8 @@ module Maintenance
   end
 
   def weekly
+    return if Danbooru.config.readonly_mode
+
     #ignoring_exceptions { ApproverPruner.prune! }
     #ignoring_exceptions { TagRelationshipRetirementService.find_and_retire! }
   end

--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -23,7 +23,7 @@ class SessionLoader
       load_remember_token
     end
 
-    CurrentUser.user.unban! if CurrentUser.user.ban_expired?
+    CurrentUser.user.unban! if CurrentUser.user.ban_expired? && !Danbooru.config.readonly_mode
     if CurrentUser.user.is_blocked?
       recent_ban = CurrentUser.user.recent_ban
       ban_message = "Account is banned: forever"
@@ -33,8 +33,8 @@ class SessionLoader
       raise AuthenticationFailure.new(ban_message)
     end
     set_statement_timeout
-    update_last_logged_in_at
-    update_last_ip_addr
+    update_last_logged_in_at unless Danbooru.config.readonly_mode
+    update_last_ip_addr unless Danbooru.config.readonly_mode
     set_time_zone
     set_safe_mode
     refresh_old_remember_token

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -251,6 +251,8 @@ class Dmail < ApplicationRecord
   end
 
   def mark_as_read!
+    return if Danbooru.config.readonly_mode
+
     update_column(:is_read, true)
     owner.dmails.unread.count.tap do |unread_count|
       owner.update(has_mail: (unread_count > 0), unread_dmail_count: unread_count)

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -113,7 +113,7 @@ class ForumTopic < ApplicationRecord
     end
 
     def mark_as_read!(user = CurrentUser.user)
-      return if user.is_anonymous?
+      return if user.is_anonymous? || Danbooru.config.readonly_mode
 
       match = ForumTopicVisit.where(:user_id => user.id, :forum_topic_id => id).first
       if match

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -114,6 +114,12 @@
   </header>
 
   <div id="page">
+    <% if Danbooru.config.readonly_mode %>
+    <div id="readonly-notice">
+      <h1>The site is currently in readonly mode. </h1>
+    </div>
+    <% end %>
+
     <%= render "news_updates/listing" %>
 
     <% if CurrentUser.user.is_banned? %>

--- a/app/views/pool_elements/_new.html.erb
+++ b/app/views/pool_elements/_new.html.erb
@@ -4,7 +4,7 @@
   <div class="input">
     <label>Pool Name</label>
     <span id="pool-name-container"><%= text_field_tag "pool_name", "", :size => 20, :data => { autocomplete: "pool" } %></span>
-    <span id="pool-name-hint" class="hint">Search for a pool containing (<%= link_to "see full list", all_select_pool_element_path, :remote => true %>)</span>
+    <span id="pool-name-hint" class="hint">Search for a pool containing (<%= link_to "see full list", gallery_pools_path %>)</span>
   </div>
 
   <div class="input">

--- a/app/views/pool_elements/all_select.js.erb
+++ b/app/views/pool_elements/all_select.js.erb
@@ -1,2 +1,0 @@
-$("#pool-name-container").html(<%= raw select_tag("pool_id", options_for_select(@pools.map {|x| [x.name, x.id]})).to_json %>);
-$("#pool-name-hint").hide();

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -957,6 +957,10 @@ fart'
     def image_rescales
       []
     end
+
+    def readonly_mode
+      return false
+    end
   end
 
   class EnvironmentConfiguration

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,11 +240,7 @@ Rails.application.routes.draw do
     end
     resource :order, :only => [:edit], :controller => "pool_orders"
   end
-  resource :pool_element, :only => [:create, :destroy] do
-    collection do
-      get :all_select
-    end
-  end
+  resource :pool_element, :only => [:create, :destroy]
   resources :pool_versions, :only => [:index] do
     member do
       get :diff


### PR DESCRIPTION
As it says, prevents any changes to the database if the config is set to true. Allows only `index`, `show`, and `search` actions, plus a few whitelisted ones. A few actions like viewing dmails/forum posts or loading any page could trigger database updates. I special cased the ones I found which should be most if not all of them.
Users will remain logged in until they choose to log out but will not be able to start a new session.

Small extra: Remove `all_select` from PoolElementsController. This was used to display all pools to the user on click when adding a post to a pool on the posts show page. This is just not useful since there are way too many, my browser also has to think for a few seconds to display the huge list. Instead redirect to the gallery page.