### PR TITLE
[Tag Relationships] Make tag links point to wiki pages, not search page

### DIFF
--- a/app/views/tag_aliases/_listing.html.erb
+++ b/app/views/tag_aliases/_listing.html.erb
@@ -12,8 +12,8 @@
   <tbody>
     <% tag_aliases.each do |tag_alias| %>
       <tr id="tag-alias-<%= tag_alias.id %>" class="tag-alias" data-alias-id="<%= tag_alias.id %>">
-        <td class="category-<%= tag_alias.antecedent_tag.try(:category) %>"><%= link_to tag_alias.antecedent_name, posts_path(:tags => tag_alias.antecedent_name) %> <span class="count"><%= tag_alias.antecedent_tag.post_count rescue 0 %></span></td>
-        <td class="category-<%= tag_alias.consequent_tag.try(:category) %>"><%= link_to tag_alias.consequent_name, posts_path(:tags => tag_alias.consequent_name) %> <span class="count"><%= tag_alias.consequent_tag.post_count rescue 0 %></span>
+        <td class="category-<%= tag_alias.antecedent_tag.try(:category) %>"><%= link_to tag_alias.antecedent_name, show_or_new_wiki_pages_path(:title => tag_alias.antecedent_name) %> <span class="count"><%= tag_alias.antecedent_tag.post_count rescue 0 %></span></td>
+        <td class="category-<%= tag_alias.consequent_tag.try(:category) %>"><%= link_to tag_alias.consequent_name, show_or_new_wiki_pages_path(:title => tag_alias.consequent_name) %> <span class="count"><%= tag_alias.consequent_tag.post_count rescue 0 %></span>
         <% if CurrentUser.is_member? && tag_alias.status == "pending" && tag_alias.has_transitives %><span class="redtext"> HAS TRANSITIVES</span><% end %></td>
         <td>
           <% if tag_alias.forum_topic_id %>

--- a/app/views/tag_aliases/show.html.erb
+++ b/app/views/tag_aliases/show.html.erb
@@ -3,8 +3,8 @@
     <h1>Tag Alias: <%= @tag_alias.antecedent_name %> -&gt; <%= @tag_alias.consequent_name %></h1>
 
     <ul>
-      <li><strong>From</strong> <%= link_to @tag_alias.antecedent_name, posts_path(:tags => @tag_alias.antecedent_name) %></li>
-      <li><strong>To</strong> <%= link_to @tag_alias.consequent_name, posts_path(:tags => @tag_alias.consequent_name) %></li>
+      <li><strong>From</strong> <%= link_to @tag_alias.antecedent_name, show_or_new_wiki_pages_path(:title => @tag_alias.antecedent_name) %></li>
+      <li><strong>To</strong> <%= link_to @tag_alias.consequent_name, show_or_new_wiki_pages_path(:title => @tag_alias.consequent_name) %></li>
       <% if @tag_alias.forum_topic_id %>
         <li><strong>Reference</strong> <%= link_to "topic ##{@tag_alias.forum_topic_id}", forum_topic_path(@tag_alias.forum_topic_id) %></li>
       <% end %>

--- a/app/views/tag_implications/_listing.html.erb
+++ b/app/views/tag_implications/_listing.html.erb
@@ -12,8 +12,8 @@
   <tbody>
     <% tag_implications.each do |tag_implication| %>
       <tr class="tag-implication" id="tag-implication-<%= tag_implication.id %>" data-implication-id="<%= tag_implication.id %>">
-        <td class="category-<%= tag_implication.antecedent_tag.try(:category) %>"><%= link_to tag_implication.antecedent_name, posts_path(:tags => tag_implication.antecedent_name) %> <span class="count"><%= tag_implication.antecedent_tag.post_count rescue 0 %></span></td>
-        <td class="category-<%= tag_implication.consequent_tag.try(:category) %>"><%= link_to tag_implication.consequent_name, posts_path(:tags => tag_implication.consequent_name) %> <span class="count"><%= tag_implication.consequent_tag.post_count rescue 0 %></span></td>
+        <td class="category-<%= tag_implication.antecedent_tag.try(:category) %>"><%= link_to tag_implication.antecedent_name, show_or_new_wiki_pages_path(:title => tag_implication.antecedent_name) %> <span class="count"><%= tag_implication.antecedent_tag.post_count rescue 0 %></span></td>
+        <td class="category-<%= tag_implication.consequent_tag.try(:category) %>"><%= link_to tag_implication.consequent_name, show_or_new_wiki_pages_path(:title => tag_implication.consequent_name) %> <span class="count"><%= tag_implication.consequent_tag.post_count rescue 0 %></span></td>
         <td>
           <% if tag_implication.forum_topic_id %>
             <%= link_to tag_implication.forum_topic_id, forum_topic_path(tag_implication.forum_topic_id) %>

--- a/app/views/tag_implications/show.html.erb
+++ b/app/views/tag_implications/show.html.erb
@@ -3,8 +3,8 @@
     <h1>Tag Implication: <%= @tag_implication.antecedent_name %> -&gt; <%= @tag_implication.consequent_name %></h1>
 
     <ul>
-      <li><strong>From</strong> <%= link_to @tag_implication.antecedent_name, posts_path(:tags => @tag_implication.antecedent_name) %></li>
-      <li><strong>To</strong> <%= link_to @tag_implication.consequent_name, posts_path(:tags => @tag_implication.consequent_name) %></li>
+      <li><strong>From</strong> <%= link_to @tag_implication.antecedent_name, show_or_new_wiki_pages_path(:title => @tag_implication.antecedent_name) %></li>
+      <li><strong>To</strong> <%= link_to @tag_implication.consequent_name, show_or_new_wiki_pages_path(:title => @tag_implication.consequent_name) %></li>
       <% if @tag_implication.forum_topic_id %>
         <li><strong>Reference</strong> <%= link_to "topic ##{@tag_implication.forum_topic_id}", forum_topic_path(@tag_implication.forum_topic_id) %></li>
       <% end %>


### PR DESCRIPTION
At the moment, if you click on the tags while browsing the alias / implications listing page, you will be taken to the search page with that tag. 

![links](https://user-images.githubusercontent.com/1503448/140811417-03ac9395-c3db-4690-880f-bb7ed656578a.png)
 
It is a lot more helpful to open the wiki page instead.
This way, you can not only check the tag's definition, but also see all other relationships it has at a glance.

The links on the individual alias pages are similarly changed as well.

![link2](https://user-images.githubusercontent.com/1503448/140811515-94b85dd4-e5a0-4af8-9d07-c11b8f100f42.png)
