### PR TITLE
[DText] Fix the bugged preview window in the upload form

### DIFF
--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -285,7 +285,7 @@ div.dtext-formatter {
         background: #00000040;
       }
     }
-    div.dtext-formatter-preview { display: none; }
+    div.dtext-formatter-preview { display: none !important; }
     div.dtext-formatter-charcount { color: black; }
   }
   &[data-editing="false"] {
@@ -296,7 +296,7 @@ div.dtext-formatter {
       }
     }
     div.dtext-formatter-buttons { visibility: hidden; }
-    textarea.dtext-formatter-input { display: none; }
+    textarea.dtext-formatter-input { display: none !important; }
   }
 }
 


### PR DESCRIPTION
This is a relatively minor fix to a bug that exists on the upload page.
The existing style sets all textarea fields on that page to `display: inline-block`, which prevents it from being hidden with `display: none` when looking at the preview.

![unknown](https://user-images.githubusercontent.com/1503448/142734532-1d7954ae-0ffd-4aad-bb87-3ad828ee7019.png)

This fix simply adds `!important` to `display: none` to prevent issues like this.

