### PR TITLE
Use .gitattributes to force the equivalent of core.autocrlf=false

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# This "unsets" the git "text" attribute on all files, which tells git to
+# not do any line-ending conversion between LF and CRLF on check-in and
+# check-out. This is like core.autocrlf=false, but doesn't require the user to
+# edit their git config, instead it overrides it.
+* -text


### PR DESCRIPTION
I spent almost a week trying to get vagrant to work, and this was the (main) problem.
Thanks to @Earlopain for the help.
To avoid anyone else having this problem, it's possible to override the core.autocrlf behaviour. I learned about it from [Gang-Garrison-2/.gitattributes](https://github.com/Gang-Garrison-2/Gang-Garrison-2/blob/master/.gitattributes), the explanation is taken verbatim from there too