### PR TITLE
[DText] Prevent zalgo from overflowing

### DIFF
--- a/app/controllers/dtext_previews_controller.rb
+++ b/app/controllers/dtext_previews_controller.rb
@@ -1,24 +1,7 @@
 class DtextPreviewsController < ApplicationController
   def create
-    @body = params[:body] || ""
-    @post_ids = Set.new
-    @html = ""
-    begin
-      parsed = DTextRagel.parse(@body, disable_mentions: true, allow_color: CurrentUser.user.is_privileged?)
-      raise DTextRagel::Error.new if parsed.nil?
-      @post_ids.merge(parsed[1]) if parsed[1].present?
-      @html = parsed[0].html_safe
-    rescue DTextRagel::Error => e
-    end
-    render json: {html: @html, posts: deferred_posts(@post_ids)}
-  end
-
-  private
-
-  def deferred_posts(ids)
-    Post.includes(:uploader).where(id: ids.to_a).find_each.reduce({}) do |post_hash, p|
-      post_hash[p.id] = p.minimal_attributes
-      post_hash
-    end
+    body = params[:body] || ""
+    dtext = helpers.format_text(body, allow_color: CurrentUser.user.is_privileged?)
+    render json: { html: dtext, posts: deferred_posts }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,7 +81,7 @@ module ApplicationHelper
     render "application/hideable_form_search", path: path, show_on_load: show_on_load, block: block
   end
 
-  def format_text(text, **options)
+  def dtext_ragel(text, **options)
     options.merge!(disable_mentions: true)
     parsed = DTextRagel.parse(text, **options)
     return raw "" if parsed.nil?
@@ -91,8 +91,17 @@ module ApplicationHelper
     raw ""
   end
 
+  def format_text(text, **options)
+    # preserve the currrent inline behaviour
+    if options[:inline]
+      dtext_ragel(text, options)
+    else
+      raw %(<div class="styled-dtext">#{dtext_ragel(text, options)}</div>)
+    end
+  end
+
   def strip_dtext(text)
-    format_text(text, strip: true)
+    dtext_ragel(text, strip: true)
   end
 
   def error_messages_for(instance_name)

--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -1,4 +1,8 @@
-
+.dtext-container {
+  overflow: auto;
+  word-wrap: anywhere;
+  overflow-wrap: anywhere;
+}
 
 .styled-dtext {
   line-height: 1.4em;

--- a/app/javascript/src/styles/specific/blips.scss
+++ b/app/javascript/src/styles/specific/blips.scss
@@ -3,7 +3,6 @@
 div#c-blips {
   article.blip {
     margin-bottom: $base-padding;
-    word-wrap: break-word;
 
     &[data-is-deleted="true"] {
       background-color: $blip-hidden-background;

--- a/app/javascript/src/styles/specific/comments.scss
+++ b/app/javascript/src/styles/specific/comments.scss
@@ -6,7 +6,6 @@ div.comments-for-post {
   div.list-of-comments {
     article.comment {
       border-radius: $border-radius-half;
-      word-wrap: break-word;
       margin-bottom: $padding-050;
 
       &:target {
@@ -83,7 +82,6 @@ div#c-comments {
       padding-left: $padding-050;
       padding-bottom: $padding-025;
       margin-bottom: $padding-100;
-      word-wrap: break-word;
 
       .comments {
         margin-left: 2rem;

--- a/app/javascript/src/styles/specific/forum.scss
+++ b/app/javascript/src/styles/specific/forum.scss
@@ -3,7 +3,6 @@
 div.list-of-forum-posts {
   article {
     margin: 1em 0em;
-    word-wrap: break-word;
 
     a.voted {
       font-weight: bold;

--- a/app/javascript/src/styles/specific/users.scss
+++ b/app/javascript/src/styles/specific/users.scss
@@ -40,8 +40,6 @@ div#c-users {
       }
       div {
         flex-basis: 50%;
-        word-wrap: anywhere;
-        overflow-wrap: anywhere;
       }
     }
 

--- a/app/views/admin/staff_notes/partials/_staff_note.html.erb
+++ b/app/views/admin/staff_notes/partials/_staff_note.html.erb
@@ -12,7 +12,7 @@
     <% unless @user %>
     <h4>On <%= link_to_user staff_note.user %></h4>
     <% end %>
-    <div class="body styled-dtext">
+    <div class="body dtext-container">
       <%= format_text(staff_note.body, allow_color: true) %>
     </div>
   </div>

--- a/app/views/artist_commentaries/_show.html.erb
+++ b/app/views/artist_commentaries/_show.html.erb
@@ -14,7 +14,7 @@
 <% if artist_commentary.original_present? %>
   <%= tag.section id: "original-artist-commentary", style: ("display: none" if artist_commentary.translated_present?) do %>
     <h4><%= artist_commentary.original_title %></h4>
-    <div class="styled-dtext">
+    <div class="dtext-container">
       <%= format_text(artist_commentary.original_description) %>
     </div>
   <% end %>
@@ -29,7 +29,7 @@
         <span class="disabled"><%= artist_commentary.original_title %></span>
       <% end %>
     </h4>
-    <div class="styled-dtext">
+    <div class="dtext-container">
       <% if artist_commentary.translated_description.present? %>
         <%= format_text(artist_commentary.translated_description, :disable_mentions => true) %>
       <% else %>

--- a/app/views/artist_commentaries/index.html.erb
+++ b/app/views/artist_commentaries/index.html.erb
@@ -18,13 +18,13 @@
             <td><%= PostPresenter.preview(commentary.post, :tags => "status:any") %></td>
             <td>
               <h3><%= h(commentary.original_title) %></h3>
-              <div class="styled-dtext">
+              <div class="dtext-container">
                 <%= format_text(commentary.original_description) %>
               </div>
             </td>
             <td>
               <h3><%= h(commentary.translated_title) %></h3>
-              <div class="styled-dtext">
+              <div class="dtext-container">
                 <%= format_text(commentary.translated_description) %>
               </div>
             </td>

--- a/app/views/artist_commentary_versions/_revert_listing.html.erb
+++ b/app/views/artist_commentary_versions/_revert_listing.html.erb
@@ -21,13 +21,13 @@
           <td><%= link_to commentary_version.post_id, post_path(commentary_version.post_id) %></td>
           <td>
             <h3><%= h(commentary_version.original_title) %></h3>
-            <div class="styled-dtext">
+            <div class="dtext-container">
               <%= format_text(commentary_version.original_description) %>
             </div>
           </td>
           <td>
             <h3><%= h(commentary_version.translated_title) %></h3>
-            <div class="styled-dtext">
+            <div class="dtext-container">
               <%= format_text(commentary_version.translated_description) %>
             </div>
           </td>

--- a/app/views/artist_commentary_versions/_standard_listing.html.erb
+++ b/app/views/artist_commentary_versions/_standard_listing.html.erb
@@ -20,13 +20,13 @@
           <td><%= link_to "#{commentary_version.post_id}.#{commentary_version.id}»", artist_commentary_versions_path(search: {post_id: commentary_version.post_id}) %></td>
           <td>
             <h3><%= h(commentary_version.original_title) %></h3>
-            <div class="styled-dtext">
+            <div class="dtext-container">
               <%= format_text(commentary_version.original_description) %>
             </div>
           </td>
           <td>
             <h3><%= h(commentary_version.translated_title) %></h3>
-            <div class="styled-dtext">
+            <div class="dtext-container">
               <%= format_text(commentary_version.translated_description) %>
             </div>
           </td>

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -3,7 +3,7 @@
     <h1>Artist: <%= link_to @artist.pretty_name, posts_path(:tags => @artist.name), :class => "tag-type-#{@artist.category_name}" %></h1>
 
     <% if @artist.notes.present? && @artist.visible? %>
-      <div class="styled-dtext">
+      <div class="dtext-container">
         <%= format_text(@artist.notes) %>
       </div>
 

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -30,7 +30,7 @@
             <td><%= time_ago_in_words_tagged(ban.created_at) %></td>
             <td><%= ban.humanized_duration %></td>
             <td><%= ban.humanized_expiration %></td>
-            <td class="col-expand styled-dtext"><%= format_text ban.reason %></td>
+            <td class="col-expand dtext-container"><%= format_text ban.reason %></td>
             <td>
               <% if CurrentUser.is_moderator? %>
                 <%= link_to "Edit", edit_ban_path(ban) %>

--- a/app/views/bans/show.html.erb
+++ b/app/views/bans/show.html.erb
@@ -5,7 +5,7 @@
       <li><strong>User</strong>: <%= link_to_user(@ban.user) %></li>
       <li><strong>Expires</strong>: <%= @ban.humanized_expiration %></li>
       <li><strong>Reason</strong>:
-        <div class="styled-dtext"><%= format_text @ban.reason %>
+        <div class="dtext-container"><%= format_text @ban.reason %>
         </div>
       </li>
     </ul>

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -20,7 +20,7 @@
       <% if blip.response? %>
         <h6><%= link_to "In response to blip ##{blip.response_to}", blip_path(id: blip.response_to) %> </h6>
       <% end %>
-      <div class="body styled-dtext">
+      <div class="body dtext-container">
         <%= format_text(blip.body, allow_color: blip.creator.is_privileged?) %>
       </div>
       <% if blip.was_warned? %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -19,7 +19,7 @@
       </div>
     </div>
     <div class="content">
-      <div class="body styled-dtext">
+      <div class="body dtext-container">
         <%= format_text(comment.body, allow_color: comment.creator.is_privileged?) %>
 
         <%= render "application/update_notice", record: comment %>

--- a/app/views/deleted_posts/index.html.erb
+++ b/app/views/deleted_posts/index.html.erb
@@ -16,7 +16,7 @@
       <td><%= link_to post.id, post_path(post) %></td>
       <td><%= link_to_user post.uploader %></td>
       <td><%= post.tag_string %></td>
-      <td class="styled-dtext"><%= format_text(post.flags.order(id: :desc).first&.reason) %></td>
+      <td class="dtext-container"><%= format_text(post.flags.order(id: :desc).first&.reason) %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/views/dmails/show.html.erb
+++ b/app/views/dmails/show.html.erb
@@ -14,7 +14,7 @@
       </ul>
 
       <h3>Body</h3>
-      <div class="styled-dtext">
+      <div class="dtext-container">
         <%= format_text(@dmail.body) %>
 
         <% if @dmail.is_automated? %>

--- a/app/views/dtext/_form.html.erb
+++ b/app/views/dtext/_form.html.erb
@@ -8,7 +8,7 @@
     <% else %>
       <input type="text" id="<%= input_id %>" class="text optional <%= input_classes %>" name="<%= input_name %>" value="<%= value %>">
     <% end %>
-    <div id="<%= preview_id %>" class="dtext-preview styled-dtext"></div>
+    <div id="<%= preview_id %>" class="dtext-preview dtext-container"></div>
   </div>
    <span class="hint">All text is formatted using <%= link_to "DText", help_page_path(id: "dtext"), :target => "_blank", tabindex: "-1" %></span>
 </div>

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -19,7 +19,7 @@
       </div>
     </div>
     <div class="content">
-      <div class="styled-dtext">
+      <div class="dtext-container">
         <%= format_text(parse_embedded_tag_request_text(forum_post.body), allow_color: forum_post.creator.is_privileged?) %>
       </div>
       <%= render "application/update_notice", record: forum_post %>

--- a/app/views/help/show.html.erb
+++ b/app/views/help/show.html.erb
@@ -4,7 +4,7 @@
     <section id="content">
       <div style="margin-bottom: 1em;">
         <h1><%= "Help: #{HelpPage.title(@help.name)}" %></h1>
-        <div class="styled-dtext">
+        <div class="dtext-container">
           <%= format_text(@wiki_page.body, allow_color: true) %>
         </div>
       </div>

--- a/app/views/maintenance/user/dmail_filters/edit.html.erb
+++ b/app/views/maintenance/user/dmail_filters/edit.html.erb
@@ -15,7 +15,7 @@
       </ul>
 
       <h3>Body</h3>
-      <div class="styled-dtext">
+      <div class="dtext-container">
         <%= format_text(@dmail.body) %>
       </div>
     </div>

--- a/app/views/mod_actions/index.html.erb
+++ b/app/views/mod_actions/index.html.erb
@@ -17,7 +17,7 @@
           <tr>
             <td><%= compact_time mod_action.created_at %></td>
             <td><%= link_to_user mod_action.creator %></td>
-            <td class="styled-dtext"><%= format_text(mod_action.format_description) %></td>
+            <td class="dtext-container"><%= format_text(mod_action.format_description) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/moderator/dashboards/_activity_mod_action.html.erb
+++ b/app/views/moderator/dashboards/_activity_mod_action.html.erb
@@ -10,7 +10,7 @@
     <% @dashboard.mod_actions.each do |mod_action| %>
       <tr>
         <td><%= link_to_user mod_action.creator %></td>
-        <td class="styled-dtext"><%= format_text(mod_action.format_description) %></td>
+        <td class="dtext-container"><%= format_text(mod_action.format_description) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/moderator/dashboards/_activity_user_feedback.html.erb
+++ b/app/views/moderator/dashboards/_activity_user_feedback.html.erb
@@ -11,7 +11,7 @@
     <% @dashboard.user_feedbacks.each do |record| %>
       <tr class="feedback-category-<%= record.category %>">
         <td><%= link_to_user(record.user) %></td>
-        <td class="styled-dtext"><%= format_text(record.body) %></td>
+        <td class="dtext-container"><%= format_text(record.body) %></td>
         <td><%= time_ago_in_words_tagged(record.created_at) %></td>
       </tr>
     <% end %>

--- a/app/views/news_updates/_listing.html.erb
+++ b/app/views/news_updates/_listing.html.erb
@@ -5,6 +5,6 @@
       (<%= time_ago_in_words NewsUpdate.recent[0].created_at %> ago)
       <span id="news-showtext" class="showtext">Click to show.</span>
     </h6>
-    <div class="newsbody styled-dtext"><%= format_text(NewsUpdate.recent[0].message) %></div>
+    <div class="newsbody dtext-container"><%= format_text(NewsUpdate.recent[0].message) %></div>
   </div>
 <% end %>

--- a/app/views/news_updates/_listing_home.html.erb
+++ b/app/views/news_updates/_listing_home.html.erb
@@ -1,3 +1,3 @@
 <% if NewsUpdate.recent.present? %>
-  <div class="styled-dtext"><%= format_text(NewsUpdate.recent[0].message) %></div>
+  <div class="dtext-container"><%= format_text(NewsUpdate.recent[0].message) %></div>
 <% end %>

--- a/app/views/news_updates/index.html.erb
+++ b/app/views/news_updates/index.html.erb
@@ -18,7 +18,7 @@
           <tr id="news-update-<%= news_update.id %>">
             <td><%= link_to_user news_update.creator %></td>
             <td><%= compact_time news_update.updated_at %></td>
-            <td><div class="styled-dtext"><%= format_text news_update.message %></div></td>
+            <td><div class="dtext-container"><%= format_text news_update.message %></div></td>
             <% if CurrentUser.is_moderator? %>
               <td><%= link_to "Edit", edit_news_update_path(news_update) %> | <%= link_to "Delete", news_update_path(news_update), :method => :delete %></td>
             <% end %>

--- a/app/views/pools/show.html.erb
+++ b/app/views/pools/show.html.erb
@@ -8,7 +8,7 @@
       <% end %>
     </h2>
 
-    <div id="description" class="styled-dtext">
+    <div id="description" class="dtext-container">
       <%= format_text(@pool.description) %>
     </div>
 

--- a/app/views/post_appeals/_new.html.erb
+++ b/app/views/post_appeals/_new.html.erb
@@ -1,5 +1,5 @@
 <div class="appeal-dialog-body">
-  <div class="styled-dtext">
+  <div class="dtext-container">
     <%= format_text(WikiPage.titled(Danbooru.config.appeal_notice_wiki_page).first.try(&:body)) %>
   </div>
 

--- a/app/views/post_events/index.html.erb
+++ b/app/views/post_events/index.html.erb
@@ -23,7 +23,7 @@
               <% end %>
               <br><%= time_ago_in_words_tagged event.created_at %>
             </td>
-            <td class="col-expand styled-dtext"><%= format_text event.reason %></td>
+            <td class="col-expand dtext-container"><%= format_text event.reason %></td>
             <td><%= event.is_resolved %></td>
           </tr>
         <% end %>

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -5,7 +5,7 @@
   </div>
   
   
-  <div class="styled-dtext">
+  <div class="dtext-container">
     <%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page).first.try(&:body)) %>
   </div>
 </div>
@@ -23,7 +23,7 @@
     <% Danbooru.config.flag_reasons.each do |flag_reason| %>
       <%= radio_button_tag "post_flag[reason_name]", flag_reason[:name], false %>
       <label for="post_flag_reason_name_<%= flag_reason[:name] %>"><%= format_text(flag_reason[:reason], inline: true) %></label>
-      <div class="styled-dtext"><%= format_text(flag_reason[:text]) %></div>
+      <div class="dtext-container"><%= format_text(flag_reason[:text]) %></div>
       
       <% if flag_reason[:parent] %>
         <%= f.input :parent_id, as: :integer, label: "Inferior of Post #" %>
@@ -36,7 +36,7 @@
         
     <%= radio_button_tag "post_flag[reason_name]", "user", false, disabled: !(@post.uploader_id == CurrentUser.id && @post.created_at > 48.hours.ago) %>
     <label for="post_flag_reason_name_user">I'm the uploader, and I uploaded the file by mistake (only possible within 48 hours of uploading).</label>
-    <div class="styled-dtext"><%= format_text(Danbooru.config.flag_reason_48hours) %></div>
+    <div class="dtext-container"><%= format_text(Danbooru.config.flag_reason_48hours) %></div>
     <% if @post.uploader_id == CurrentUser.id && @post.created_at > 48.hours.ago %>
       <%= dtext_field "post_flag", "user_reason", name: "Reason", preview_id: "dtext-preview-for-post-flag", type: "string" %>
     <% end %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -20,7 +20,7 @@
         <% @post_flags.each do |post_flag| %>
           <tr class="resolved-<%= post_flag.is_resolved? %>">
             <td><%= PostPresenter.preview(post_flag.post, :tags => "status:any") %></td>
-            <td class="styled-dtext">
+            <td class="dtext-container">
               <%= format_text post_flag.reason %>
             </td>
             <td>

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -1,5 +1,5 @@
 <div class="replace-image-dialog-body">
-  <div class="styled-dtext">
+  <div class="dtext-container">
     <%= format_text(WikiPage.titled(Danbooru.config.replacement_notice_wiki_page).first.try(&:body)) %>
   </div>
 

--- a/app/views/post_sets/show.html.erb
+++ b/app/views/post_sets/show.html.erb
@@ -25,7 +25,7 @@
     <% if @post_set.description.blank? %>
       <div class='set-description'>No description.</div>
     <% else %>
-      <div class='set-description styled-dtext'><%= format_text @post_set.description %></div>
+      <div class='set-description dtext-container'><%= format_text @post_set.description %></div>
     <% end %>
     <div class='set-description-bottom'></div>
 

--- a/app/views/post_versions/_listing.html.erb
+++ b/app/views/post_versions/_listing.html.erb
@@ -43,7 +43,7 @@
             <h2>Description</h2>
             <div class="closebutton">X</div>
             <div class='desc-popup-inner'>
-              <p class="styled-dtext"><%= format_text(post_version.description) %></p>
+              <p class="dtext-container"><%= format_text(post_version.description) %></p>
             </div>
           </div>
         <% end %>
@@ -74,4 +74,3 @@
     </div>
   <% end %>
 </div>
-

--- a/app/views/posts/partials/index/_excerpt.html.erb
+++ b/app/views/posts/partials/index/_excerpt.html.erb
@@ -5,7 +5,7 @@
     <% post_set.artist.tap do |artist| %>
       <% if artist.visible? %>
         <% unless artist.notes.blank? %>
-          <div class="styled-dtext">
+          <div class="dtext-container">
             <%= format_text(artist.notes) %>
           </div>
         <% end %>
@@ -23,7 +23,7 @@
     <% end %>
   <% elsif post_set.wiki_page.present? %>
     <% post_set.wiki_page.tap do |wiki_page| %>
-      <div class="styled-dtext">
+      <div class="dtext-container">
         <% if wiki_page.other_names.present? %>
           <p><%= wiki_page_other_names_list(wiki_page) %></p>
         <% end %>
@@ -46,7 +46,7 @@
         <% end %>
       </h4>
 
-      <div id="description" class="styled-dtext">
+      <div id="description" class="dtext-container">
         <%= format_text(post_set.pool.description) %>
       </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -156,7 +156,7 @@
               <span class="section-arrow"></span>
               <span>Description</span>
             </div>
-            <div class="expandable-content styled-dtext original-artist-commentary">
+            <div class="expandable-content dtext-container original-artist-commentary">
               <%= format_text(@post.description, max_thumbs: 0) %>
             </div>
           </div>

--- a/app/views/static/terms_of_service.html.erb
+++ b/app/views/static/terms_of_service.html.erb
@@ -1,7 +1,7 @@
 <div id="c-static">
   <div id="a-terms-of-service">
 
-    <div class="styled-dtext">
+    <div class="dtext-container">
     <%= format_text(@page.body, allow_color: true) %>
     </div>
 

--- a/app/views/takedowns/show.html.erb
+++ b/app/views/takedowns/show.html.erb
@@ -101,7 +101,7 @@
 
     <% if !@takedown.notes.blank? && @takedown.notes.downcase != "none" %>
       <h3>Admin notes</h3>
-      <div class="box-section styled-dtext">
+      <div class="box-section dtext-container">
         <% if !@takedown.reason_hidden || CurrentUser.is_admin? %>
           <%= format_text(@takedown.notes) %>
           <% if @takedown.reason_hidden %><span class="redtext">(HIDDEN)</span><% end %>

--- a/app/views/tickets/new_types/_blip.html.erb
+++ b/app/views/tickets/new_types/_blip.html.erb
@@ -6,7 +6,9 @@
       <h4>You are reporting the following blip:</h4>
       <div class="author"><%= link_to_user(@ticket.blip.creator) %></div>
       <span class="date" title="Posted on <%= @ticket.blip.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@ticket.blip.created_at) %> ago</span>
-      <br /><br />
-      <%= format_text(@ticket.blip.body) %>
+      <br><br>
+      <div class="dtext-container">
+        <%= format_text(@ticket.blip.body) %>
+      </div>
     </div>
 <% end %>

--- a/app/views/tickets/new_types/_comment.html.erb
+++ b/app/views/tickets/new_types/_comment.html.erb
@@ -7,7 +7,9 @@
       <h4>You are reporting the following comment:</h4>
       <div class="author"><%= link_to_user @comment.creator %></div>
       <span class="date" title="Posted on <%= @comment.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@comment.created_at) %> ago</span>
-      <br /><br />
-      <%= format_text(@comment.body) %>
+      <br><br>
+      <div class="dtext-container">
+        <%= format_text(@comment.body) %>
+      </div>
     </div>
 <% end %>

--- a/app/views/tickets/new_types/_dmail.html.erb
+++ b/app/views/tickets/new_types/_dmail.html.erb
@@ -8,6 +8,9 @@
     <div class='author'><%= link_to_user @dmail.from %></div>
     <span class="date" title="Sent on <%= @dmail.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@dmail.created_at) %>
       ago</span>
-    <%= format_text(@dmail.body) %>
+    <br><br>
+    <div class="dtext-container">
+      <%= format_text(@dmail.body) %>
+    </div>
   </div>
 <% end %>

--- a/app/views/tickets/new_types/_forum.html.erb
+++ b/app/views/tickets/new_types/_forum.html.erb
@@ -7,6 +7,9 @@
       <h4>You are reporting the following forum post:</h4>
       <div class='author'><%= link_to_user(@forum.creator) %></div>
       <span class="date" title="Posted on <%= @forum.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@forum.created_at) %> ago</span>
-      <%= format_text(@forum.body) %>
+      <br><br>
+      <div class="dtext-container">
+        <%= format_text(@forum.body) %>
+      </div>
     </div>
 <% end %>

--- a/app/views/tickets/new_types/_wiki.html.erb
+++ b/app/views/tickets/new_types/_wiki.html.erb
@@ -7,6 +7,9 @@
       <h4>You are reporting the following wiki page:</h4>
       <div class='page'><%= link_to_wiki @wiki.title %></div>
       <span class="date" title="Posted on <%= @wiki.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@wiki.created_at) %> ago</span>
-      <%= format_text(@wiki.body) %>
+      <br><br>
+      <div class="dtext-container">
+        <%= format_text(@wiki.body) %>
+      </div>
     </div>
 <% end %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -64,7 +64,7 @@
           <% end %>
 
           <% if @ticket.can_see_reason?(CurrentUser) %>
-            <td class="styled-dtext"><%= format_text(@ticket.reason) %></td>
+            <td class="dtext-container"><%= format_text(@ticket.reason) %></td>
           <% else %>
             <td><span style="cursor:help;" class="redtext" title="Due to privacy concerns, this information is confidential">Confidential</span></td>
           <% end %>
@@ -83,7 +83,7 @@
           <tr>
             <td><span class='title'>Response</span></td>
             <% if @ticket.can_see_response?(CurrentUser) %>
-              <td class="styled-dtext"><%= format_text(!@ticket.response.blank? ? @ticket.response : "No response.") %></td>
+              <td class="dtext-container"><%= format_text(!@ticket.response.blank? ? @ticket.response : "No response.") %></td>
             <% else %>
               <td><span style="cursor:help;" class="redtext" title="Due to privacy concerns, this information is confidential">Confidential</span></td>
             <% end %>

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -19,7 +19,7 @@
             <td><%= link_to_user feedback.creator %></td>
             <td><%= compact_time(feedback.created_at) %></td>
             <td>
-              <div class="styled-dtext">
+              <div class="dtext-container">
                 <%= format_text(feedback.body) %>
               </div>
               <%= render "application/update_notice", record: feedback, interval: 0.minutes %>

--- a/app/views/user_feedbacks/show.html.erb
+++ b/app/views/user_feedbacks/show.html.erb
@@ -7,7 +7,7 @@
       <li><strong>Date</strong> <%= @user_feedback.created_at %></li>
       <li><strong>Category</strong> <%= @user_feedback.category %></li>
       <li><strong>Message</strong>
-        <div class="styled-dtext"><%= format_text @user_feedback.body %></div></li>
+        <div class="dtext-container"><%= format_text @user_feedback.body %></div></li>
     </ul>
 
     <% if @user_feedback.editable_by?(CurrentUser.user) %>

--- a/app/views/user_mailer/dmail_notice.html.erb
+++ b/app/views/user_mailer/dmail_notice.html.erb
@@ -3,7 +3,7 @@
 <body>
 <p><%= @dmail.from.name %> said:</p>
 
-<div class="styled-dtext">
+<div class="dtext-container">
   <%= format_text(@dmail.body, base_url: root_url, max_thumbs: 0) %>
 </div>
 

--- a/app/views/users/_about.html.erb
+++ b/app/views/users/_about.html.erb
@@ -2,13 +2,13 @@
   <% if user.profile_about.present? %>
     <div class="box-section about-piece" id="about-info">
       <h3>About:</h3>
-      <div class="content styled-dtext"><%= format_text(user.profile_about, allow_color: true) %></div>
+      <div class="content dtext-container"><%= format_text(user.profile_about, allow_color: true) %></div>
     </div>
   <% end %>
   <% if user.profile_artinfo.present? %>
     <div class="box-section about-piece" id="about-artinfo">
       <h3>Artist Information:</h3>
-      <div class="content styled-dtext"><%= format_text(user.profile_artinfo, allow_color: true) %></div>
+      <div class="content dtext-container"><%= format_text(user.profile_artinfo, allow_color: true) %></div>
     </div>
   <% end %>
 </div>

--- a/app/views/users/_ban_notice.html.erb
+++ b/app/views/users/_ban_notice.html.erb
@@ -1,5 +1,5 @@
 <div class="ui-corner-all site-notice" id="ban-notice">
   <h1>Your account has been banned</h1>
-  <div class="styled-dtext">Reason: <%= format_text CurrentUser.user.recent_ban.reason %></div>
+  <div class="dtext-container">Reason: <%= format_text CurrentUser.user.recent_ban.reason %></div>
   <p>Ban expires: <%= CurrentUser.user.recent_ban.expire_days %></p>
 </div>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -23,7 +23,7 @@
       <% if user.is_banned? && user.recent_ban %>
         <tr>
           <th>Ban reason</th>
-          <td class="styled-dtext"><%= format_text presenter.ban_reason %></td>
+          <td class="dtext-container"><%= format_text presenter.ban_reason %></td>
         </tr>
       <% end %>
 

--- a/app/views/wiki_page_versions/show.html.erb
+++ b/app/views/wiki_page_versions/show.html.erb
@@ -5,7 +5,7 @@
     <section id="content">
       <h1 id="wiki-page-title"><%= @wiki_page_version.pretty_title %> <span class="version">(<%= time_ago_in_words_tagged(@wiki_page_version.updated_at) %>)</span></h1>
 
-      <div id="wiki-page-body" class="dtext styled-dtext">
+      <div id="wiki-page-body" class="dtext dtext-container">
         <% if @wiki_page_version.visible? %>
           <% if @wiki_page_version.other_names.present? %>
             <p><%= wiki_page_other_names_list(@wiki_page_version) %></p>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -16,7 +16,7 @@
         <% end %>
       </h1>
 
-      <div id="wiki-page-body" class="styled-dtext">
+      <div id="wiki-page-body" class="dtext-container">
         <% if @wiki_page.visible? %>
           <%= format_text(@wiki_page.body, allow_color: true, max_thumbs: 75) %>
 

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -6,7 +6,7 @@
       <h1 id="wiki-page-title">
         <%= link_to @wiki_page.pretty_title_with_category, posts_path(:tags => @wiki_page.title), :class => "tag-type-#{@wiki_page.category_name}" %>
       </h1>
-      <div id="wiki-page-body" class="styled-dtext">
+      <div id="wiki-page-body" class="dtext-container">
         <p>This wiki page does not exist. <%= link_to "Create new wiki page", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>.</p>
       </div>
 


### PR DESCRIPTION
Basically the same as #309 but it doesn't try to adress deeply nested dtext. I also renamed the css class which I didn't do previously for some reason.

Zalgo no longer extends top/bottom and a long string of `a`s no longer extends to the right. Trying to fix the nested dtext introduced more problems that I was willing/capable to fix.

![image](https://user-images.githubusercontent.com/14981592/140619637-984dbd24-5087-4cde-af11-db3b0c046cc3.png)

#344 or this should be rebased once one gets merged as I don't know how well it will play together.
