### PR TITLE
[Users] Add default to user about/artinfo

### DIFF
--- a/db/migrate/20220219202441_set_user_text_defaults.rb
+++ b/db/migrate/20220219202441_set_user_text_defaults.rb
@@ -1,0 +1,10 @@
+class SetUserTextDefaults < ActiveRecord::Migration[6.1]
+  def up
+    change_column :users, :profile_about, :text, default: ""
+    change_column :users, :profile_artinfo, :text, default: ""
+    User.without_timeout do
+      User.where(profile_about: nil).in_batches.update_all(profile_about: "")
+      User.where(profile_artinfo: nil).in_batches.update_all(profile_artinfo: "")
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2603,8 +2603,8 @@ furry -rating:s'::text,
     bit_prefs bigint DEFAULT 0 NOT NULL,
     last_ip_addr inet,
     unread_dmail_count integer DEFAULT 0 NOT NULL,
-    profile_about text,
-    profile_artinfo text,
+    profile_about text DEFAULT ''::text,
+    profile_artinfo text DEFAULT ''::text,
     avatar_id integer
 );
 
@@ -5206,6 +5206,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210625155528'),
 ('20210718172512'),
 ('20220106081415'),
-('20220203154846');
+('20220203154846'),
+('20220219202441');
 
 


### PR DESCRIPTION
This fixes generating modactions for users who have never edited their profile
when an admin does so, since the value changed from null to the empty string