### PR TITLE
Add subheader menus to the pages that are missing them

### DIFF
--- a/app/views/admin/_secondary_links.html.erb
+++ b/app/views/admin/_secondary_links.html.erb
@@ -1,8 +1,12 @@
 <% content_for(:secondary_links) do %>
   <menu>
     <%= subnav_link_to "Dashboard", admin_dashboard_path %>
+    <li>|</li>
     <%= subnav_link_to "Exceptions", admin_exceptions_path %>
     <%= subnav_link_to "Staff Notes", admin_staff_notes_path %>
     <%= subnav_link_to "BUR Import", new_admin_alias_and_implication_import_path %>
+    <li>|</li>
+    <%= subnav_link_to "Post  Votes", controller: "/post_votes", action: "index" %>
+    <%= subnav_link_to "Comment Votes", controller: "/comment_votes", action: "index" %>
   </menu>
 <% end %>

--- a/app/views/admin/_secondary_links.html.erb
+++ b/app/views/admin/_secondary_links.html.erb
@@ -1,0 +1,8 @@
+<% content_for(:secondary_links) do %>
+  <menu>
+    <%= subnav_link_to "Dashboard", admin_dashboard_path %>
+    <%= subnav_link_to "Exceptions", admin_exceptions_path %>
+    <%= subnav_link_to "Staff Notes", admin_staff_notes_path %>
+    <%= subnav_link_to "BUR Import", new_admin_alias_and_implication_import_path %>
+  </menu>
+<% end %>

--- a/app/views/admin/alias_and_implication_imports/new.html.erb
+++ b/app/views/admin/alias_and_implication_imports/new.html.erb
@@ -39,6 +39,8 @@ mass update aaa -> bbb
   </div>
 </div>
 
+<%= render "admin/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Alias &amp; Implication Import
 <% end %>

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -24,6 +24,8 @@
   </div>
 </div>
 
+<%= render "admin/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Admin Dashboard
 <% end %>

--- a/app/views/admin/exceptions/index.html.erb
+++ b/app/views/admin/exceptions/index.html.erb
@@ -25,6 +25,8 @@
   </tbody>
 </table>
 
+<%= render "admin/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Exceptions
 <% end %>

--- a/app/views/admin/exceptions/show.html.erb
+++ b/app/views/admin/exceptions/show.html.erb
@@ -17,6 +17,8 @@
   <pre class="box-section"><%= @exception_log.trace %></pre>
 </div>
 
+<%= render "admin/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Exceptions - <%= @exception_log.code %>
 <% end %>

--- a/app/views/comment_votes/index.html.erb
+++ b/app/views/comment_votes/index.html.erb
@@ -68,7 +68,7 @@
   </div>
 </div>
 
-<%= render "static/secondary_empty" %>
+<%= render "admin/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Comment Votes

--- a/app/views/comment_votes/index.html.erb
+++ b/app/views/comment_votes/index.html.erb
@@ -68,6 +68,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Comment Votes
 <% end %>

--- a/app/views/deleted_posts/index.html.erb
+++ b/app/views/deleted_posts/index.html.erb
@@ -26,6 +26,8 @@
   <%= numbered_paginator(@posts) %>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Deleted Posts
 <% end %>

--- a/app/views/deleted_posts/index.html.erb
+++ b/app/views/deleted_posts/index.html.erb
@@ -26,7 +26,7 @@
   <%= numbered_paginator(@posts) %>
 </div>
 
-<%= render "static/secondary_empty" %>
+<%= render "mod_actions/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Deleted Posts

--- a/app/views/dmails/_secondary_links.html.erb
+++ b/app/views/dmails/_secondary_links.html.erb
@@ -1,13 +1,13 @@
 <% content_for(:secondary_links) do %>
   <menu>
-    <li><%= render "quick_search" %></li>
+    <li><%= render "dmails/quick_search" %></li>
     <%= subnav_link_to "All", all_dmails_path(set_default_folder: true) %>
     <%= subnav_link_to "Received", received_dmails_path(set_default_folder: true) %>
     <%= subnav_link_to "Sent", sent_dmails_path(set_default_folder: true) %>
     <%= subnav_link_to "Spam", spam_dmails_path %>
     <li>|</li>
     <%= subnav_link_to "New", new_dmail_path %>
-    <%= subnav_link_to "Mark all as read", {:controller => "dmails", :action => "mark_all_as_read"}, :method => :post%></li>
+    <%= subnav_link_to "Mark all as read", {:controller => "/dmails", :action => "mark_all_as_read"}, :method => :post%></li>
     <li>|</li>
     <%= subnav_link_to "Help", help_page_path(id: "dmail") %>
   </menu>

--- a/app/views/edit_histories/_secondary_links.html.erb
+++ b/app/views/edit_histories/_secondary_links.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:secondary_links) do %>
+  <menu>
+    <%= subnav_link_to "Listing", edit_histories_path %>
+  </menu>
+<% end %>

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -36,6 +36,8 @@
   </div>
 </div>
 
+<%= render "edit_histories/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Edit Histories
 <% end %>

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -25,6 +25,8 @@
   </div>
 </div>
 
+<%= render "edit_histories/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Edit History
 <% end %>

--- a/app/views/iqdb_queries/show.html.erb
+++ b/app/views/iqdb_queries/show.html.erb
@@ -22,6 +22,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Similar Images Search
 <% end %>

--- a/app/views/maintenance/user/api_keys/show.html.erb
+++ b/app/views/maintenance/user/api_keys/show.html.erb
@@ -10,6 +10,8 @@
   </div>
 </div>
 
+<%= render "users/secondary_links" %>
+
 <% content_for(:page_title) do %>
   API Key
 <% end %>

--- a/app/views/maintenance/user/api_keys/view.html.erb
+++ b/app/views/maintenance/user/api_keys/view.html.erb
@@ -27,6 +27,8 @@
   </div>
 </div>
 
+<%= render "users/secondary_links" %>
+
 <% content_for(:page_title) do %>
   API Key
 <% end %>

--- a/app/views/maintenance/user/count_fixes/new.html.erb
+++ b/app/views/maintenance/user/count_fixes/new.html.erb
@@ -10,6 +10,8 @@
   </div>
 </div>
 
+<%= render "users/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Refresh Counts
 <% end %>

--- a/app/views/maintenance/user/deletions/show.html.erb
+++ b/app/views/maintenance/user/deletions/show.html.erb
@@ -34,6 +34,8 @@
   </div>
 </div>
 
+<%= render "users/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Delete Account
 <% end %>

--- a/app/views/maintenance/user/dmail_filters/edit.html.erb
+++ b/app/views/maintenance/user/dmail_filters/edit.html.erb
@@ -32,6 +32,8 @@
   </div>
 </div>
 
+<%= render "dmails/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Edit Message Filters
 <% end %>

--- a/app/views/maintenance/user/email_changes/new.html.erb
+++ b/app/views/maintenance/user/email_changes/new.html.erb
@@ -26,6 +26,8 @@
   </div>
 </div>
 
+<%= render "users/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Change Email
 <% end %>

--- a/app/views/maintenance/user/passwords/edit.html.erb
+++ b/app/views/maintenance/user/passwords/edit.html.erb
@@ -11,6 +11,8 @@
   </div>
 </div>
 
+<%= render "users/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Change Password
 <% end %>

--- a/app/views/mod_actions/_secondary_links.html.erb
+++ b/app/views/mod_actions/_secondary_links.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:secondary_links) do %>
+  <menu>
+    <%= subnav_link_to "Mod Actions", mod_actions_path %>
+    <li>|</li>
+    <%= subnav_link_to "Approvals", post_approvals_path %>
+    <% if CurrentUser.can_approve_posts? %>
+        <%= subnav_link_to "Disapprovals", moderator_post_disapprovals_path %>
+    <% end %>
+    <%= subnav_link_to "Deletions", deleted_posts_path %>
+  </menu>
+<% end %>
+

--- a/app/views/mod_actions/index.html.erb
+++ b/app/views/mod_actions/index.html.erb
@@ -27,6 +27,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Mod Actions
 <% end %>

--- a/app/views/mod_actions/index.html.erb
+++ b/app/views/mod_actions/index.html.erb
@@ -27,7 +27,7 @@
   </div>
 </div>
 
-<%= render "static/secondary_empty" %>
+<%= render "mod_actions/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Mod Actions

--- a/app/views/moderator/_secondary_links.html.erb
+++ b/app/views/moderator/_secondary_links.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:secondary_links) do %>
+  <menu>
+    <%= subnav_link_to "Dashboard", moderator_dashboard_path %>
+    <%= subnav_link_to "IP Addresses", moderator_ip_addrs_path %>
+  </menu>
+<% end %>

--- a/app/views/moderator/dashboards/show.html.erb
+++ b/app/views/moderator/dashboards/show.html.erb
@@ -22,6 +22,8 @@
   </div>
 </div>
 
+<%= render "moderator/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Mod Dashboard
 <% end %>

--- a/app/views/moderator/ip_addrs/index.html.erb
+++ b/app/views/moderator/ip_addrs/index.html.erb
@@ -18,6 +18,8 @@
   </div>
 </div>
 
+<%= render "moderator/secondary_links" %>
+
 <% content_for(:page_title) do %>
   IP Addresses
 <% end %>

--- a/app/views/moderator/post/disapprovals/index.html.erb
+++ b/app/views/moderator/post/disapprovals/index.html.erb
@@ -49,7 +49,7 @@
   </div>
 </div>
 
-<%= render "static/secondary_empty" %>
+<%= render "mod_actions/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Post Disapprovals

--- a/app/views/moderator/post/disapprovals/index.html.erb
+++ b/app/views/moderator/post/disapprovals/index.html.erb
@@ -49,6 +49,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Post Disapprovals
 <% end %>

--- a/app/views/moderator/post/posts/confirm_delete.html.erb
+++ b/app/views/moderator/post/posts/confirm_delete.html.erb
@@ -32,6 +32,8 @@
   <%= submit_tag "Cancel" %>
 <% end %>
 
+<%= render "posts/partials/common/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Delete Post - #<%= @post.id %>
 <% end %>

--- a/app/views/moderator/post/posts/confirm_move_favorites.html.erb
+++ b/app/views/moderator/post/posts/confirm_move_favorites.html.erb
@@ -11,6 +11,8 @@
   <%= submit_tag "Cancel" %>
 <% end %>
 
+<%= render "posts/partials/common/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Move Favorites - #<%= @post.id %>
 <% end %>

--- a/app/views/post_appeals/index.html.erb
+++ b/app/views/post_appeals/index.html.erb
@@ -54,6 +54,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Appeals
 <% end %>

--- a/app/views/post_appeals/new.html.erb
+++ b/app/views/post_appeals/new.html.erb
@@ -4,6 +4,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   New Appeal - #<%= @post_appeal.post_id %>
 <% end %>

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -37,6 +37,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Approvals
 <% end %>

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -37,7 +37,7 @@
   </div>
 </div>
 
-<%= render "static/secondary_empty" %>
+<%= render "mod_actions/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Approvals

--- a/app/views/post_events/index.html.erb
+++ b/app/views/post_events/index.html.erb
@@ -32,6 +32,8 @@
   </div>
 </div>
 
+<%= render "posts/partials/common/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Events
 <% end %>

--- a/app/views/post_flags/_secondary_links.html.erb
+++ b/app/views/post_flags/_secondary_links.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:secondary_links) do %>
+  <menu>
+    <%= subnav_link_to "Listing", post_flags_path %>
+    <%= subnav_link_to "Help", help_page_path(id: "flag_reasons") %>
+  </menu>
+<% end %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -62,6 +62,8 @@
   </div>
 </div>
 
+<%= render "post_flags/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Flags
 <% end %>

--- a/app/views/post_flags/new.html.erb
+++ b/app/views/post_flags/new.html.erb
@@ -4,6 +4,8 @@
   </div>
 </div>
 
+<%= render "post_flags/secondary_links" %>
+
 <% content_for(:page_title) do %>
   New Flag - #<%= @post_flag.post_id %>
 <% end %>

--- a/app/views/post_replacements/_secondary_links.html.erb
+++ b/app/views/post_replacements/_secondary_links.html.erb
@@ -1,0 +1,5 @@
+<% content_for(:secondary_links) do %>
+  <menu>
+    <%= subnav_link_to "Listing", post_replacements_path %>
+  </menu>
+<% end %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -101,6 +101,8 @@
   </div>
 </div>
 
+<%= render "post_replacements/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Post Replacements
 <% end %>

--- a/app/views/post_replacements/new.html.erb
+++ b/app/views/post_replacements/new.html.erb
@@ -4,6 +4,8 @@
   </div>
 </div>
 
+<%= render "post_replacements/secondary_links" %>
+
 <% content_for(:page_title) do %>
   New Post Replacement - #<%= @post_replacement.post_id %>
 <% end %>

--- a/app/views/post_votes/index.html.erb
+++ b/app/views/post_votes/index.html.erb
@@ -65,7 +65,7 @@
   </div>
 </div>
 
-<%= render "static/secondary_empty" %>
+<%= render "admin/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Post Votes

--- a/app/views/post_votes/index.html.erb
+++ b/app/views/post_votes/index.html.erb
@@ -65,6 +65,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Post Votes
 <% end %>

--- a/app/views/static/404.html.erb
+++ b/app/views/static/404.html.erb
@@ -3,3 +3,5 @@
 <% content_for(:page_title) do %>
   Not Found
 <% end %>
+
+<%= render "static/secondary_empty" %>

--- a/app/views/static/_secondary_empty.html.erb
+++ b/app/views/static/_secondary_empty.html.erb
@@ -1,0 +1,3 @@
+<% content_for(:secondary_links) do %>
+    <menu class="secondary">&nbsp;</menu>
+<% end %>

--- a/app/views/static/access_denied.html.erb
+++ b/app/views/static/access_denied.html.erb
@@ -4,6 +4,8 @@
 
 <%= link_to "Go back", :back, :rel => "prev" %>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Access Denied
 <% end %>

--- a/app/views/static/bookmarklet.html.erb
+++ b/app/views/static/bookmarklet.html.erb
@@ -25,6 +25,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Bookmarklet
 <% end %>

--- a/app/views/static/contact.html.erb
+++ b/app/views/static/contact.html.erb
@@ -9,6 +9,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Contact
 <% end %>

--- a/app/views/static/discord.html.erb
+++ b/app/views/static/discord.html.erb
@@ -10,6 +10,8 @@
   <% end %>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Discord Server
 <% end %>

--- a/app/views/static/error.html.erb
+++ b/app/views/static/error.html.erb
@@ -10,6 +10,8 @@
   <p>An error happened but there are no details provided. That's pretty odd.</p>
 <% end %>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Unexpected Error
 <% end %>

--- a/app/views/static/keyboard_shortcuts.html.erb
+++ b/app/views/static/keyboard_shortcuts.html.erb
@@ -63,6 +63,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Keyboard Shortcuts
 <% end %>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -131,6 +131,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Site Map
 <% end %>

--- a/app/views/static/takedown.html.erb
+++ b/app/views/static/takedown.html.erb
@@ -27,6 +27,8 @@
 </div>
 <div class="Clear">&nbsp;</div>
 
+<%= render "takedowns/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Takedown Policy
 <% end %>

--- a/app/views/static/terms_of_service.html.erb
+++ b/app/views/static/terms_of_service.html.erb
@@ -11,6 +11,8 @@
   <% end %>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Rules
 <% end %>

--- a/app/views/static/theme.html.erb
+++ b/app/views/static/theme.html.erb
@@ -91,6 +91,8 @@
   });
 <% end -%>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Themes
 <% end %>

--- a/app/views/static/theme.html.erb
+++ b/app/views/static/theme.html.erb
@@ -32,7 +32,7 @@
     </select>
   </div>
   <div class="input">
-    <lablel for="theme_navbar">Navigation bar location</lablel>
+    <label for="theme_navbar">Navigation bar location</label>
     <select id="theme_navbar">
       <option value="top">Top(default)</option>
       <option value="bottom">Bottom</option>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -442,6 +442,8 @@
   </div>
 </div>
 
+<%= render "static/secondary_empty" %>
+
 <% content_for(:page_title) do %>
   Stats
 <% end %>

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -18,6 +18,8 @@
   </div>
 </div>
 
+<%= render "tags/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Tag Correction
 <% end %>

--- a/app/views/tag_type_versions/index.html.erb
+++ b/app/views/tag_type_versions/index.html.erb
@@ -36,6 +36,8 @@
   </div>
 </div>
 
+<%= render "tags/secondary_links" %>
+
 <% content_for(:page_title) do %>
   Tag Type Versions
 <% end %>

--- a/app/views/users/upload_limit.html.erb
+++ b/app/views/users/upload_limit.html.erb
@@ -43,6 +43,8 @@
   <% end %>
 </div>
 
+<%= render "secondary_links" %>
+
 <% content_for(:page_title) do %>
   Upload Limit
 <% end %>


### PR DESCRIPTION
This is a pretty simple fix that restores subheaders on the pages that were missing them.

![comparison](https://user-images.githubusercontent.com/1503448/135388310-a01a6e72-4182-476e-94ec-100d36516254.png)

It's not a critical issue, but it's somewhat irritating from a user experience.
Without this, the site layout shifts up and down when navigating between certain pages.

Most affected pages get a blank header, just to properly space things out:
- `iqdb_queries`
- `post_appeals`
- `static/404`
- `static/access_denied`
- `static/bookmarklet`
- `static/contact`
- `static/discord`
- `static/error`
- `static/keyboard_shortcuts`
- `static/site_map`
- `static/terms_of_service`
- `static/theme`
- `stats`

Some pages inherited sheaders from other relevant pages:
- `maintenance/user/api_keys`  [users]
- `maintenance/user/count_fixes` [users]
- `maintenance/user/deletions` [users]
- `maintenance/user/dmail_filters` [dmails]
- `maintenance/user/email_changes` [users]
- `maintenance/user/passwords` [users]
- `moderator/post/posts/confirm_delete` [posts]
- `moderator/post/posts/confirm_move_favorites` [posts]
- `post_events` [posts]
- `static/takedown` [takedowns]
- `tag_corrections` [tags]
- `tag_type_versions` [tags]
- `users/upload_limit` [users]

Other pages were given custom subheaders:
- `admin/alias_and_implication_imports`
- `admin/dashboards`
- `admin/exceptions`
- `comment_votes`
- `deleted_posts`
- `edit_histories`
- `mod_actions`
- `moderator/dashboards`
- `moderator/ip_addrs`
- `moderator/post/disapprovals`
- `post_approvals`
- `post_flags`
- `post_replacements`
- `post_votes`