### PR TITLE
[ForumPost] Include the poster's username in the API response

### DIFF
--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -108,6 +108,10 @@ class ForumPost < ApplicationRecord
     def hidden_attributes
       super + [:text_index]
     end
+
+    def method_attributes
+      super + [:creator_name, :updater_name]
+    end
   end
 
   extend SearchMethods


### PR DESCRIPTION
It's exactly what it sounds like.
The comments API endpoint returns the poster's name, in addition to their user ID:
```JSON
{
  "id": 6002077,
  "created_at": "2021-10-08T09:28:15.468-07:00",
  "post_id": 2965657,
  "creator_id": 243774,
  "body": "MY CABBAGES!",
  "score": 0,
  "updated_at": "2021-10-08T09:28:15.468-07:00",
  "updater_id": 243774,
  "do_not_bump_post": false,
  "is_hidden": false,
  "is_sticky": false,
  "warning_type": null,
  "warning_user_id": null,
  "creator_name": "The_Burned_Fur",
  "updater_name": "The_Burned_Fur"
}
```
The forum posts endpoint does not:
```JSON
{
  "id": 317906,
  "created_at": "2021-10-08T05:47:52.241-07:00",
  "updated_at": "2021-10-08T05:47:52.241-07:00",
  "body": "Fixed the BUR to remove redundant implications.",
  "creator_id": 860811,
  "updater_id": 860811,
  "topic_id": 30988,
  "is_hidden": false,
  "warning_type": null,
  "warning_user_id": null
}
```
I see no reason why that would be necessary.
The current approach incentivizes 3rd party app developers to look up usernames through the API, which is far from ideal, as it is not possible to bulk search for users by their ID.