### PR TITLE
[BUR] Fix approving inverse implications when inverse is rejected

### DIFF
--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -67,7 +67,7 @@ class TagImplication < TagRelationship
     extend Memoist
 
     def parents
-      self.class.where("consequent_name = ?", antecedent_name)
+      self.class.duplicate_relevant.where("consequent_name = ?", antecedent_name)
     end
     memoize :parents
   end


### PR DESCRIPTION
Fixes approving https://e621.net/bulk_update_requests/1619 https://e621.net/admin/exceptions/3676846

* Implication `a -> b` exists and is pending 
* Implication is rejected
* BUR `imply b -> a` is created
* => You cannot approve this BUR

Because it's trying to update the descendants of all implications, including rejected ones is goes into an infinite loop trying to update them. It should not consider rejected ones, they have no need of being updated anymore.

You can still try to create two inverse implications and get in the loop, because `absence_of_circular_relation` only checks for active implications. Changing that there would prevent creating burs though which I think shouldn't happen, so I left it be. If it would also be changed there you won't be able to create the bur `imply b -> a` while implication `a -> b` is still pending.