### PR TITLE
[Search] Add pending replacements field

### DIFF
--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -443,6 +443,10 @@ class ElasticPostQueryBuilder
       (q[:inpool] ? must : must_not).push({exists: {field: :pools}})
     end
 
+    if q.include?(:pending_replacements)
+      must.push({term: {has_pending_replacements: q[:pending_replacements]}})
+    end
+
     add_tag_string_search_relation(q[:tags], must)
 
     if q[:upvote].present?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,7 +10,7 @@ class Tag < ApplicationRecord
 
   BOOLEAN_METATAGS = %w[
     hassource hasdescription ratinglocked notelocked statuslocked
-    tagslocked hideanon hidegoogle isparent ischild inpool
+    tagslocked hideanon hidegoogle isparent ischild inpool pending_replacements
   ]
 
   METATAGS = %w[

--- a/script/fixes/104_1_add_elasticsearch_replacement_index.rb
+++ b/script/fixes/104_1_add_elasticsearch_replacement_index.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment'))
+
+client = Post.__elasticsearch__.client
+client.indices.put_mapping index: Post.index_name, body: { properties: { has_pending_replacements: { type: "boolean" } } }

--- a/script/fixes/104_2_add_elasticsearch_replacement_data.rb
+++ b/script/fixes/104_2_add_elasticsearch_replacement_data.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment'))
+
+Post.find_each do |post|
+  puts post.id.to_s
+  post.__elasticsearch__.update_document_attributes has_pending_replacements: post.replacements.pending.any?
+end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2118,6 +2118,31 @@ class PostTest < ActiveSupport::TestCase
         relation = Post.tag_match("-aaa id:>0")
       end
     end
+
+    should "return posts for replacements" do
+      assert_tag_match([], "pending_replacements:true")
+      assert_tag_match([], "pending_replacements:false")
+      post = FactoryBot.create(:post)
+      replacement = FactoryBot.create(:png_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: post)
+      assert_tag_match([post], "pending_replacements:true")
+    end
+
+    should "return no posts when the replacement is not pending anymore" do
+      post1 = FactoryBot.create(:post)
+      post2 = FactoryBot.create(:post)
+      post3 = FactoryBot.create(:post)
+      post4 = FactoryBot.create(:post)
+      replacement1 = FactoryBot.create(:png_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: post1)
+      replacement1.reject!
+      replacement2 = FactoryBot.create(:png_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: post2)
+      replacement2.approve!
+      replacement3 = FactoryBot.create(:png_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: post3)
+      replacement3.promote!
+      replacement4 = FactoryBot.create(:png_replacement, creator: @user, creator_ip_addr: '127.0.0.1', post: post4)
+      replacement4.destroy!
+      assert_tag_match([], "pending_replacements:true")
+      assert_tag_match([post1, post2, post3, post4], "pending_replacements:false")
+    end
   end
 
   context "Voting:" do


### PR DESCRIPTION
Makes it possible to search for pending replacements with the search system via `pending_replacements:true`.

This adds a new elasticsearch index to store this information. There is also a migration script which adds this field, that should be run after this is deployed. To my understanding the script can be run while the site is operating. There don't seem to be any negative effects if the index is missing in the documents.

I only added the new field to the `ElasticPostQueryBuilder`, `PostQueryBuilder` looks like it should not recieve new features https://github.com/zwagoth/e621ng/commit/d8cffc4be132c8dc6f79fe4f1e556e28e1e91d45