### PR TITLE
Revert "[NewsUpdate] Fix new entries not being displayed immediately"

### DIFF
--- a/app/models/news_update.rb
+++ b/app/models/news_update.rb
@@ -6,8 +6,8 @@ class NewsUpdate < ApplicationRecord
   after_destroy :invalidate_cache
 
   def self.recent
-    Cache.get('recent_news', 1.day) do
-      order('id desc').first
+    @recent_news ||= Cache.get('recent_news', 1.day) do
+      self.order('id desc').first(1)
     end
   end
 

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -114,7 +114,7 @@
   </header>
 
   <div id="page">
-    <%= render "news_updates/listing", update: NewsUpdate.recent %>
+    <%= render "news_updates/listing" %>
 
     <% if CurrentUser.user.is_banned? %>
       <%= render "users/ban_notice" %>

--- a/app/views/news_updates/_listing.html.erb
+++ b/app/views/news_updates/_listing.html.erb
@@ -1,10 +1,10 @@
-<% if update.present? %>
-  <div class="ui-state-highlight site-notice" style="display: none;" id="news" data-id="<%= update.id %>">
+<% if NewsUpdate.recent.present? %>
+  <div class="ui-state-highlight site-notice" style="display: none;" id="news" data-id="<%= NewsUpdate.recent[0].id %>">
     <div id="news-closebutton" class="closebutton">Dismiss</div>
-    <h6>News - <%= update.created_at.strftime("%b %d, %Y") %>
-      (<%= time_ago_in_words update.created_at %> ago)
+    <h6>News - <%= NewsUpdate.recent[0].created_at.strftime("%b %d, %Y") %>
+      (<%= time_ago_in_words NewsUpdate.recent[0].created_at %> ago)
       <span id="news-showtext" class="showtext">Click to show.</span>
     </h6>
-    <div class="newsbody styled-dtext"><%= format_text(update.message) %></div>
+    <div class="newsbody styled-dtext"><%= format_text(NewsUpdate.recent[0].message) %></div>
   </div>
 <% end %>

--- a/app/views/news_updates/_listing_home.html.erb
+++ b/app/views/news_updates/_listing_home.html.erb
@@ -1,0 +1,3 @@
+<% if NewsUpdate.recent.present? %>
+  <div class="styled-dtext"><%= format_text(NewsUpdate.recent[0].message) %></div>
+<% end %>


### PR DESCRIPTION
Reverts zwagoth/e621ng#299

This was causing an exception related to cached array values in production, and needs to be further debugged. For the time being this is a revert action to get things going again.