### PR TITLE
Fix blacklist not applying on videos

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -1,5 +1,6 @@
 import Utility from './utility'
 import LS from './local_storage'
+import Post from './posts';
 
 let Blacklist = {};
 
@@ -103,85 +104,9 @@ Blacklist.domEntryToggle = function (e) {
   Blacklist.apply();
 };
 
-Blacklist.postSaveReplaceSrcPicture = function (post, picture) {
-  const sources = picture.children('source');
-  const img = picture.children('img');
-
-  if (!img || !sources || sources.length !== 2)
-    return;
-
-  if (!img.attr('data-crop-url'))
-    img.attr('data-crop-url', $(sources[0]).attr('srcset'));
-  if (!img.attr('data-orig-url'))
-    img.attr('data-orig-url', $(sources[1]).attr('srcset'));
-
-  if (post.hasClass('post-thumbnail-blacklisted')) {
-    post.removeClass('blacklisted-active');
-    img.attr('src', '/images/blacklisted-preview.png');
-    $(sources[0]).attr('srcset', '/images/blacklisted-preview.png');
-    $(sources[1]).attr('srcset', '/images/blacklisted-preview.png');
-  }
-};
-
-Blacklist.postRestoreSrcPicture = function (post, picture) {
-  const sources = picture.children('source');
-  const img = picture.children('img');
-
-  if (!img || !sources || sources.length !== 2)
-    return;
-
-  const cropUrl = img.attr('data-crop-url');
-  const origUrl = img.attr('data-orig-url');
-
-  if (!cropUrl || !origUrl) {
-    return;
-  }
-
-  $(sources[0]).attr('srcset', img.attr('data-crop-url'));
-  $(sources[1]).attr('srcset', img.attr('data-orig-url'));
-  img.attr('src', img.attr('data-orig-url'));
-};
-
-Blacklist.postSaveReplaceSrc = function (post) {
-  const picture = post.find("picture");
-  if (picture.length) {
-    Blacklist.postSaveReplaceSrcPicture(post, picture);
-    return;
-  }
-
-  const img = post.children("img")[0];
-  if (!img)
-    return;
-  const $img = $(img);
-  if (!$img.attr('data-orig-url'))
-    $img.attr("data-orig-url", $img.attr('src'));
-
-  if (post.attr('id') === 'image-container' || post.hasClass('post-thumbnail') || post.hasClass('post-thumbnail-blacklisted')) {
-    $img.attr('src', '/images/blacklisted-preview.png');
-    post.removeClass('blacklisted-active').addClass('blacklisted-active-visible');
-  }
-};
-
-Blacklist.postRestoreSrc = function (post) {
-  const picture = post.find("picture");
-  if (picture.length) {
-    Blacklist.postRestoreSrcPicture(post, picture);
-    return;
-  }
-  const img = post.children("img")[0];
-  if (!img)
-    return;
-  const $img = $(img);
-  if (!$img.attr('data-orig-url'))
-    return;
-  $img.attr('src', $img.attr('data-orig-url'));
-  $img.attr('data-orig-url', null);
-};
-
 Blacklist.postHide = function (post) {
   const $post = $(post);
-  $post.addClass("blacklisted").addClass("blacklisted-active");
-  Blacklist.postSaveReplaceSrc($post);
+  $post.addClass("blacklisted");
 
   const $video = $post.find("video").get(0);
   if ($video) {
@@ -192,8 +117,8 @@ Blacklist.postHide = function (post) {
 
 Blacklist.postShow = function (post) {
   const $post = $(post);
-  Blacklist.postRestoreSrc(post);
-  $post.addClass("blacklisted").removeClass("blacklisted-active").removeClass("blacklisted-active-visible");
+  $post.removeClass("blacklisted");
+  Post.resize_notes();
 };
 
 Blacklist.sidebarUpdate = function () {
@@ -221,7 +146,7 @@ Blacklist.sidebarUpdate = function () {
     link.text(entry.tags);
     link.addClass("blacklist-toggle-link");
     if (entry.disabled) {
-      link.addClass("blacklisted-active");
+      link.addClass("entry-disabled");
     }
     link.attr("href", `/posts?tags=${encodeURIComponent(entry.tags)}`);
     link.attr("title", entry.tags);

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -188,21 +188,16 @@ let Note = {
     },
 
     scale_all: function() {
-      var container = document.getElementById('note-container');
-      if (container === null) {
+      var $container = $("#note-container");
+      if ($container.length === 0) {
         return;
       }
       // Hide notes while rescaling, to prevent unnecessary reflowing
-      var was_visible = container.style.display !== 'none';
-      if (was_visible) {
-        container.style.display = 'none';
-      }
+      $container.data("resizing", true);
       $(".note-box").each(function(i, v) {
         Note.Box.scale($(v));
       });
-      if (was_visible) {
-        container.style.display = 'block';
-      }
+      $container.data("resizing", false);
     },
 
     toggle_all: function() {

--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -582,9 +582,6 @@ Post.resize_image = function (post, target_size) {
 Post.resize_to = function(target_size) {
   target_size = update_size_selector(target_size);
 
-  if ($("#image-container").hasClass("blacklisted-active-visible"))
-    return;
-
   const post = Post.currentPost();
   if (is_video(post)) {
     Post.resize_video(post, target_size);
@@ -668,9 +665,6 @@ Post.initialize_resize = function () {
 Post.resize_cycle_mode = function(e) {
   if(e && e.target)
     e.preventDefault();
-
-  if ($("#image-container").hasClass("blacklisted-active-visible"))
-    return;
 
   Post.resize_to("next");
 }

--- a/app/javascript/src/javascripts/thumbnails.js
+++ b/app/javascript/src/javascripts/thumbnails.js
@@ -38,16 +38,11 @@ Thumbnails.initialize = function () {
     for (const key in postData) {
       newTag.attr("data-" + key.replace(/_/g, '-'), postData[key]);
     }
-    newTag.attr('class', blacklisted ? "post-thumbnail blacklisted blacklisted-active" : "post-thumbnail");
+    newTag.attr('class', blacklisted ? "post-thumbnail blacklisted" : "post-thumbnail");
     if (p.hasClass('thumb-placeholder-link'))
       newTag.addClass('dtext');
     const img = $('<img>');
-    newTag.attr('data-orig-url', postData.preview_url || '/images/deleted-preview.png');
-    if (blacklisted) {
-      img.attr('src', '/images/blacklisted-preview.png');
-    } else {
-      img.attr('src', postData.preview_url || '/images/deleted-preview.png');
-    }
+    img.attr('src', postData.preview_url || '/images/deleted-preview.png');
     img.attr({
       height: postData.preview_url ? postData.preview_height : 150,
       width: postData.preview_url ? postData.preview_width : 150,

--- a/app/javascript/src/javascripts/thumbnails.js
+++ b/app/javascript/src/javascripts/thumbnails.js
@@ -35,6 +35,9 @@ Thumbnails.initialize = function () {
     });
     const newTag = $('<div>');
     const blacklisted = DAB ? false : blacklist_hit_count > 0;
+    if (blacklist_hit_count > 0) {
+      Blacklist.post_count++;
+    }
     for (const key in postData) {
       newTag.attr("data-" + key.replace(/_/g, '-'), postData[key]);
     }
@@ -56,6 +59,7 @@ Thumbnails.initialize = function () {
     newTag.append(link);
     p.replaceWith(newTag);
   });
+  Blacklist.sidebarUpdate();
 };
 
 $(document).ready(function () {

--- a/app/javascript/src/styles/common/_comment_container.scss
+++ b/app/javascript/src/styles/common/_comment_container.scss
@@ -13,7 +13,7 @@
     background: $lighten-background-5;
 
     .avatar {
-      .post-thumbnail {
+      .post-thumbnail:not(.blacklisted) {
         img {
           height: auto;
           width: auto;

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -32,7 +32,7 @@
       vertical-align: bottom;
     }
 
-    a.blacklisted-active {
+    a.entry-disabled {
       text-decoration: line-through;
     }
   }
@@ -64,14 +64,19 @@
   }
 }
 
-.post-preview.blacklisted-active, #c-comments .post.blacklisted-active {
+.post-preview.blacklisted, #c-comments .post.blacklisted {
   display: none !important;
 }
 
-#image-container.blacklisted-active, .post-thumbnail.blacklisted-active {
-  img {
-    height: 150px;
-    width: 150px;
+#image-container.blacklisted, .post-thumbnail.blacklisted {
+  img, video {
+    height: 0px;
+    width: 0px;
+    padding: 150px 150px 0px 0px;
+    background: url("images/blacklisted-preview.png");
+  }
+
+  #note-container {
+    display: none;
   }
 }
-

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -64,11 +64,12 @@
   }
 }
 
-.post-preview.blacklisted, #c-comments .post.blacklisted {
-  display: none !important;
+// Hide blacklist box on post index page only
+#c-posts #a-index .post-preview.blacklisted {
+  display: none;
 }
 
-#image-container.blacklisted, .post-thumbnail.blacklisted {
+#image-container.blacklisted, .post-thumbnail.blacklisted, .post-preview.blacklisted {
   img, video {
     height: 0px;
     width: 0px;

--- a/app/javascript/src/styles/specific/notes.scss
+++ b/app/javascript/src/styles/specific/notes.scss
@@ -4,6 +4,10 @@ div#note-container {
   position: absolute;
   z-index: 50;
 
+  &[data-resizing=true] {
+    display: none;
+  }
+
   div.note-body {
     position: absolute;
     border: 1px solid $note-border;

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,8 @@ default: &default
 
   # Additional paths webpack should look up modules
   # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: []
+  additional_paths:
+    - public
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
Like bitwolfy sugested in #318. This removes a bunch of code related to switching back and forth the `src` attribute. Instead it simply hides the image and displays the blacklist notice seperatly. Should you for some godforsaken reason have no javascript available all posts will simply display, just like it was beforehand.

Seems like I also accidentally fixed blacklist toggling on wiki pages with this. Maybe also in other places, who knows. Also fixes a display error when hiding deferred posts, they were not accounted in the blacklist counter.