### PR TITLE
[DText] Prevent content from overflowing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,6 +82,14 @@ module ApplicationHelper
   end
 
   def format_text(text, **options)
+    raw %(<div class="dtext-content">#{dtext_ragel(text, options)}</div>)
+  end
+
+  def strip_dtext(text)
+    dtext_ragel(text, strip: true)
+  end
+
+  def dtext_ragel(text, **options)
     options.merge!(disable_mentions: true)
     parsed = DTextRagel.parse(text, **options)
     return raw "" if parsed.nil?
@@ -89,10 +97,6 @@ module ApplicationHelper
     raw parsed[0]
   rescue DTextRagel::Error => e
     raw ""
-  end
-
-  def strip_dtext(text)
-    format_text(text, strip: true)
   end
 
   def error_messages_for(instance_name)

--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -1,6 +1,10 @@
+.styled-dtext  {
+  display: grid;
+}
 
-
-.styled-dtext {
+.dtext-content {
+  overflow: auto;
+  display: inline;
   line-height: 1.4em;
 
   h1, h2, h3 {

--- a/app/javascript/src/styles/common/spoiler.scss
+++ b/app/javascript/src/styles/common/spoiler.scss
@@ -1,4 +1,4 @@
-.styled-dtext .spoiler {
+.dtext-content .spoiler {
   color: $spoiler-color;
   background: $spoiler-background;
 


### PR DESCRIPTION
Prevent dtext from overflowing out of its content box with deeply nested dtext or spooky zaglo text.

Here's some before/after footage. Ignore the pause in the middle, I'm restarting the server.
https://user-images.githubusercontent.com/14981592/130659211-4d679a81-1ee0-4f17-be4c-a527381e5f44.mp4

Stuff seems to work fine with this change, though testing this extensively is not that easy for me since I'm missing some real world data. I'll test this some more myself at a later date.
