### PR TITLE
Show the alias and implication list on the artist page

### DIFF
--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -12,6 +12,7 @@
       <p><%= link_to "View wiki page", show_or_new_wiki_pages_path(:title => @artist.name) %></p>
     <% end %>
 
+    <%= artist_alias_and_implication_list(@artist) %>
     <%= yield %>
 
     <div class="recent-posts">


### PR DESCRIPTION
This implements the second option from #316:
Display the alias and implication information on the artist page, similar to how it works on normal wiki pages.
![Imgur](https://imgur.com/Kg6AaPI.png)
I'm new to Ruby, so let me know if changes are needed