### PR TITLE
Dtext spoiler formatting

### DIFF
--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -112,9 +112,7 @@ $paginator-hover-background: $link-hover-color;
 // Spoilers
 $spoiler-color: black;
 $spoiler-background: black;
-$spoiler-link-color: black;
 $spoiler-hover-color: white;
-$spoiler-link-hover-color: white;
 
 // User Ranks
 $rank-admin-color: darken(orange, 5%);

--- a/app/javascript/src/styles/common/spoiler.scss
+++ b/app/javascript/src/styles/common/spoiler.scss
@@ -1,23 +1,29 @@
-
-
-.spoiler {
+.styled-dtext .spoiler {
   color: $spoiler-color;
   background: $spoiler-background;
-}
 
-.spoiler a.dtext-link {
-  color: $spoiler-color;
-}
+  a {
+    color: $spoiler-color;
+  }
 
-.spoiler:hover {
-  color: $spoiler-hover-color;
-}
+  .inline-code, pre, blockquote, div.expandable {
+    background-color: $spoiler-background;
+  }
 
-.spoiler:hover a.dtext-link {
-  @include themable {
-    color: themed('color-spoiler-link');
-    &:hover {
-      color: themed('color-spoiler-link-hover');  
+  &:hover {
+    color: $spoiler-hover-color;
+
+    a {
+      @include themable {
+        color: themed('color-spoiler-link');
+        &:hover {
+          color: themed('color-spoiler-link-hover');
+        }
+      }
+    }
+
+    .inline-code {
+      background-color: $dtext-code-background;
     }
   }
 }

--- a/app/javascript/src/styles/common/spoiler.scss
+++ b/app/javascript/src/styles/common/spoiler.scss
@@ -5,14 +5,19 @@
   background: $spoiler-background;
 }
 
-.spoiler a {
-  color: $spoiler-link-color;
+.spoiler a.dtext-link {
+  color: $spoiler-color;
 }
 
 .spoiler:hover {
   color: $spoiler-hover-color;
 }
 
-.spoiler:hover a{
-  color: $spoiler-link-hover-color;
+.spoiler:hover a.dtext-link {
+  @include themable {
+    color: themed('color-spoiler-link');
+    &:hover {
+      color: themed('color-spoiler-link-hover');  
+    }
+  }
 }

--- a/app/javascript/src/styles/themes/_theme_bloodlust.scss
+++ b/app/javascript/src/styles/themes/_theme_bloodlust.scss
@@ -1,5 +1,6 @@
 $bloodlust-color-background: #000000;
 $bloodlust-color-section:    #333333;
+$bloodlust-color-link:       #ffee95;
 $bloodlust-color-link-hover: #f68b00;
 $bloodlust-color-text-muted: #999999;
 
@@ -17,7 +18,7 @@ $theme_bloodlust: (
   "color-text-muted":             $bloodlust-color-text-muted,
   "color-text-white":             #ffffff,
 
-  "color-link":                   #ffee95,
+  "color-link":                   $bloodlust-color-link,
   "color-link-hover":             $bloodlust-color-link-hover,
   "color-link-active":            #ffffff,
 
@@ -33,8 +34,8 @@ $theme_bloodlust: (
 
   // Detail Colors
   "color-detail-quote":           #67717b,
-  "color-detail-code":      #ffe380,
-  "color-detail-expandable":            #427982,
+  "color-detail-code":            #ffe380,
+  "color-detail-expandable":      #427982,
 
   // User Groups
   "color-user-member":            #ffee95,
@@ -50,4 +51,8 @@ $theme_bloodlust: (
   // Tag Categories
   "color-tag-general":            #ffee95,
   "color-tag-general-alt":        #f68b00,
+
+  // Spoilers
+  "color-spoiler-link":           $bloodlust-color-link,
+  "color-spoiler-link-hover":     $bloodlust-color-link-hover,
 );

--- a/app/javascript/src/styles/themes/_theme_hexagon.scss
+++ b/app/javascript/src/styles/themes/_theme_hexagon.scss
@@ -1,4 +1,5 @@
-$hexagon-color-background:        #020F23;
+$hexagon-color-background:        #020f23;
+$hexagon-color-link:              #b4c7d9;
 $hexagon-color-link-hover:        #e9f2fa;
 $hexagon-color-text-muted:        #999999;
 $hexagon-color-section:           #1f3c67;
@@ -21,8 +22,8 @@ $theme_hexagon: (
   "color-text-muted":             #999999,
   "color-text-white":             #ffffff,
 
-  "color-link":                   #b4c7d9,
-  "color-link-hover":             #e9f2fa,
+  "color-link":                   $hexagon-color-link,
+  "color-link-hover":             $hexagon-color-link-hover,
   "color-link-active":            #e8c446,
 
   "color-link-last-page":         $hexagon-color-text-muted,
@@ -90,4 +91,7 @@ $theme_hexagon: (
   "color-tag-pool":               wheat,
   "color-tag-pool-alt":           #d0b27a,
 
+  // Spoilers
+  "color-spoiler-link":           $hexagon-color-link,
+  "color-spoiler-link-hover":     $hexagon-color-link-hover,
 );

--- a/app/javascript/src/styles/themes/_theme_hotdog.scss
+++ b/app/javascript/src/styles/themes/_theme_hotdog.scss
@@ -1,7 +1,7 @@
 $theme_hotdog: (
   // Layout Colors
-  "color-background":             #FFFF00,                // Main background (dark blue, large hexagons)
-  "color-foreground":             #FF0000,                // Foreground (lighter blue, small hexagons)
+  "color-background":             #ffff00,                // Main background (dark blue, large hexagons)
+  "color-foreground":             #ff0000,                // Foreground (lighter blue, small hexagons)
   "color-section":                #c53c38,                // Foreground sections - boxes, sections, etc
 
   // Main Colors
@@ -22,8 +22,8 @@ $theme_hotdog: (
 
   // Detail Colors
   "color-detail-quote":           #67717b,
-  "color-detail-code":      #ffe380,
-  "color-detail-expandable":            #427982,
+  "color-detail-code":            #ffe380,
+  "color-detail-expandable":      #427982,
 
   // User Groups
   "color-user-member":            #000000,
@@ -39,4 +39,8 @@ $theme_hotdog: (
   // Tag Categories
   "color-tag-general":            #000000,
   "color-tag-general-alt":        #999999,
+
+  // Spoilers
+  "color-spoiler-link":           #ffff00,
+  "color-spoiler-link-hover":     #ff0000,
 );

--- a/app/javascript/src/styles/themes/_theme_serpent.scss
+++ b/app/javascript/src/styles/themes/_theme_serpent.scss
@@ -23,8 +23,8 @@ $theme_serpent: (
 
   // Detail Colors
   "color-detail-quote":           #67717b,
-  "color-detail-code":      #ffe380,
-  "color-detail-expandable":            #427982,
+  "color-detail-code":            #ffe380,
+  "color-detail-expandable":      #427982,
 
   // User Groups
   "color-user-member":            #005500,
@@ -40,4 +40,8 @@ $theme_serpent: (
   // Tag Categories
   "color-tag-general":            #005500,
   "color-tag-general-alt":        #3A8F3A,
+
+  // Spoilers
+  "color-spoiler-link":           #44a544,
+  "color-spoiler-link-hover":     #e8c446,
 );


### PR DESCRIPTION
Fixes #272 and some other issues with special elements in spoilers, namely (inline) code, quotes and sections. Links in spoilers now use theme-appropriate colors. I tested this on all themes and it looks fine on all of them.
The styling of code, quotes and sections isn't perfect but it's the best I could come up with and an improvement over the current variant.

Old:
![image](https://user-images.githubusercontent.com/14981592/129411198-744a3cc5-2c72-4258-8b29-02a982773b15.png)
![image](https://user-images.githubusercontent.com/14981592/129411245-7ed54b9e-98e5-497e-94ca-43943dfe3ea2.png)

New:
![image](https://user-images.githubusercontent.com/14981592/129411109-c87d3ac7-388a-4a47-87bc-685ae482fadf.png)
![image](https://user-images.githubusercontent.com/14981592/129411152-defe27c5-ff5b-4b03-a4dc-aca092f8b1e1.png)

Heres the dtext I used in the screenshots:
```
[spoiler]Some very hidden text with `inline code` and a link "to somehere":https://google.com , also [code]code block
abc
def
[/code]
Some more text xyz
[quote]"admin":/user/show/1 said:
test quote `test`
[/quote]
now a section
[section=Expandable]
test abc
[/section]
finish
[/spoiler]
```