### PR TITLE
Display duplicate tickets on create

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -12,6 +12,8 @@ class TicketsController < ApplicationController
   def new
     @ticket = Ticket.new(qtype: params[:type], disp_id: params[:disp_id])
     check_new_permission(@ticket)
+    @duplicates = Ticket.open_duplicates(params[:type], params[:disp_id])
+    @duplicates = @duplicates.select {|t| t.can_see_details?(CurrentUser.user)}
   end
 
   def create

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -646,7 +646,7 @@ class Ticket < ApplicationRecord
     end
   end
 
-  def open_duplicates
+  def self.open_duplicates(qtype, disp_id)
     Ticket.where('qtype = ? and disp_id = ? and status = ?', qtype, disp_id, 'pending')
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -176,14 +176,6 @@ class Ticket < ApplicationRecord
       def can_create_for?(user)
         forum.visible?(user)
       end
-
-      def can_see_details?(user)
-        if forum
-          forum.visible?(user)
-        else
-          true
-        end
-      end
     end
 
     module CommentType

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -21,6 +21,12 @@
         </div>
       <% elsif @ticket.type_valid %>
         <%= render partial: "tickets/new_types/#{@ticket.qtype}" %>
+        <% if @duplicates.any? %>
+          <p class='nomargin'>There are already pending tickets. Please check them before filing one yourself: 
+          <% @duplicates.each do |dup| %>
+            <%= link_to("ticket ##{dup.id}", ticket_path(dup.id)) %>
+          <% end %></p>
+        <% end %>
       <% else %>
         <% @found_item = false %>
         <div class='section' style='width:80em;'>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -47,7 +47,7 @@
           <tr>
             <td><span class="title">Open Duplicates</span></td>
             <td><ul>
-              <% @ticket.open_duplicates.where('id != ?', @ticket.id).find_each do |dup| %>
+              <% Ticket.open_duplicates(@ticket.qtype, @ticket.disp_id).where('id != ?', @ticket.id).find_each do |dup| %>
               <li><%= link_to("Ticket #{dup.id} - #{dup.subject}", ticket_path(dup.id)) %></li>
               <% end %>
             </ul></td>


### PR DESCRIPTION
Show the user a notice when they are reporting something that is already reported, if they are able to view the tickets. User reports and other restricted tickets will not be shown. Only tickets directly visible to the user are considered.

![image](https://user-images.githubusercontent.com/14981592/129442746-60fb48f9-44c6-4181-a7c2-18681e92ef52.png)

Also makes it possble to view forum post tickets after the forum post has been hidden. Previously you could'nt even view your own tickets after they have been handled (and from other users as well). This matches the behavious of the other ticket types for public resources.