### PR TITLE
[Autocomplete] Open the tag's wiki page on middle click

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -256,6 +256,15 @@ Autocomplete.render_item = function(list, item) {
   $link.on("click.danbooru", function(e) {
     e.preventDefault();
   });
+  
+  // Open the wiki page on middle-click
+  if(item.type === "tag") {
+    $link.on("auxclick", function(e) {
+      if (e.button !== 1) return;
+      e.preventDefault();
+      window.open("/wiki_pages/show_or_new?title=" + encodeURIComponent(item.value), "_blank");
+    });
+  }
 
   if (item.antecedent) {
     var antecedent = item.antecedent.replace(/_/g, " ");


### PR DESCRIPTION
This is a pretty simple change, made by request.

![mammal](https://user-images.githubusercontent.com/1503448/136849236-d9814595-54ec-45c9-b460-efeac7a31056.png)

Instead of opening a tag search when middle-clicking on a tag in autocomplete, a corresponding wiki page is opened instead.
This is done by listening to an `auxclick` event in order to preserve the original link, so that it would still be possible to right-click it, and open the search for that tag in a new tab.