### PR TITLE
[ModActions] Remove description search parameter

### DIFF
--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -5,56 +5,6 @@ class ModAction < ApplicationRecord
 
   serialize :values_old
 
-  #####DIVISIONS#####
-  #Groups:     0-999
-  #Individual: 1000-1999
-  #####Actions#####
-  #Create:   0
-  #Update:   1
-  #Delete:   2
-  #Undelete: 3
-  #Ban:      4
-  #Unban:    5
-  #Misc:     6-19
-  enum category: {
-      user_delete: 2,
-      user_ban: 4,
-      user_unban: 5,
-      user_name_change: 6,
-      user_level_change: 7,
-      user_approval_privilege: 8,
-      user_upload_privilege: 9,
-      user_account_upgrade: 19,
-      user_feedback_update: 21,
-      user_feedback_delete: 22,
-      post_delete: 42,
-      post_undelete: 43,
-      post_ban: 44,
-      post_unban: 45,
-      post_permanent_delete: 46,
-      post_move_favorites: 47,
-      pool_delete: 62,
-      pool_undelete: 63,
-      artist_ban: 184,
-      artist_unban: 185,
-      comment_update: 81,
-      comment_delete: 82,
-      forum_topic_delete: 202,
-      forum_topic_undelete: 203,
-      forum_topic_lock: 206,
-      forum_post_update: 101,
-      forum_post_delete: 102,
-      tag_alias_create: 120,
-      tag_alias_update: 121,
-      tag_implication_create: 140,
-      tag_implication_update: 141,
-      ip_ban_create: 160,
-      ip_ban_delete: 162,
-      mass_update: 1000,
-      bulk_revert: 1001,
-      other: 2000
-  }
-
   KnownActions = [
       :artist_ban,
       :artist_unban,
@@ -148,21 +98,12 @@ class ModAction < ApplicationRecord
     q.apply_default_order(params)
   end
 
-
-  def category_id
-    self.class.categories[category]
-  end
-
-  def method_attributes
-    super + [:category_id]
-  end
-
   def hidden_attributes
     super + [:values]
   end
 
   def self.log(cat = :other, details = {})
-    create(category: categories.fetch(cat, 2000), action: cat.to_s, values: details)
+    create(action: cat.to_s, values: details)
   end
 
   def initialize_creator

--- a/app/views/mod_actions/_search.html.erb
+++ b/app/views/mod_actions/_search.html.erb
@@ -1,6 +1,5 @@
 <%= simple_form_for(:search, method: :get, url: mod_actions_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name), data: { autocomplete: "user" } } %>
-  <%= f.input :description_matches, label: "Description" %>
-  <%= f.input :action, label: "Action", collection: ModAction::KnownActions.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true,selected: params.dig(:search, :action) %>
+  <%= f.input :action, label: "Action", collection: ModAction::KnownActions.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true, selected: params.dig(:search, :action) %>
   <%= f.submit "Search" %>
 <% end %>

--- a/db/migrate/20210718172512_drop_unused_mod_action_fields.rb
+++ b/db/migrate/20210718172512_drop_unused_mod_action_fields.rb
@@ -1,0 +1,11 @@
+class DropUnusedModActionFields < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :mod_actions, :category
+    remove_column :mod_actions, :description
+  end
+
+  def down
+    add_column :mod_actions, :category, :text
+    add_column :mod_actions, :description, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1180,12 +1180,10 @@ CREATE SEQUENCE public.mod_actions_id_seq
 CREATE TABLE public.mod_actions (
     id integer DEFAULT nextval('public.mod_actions_id_seq'::regclass) NOT NULL,
     creator_id integer,
-    description text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     action text,
-    "values" json,
-    category integer
+    "values" json
 );
 
 
@@ -5264,6 +5262,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210425020131'),
 ('20210426025625'),
 ('20210430201028'),
-('20210506235640');
+('20210506235640'),
+('20210718172512');
 
 

--- a/test/factories/mod_action.rb
+++ b/test/factories/mod_action.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory(:mod_action) do
     creator :factory => :user
     action { "1234" }
-    category { 3 }
     values { {a: 'b'} }
   end
 end


### PR DESCRIPTION
Description is not filled anymore, previously the full message was saved instead of values to construct the message from if I understand correctly. Also remove the category. The list was severely outdated, missing over half of the possible entries. It was also not exposed in any way. Dropping those fields should be good from my understanding.