### PR TITLE
Enhance IP searching capabilities

### DIFF
--- a/app/controllers/artist_versions_controller.rb
+++ b/app/controllers/artist_versions_controller.rb
@@ -3,8 +3,15 @@ class ArtistVersionsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @artist_versions = ArtistVersion.search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @artist_versions = ArtistVersion.search(search_params).paginate(params[:page], limit: params[:limit], search_count: params[:search])
     respond_with(@artist_versions)
   end
 
+  private
+
+  def search_params
+    permitted_params = %i[name updater_name updater_id artist_id is_active is_banned order]
+    permitted_params += %i[ip_addr] if CurrentUser.is_moderator?
+    params.fetch(:search, {}).permit(permitted_params)
+  end
 end

--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -97,7 +97,9 @@ class BlipsController < ApplicationController
   private
 
   def search_params
-    params.fetch(:search, {}).permit!
+    permitted_params = %i[body_matches response_to creator_name creator_id order]
+    permitted_params += %i[ip_addr] if CurrentUser.is_moderator?
+    params.fetch(:search, {}).permit(permitted_params)
   end
 
   def blip_params(mode)

--- a/app/controllers/comment_votes_controller.rb
+++ b/app/controllers/comment_votes_controller.rb
@@ -25,7 +25,7 @@ class CommentVotesController < ApplicationController
   end
 
   def index
-    @comment_votes = CommentVote.includes(:user, comment: [:creator]).search(params).paginate(params[:page], limit: 100)
+    @comment_votes = CommentVote.includes(:user, comment: [:creator]).search(search_params).paginate(params[:page], limit: 100)
   end
 
   def lock

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -118,6 +118,12 @@ private
     end
   end
 
+  def search_params
+    permitted_params = %i[body_matches post_id post_tags_match creator_name creator_id poster_id is_sticky do_not_bump_post order]
+    permitted_params += %i[is_hidden ip_addr] if CurrentUser.is_moderator?
+    params.fetch(:search, {}).permit(permitted_params)
+  end
+
   def comment_params(context)
     permitted_params = %i[body post_id]
     permitted_params += %i[do_not_bump_post] if context == :create

--- a/app/controllers/note_versions_controller.rb
+++ b/app/controllers/note_versions_controller.rb
@@ -2,9 +2,17 @@ class NoteVersionsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @note_versions = NoteVersion.search(search_params).paginate(params[:page], :limit => params[:limit])
+    @note_versions = NoteVersion.search(search_params).paginate(params[:page], limit: params[:limit])
     respond_with(@note_versions) do |format|
       format.html { @note_versions = @note_versions.includes(:updater) }
     end
+  end
+
+  private
+
+  def search_params
+    permitted_params = %i[updater_id post_id note_id is_active body_matches]
+    permitted_params += %i[ip_addr] if CurrentUser.is_moderator?
+    params.fetch(:search, {}).permit(permitted_params)
   end
 end

--- a/app/controllers/pool_versions_controller.rb
+++ b/app/controllers/pool_versions_controller.rb
@@ -7,7 +7,7 @@ class PoolVersionsController < ApplicationController
       @pool = Pool.find(params[:search][:pool_id])
     end
 
-    @pool_versions = PoolArchive.search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @pool_versions = PoolArchive.search(search_params).paginate(params[:page], limit: params[:limit], search_count: params[:search])
     respond_with(@pool_versions)
   end
 
@@ -19,5 +19,13 @@ class PoolVersionsController < ApplicationController
     else
       @other_version = @pool_version.previous
     end
+  end
+
+  private
+
+  def search_params
+    permitted_params = %i[updater_id updater_name pool_id]
+    permitted_params += %i[ip_addr] if CurrentUser.is_moderator?
+    params.fetch(:search, {}).permit(permitted_params)
   end
 end

--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -10,7 +10,8 @@ class PostFlagsController < ApplicationController
   end
 
   def index
-    @post_flags = PostFlag.search(search_params).includes(:creator, post: [:flags, :uploader, :approver])
+    @search_params = search_params
+    @post_flags = PostFlag.search(@search_params).includes(:creator, post: [:flags, :uploader, :approver])
     @post_flags = @post_flags.paginate(params[:page], limit: params[:limit])
     respond_with(@post_flags)
   end
@@ -48,6 +49,13 @@ class PostFlagsController < ApplicationController
   end
 
   private
+
+  def search_params
+    # creator_id and creator_name are special cased in the model search function
+    permitted_params = %i[reason_matches creator_id creator_name post_id post_tags_match is_resolved category]
+    permitted_params += %i[ip_addr] if CurrentUser.is_moderator?
+    params.fetch(:search, {}).permit(permitted_params)
+  end
 
   def post_flag_params
     params.fetch(:post_flag, {}).permit(%i[post_id reason_name user_reason parent_id])

--- a/app/controllers/post_votes_controller.rb
+++ b/app/controllers/post_votes_controller.rb
@@ -22,7 +22,7 @@ class PostVotesController < ApplicationController
   end
 
   def index
-    @post_votes = PostVote.includes(:user).search(params).paginate(params[:page], limit: 100)
+    @post_votes = PostVote.includes(:user).search(search_params).paginate(params[:page], limit: 100)
   end
 
   def lock

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -139,6 +139,7 @@ class UsersController < ApplicationController
 
   def user_search_params
     permitted_params = %i[name_matches level min_level max_level can_upload_free can_approve_posts order]
+    permitted_params += [:ip_addr] if CurrentUser.is_moderator?
     permitted_params += [:email_matches] if CurrentUser.is_admin?
     params.fetch(:search, {}).permit(permitted_params)
   end

--- a/app/controllers/wiki_page_versions_controller.rb
+++ b/app/controllers/wiki_page_versions_controller.rb
@@ -2,7 +2,7 @@ class WikiPageVersionsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @wiki_page_versions = WikiPageVersion.search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @wiki_page_versions = WikiPageVersion.search(search_params).paginate(params[:page], limit: params[:limit], search_count: params[:search])
     respond_with(@wiki_page_versions)
   end
 
@@ -19,5 +19,13 @@ class WikiPageVersionsController < ApplicationController
 
     @thispage = WikiPageVersion.find(params[:thispage])
     @otherpage = WikiPageVersion.find(params[:otherpage])
+  end
+
+  private
+
+  def search_params
+    permitted_params = %i[updater_id wiki_page_id title body is_locked is_deleted]
+    permitted_params += %i[ip_addr] if CurrentUser.is_moderator?
+    params.fetch(:search, {}).permit(permitted_params)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -150,10 +150,6 @@ module ApplicationHelper
     link_to ip, moderator_ip_addrs_path(:search => {:ip_addr => ip})
   end
 
-  def link_to_search(search)
-    link_to search, posts_path(tags: search), rel: "nofollow"
-  end
-
   def link_to_wiki(*wiki_titles, **options)
     links = wiki_titles.map do |title|
       link_to title.tr("_", " "), wiki_pages_path(title: title)

--- a/app/helpers/moderator/ip_addrs_helper.rb
+++ b/app/helpers/moderator/ip_addrs_helper.rb
@@ -1,0 +1,70 @@
+module Moderator
+  module IpAddrsHelper
+    def link_to_ip_search(type, ip_addr, count)
+      path = ip_addr_search_path type, ip_addr
+      if path.present?
+        link_to count, path
+      else
+        count
+      end
+    end
+
+    def link_to_user_id_search(type, user_id, count)
+      path = user_id_search_path type, user_id
+      if path.present?
+        link_to count, path
+      else
+        count
+      end
+    end
+
+    private
+
+    def ip_addr_search_path(type, ip_addr)
+      # post archive and posts don't support ip searches
+      case type
+      when :comment
+        comments_path(group_by: "comment", search: { ip_addr: ip_addr })
+      when :blip
+        blips_path(search: { ip_addr: ip_addr })
+      when :post_flag
+        post_flags_path(search: { ip_addr: ip_addr })
+      when :users
+        users_path(search: { ip_addr: ip_addr })
+      when :artist_version
+        artist_versions_path(search: { ip_addr: ip_addr })
+      when :note_version
+        note_versions_path(search: { ip_addr: ip_addr })
+      when :pool_version
+        pool_versions_path(search: { ip_addr: ip_addr })
+      when :wiki_page_version
+        wiki_page_versions_path(search: { ip_addr: ip_addr })
+      end
+    end
+
+    def user_id_search_path(type, user_id)
+      case type
+      when :comment
+        comments_path(group_by: "comment", search: { creator_id: user_id })
+      when :blip
+        blips_path(search: { creator_id: user_id })
+      when :post_flag
+        post_flags_path(search: { creator_id: user_id })
+      when :posts
+        posts_path(tags: "user_id:#{user_id}")
+      when :last_login
+        user_path user_id
+      when :artist_version
+        artist_versions_path(search: { updater_id: user_id })
+      when :note_version
+        note_versions_path(search: { updater_id: user_id })
+      when :pool_version
+        pool_versions_path(search: { updater_id: user_id })
+      when :post_version
+        post_versions_path(search: { updater_id: user_id })
+      when :wiki_page_version
+        wiki_page_versions_path(search: { updater_id: user_id })
+      end
+    end
+  end
+end

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -30,19 +30,14 @@ module Moderator
       end
 
       sums = {}
-      add_by_ip_addr(sums, :wiki_page, ip_addrs, ::WikiPageVersion, :updater_ip_addr, :updater_id)
       add_by_ip_addr(sums, :comment, ip_addrs, ::Comment, :creator_ip_addr, :creator_id)
       add_by_ip_addr(sums, :dmail, ip_addrs, ::Dmail, :creator_ip_addr, :from_id)
       add_by_ip_addr(sums, :blip, ip_addrs, ::Blip, :creator_ip_addr, :creator_id)
-      add_by_ip_addr(sums, :post_appeal, ip_addrs, ::PostAppeal, :creator_ip_addr, :creator_id)
       add_by_ip_addr(sums, :post_flag, ip_addrs, ::PostFlag, :creator_ip_addr, :creator_id)
-      add_by_ip_addr(sums, :upload, ip_addrs, ::Upload, :uploader_ip_addr, :uploader_id)
-      add_by_ip_addr(sums, :user_record, ip_addrs, ::UserFeedback, :creator_ip_addr, :creator_id)
       add_by_ip_addr(sums, :posts, ip_addrs, ::Post, :uploader_ip_addr, :uploader_id)
       sums[:last_login] = Hash[User.where(last_ip_addr: ip_addrs).collect { |user| [user.id, 1] }]
 
       if with_history
-        add_by_ip_addr(sums, :artist_commentary_version, ip_addrs, ::ArtistCommentaryVersion, :updater_ip_addr, :updater_id)
         add_by_ip_addr(sums, :artist_version, ip_addrs, ::ArtistVersion, :updater_ip_addr, :updater_id)
         add_by_ip_addr(sums, :note_version, ip_addrs, ::NoteVersion, :updater_ip_addr, :updater_id)
         add_by_ip_addr(sums, :pool_version, ip_addrs, ::PoolArchive, :updater_ip_addr, :updater_id)
@@ -66,19 +61,14 @@ module Moderator
       end
 
       sums = {}
-      add_by_user_id(sums, :wiki_page, user_ids, ::WikiPageVersion, :updater_ip_addr, :updater_id)
       add_by_user_id(sums, :comment, user_ids, ::Comment, :creator_ip_addr, :creator_id)
       add_by_user_id(sums, :dmail, user_ids, ::Dmail, :creator_ip_addr, :from_id)
       add_by_user_id(sums, :blip, user_ids, ::Blip, :creator_ip_addr, :creator_id)
-      add_by_user_id(sums, :post_appeal, user_ids, ::PostAppeal, :creator_ip_addr, :creator_id)
       add_by_user_id(sums, :post_flag, user_ids, ::PostFlag, :creator_ip_addr, :creator_id)
-      add_by_user_id(sums, :upload, user_ids, ::Upload, :uploader_ip_addr, :uploader_id)
-      add_by_user_id(sums, :user_record, user_ids, ::UserFeedback, :creator_ip_addr, :creator_id)
       add_by_user_id(sums, :posts, user_ids, ::Post, :uploader_ip_addr, :uploader_id)
       add_by_user_id(sums, :users, user_ids, ::User, :last_ip_addr, :id)
 
       if with_history
-        add_by_user_id(sums, :artist_commentary_version, user_ids, ::ArtistCommentaryVersion, :updater_ip_addr, :updater_id)
         add_by_user_id(sums, :artist_version, user_ids, ::ArtistVersion, :updater_ip_addr, :updater_id)
         add_by_user_id(sums, :note_version, user_ids, ::NoteVersion, :updater_ip_addr, :updater_id)
         add_by_user_id(sums, :pool_version, user_ids, ::PoolArchive, :updater_ip_addr, :updater_id)

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -35,7 +35,7 @@ module Moderator
       add_by_ip_addr(sums, :blip, ip_addrs, ::Blip, :creator_ip_addr, :creator_id)
       add_by_ip_addr(sums, :post_flag, ip_addrs, ::PostFlag, :creator_ip_addr, :creator_id)
       add_by_ip_addr(sums, :posts, ip_addrs, ::Post, :uploader_ip_addr, :uploader_id)
-      sums[:last_login] = Hash[User.where(last_ip_addr: ip_addrs).collect { |user| [user.id, 1] }]
+      add_by_ip_addr(sums, :last_login, ip_addrs, ::User, :last_ip_addr, :id)
 
       if with_history
         add_by_ip_addr(sums, :artist_version, ip_addrs, ::ArtistVersion, :updater_ip_addr, :updater_id)

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -8,9 +8,9 @@ module Moderator
 
     def execute
       if params[:user_id].present?
-        search_by_user_id(params[:user_id].split(/,/).map(&:strip))
+        search_by_user_id(params[:user_id].split(/,/).map(&:strip), params[:with_history])
       elsif params[:user_name].present?
-        search_by_user_name(params[:user_name].split(/,/).map(&:strip))
+        search_by_user_name(params[:user_name].split(/,/).map(&:strip), params[:with_history])
       elsif params[:ip_addr].present?
         search_by_ip_addr(params[:ip_addr].split(/,/).map(&:strip), params[:with_history])
       else

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -7,12 +7,13 @@ module Moderator
     end
 
     def execute
+      with_history = params[:with_history].to_s.truthy?
       if params[:user_id].present?
-        search_by_user_id(params[:user_id].split(/,/).map(&:strip), params[:with_history])
+        search_by_user_id(params[:user_id].split(/,/).map(&:strip), with_history)
       elsif params[:user_name].present?
-        search_by_user_name(params[:user_name].split(/,/).map(&:strip), params[:with_history])
+        search_by_user_name(params[:user_name].split(/,/).map(&:strip), with_history)
       elsif params[:ip_addr].present?
-        search_by_ip_addr(params[:ip_addr].split(/,/).map(&:strip), params[:with_history])
+        search_by_ip_addr(params[:ip_addr].split(/,/).map(&:strip), with_history)
       else
         []
       end
@@ -20,7 +21,7 @@ module Moderator
 
     private
 
-    def search_by_ip_addr(ip_addrs, with_history = false)
+    def search_by_ip_addr(ip_addrs, with_history)
       def add_by_ip_addr(target, name, ips, klass, ip_field, id_field)
         if ips.size == 1
           target.merge!({name => klass.where("#{ip_field} <<= ?", ips[0]).group(id_field).count})
@@ -50,12 +51,12 @@ module Moderator
       {sums: sums, users: users}
     end
 
-    def search_by_user_name(user_names, with_history = false)
+    def search_by_user_name(user_names, with_history)
       user_ids = user_names.map { |name| ::User.name_to_id(name) }
       search_by_user_id(user_ids, with_history)
     end
 
-    def search_by_user_id(user_ids, with_history = false)
+    def search_by_user_id(user_ids, with_history)
       def add_by_user_id(target, name, ids, klass, ip_field, id_field)
           target.merge!({name => klass.where(id_field => ids).where.not(ip_field => nil).group(ip_field).count})
       end

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -38,6 +38,10 @@ class ArtistVersion < ApplicationRecord
       q = q.attribute_matches(:is_active, params[:is_active])
       q = q.attribute_matches(:is_banned, params[:is_banned])
 
+      if params[:ip_addr].present?
+        q = q.where("updater_ip_addr <<= ?", params[:ip_addr])
+      end
+
       params[:order] ||= params.delete(:sort)
       if params[:order] == "name"
         q = q.order("artist_versions.name").default_order

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -95,6 +95,10 @@ class Blip < ApplicationRecord
         q = q.for_creator(params[:creator_id].to_i)
       end
 
+      if params[:ip_addr].present?
+        q = q.where("creator_ip_addr <<= ?", params[:ip_addr])
+      end
+
       case params[:order]
       when "updated_at", "updated_at_desc"
         q = q.order("blips.updated_at DESC")

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -94,6 +94,10 @@ class Comment < ApplicationRecord
         q = q.poster_id(params[:poster_id].to_i)
       end
 
+      if params[:ip_addr].present?
+        q = q.where("creator_ip_addr <<= ?", params[:ip_addr])
+      end
+
       q = q.attribute_matches(:is_hidden, params[:is_hidden])
       q = q.attribute_matches(:is_sticky, params[:is_sticky])
       q = q.attribute_matches(:do_not_bump_post, params[:do_not_bump_post])

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -21,6 +21,10 @@ class NoteVersion < ApplicationRecord
     q = q.attribute_matches(:is_active, params[:is_active])
     q = q.attribute_matches(:body, params[:body_matches])
 
+    if params[:ip_addr].present?
+      q = q.where("updater_ip_addr <<= ?", params[:ip_addr])
+    end
+
     q.apply_default_order(params)
   end
 

--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -31,6 +31,10 @@ class PoolArchive < ApplicationRecord
         q = q.where(pool_id: params[:pool_id].split(",").map(&:to_i))
       end
 
+      if params[:ip_addr].present?
+        q = q.where("updater_ip_addr <<= ?", params[:ip_addr])
+      end
+
       q.apply_default_order(params)
     end
   end

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -93,6 +93,10 @@ class PostFlag < ApplicationRecord
 
       q = q.attribute_matches(:is_resolved, params[:is_resolved])
 
+      if params[:ip_addr].present?
+        q = q.where("creator_ip_addr <<= ?", params[:ip_addr])
+      end
+
       case params[:category]
       when "normal"
         q = q.where("reason NOT IN (?)", [Reasons::UNAPPROVED, Reasons::BANNED])

--- a/app/models/post_vote.rb
+++ b/app/models/post_vote.rb
@@ -51,15 +51,28 @@ class PostVote < ApplicationRecord
 
       if params[:user_name].present?
         user_id = User.name_to_id(params[:user_name])
-        q = q.where('user_id = ?', user_id) if user_id
+        if user_id
+          q = q.where('user_id = ?', user_id)
+        else
+          q = q.none
+        end
       end
 
       if params[:user_id].present?
         q = q.where('user_id = ?', params[:user_id].to_i)
       end
 
-      q = q.order(id: :desc)
+      allow_complex_parameters = (params.keys & %w[post_id user_name user_id]).any?
 
+      if params[:timeframe].present? && allow_complex_parameters
+        q = q.where("updated_at >= ?", params[:timeframe].to_i.days.ago)
+      end
+
+      if params[:order] == "ip_addr" && allow_complex_parameters
+        q = q.order(:user_ip_addr)
+      else
+        q = q.apply_default_order(params)
+      end
       q
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -856,9 +856,8 @@ class User < ApplicationRecord
                     {:len => bitprefs_length, :bits => bitprefs_exclude})
       end
 
-      # TODO: Fix this as soon as possible.
-      if params[:current_user_first].to_s.truthy? && !CurrentUser.is_anonymous?
-        q = q.order(Arel.sql("users.id = #{CurrentUser.user.id.to_i} desc"))
+      if params[:ip_addr].present?
+        q = q.where("last_ip_addr <<= ?", params[:ip_addr])
       end
 
       case params[:order]

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -29,6 +29,10 @@ class WikiPageVersion < ApplicationRecord
       q = q.attribute_matches(:is_locked, params[:is_locked])
       q = q.attribute_matches(:is_deleted, params[:is_deleted])
 
+      if params[:ip_addr].present?
+        q = q.where("updater_ip_addr <<= ?", params[:ip_addr])
+      end
+
       q.apply_default_order(params)
     end
   end

--- a/app/views/blips/_search.html.erb
+++ b/app/views/blips/_search.html.erb
@@ -1,7 +1,10 @@
 <%= hideable_form_search path: blips_path do |f| %>
-  <%= f.input :creator_name, label: "Blipper", input_html: {data: {autocomplete: "user"}} %>
-  <%= f.input :body_matches, label: "Body" %>
-  <%= f.input :response_to, label: "Parent Blip #" %>
-  <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc)] %>
+  <%= f.input :creator_name, label: "Blipper", input_html: {value: params.dig(:search, :creator_name), data: {autocomplete: "user"}} %>
+  <%= f.input :body_matches, label: "Body", input_html: {value: params.dig(:search, :body_matches)} %>
+  <%= f.input :response_to, label: "Parent Blip #", input_html: {value: params.dig(:search, :response_to)} %>
+  <% if CurrentUser.is_moderator? %>
+    <%= f.input :ip_addr, label: "Ip Address", input_html: {value: params.dig(:search, :ip_addr)} %>
+  <% end %>
+  <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc)], selected: params.dig(:search, :order) %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/comment_votes/index.html.erb
+++ b/app/views/comment_votes/index.html.erb
@@ -1,29 +1,20 @@
 <div id="c-comment-votes">
   <div id="a-index">
-    <div class='section'>
-      <table class="search">
-        <%= form_tag({action: "index"}, method: :get) do %>
-          <tr>
-            <td><label for="user_name">User</label></td>
-            <td><%= text_field_tag "user_name", params[:user_name], id: "user_name", size: 25 %> <%= submit_tag "Search" %></td>
-          </tr>
-        <% end %>
-        <%= form_tag({action: "index"}, method: :get) do %>
-          <tr>
-            <td><label for="post_id">Comment ID</label></td>
-            <td><%= text_field_tag "comment_id", params[:post_id], id: "comment_id", size: 25 %> <%= submit_tag "Search" %></td>
-          </tr>
-        <% end %>
-      </table>
-    </div>
+    <%= simple_form_for(:search, method: :get, html: { class: "inline-form" }) do |f| %>
+      <%= f.input :user_name, label: "Username", input_html: { value: params.dig(:search, :user_name), data: { autocomplete: "user" }} %>
+      <%= f.input :comment_id, label: "Comment ID", input_html: { value: params.dig(:search, :comment_id) } %>
+      <%= f.input :timeframe, label: "Timeframe", include_blank: true, collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]], selected: params[:search][:timeframe] %>
+      <%= f.input :order, collection: [["Created", "id"], ["IP Address", "ip_addr"]], selected: params[:search][:order] %>
+      <%= f.submit "Search" %>
+    <% end %>
 
     <table class="striped" id='votes'>
       <thead>
       <tr>
         <th style='width:8%;'>ID</th>
         <th style='width:8%;'>Comment</th>
-        <th>Comment User</th>
-        <th style='width:40%;'>User</th>
+        <th style='width:20%;'>Comment User</th>
+        <th style='width:20%;'>User</th>
         <th style='width:10%;'>Vote</th>
         <th style='width:16%;'>Created</th>
         <th style='width:17%;'>Updated</th>
@@ -63,7 +54,7 @@
     <% end -%>
 
     <div id="paginator">
-      <%= sequential_paginator(@comment_votes) %>
+      <%= numbered_paginator(@comment_votes) %>
     </div>
   </div>
 </div>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -51,7 +51,7 @@
               <li>|</li>
               <%= comment_vote_block(comment, @comment_votes[comment.id]) %>
               <% if CurrentUser.is_admin? %>
-                <li><%= link_to "(List)", controller: 'comment_votes', comment_id: comment.id %></li>
+                <li><%= link_to "(List)", controller: 'comment_votes', search: { comment_id: comment.id } %></li>
               <% end %>
               <% if CurrentUser.is_member? %>
                 <li>|</li>

--- a/app/views/comments/search.html.erb
+++ b/app/views/comments/search.html.erb
@@ -7,7 +7,10 @@
       <%= f.input :creator_name, label: "Commenter", input_html: { data: { autocomplete: "user" } } %>
       <%= f.input :body_matches, label: "Body" %>
       <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
-      <%= f.input :is_hidden, label: "Hidden?", collection: [["Yes", true], ["No", false]] %>
+      <% if CurrentUser.is_moderator? %>
+        <%= f.input :ip_addr, label: "Ip Address" %>
+        <%= f.input :is_hidden, label: "Hidden?", collection: [["Yes", true], ["No", false]] %>
+      <% end %>
       <%= f.input :is_sticky, label: "Sticky?", collection: [["Yes", true], ["No", false]] %>
       <%= f.input :do_not_bump_post, label: "Bumping?", collection: [["Yes", false], ["No", true]] %>
       <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc), %w(Score score_desc), %w(Post post_id_desc)] %>

--- a/app/views/moderator/ip_addrs/_ip_listing.html.erb
+++ b/app/views/moderator/ip_addrs/_ip_listing.html.erb
@@ -1,4 +1,4 @@
-<p><%= link_to "Search for users with these IP addresses", moderator_ip_addrs_path(:search => {:ip_addr => @results[:ip_addrs].reject{|ip| ip == "127.0.0.1"}.join(",")}) %></p>
+<p><%= link_to "Search for users with these IP addresses", moderator_ip_addrs_path(search: {ip_addr: @results[:ip_addrs].reject{|ip| ip == "127.0.0.1"}.join(","), with_history: params[:search][:with_history]}) %></p>
 
 <table class="striped">
   <thead>

--- a/app/views/moderator/ip_addrs/_ip_listing.html.erb
+++ b/app/views/moderator/ip_addrs/_ip_listing.html.erb
@@ -14,7 +14,7 @@
       <tr>
         <td><%= link_to_ip ip_addr %></td>
         <td><%= name.to_s.tr '_', ' ' %></td>
-        <td><%= count %></td>
+        <td><%= link_to_ip_search name, ip_addr, count %></td>
       </tr>
     <% end %>
   <% end %>

--- a/app/views/moderator/ip_addrs/_search.html.erb
+++ b/app/views/moderator/ip_addrs/_search.html.erb
@@ -5,6 +5,6 @@
   <%= f.input :user_id, label: "User IDs", input_html: { value: params.dig(:search, :user_id) } %>
   <%= f.input :user_name, label: "User Names", input_html: { value: params.dig(:search, :user_name) } %>
   <%= f.input :ip_addr, label: "IP Addresses", input_html: { value: params.dig(:search, :ip_addr) } %>
-  <%= f.input :with_history, label: "With History", as: :boolean, input_html: { checked: params.dig(:search, :with_history) } %>
+  <%= f.input :with_history, label: "With History", as: :boolean, input_html: { checked: params.dig(:search, :with_history).to_s.truthy? } %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/moderator/ip_addrs/_user_listing.erb
+++ b/app/views/moderator/ip_addrs/_user_listing.erb
@@ -15,7 +15,7 @@
       <tr>
         <td><%= link_to_user @results[:users][uid] %></td>
         <td><%= name.to_s.tr '_', ' ' %></td>
-        <td><%= count %></td>
+        <td><%= link_to_user_id_search name, uid, count %></td>
         <td><%= link_to "Show IP addresses", moderator_ip_addrs_path(:search => {:user_id => uid}) %></td>
       </tr>
     <% end %>

--- a/app/views/moderator/ip_addrs/_user_listing.erb
+++ b/app/views/moderator/ip_addrs/_user_listing.erb
@@ -1,4 +1,4 @@
-<p><%= link_to "Search for IP addresses with these users", moderator_ip_addrs_path(:search => {:user_id => @results[:users].map { |user_id, _| user_id }.join(",")}) %></p>
+<p><%= link_to "Search for IP addresses with these users", moderator_ip_addrs_path(search: {user_id: @results[:users].map { |user_id, _| user_id }.join(","), with_history: params[:search][:with_history]}) %></p>
 
 <table class="striped">
   <thead>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -4,6 +4,7 @@
   <%= f.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :post_id) } %>
   <% if CurrentUser.is_moderator? %>
     <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name), data: { autocomplete: "user" } } %>
+    <%= f.input :ip_addr, label: "Ip Address", input_html: { value: params.dig(:search, :ip_addr)} %>
   <% end %>
   <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params.dig(:search, :is_resolved) %>
   <%= f.input :category, label: "Category", collection: ["normal", "unapproved", "deleted", "banned", "duplicate"], include_blank: true, selected: params.dig(:search, :category) %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -27,30 +27,30 @@
               <%= link_to post_flag.post.flags.size, post_flags_path(search: { post_id: post_flag.post_id }) %>
             </td>
             <td>
-              <%= link_to post_flag.category.to_s, post_flags_path(search: params[:search].merge(category: post_flag.category)) %>
+              <%= link_to post_flag.category.to_s, post_flags_path(search: @search_params.merge(category: post_flag.category)) %>
             </td>
             <td>
-              <%= link_to post_flag.is_resolved?.to_s, post_flags_path(search: params[:search].merge(is_resolved: post_flag.is_resolved?)) %>
+              <%= link_to post_flag.is_resolved?.to_s, post_flags_path(search: @search_params.merge(is_resolved: post_flag.is_resolved?)) %>
             </td>
             <td>
               <%= compact_time post_flag.post.created_at %>
               <br> by <%= link_to_user post_flag.post.uploader %>
-              <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} user:#{post_flag.post.uploader.name}".strip)) %>
+              <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} user:#{post_flag.post.uploader.name}".strip)) %>
             </td>
             <td>
               <%= compact_time post_flag.created_at %>
               <% if CurrentUser.can_view_flagger_on_post?(post_flag) %>
                 <br> by <%= link_to_user post_flag.creator %>
-                <%= link_to "»", post_flags_path(search: params[:search].merge(creator_name: post_flag.creator.name)) %>
+                <%= link_to "»", post_flags_path(search: @search_params.merge(creator_name: post_flag.creator.name)) %>
               <% end %>
             </td>
             <td>
               <% if post_flag.post.approver %>
                 <%= link_to_user post_flag.post.approver %>
-                <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:#{post_flag.post.approver.name}".strip)) %>
+                <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} approver:#{post_flag.post.approver.name}".strip)) %>
               <% else %>
                 <em>none</em>
-                <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:none".strip)) %>
+                <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} approver:none".strip)) %>
               <% end %>
             </td>
           </tr>

--- a/app/views/post_votes/index.html.erb
+++ b/app/views/post_votes/index.html.erb
@@ -1,21 +1,12 @@
 <div id="c-post-votes">
   <div id="a-index">
-    <div class='section'>
-      <table class="search">
-        <%= form_tag({action: "index"}, method: :get) do %>
-          <tr>
-            <td><label for="user_name">User</label></td>
-            <td><%= text_field_tag "user_name", params[:user_name], id: "user_name", size: 25 %> <%= submit_tag "Search" %></td>
-          </tr>
-        <% end %>
-        <%= form_tag({action: "index"}, method: :get) do %>
-          <tr>
-            <td><label for="post_id">Post ID</label></td>
-            <td><%= text_field_tag "post_id", params[:post_id], id: "post_id", size: 25 %> <%= submit_tag "Search" %></td>
-          </tr>
-        <% end %>
-      </table>
-    </div>
+    <%= simple_form_for(:search, method: :get, html: { class: "inline-form" }) do |f| %>
+      <%= f.input :user_name, label: "Username", input_html: { value: params.dig(:search, :user_name), data: { autocomplete: "user" } } %>
+      <%= f.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :post_id) } %>
+      <%= f.input :timeframe, label: "Timeframe", include_blank: true, collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]], selected: params[:search][:timeframe] %>
+      <%= f.input :order, collection: [["Created", "id"], ["IP Address", "ip_addr"]], selected: params[:search][:order] %>
+      <%= f.submit "Search" %>
+    <% end %>
 
     <table class='striped' id='votes'>
       <thead>
@@ -60,7 +51,7 @@
     <% end -%>
 
     <div id="paginator">
-      <%= sequential_paginator(@post_votes) %>
+      <%= numbered_paginator(@post_votes) %>
     </div>
   </div>
 </div>

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -7,7 +7,7 @@
   </li>
   <li>Rating: <%= pretty_html_rating(post) %></li>
   <li>Score: <%= post_vote_block(post, post.own_vote) %>
-    <% if CurrentUser.is_admin? %><span><%= link_to "(votes)", controller: :post_votes, post_id: post.id%></span><% end %>
+    <% if CurrentUser.is_admin? %><span><%= link_to "(votes)", controller: :post_votes, search: { post_id: post.id} %></span><% end %>
   </li>
   <li>
     Posted: <%= link_to time_ago_in_words_tagged(post.created_at), posts_path(:tags => "date:#{post.created_at.to_date}"), :rel => "nofollow" %>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -36,7 +36,7 @@
           <% end %>
           (<%= link_to "comments on", comments_path(group_by: :comment, search: {poster_id: user.id}) %>)
           <% if CurrentUser.is_moderator? %>
-            (<%= link_to "votes", action: "index", controller: "post_votes", user_id: user.id %>)
+            (<%= link_to "votes", action: "index", controller: "post_votes", search: { user_name: user.name } %>)
           <% end %>
         </td>
         <th>Upload Limit</th>
@@ -90,7 +90,7 @@
         <th>Comments</th>
         <td><%= presenter.comment_count(self) %> on <%= presenter.commented_posts_count(self) %> posts
           <% if CurrentUser.is_moderator? %>
-            (<%= link_to "votes", action: "index", controller: "comment_votes", user_id: user.id %>)
+            (<%= link_to "votes", action: "index", controller: "comment_votes", search: { user_name: user.name } %>)
           <% end %></td>
         <th>Artist Changes</th>
         <td><%= presenter.artist_version_count(self) %></td>


### PR DESCRIPTION
Requested by NotMeNotYou.

This is seperated into two parts:

1. Link to the specific actions on the ip_addr search page
I removed a few that I though are not needed. Appeals and artist commentaries are unused, wiki pages are already part of the "With History" option, uploads are contained within posts, user records are only creatable by admins.
The remaining ones get linked insofar it is possible. Posts and post versions cannot be filtered by ip without adding a new index to elasticsearch and dmails should simply not be searchable.
Also fixes with_history not being passed when searching by user.

2. Make it easier to detect post/comment vote cheating
This adds ip ordering and a timeframe option. These ones only have an effect when searching by other fields since there is no index.
I changed the paginator to numbered because of the ordering that can now happend, the sequential paginator would ignore it otherwise.

https://cdn.discordapp.com/attachments/686236223949242503/904102434253717504/Peek_2021-10-30_22-13.webm