### PR TITLE
[Posts] Make the search terms in the post navbar into a link

### DIFF
--- a/app/views/posts/partials/show/_search_seq.html.erb
+++ b/app/views/posts/partials/show/_search_seq.html.erb
@@ -2,7 +2,14 @@
   <ul>
     <li class="active">
       <%= link_to "&lsaquo;&thinsp;prev".html_safe, show_seq_post_path(post, :q => params[:q], :seq => "prev"), :rel => "prev nofollow", :class => "prev" %>
-      <span class="search-name">Search: <%= params[:q].presence || "(none)" %></span>
+      <span class="search-name">
+        Search: 
+        <% if params[:q].presence.nil? %>
+          (none)
+        <% else %>
+          <%= link_to params[:q].presence, posts_path(:tags => params[:q].presence) %>
+        <% end %>
+      </span>
       <%= link_to "next&thinsp;&rsaquo;".html_safe, show_seq_post_path(post, :q => params[:q], :seq => "next"), :rel => "next nofollow", :class => "next" %>
     </li>
   </ul>

--- a/app/views/posts/partials/show/_search_seq.html.erb
+++ b/app/views/posts/partials/show/_search_seq.html.erb
@@ -2,12 +2,11 @@
   <ul>
     <li class="active">
       <%= link_to "&lsaquo;&thinsp;prev".html_safe, show_seq_post_path(post, :q => params[:q], :seq => "prev"), :rel => "prev nofollow", :class => "prev" %>
-      <span class="search-name">
-        Search: 
-        <% if params[:q].presence.nil? %>
-          (none)
+      <span class="search-name"> 
+        <% if params[:q].nil? %>
+          Search: (none)
         <% else %>
-          <%= link_to params[:q].presence, posts_path(:tags => params[:q].presence) %>
+          <%= link_to("Search: #{params[:q]}", posts_path(:tags => params[:q])) %>
         <% end %>
       </span>
       <%= link_to "next&thinsp;&rsaquo;".html_safe, show_seq_post_path(post, :q => params[:q], :seq => "next"), :rel => "next nofollow", :class => "next" %>


### PR DESCRIPTION
![navbar](https://user-images.githubusercontent.com/1503448/138579707-c29dc112-9acd-44bd-8333-69deda8bff4e.png)

The search terms in the navbar on the post page are currently being returned as plain text.
This change turns them into a link back to the search page with the specified tags.

It's especially useful on the mobile version of the site, since it lacks the searchbar on the post page.