### PR TITLE
[Rails] Allow easy disable of the cache_store

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -192,6 +192,10 @@ fart'
       false
     end
 
+    def disable_cache_store
+      false
+    end
+
     # Members cannot post more than X comments in an hour.
     def member_comment_limit
       15

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,18 +16,16 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
+  # Does not affect the cache_store
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
 
   # Don't care if the mailer can't send.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,8 +41,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -54,9 +54,6 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,7 +24,6 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,41 +1,17 @@
-# Rails.application.configure do
-#   if Rails.env.test? || Danbooru.
-#     cache_config = [:memory_store, { size: 32.megabytes }]
-#   else
-#     cache_config = [
-#         :redis_cache_store,
-#         {
-#             url: Danbooru.config.redis_url,
-#             namespace: Danbooru.config.safe_app_name,
-#             connect_timeout:   30, # default: 20 seconds
-#             write_timeout:    0.2, # default: 1 second
-#             read_timeout:     0.2, # default: 1 second
-#             reconnect_attempts: 0, # default: 0
-#             error_handler: ->(method:, returning:, exception:) {
-#               DanbooruLogger.log(exception, method: method, returning: returning)
-#             }
-#         }
-#     ]
-#   end
-#
-#   cache_store = ActiveSupport::Cache.lookup_store(cache_config)
-#
-#   config.cache_store = cache_store
-#   config.action_controller.cache_store = cache_store
-#   Rails.cache = cache_store
-# end
-
+def get_cache_store
+  if Rails.env.test?
+    [:memory_store, { size: 32.megabytes }]
+  elsif Danbooru.config.disable_cache_store
+    :null_store
+  else
+    [:mem_cache_store, Danbooru.config.memcached_servers, { namespace: Danbooru.config.safe_app_name }]
+  end
+end
 
 Rails.application.configure do
   begin
-    if Rails.env.test?
-      config.cache_store = :memory_store, { size: 32.megabytes }
-      config.action_controller.cache_store = :memory_store, { size: 32.megabytes }
-      Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
-    else
-      config.cache_store = :mem_cache_store, Danbooru.config.memcached_servers, { namespace: Danbooru.config.safe_app_name }
-      config.action_controller.cache_store = :mem_cache_store, Danbooru.config.memcached_servers, { namespace: Danbooru.config.safe_app_name }
-      Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
-    end
+    config.cache_store = get_cache_store
+    config.action_controller.cache_store = get_cache_store
+    Rails.cache = ActiveSupport::Cache.lookup_store(Rails.application.config.cache_store)
   end
 end


### PR DESCRIPTION
Setting it in the individual environment config does not work because it
was overwritten by the cache_store.rb initializer

I was removing the cache logic every time I wanted to test something which is cached. Setting it in the evironment file (like with `rails  dev:cache`) had no effect which I asume is because those get loaded before the initializers. 