### PR TITLE
Give active buttons their own background color

### DIFF
--- a/app/javascript/src/styles/specific/uploads.scss
+++ b/app/javascript/src/styles/specific/uploads.scss
@@ -17,7 +17,7 @@ div#c-uploads {
     .toggle-button:last-child { margin-right: 0; }
 
     .toggle-button.active {
-      @include themable { background-color: themed("color-link-active"); }
+      @include themable { background-color: themed("color-button-active"); }
     }
 
     .rating-e.active {

--- a/app/javascript/src/styles/themes/_theme_bloodlust.scss
+++ b/app/javascript/src/styles/themes/_theme_bloodlust.scss
@@ -21,6 +21,7 @@ $theme_bloodlust: (
   "color-link":                   $bloodlust-color-link,
   "color-link-hover":             $bloodlust-color-link-hover,
   "color-link-active":            #ffffff,
+  "color-button-active":          #e8c446,
 
   "color-link-last-page":         $bloodlust-color-text-muted,
   "color-link-last-hover":        $bloodlust-color-link-hover,

--- a/app/javascript/src/styles/themes/_theme_hexagon.scss
+++ b/app/javascript/src/styles/themes/_theme_hexagon.scss
@@ -25,6 +25,7 @@ $theme_hexagon: (
   "color-link":                   $hexagon-color-link,
   "color-link-hover":             $hexagon-color-link-hover,
   "color-link-active":            #e8c446,
+  "color-button-active":          #e8c446,
 
   "color-link-last-page":         $hexagon-color-text-muted,
   "color-link-last-hover":        $hexagon-color-link-hover,

--- a/app/javascript/src/styles/themes/_theme_hotdog.scss
+++ b/app/javascript/src/styles/themes/_theme_hotdog.scss
@@ -12,6 +12,7 @@ $theme_hotdog: (
   "color-link":                   #000000,
   "color-link-hover":             #666666,
   "color-link-active":            #ffe380,
+  "color-button-active":          #ffe380,
 
   "color-success":                darkgreen,
   "color-danger":                 maroon,

--- a/app/javascript/src/styles/themes/_theme_pony.scss
+++ b/app/javascript/src/styles/themes/_theme_pony.scss
@@ -13,6 +13,7 @@ $theme_pony: (
   "color-link":                   #b4c7d9,
   "color-link-hover":             #e9f2fa,
   "color-link-active":            #e8c446,
+  "color-button-active":          #e8c446,
 
   "color-success":                darkgreen,
   "color-danger":                 maroon,

--- a/app/javascript/src/styles/themes/_theme_serpent.scss
+++ b/app/javascript/src/styles/themes/_theme_serpent.scss
@@ -13,6 +13,7 @@ $theme_serpent: (
   "color-link":                   #005500,
   "color-link-hover":             #3A8F3A,
   "color-link-active":            #e8c446,
+  "color-button-active":          #e8c446,
 
   "color-success":                darkgreen,
   "color-danger":                 maroon,


### PR DESCRIPTION
Pretty obvious problem, in hindsight. Originally reported [here](https://e621.net/forum_topics/31017).
This is what the buttons in the upload form look like with the hexagon theme:
![pr hexagon](https://user-images.githubusercontent.com/1503448/137371920-34ed72a6-f4c6-4d7e-a122-dab6d84ef40e.png)
This is what the same buttons look like with the bloodlust theme:
![pr bloodlust](https://user-images.githubusercontent.com/1503448/137371951-cdd8b760-9d1b-44b6-8553-e70185896757.png)
Yes, the exact same buttons are active. You can barely tell that they are on the bloodlust theme.

The active buttons used to use the same color as the active links. Problem is, in the bloodlust theme, that color is white.
This pull requests add a separate color variable specifically for the active buttons.