### PR TITLE
Flag page redesign

### DIFF
--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -557,10 +557,6 @@ section#image-extra-controls {
   }
 }
 
-.flag-dialog-body label {
-  white-space: normal;
-}
-
 section#tag-list {
   word-break: break-word;
 }
@@ -612,4 +608,60 @@ body[data-user-can-approve-posts="true"] .notice {
       padding: $padding-025 $padding-050;
     }
   }
+}
+
+/* Flag page */
+.flag-dialog-preview {
+  @media only screen and (min-width: 550px) {
+    display: flex;
+  }
+  
+  // Overwrite some DText styles to make the header look better
+  blockquote {
+    border: 0;
+    text-align: center;
+    h3 { padding: 0; }
+  }
+  p { margin-bottom: 0.25em; }
+}
+
+.flag-dialog-body {
+  
+  // Option label
+  label {
+    font-weight: normal;
+    font-size: 1rem;
+    cursor: pointer;
+  }
+  
+  // Option explanation
+  div.styled-dtext {
+    margin: 0.125rem 1.25rem;
+    filter: brightness(85%);
+  }
+  
+  // Align label with the explanation
+  input[type="radio"] {
+    width: 1rem;
+  }
+  
+  // Post ID input
+  form.simple_form div.input {
+    margin: -0.5rem 0 0 1.25rem;
+    label {
+      font-weight: normal;
+      margin-right: 1rem;
+      cursor: default;
+    }
+    &.post_flag_parent_id { display: flex }
+    span.error { margin-left: 1rem; }
+    input#post_flag_user_reason { width: 100%; }
+  }
+  
+  hr { margin: 0.75rem 1.25rem; }
+  h3 {
+    margin: 0.5rem 1.25rem;
+    font-weight: normal;
+  }
+  input[type="submit"] { margin: 0.75rem 1rem 0.5rem; }
 }

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -33,17 +33,12 @@
     
     <hr />
     <h3>Only use if no other option fits:</h3>
-    
+        
+    <%= radio_button_tag "post_flag[reason_name]", "user", false, disabled: !(@post.uploader_id == CurrentUser.id && @post.created_at > 48.hours.ago) %>
+    <label for="post_flag_reason_name_user">I'm the uploader, and I uploaded the file by mistake (only possible within 48 hours of uploading).</label>
+    <div class="styled-dtext"><%= format_text(Danbooru.config.flag_reason_48hours) %></div>
     <% if @post.uploader_id == CurrentUser.id && @post.created_at > 48.hours.ago %>
-      <%= radio_button_tag "post_flag[reason_name]", "user" %>
-      <label for="post_flag_reason_name_user">I'm the uploader, and I uploaded the file by mistake (only possible within 48 hours of uploading).</label>
-      <div class="styled-dtext">
-        <%= format_text("If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedowns instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above.") %>
-      </div>
       <%= dtext_field "post_flag", "user_reason", name: "Reason", preview_id: "dtext-preview-for-post-flag", type: "string" %>
-    <% else %>
-      <%= radio_button_tag "post_flag[reason_name]", "user", false, disabled: true %>
-      <label for="post_flag_reason_name_user">I'm the uploader, and I uploaded the file by mistake (only possible within 48 hours of uploading).</label>
     <% end %>
     
     <div>

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -1,11 +1,17 @@
-<div class="flag-dialog-body">
-  <div class="styled-dtext">
-    <%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page).first.try(&:body)) %>
-  </div>
+<div class="flag-dialog-preview">
 
   <div class="flag_post">
     <%= PostPresenter.preview(@post, tags: 'status:any', no_blacklist: true) %>
   </div>
+  
+  
+  <div class="styled-dtext">
+    <%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page).first.try(&:body)) %>
+  </div>
+</div>
+
+
+<div class="flag-dialog-body">
 
   <%= error_messages_for :post_flag %>
 
@@ -16,22 +22,30 @@
 
     <% Danbooru.config.flag_reasons.each do |flag_reason| %>
       <%= radio_button_tag "post_flag[reason_name]", flag_reason[:name], false %>
-      <label for="post_flag_reason_name_<%= flag_reason[:name] %>"><%= format_text(flag_reason[:reason], inline: true) %></label><br>
+      <label for="post_flag_reason_name_<%= flag_reason[:name] %>"><%= format_text(flag_reason[:reason], inline: true) %></label>
+      <div class="styled-dtext"><%= format_text(flag_reason[:text]) %></div>
+      
+      <% if flag_reason[:parent] %>
+        <%= f.input :parent_id, as: :integer, label: "Inferior of Post #" %>
+      <% end %>
+      
     <% end %>
-    <%= radio_button_tag "post_flag[reason_name]", "inferior", false %>
-    <label for="post_flag_reason_name_inferior">This post is a duplicate or an inferior version of another post
-      (smaller, lower quality, etc.)</label>
-    <%= f.input :parent_id, as: :integer, label: 'Inferior of Post #' %>
+    
+    <hr />
+    <h3>Only use if no other option fits:</h3>
+    
     <% if @post.uploader_id == CurrentUser.id && @post.created_at > 48.hours.ago %>
       <%= radio_button_tag "post_flag[reason_name]", "user" %>
-      <label for="post_flag_reason_name_user">I'm the uploader and I uploaded the file by mistake (only possible within 48
-        hours of uploading). Only use if no other reason above fits.</label>
+      <label for="post_flag_reason_name_user">I'm the uploader, and I uploaded the file by mistake (only possible within 48 hours of uploading).</label>
+      <div class="styled-dtext">
+        <%= format_text("If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedowns instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above.") %>
+      </div>
       <%= dtext_field "post_flag", "user_reason", name: "Reason", preview_id: "dtext-preview-for-post-flag", type: "string" %>
     <% else %>
       <%= radio_button_tag "post_flag[reason_name]", "user", false, disabled: true %>
-      <label for="post_flag_reason_name_user">I'm the uploader and I uploaded the file by mistake (only possible within 48
-        hours of uploading). Only use if no other reason above fits.</label>
+      <label for="post_flag_reason_name_user">I'm the uploader, and I uploaded the file by mistake (only possible within 48 hours of uploading).</label>
     <% end %>
+    
     <div>
       <%= f.submit "Submit" %>
     </div>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -681,6 +681,10 @@ fart'
       ]
     end
     
+    def flag_reason_48hours
+      "If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedowns instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above."
+    end
+    
     def deletion_reasons
       [
         "Inferior version/duplicate of post #%PARENT_ID%",
@@ -711,9 +715,6 @@ fart'
         "[[conditional_dnp|Conditional DNP]] (Only the artist is allowed to post)",
         "[[conditional_dnp|Conditional DNP]] (%OTHER_ID%)",
       ]
-    end
-    def flag_reason_48hours
-      "If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedowns instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above."
     end
 
     # Any custom code you want to insert into the default layout without

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -711,6 +711,8 @@ fart'
         "[[conditional_dnp|Conditional DNP]] (Only the artist is allowed to post)",
         "[[conditional_dnp|Conditional DNP]] (%OTHER_ID%)",
       ]
+    def flag_reason_48hours
+      "If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedowns instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above."
     end
 
     # Any custom code you want to insert into the default layout without

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -642,12 +642,42 @@ fart'
 
     def flag_reasons
       [
-          {name: 'dnp_artist', reason: "The artist of this post is on the [[avoid_posting|avoid posting list]]"},
-          {name: 'pay_content', reason: "This post is paysite or commercial content"},
-          {name: 'trace', reason: "This post is a trace of another artist's work"},
-          {name: 'previously_deleted', reason: "This image has been deleted before. Please leave any additional information in a comment below the image, or directly parent the original"},
-          {name: 'real_porn', reason: "This post contains real-life pornography"},
-          {name: 'corrupt', reason: "The file in this post is either corrupted, broken, or otherwise doesn't work"}
+          {
+            name: 'dnp_artist',
+            reason: "The artist of is on the [[avoid_posting|avoid posting list]]",
+            text: "Certain artists have requested that their work is not to be published on this site, and were granted [[avoid_posting|Do Not Post]] status.\nSometimes, that status comes with conditions; see [[conditional_dnp]] for more information"
+          },
+          {
+            name: 'pay_content',
+            reason: "Paysite, commercial, or subscription content",
+            text: "We do not host paysite or commercial content of any kind. This includes Patreon leaks, reposts from piracy websites, and so on."
+          },
+          {
+            name: 'trace',
+            reason: "Trace of another artist's work",
+            text: "Images traced from other artists' artwork are not accepted on this site. Referencing from something is fine, but outright copying someone else's work is not.\nPlease, leave more information in the comments, or simply add the original artwork as the posts's parent if it's hosted on this site."
+          },
+          {
+            name: 'previously_deleted',
+            reason: "Previously deleted",
+            text: "Posts usually get removed for a good reason, and reuploading of deleted content is not acceptable.\nPlease, leave more information in the comments, or simply add the original post as this post's parent."
+          },
+          {
+            name: 'real_porn',
+            reason: "Real-life pornography",
+            text: "Posts featuring real-life pornography are not acceptable on this site. No exceptions.\nNote that images featuring non-erotic photographs are acceptable."
+          },
+          {
+            name: 'corrupt',
+            reason: "File is either corrupted, broken, or otherwise does not work",
+            text: "Something about this post does not work quite right. This may be a broken video, or a corrupted image.\nEither way, in order to avoid confusion, please explain the situation in the comments."
+          },
+          {
+            name: 'inferior',
+            reason: "Duplicate or inferior version of another post",
+            text: "A superior version of this post already exists on the site.\nThis may include images with better visual quality (larger, less compressed), but may also feature \"fixed\" versions, with visual mistakes accounted for by the artist.\nNote that edits and alternate versions do not fall under this category.",
+            parent: true
+          },
       ]
     end
     

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -682,7 +682,7 @@ fart'
     end
     
     def flag_reason_48hours
-      "If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedowns instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above."
+      "If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedown instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above."
     end
     
     def deletion_reasons

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -711,6 +711,7 @@ fart'
         "[[conditional_dnp|Conditional DNP]] (Only the artist is allowed to post)",
         "[[conditional_dnp|Conditional DNP]] (%OTHER_ID%)",
       ]
+    end
     def flag_reason_48hours
       "If you are the artist, and want this image to be taken down [b]permanently[/b], file a \"takedown\":/static/takedowns instead.\nTo replace the image with a \"fixed\" version, upload that image first, and then use the \"Duplicate or inferior version\" reason above.\nFor accidentally released paysite or private content, use the \"Paysite, commercial, or private content\" reason above."
     end


### PR DESCRIPTION
This is a redesign of the flag page that I mocked up and proposed a few months ago.

![flagpage update](https://user-images.githubusercontent.com/1503448/135674638-f65fb06d-a6f4-4b7b-9b17-fddbe1e50725.png)

This adds detailed explanations of what each flag reason means specifically, as well as streamline the whole page somewhat.
My hope is that this will reduce the number of people who use flags incorrectly.

Since the header text is imported from a [wiki page](https://e621.net/wiki_pages/help:flag_notice), rather than specified in the settings, that page will have to be edited manually to complete the change if this pull request is accepted.
```
[quote]
h3. Abusing this system by willfully flagging posts for incorrect reasons may lead to disciplinary actions against your account.
[/quote]

Select an option below that most closely matches the reason why you believe this post should be deleted. Keep in mind that personal dislike of specific themes that may appear in images – such as gore, rape, or cub – are not valid reasons to flag the post on their own. Use the [[e621:blacklist|blacklist]] to filter out images that contain these tags.

If a reason is not listed here, check the options listed on the Report page.

If you are the owner of this submission, and would like to have it deleted (and not just replaced with an updated version), then please file a "takedown request":/static/takedown instead.
```


