### PR TITLE
[Tickets] Fix the overflow issue on mobile when creating a new ticket

### DIFF
--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -5,7 +5,7 @@
       <% @found_item = true %>
       <% if params[:type].nil? %>
         <% @found_item = false %>
-        <div class='section' style='width:80em;'>
+        <div class='section' style='max-width:80em;'>
           To submit a ticket about a problematic comment, click "Report" on the comment itself.<br/>
           To submit a ticket about a problematic forum post, click "Report" on the post itself.<br/>
           To submit a ticket about a problematic pool, click "Report" on the pool page itself.<br/>
@@ -16,14 +16,14 @@
         </div>
       <% elsif CurrentUser.is_anonymous? %>
         <% @found_item = false %>
-        <div class='section' style='width:80em;'>
+        <div class='section' style='max-width:80em;'>
           You must be logged in to submit a ticket. Please <a href='/user/login'>log in</a> and try again.
         </div>
       <% elsif @ticket.type_valid %>
         <%= render partial: "tickets/new_types/#{@ticket.qtype}" %>
       <% else %>
         <% @found_item = false %>
-        <div class='section' style='width:80em;'>
+        <div class='section' style='max-width:80em;'>
           Hmm, it seems you tried to report something that doesn't make sense.
         </div>
       <% end %>
@@ -32,7 +32,7 @@
         <%= f.hidden_field :disp_id %>
         <%= f.hidden_field :qtype %>
 
-        <div class='section' style='width:80em;'>
+        <div class='section' style='max-width:80em;'>
           <label for="ticket_reason">
             <% if params[:type] == "namechange" %>
               Desired username


### PR DESCRIPTION
This fixes a minor layout issue on the ticket creation page.

Right now, the width of several elements on that page is set to `80em` to prevent them from expanding too far on large screens.
However, on mobile devices, where the screen width is less than `80em`, the page will overflow.

![example1](https://user-images.githubusercontent.com/1503448/142468700-ca5af40b-a857-465b-9743-9beab0a4d3a7.png)
 
This fix changes that style to `max-width` instead of `width`, allowing the elements to shrink with the screen.

![example2](https://user-images.githubusercontent.com/1503448/142468802-aa3a0cc4-801c-44b7-90c5-3c060bf1b780.png)

