### PR TITLE
Add a deletion reason selector

### DIFF
--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -11,7 +11,7 @@ module Moderator
       def confirm_delete
         @post = ::Post.find(params[:id])
         @reason = @post.flags.where(is_resolved: false)&.last&.reason || ''
-        @reason = "Inferior version of post ##{@post.parent_id}." if @post.parent_id && @reason == ''
+        @reason = "Inferior version/duplicate of post ##{@post.parent_id}" if @post.parent_id && @reason == ''
       end
 
       def delete

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -35,6 +35,7 @@ export { default as Comment } from '../src/javascripts/comments.js';
 export { default as Dtext } from '../src/javascripts/dtext.js';
 export { default as Note } from '../src/javascripts/notes.js';
 export { default as Post } from '../src/javascripts/posts.js';
+export { default as PostDeletion } from "../src/javascripts/post_delete.js";
 export { default as PostModeMenu } from '../src/javascripts/post_mode_menu.js';
 export { default as PostVersions } from '../src/javascripts/post_versions.js';
 export { default as RelatedTag } from '../src/javascripts/related_tag.js';

--- a/app/javascript/src/javascripts/post_delete.js
+++ b/app/javascript/src/javascripts/post_delete.js
@@ -1,0 +1,54 @@
+let PostDeletion = {};
+
+PostDeletion.init = function() {
+  const input = $("#reason");
+  let inputVal = input.val() + "";
+
+  const buttons = $("a.delreason-button")
+    .on("click", (event) => {
+      event.stopPropagation();
+      event.preventDefault();
+
+      const $button = $(event.target);
+      if (!$button.is("a")) return;
+
+      const text = $button.data("processed");
+      input.val((index, current) => {
+        current = current.trim();
+        if ($button.hasClass("enabled")) {
+          return current
+            .replace(text, "")
+            .replace(/ \/ $|^ \/ /g, "") // trim leading and trailing slashes
+            .replace(/( \/ ){2,}/g, " / "); // trim duplicate / leftover slashes
+        } else return (current ? current + " / " : "") + text;
+      });
+      input.trigger("input");
+    })
+    .on("e621:refresh", (event) => {
+      const $button = $(event.target);
+      let text = $button.data("text");
+      for (const buttonInput of $button.find("input[type=text]"))
+        text = text.replace("%ID%", $(buttonInput).val());
+
+      $button.data("processed", text);
+      $button.toggleClass("enabled", inputVal.indexOf(text) >= 0);
+    })
+    .each((index, element) => {
+      const $button = $(element);
+      $button.find("input[type=text]").on("input", () => {
+        $button.trigger("e621:refresh");
+      })
+    });
+  buttons.trigger("e621:refresh");
+
+  input.on("input", () => {
+    inputVal = input.val() + "";
+    buttons.trigger("e621:refresh");
+  });
+
+  $("#delreason-clear").on("click", () => {
+    input.val("").trigger("input");
+  });
+}
+
+export default PostDeletion

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -54,6 +54,7 @@
 @import "specific/news_updates.scss";
 @import "specific/notes.scss";
 @import "specific/pools.scss";
+@import "specific/post_delete.scss";
 @import "specific/post_events.scss";
 @import "specific/post_flags.scss";
 @import "specific/post_mode_menu.scss";

--- a/app/javascript/src/styles/specific/post_delete.scss
+++ b/app/javascript/src/styles/specific/post_delete.scss
@@ -1,0 +1,54 @@
+#reason { width: 100%; }
+#delreason-clear { width: 5rem; }
+
+.post_delete_options {
+  display: flex;
+}
+
+#delreason-prebuilt {
+  a.delreason-button {
+    display: block;
+    cursor: pointer;
+    width: fit-content;
+    margin: 0.125rem 0;
+    padding: 0;
+    
+    // Minus / plus icons
+    &::before {
+      content: "+";
+      margin-right: 0.5em;
+      font-family: monospace;
+      font-size: 1.25em;
+    }
+    
+    // Customized inputs
+    input[type="text"] {
+      background: transparent;
+      border: 0;
+      border-bottom: 1px solid white;
+      color: white;
+      &:focus { color: white !important; }
+      background: #ffffff10;
+      border-radius: 0.125rem;
+      padding: 0 0.25rem;
+    }
+    
+    // Highlight enabled elements
+    &.enabled {
+      color: #e8c446;
+      &::before { content: "-"; }
+      input[type="text"] {
+        color: #e8c446;
+        border-color: #e8c446;
+      }
+    }
+    
+    &:hover {
+      color: #f68b00;
+      input[type="text"] {
+        color: #f68b00;
+        border-color: #f68b00;
+      }
+    }
+  }
+}

--- a/app/javascript/src/styles/specific/post_delete.scss
+++ b/app/javascript/src/styles/specific/post_delete.scss
@@ -25,29 +25,37 @@
     input[type="text"] {
       background: transparent;
       border: 0;
-      border-bottom: 1px solid white;
-      color: white;
-      &:focus { color: white !important; }
       background: #ffffff10;
       border-radius: 0.125rem;
       padding: 0 0.25rem;
     }
     
     // Highlight enabled elements
-    &.enabled {
-      color: #e8c446;
-      &::before { content: "-"; }
-      input[type="text"] {
-        color: #e8c446;
-        border-color: #e8c446;
-      }
-    }
+    &.enabled::before { content: "-"; }
     
-    &:hover {
-      color: #f68b00;
+    @include themable {
+      color: themed('color-link');
+      
+      &:hover {
+        color: themed('color-link-hover');
+        input[type="text"] {
+          color: themed('color-link-hover');
+          border-color: themed('color-link-hover');
+        }
+      }
+      
       input[type="text"] {
-        color: #f68b00;
-        border-color: #f68b00;
+        border-bottom: 1px solid themed('color-link');;
+        color: themed('color-link');
+        &:focus { color: themed('color-link') !important; }
+      }
+      
+      &.enabled {
+        color: themed('color-link-active');
+        input[type="text"] {
+          color: themed('color-link-active');
+          border-color: themed('color-link-active');
+        }
       }
     }
   }

--- a/app/views/moderator/post/posts/confirm_delete.html.erb
+++ b/app/views/moderator/post/posts/confirm_delete.html.erb
@@ -11,26 +11,51 @@
   </div>
 
   <% if @post.parent_id %>
-    <div class="input">
-      <label for="move_favorites">
-        <%= check_box_tag "move_favorites", true, true %>
-        Move favorites to parent?
-      </label>
-      <label for="copy_tags">
-        <%= check_box_tag "copy_tags", false, false %>
-        Merge tags into parent?
-      </label>
-      <label for="copy_sources">
-        <%= check_box_tag "copy_sources", false, false %>
-        Merge sources into parent?
-      </label>
+    <div class="post_delete_options">
       <%= PostPresenter.preview(@post.parent, tags: 'status:any', no_blacklist: true) %>
+      <div class="input">
+        <label for="move_favorites">
+          <%= check_box_tag "move_favorites", true, true %>
+          Move favorites to parent?
+        </label>
+        <label for="copy_tags">
+          <%= check_box_tag "copy_tags", false, false %>
+          Merge tags into parent?
+        </label>
+        <label for="copy_sources">
+          <%= check_box_tag "copy_sources", false, false %>
+          Merge sources into parent?
+        </label>
+      </div>
     </div>
   <% end %>
 
   <%= submit_tag "Delete" %>
   <%= submit_tag "Cancel" %>
+  <%= button_tag "Clear", :type => "button", :id => "delreason-clear" %>
 <% end %>
+
+<div id="delreason-prebuilt" class="simple_form">
+<b>Reason</b>
+<% Danbooru.config.deletion_reasons.each do |deletion_reason| %>
+  <% if deletion_reason.nil? || deletion_reason.empty? %>
+    <br />
+  <% else %>
+    <a class="button delreason-button" data-text="<%= deletion_reason.gsub(/%(PARENT|OTHER)_ID%/, "%ID%") %>">
+      <%= deletion_reason
+            .gsub("%PARENT_ID%", "<input type=\"text\" value=\"" + (@post.parent_id || "").to_s + "\" />")
+            .gsub("%OTHER_ID%", "<input type=\"text\" />")
+            .html_safe
+      %>
+    </a>
+  <% end %>
+<% end %>
+</div>
+
+<div id="deletion-reason-suggestions"></div>
+<%= javascript_tag nonce: true do -%>
+  Danbooru.PostDeletion.init();
+<% end -%>
 
 <% content_for(:page_title) do %>
   Delete Post - #<%= @post.id %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -657,6 +657,36 @@ fart'
           {name: 'corrupt', reason: "The file in this post is either corrupted, broken, or otherwise doesn't work"}
       ]
     end
+    
+    def deletion_reasons
+      [
+        "Inferior version/duplicate of post #%PARENT_ID%",
+        "Previously deleted (post #%PARENT_ID%)",
+        "Excessive same base image set",
+        "Colored base",
+        "",
+        "Does not meet minimum quality standards (Artistic)",
+        "Does not meet minimum quality standards (Resolution)",
+        "Does not meet minimum quality standards (Compression)",
+        "Does not meet minimum quality standards (Low quality/effort edit)",
+        "Does not meet minimum quality standards (Bad digitization of traditional media)",
+        "Does not meet minimum quality standards (%OTHER_ID%)",
+        "Broken/corrupted file",
+        "JPG resaved as PNG",
+        "",
+        "Irrelevant to site (Human only)",
+        "Irrelevant to site (Screencap)",
+        "Irrelevant to site (Zero pictured)",
+        "Irrelevant to site (%OTHER_ID%)",
+        "",
+        "Paysite/commercial content",
+        "Traced artwork",
+        "Takedown #%OTHER_ID%",
+        "The artist of this post is on the [[avoid_posting|avoid posting list]]",
+        "Conditional DNP: Only the artist is allowed to post",
+        "Conditional DNP: %OTHER_ID%",
+      ]
+    end
 
     # Any custom code you want to insert into the default layout without
     # having to modify the templates.


### PR DESCRIPTION
![post_delete](https://user-images.githubusercontent.com/1503448/136471356-8e8e6e0c-481e-4bf5-bbe6-054d211ba162.png)

A selector is created on the confirm_delete page with a bunch of prebuilt reasons.
I find a feature like this to be extremely useful, as it simplifies the deletion process and reduces the number of potential typos.

When the user clicks on a reason, it is added to the input field at the top. Clicking on the same reason again removes it.
Some deletion reasons have inputs, allowing for easier customization.

I have also moved the "merge favorites / tags / sources" checkboxes to be side by side with the parent preview, to save some space.