### PR TITLE
Always show the wiki link on the artist page

### DIFF
--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -8,6 +8,8 @@
       </div>
 
       <p><%= link_to "View wiki page", @artist.wiki_page %></p>
+    <% else %>
+      <p><%= link_to "View wiki page", show_or_new_wiki_pages_path(:title => @artist.name) %></p>
     <% end %>
 
     <%= yield %>


### PR DESCRIPTION
This is made to address #316.

Clicking on the `?` link next to the tag in the post's sidebar takes you to the artist page, instead of a normal wiki page, if that tag belongs to the artist category.
Unlike with the normal wiki page, the artist page does not show any aliases or implications the tag may or may not have. That means that in order to look those up, you would have to open a different page and run a separate search.
While this is not the worst thing in the world, having to do that over and over again is irritating.

With this fix, if the artist page does not exist, or lacks a corresponding wiki page, a `/wiki_pages/show_or_new` link is displayed instead.

![wiki](https://user-images.githubusercontent.com/1503448/135397282-7b67a55d-a695-473f-b28a-ac24c65c3c1e.png)

It's not the prettiest solution, but it's definitely the most straightforward one.