### PR TITLE
[Users] Fix a word-breaking issue on the profile page

### DIFF
--- a/app/javascript/src/styles/specific/users.scss
+++ b/app/javascript/src/styles/specific/users.scss
@@ -40,8 +40,8 @@ div#c-users {
       }
       div {
         flex-basis: 50%;
-        overflow-wrap: break-word;
-        word-break: break-all;
+        word-wrap: anywhere;
+        overflow-wrap: anywhere;
       }
     }
 


### PR DESCRIPTION
The user profile page currently has the following issue:

![fix before](https://user-images.githubusercontent.com/1503448/138543410-d9157fd2-45ec-436d-9dae-80edfb06869b.png)
The styles on the "About" section are set up to break the line anywhere in the word. This pull request fixes it.

![fix after](https://user-images.githubusercontent.com/1503448/138543435-c6d5ea5e-1564-4c35-8a85-339a3dacc7d8.png)

I believe that the original intent was to prevent users from artificially extending the page horizontally by inserting a long string of characters into the "About" section. This fix addresses it as well.
![fix add](https://user-images.githubusercontent.com/1503448/138543407-8de39685-2890-4562-b016-713dcb5aad70.png)

