### PR TITLE
Small things

### DIFF
--- a/app/javascript/src/javascripts/forum_posts.js
+++ b/app/javascript/src/javascripts/forum_posts.js
@@ -8,14 +8,15 @@ ForumPost.initialize_all = function() {
     $(".forum-post-reply-link").on('click', ForumPost.quote);
     $(".forum-post-hide-link").on('click', ForumPost.hide);
     $(".forum-post-unhide-link").on('click', ForumPost.unhide);
-    $(".forum-vote-up").on('click', ForumPost.vote_up);
-    $(".forum-vote-meh").on('click', ForumPost.vote_meh);
-    $(".forum-vote-down").on('click', ForumPost.vote_down);
+    $(".forum-vote-up").on('click', evt => ForumPost.vote(evt, 1));
+    $(".forum-vote-meh").on('click', evt => ForumPost.vote(evt, 0));
+    $(".forum-vote-down").on('click', evt => ForumPost.vote(evt, -1));
     $(document).on('click', ".forum-vote-remove", ForumPost.vote_remove);
   }
 }
 
-ForumPost.vote = function(id, score) {
+ForumPost.vote = function(evt, score) {
+  evt.preventDefault();
   const create_post = function(new_vote) {
     const score_map = {'1': 'fa-thumbs-up', '0': 'fa-meh', '-1': 'fa-thumbs-down' };
     const score_map_2 = {'1': 'up', '0': 'meh', '-1': 'down'};
@@ -25,6 +26,7 @@ ForumPost.vote = function(id, score) {
     container.append(link1).append(' ').append(link2);
     $(`#forum-post-votes-for-${new_vote.forum_post_id}`).prepend(container);
   };
+  const id = $(evt.target.parentNode).data('forum-id');
   $.ajax({
     url: `/forum_posts/${id}/votes.json`,
     type: 'POST',
@@ -39,19 +41,8 @@ ForumPost.vote = function(id, score) {
   });
 }
 
-ForumPost.vote_up = function(evt) {
-  ForumPost.vote($(evt.target.parentNode).data('forum-id'), 1);
-}
-
-ForumPost.vote_meh = function(evt) {
-  ForumPost.vote($(evt.target.parentNode).data('forum-id'), 0);
-}
-
-ForumPost.vote_down = function(evt) {
-  ForumPost.vote($(evt.target.parentNode).data('forum-id'), -1);
-}
-
 ForumPost.vote_remove = function(evt) {
+  evt.preventDefault();
   const id = $(evt.target.parentNode).data('forum-id');
   $.ajax({
     url: `/forum_posts/${id}/votes.json`,

--- a/app/javascript/src/javascripts/uploader.vue
+++ b/app/javascript/src/javascripts/uploader.vue
@@ -14,6 +14,7 @@
                     <div v-if="!disableFileUpload">
                         <label>File:
                             <input type="file" ref="post_file" @change="updatePreview" @keyup="updatePreview"
+                                   accept="image/png,image/apng,image/jpeg,image/gif,video/webm,.png,.apng,.jpg,.jpeg,.gif,.webm"
                                    :disabled="disableFileUpload"/>
                         </label>
                         <button @click="clearFile" v-show="disableURLUpload">Clear</button>

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -261,7 +261,7 @@ class PostQueryBuilder
     if q[:flagger_ids_neg]
       q[:flagger_ids_neg].each do |flagger_id|
         if CurrentUser.can_view_flagger?(flagger_id)
-          post_ids = PostFlag.unscoped.search({:creator_id => flagger_id, :category => "normal"}).reorder("").select {|flag| flag.not_uploaded_by?(CurrentUser.id)}.map {|flag| flag.post_id}.uniq
+          post_ids = PostFlag.unscoped.search({:creator_id => flagger_id, :category => "normal"}).reorder("").pluck(:post_id).uniq
           if post_ids.any?
             relation = relation.where.not("posts.id": post_ids)
           end
@@ -276,7 +276,7 @@ class PostQueryBuilder
         elsif flagger_id == "none"
           relation = relation.where('NOT EXISTS (' + PostFlag.unscoped.search({:category => "normal"}).where('post_id = posts.id').reorder('').select('1').to_sql + ')')
         elsif CurrentUser.can_view_flagger?(flagger_id)
-          post_ids = PostFlag.unscoped.search({:creator_id => flagger_id, :category => "normal"}).reorder("").select {|flag| flag.not_uploaded_by?(CurrentUser.id)}.map {|flag| flag.post_id}.uniq
+          post_ids = PostFlag.unscoped.search({:creator_id => flagger_id, :category => "normal"}).reorder("").pluck(:post_id).uniq
           relation = relation.where("posts.id": post_ids)
         end
       end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -342,10 +342,11 @@ class Artist < ApplicationRecord
     end
 
     def notes=(text)
-      if notes != text
-        notes_will_change!
-        @notes = text
-      end
+      return if wiki_page.blank? && text.empty?
+      return if notes == text
+
+      notes_will_change!
+      @notes = text
     end
 
     def reload(options = nil)

--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -1,5 +1,4 @@
 class PostArchive < ApplicationRecord
-  class RevertError < Exception ; end
   extend Memoist
 
   belongs_to :post
@@ -330,8 +329,6 @@ class PostArchive < ApplicationRecord
   end
 
   def undo
-    raise RevertError unless post.visible?
-
     if description_changed
       post.description = previous.description
     end
@@ -374,12 +371,11 @@ class PostArchive < ApplicationRecord
   end
 
   def can_undo?(user)
-    return version > 1 if user.is_admin?
-    version > 1 && post&.visible? && user.is_member?
+    version > 1 && user.is_member?
   end
 
   def can_revert_to?(user)
-    post&.visible? && user.is_member?
+    user.is_member?
   end
 
   def method_attributes

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -68,7 +68,6 @@ class PostFlag < ApplicationRecord
 
       if params[:creator_id].present?
         if CurrentUser.can_view_flagger?(params[:creator_id].to_i)
-          q = q.where.not(post_id: CurrentUser.user.posts)
           q = q.where("creator_id = ?", params[:creator_id].to_i)
         else
           q = q.none
@@ -78,7 +77,6 @@ class PostFlag < ApplicationRecord
       if params[:creator_name].present?
         flagger_id = User.name_to_id(params[:creator_name].strip)
         if flagger_id && CurrentUser.can_view_flagger?(flagger_id)
-          q = q.where.not(post_id: CurrentUser.user.posts)
           q = q.where("creator_id = ?", flagger_id)
         else
           q = q.none
@@ -236,14 +234,6 @@ class PostFlag < ApplicationRecord
 
   def flag_count_for_creator
     PostFlag.where(:creator_id => creator_id).recent.count
-  end
-
-  def uploader_id
-    @uploader_id ||= Post.find(post_id).uploader_id
-  end
-
-  def not_uploaded_by?(userid)
-    uploader_id != userid
   end
 
   def parent_post

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -271,7 +271,7 @@ class PostPresenter < Presenter
   end
 
   def has_sequential_navigation?(params)
-    return false if Tag.has_metatag?(params[:q], :order, :ordfav, :ordpool)
+    return false if Tag.has_metatag?(params[:q], :order, :ordpool)
     return false if params[:pool_id].present? || params[:post_set_id].present?
     true
   end

--- a/app/views/bans/show.html.erb
+++ b/app/views/bans/show.html.erb
@@ -9,9 +9,10 @@
         </div>
       </li>
     </ul>
-
-    <%= form_tag(ban_path(@ban), :method => :delete) do %>
-      <%= submit_tag "Unban" %>
+    <% if CurrentUser.is_moderator? %>
+      <%= form_tag(ban_path(@ban), :method => :delete) do %>
+        <%= submit_tag "Unban" %>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/help/_form.html.erb
+++ b/app/views/help/_form.html.erb
@@ -1,5 +1,5 @@
-<%= f.input :name, hint: "This is the link for the help page (e.g., <code>tag_scripts</code> for <code>help/show/tag_scripts</code>).".html_safe %>
+<%= f.input :name, hint: "This is the link for the help page (e.g., <code>tag_scripts</code> for <code>help/tag_scripts</code>).".html_safe %>
 <%= f.input :title, hint: 'This is for adding custom titles. If left blank the name field will be used instead.' %>
 <%= f.input :wiki_page, hint: 'The wiki page you want to display.' %>
-<%= f.input :related, hint: 'The related help pages you want to link to. They show up at the top of this help page.' %>
+<%= f.input :related, hint: 'The related help pages you want to link to. They show up at the top of this help page. <br> Seperate with a comma followed by a space (e.g. <code>dtext, forum</code>).'.html_safe %>
 <%= f.button :submit, "Save" %>

--- a/app/views/post_sets/show.html.erb
+++ b/app/views/post_sets/show.html.erb
@@ -20,7 +20,7 @@
     <span class="date" title="<%= @post_set.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@post_set.created_at) + " ago" %></span>
     |
     Updated:
-    <span class="date" title="<%= @post_set.updated_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@post_set.updated_at) + " ago" %></span><br/>
+    <span class="date" title="<%= @post_set.updated_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@post_set.updated_at) + " ago" %></span><br/><br/>
 
     <% if @post_set.description.blank? %>
       <div class='set-description'>No description.</div>

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,6 +1,6 @@
 <div id="c-tags">
   <div id="a-show">
-    <h1>Tag: <%= @tag.name %></h1>
+    <h1>Tag: <%= link_to @tag.name, posts_path(:tags => @tag.name), :class => "tag-type-#{@tag.category}" %></h1>
 
     <ul>
       <li>Count: <%= @tag.post_count %></li>

--- a/test/unit/post_flag_test.rb
+++ b/test/unit/post_flag_test.rb
@@ -144,30 +144,6 @@ class PostFlagTest < ActiveSupport::TestCase
       end
     end
 
-    context "a moderator user" do
-      setup do
-        travel_to(2.weeks.ago) do
-          @dave = create(:moderator_user)
-        end
-      end
-
-      should "not be able to view flags on their own uploads" do
-        @modpost = create(:post, :tag_string => "mmm", :uploader => @dave)
-        as(@alice) do
-          @flag1 = PostFlag.create(:post => @modpost, :reason => "aaa", :is_resolved => false)
-        end
-
-        assert_equal(false, @dave.can_view_flagger_on_post?(@flag1))
-
-        as(@dave) do
-          flag2 = PostFlag.search(:creator_id => @alice.id)
-          assert_equal(0, flag2.length)
-          flag3 = PostFlag.search({})
-          assert_nil(JSON.parse(flag3.to_json)[0]["creator_id"])
-        end
-      end
-    end
-
     context "a user with no_flag=true" do
       setup do
         travel_to(2.weeks.ago) do


### PR DESCRIPTION
1. Hide the unban button on ban show if no permissions
2. Add a note on how to link to multiple other help pages
3. Colorize the tag and link to a search on tag show
4. Prevent unnecessary note changes when saving to artists. I already tried to do this previously, this way should work better. If there is no wiki page and no entered text there cannot be note changes, which where the conditions I tried to fix.
5. Do not filter out your own posts when searching for flags by creator. I believe the reason for that was to hide the flagger for those who can actually see them, like janitors or admins. But in my opinion this isn't needed. There are also a variety of ways to circumvent this, like going to the post directly to view the flagger.
6. I also removed some dead post query code I noticed because I wanted to test `q[:flagger_ids]` and `q[:flagger_ids_neg]` but those and a few others are not filled anymore
7. Fixes #289.  f20cdc5363214ddd86b32f7a7a24b2cdf69016c0 made it possible  to edit deleted posts for normal users. Both the undo and revert to methods already have access checks if the user is allowed to edit the post or not, depending on the post edit throttle.

Added 2021-08-24:

8. Default the uploaders file picker dialogue to only show files that are actually uploadable. This doesn't prevent uploading of other files, you just have to select this manually.
9. Add some padding to the set description. I found it  dificult to quickly see where it actually starts.
![image](https://user-images.githubusercontent.com/14981592/130646027-015cf8e9-e588-4cf2-b7bc-10ce745711ed.png)
![image](https://user-images.githubusercontent.com/14981592/130645899-01d65bba-4732-4f16-8aa4-a8032a69793e.png)
10. Prevent defaults when  voting on forum posts. This prevents scrolling all the way to the top and keeps the browser history clean.
