### PR TITLE
Uniform search forms

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,13 +72,6 @@ module ApplicationHelper
     raw %{<a href="#{h(url)}" #{attributes}>#{text}</a>}
   end
 
-  def form_search(path:, always_display: false, &block)
-    # dedicated search routes like /comments/search should always show
-    hideable = request.path.split("/")[2] != "search"
-    show_on_load = !params[:search].empty? || always_display || !hideable
-    render "application/form_search", path: path, hideable: hideable, show_on_load: show_on_load, block: block
-  end
-
   def dtext_ragel(text, **options)
     options.merge!(disable_mentions: true)
     parsed = DTextRagel.parse(text, **options)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,9 +72,11 @@ module ApplicationHelper
     raw %{<a href="#{h(url)}" #{attributes}>#{text}</a>}
   end
 
-  def hideable_form_search(path:, always_display: false, &block)
-    show_on_load = !params[:search].empty? || always_display
-    render "application/hideable_form_search", path: path, show_on_load: show_on_load, block: block
+  def form_search(path:, always_display: false, &block)
+    # dedicated search routes like /comments/search should always show
+    hideable = request.path.split("/")[2] != "search"
+    show_on_load = !params[:search].empty? || always_display || !hideable
+    render "application/form_search", path: path, hideable: hideable, show_on_load: show_on_load, block: block
   end
 
   def dtext_ragel(text, **options)

--- a/app/helpers/form_search_helper.rb
+++ b/app/helpers/form_search_helper.rb
@@ -1,0 +1,17 @@
+module FormSearchHelper
+  def form_search(path:, always_display: false, &block)
+    # dedicated search routes like /comments/search should always show
+    hideable = request.path.split("/")[2] != "search"
+    show_on_load = filled_form_fields(block).any? || always_display || !hideable
+    render "application/form_search", path: path, hideable: hideable, show_on_load: show_on_load, block: block
+  end
+
+  # When the simple_form has f.input :name and search[name]=test [:name] will be returned
+  # Some search params aren't exposed in the ui, but have links. In that case it
+  # isn't expected to have the form be open, since no values are set.
+  def filled_form_fields(block)
+    form_field_collector = FormFieldCollector.new
+    capture { block.call(form_field_collector) }
+    form_field_collector.fields & params[:search].keys.map(&:to_sym)
+  end
+end

--- a/app/inputs/form_field_collector.rb
+++ b/app/inputs/form_field_collector.rb
@@ -1,0 +1,16 @@
+# Captures all the input names used in a form block
+class FormFieldCollector
+  attr_reader :fields
+
+  def initialize
+    @fields = []
+  end
+
+  def input(input_name, *)
+    @fields.push input_name
+  end
+
+  # Swallow the rest
+  def method_missing(*)
+  end
+end

--- a/app/inputs/search_form_builder.rb
+++ b/app/inputs/search_form_builder.rb
@@ -1,0 +1,25 @@
+class SearchFormBuilder < SimpleForm::FormBuilder
+  def input(attribute_name, options = {}, &block)
+    options[:input_html] ||= {}
+    options[:input_html][:data] = {}
+    options[:input_html][:data][:autocomplete] = options[:autocomplete] if options[:autocomplete]
+    options = insert_value_from_search_params(attribute_name, options)
+    super
+  end
+
+  private
+
+  def insert_value_from_search_params(attribute_name, options)
+    value = @options[:search_params][attribute_name]
+    return options if value.nil?
+
+    if options[:collection]
+      options[:selected] = value
+    elsif options[:as]&.to_sym == :boolean
+      options[:input_html][:checked] = true if value == "1"
+    else
+      options[:input_html][:value] = value
+    end
+    options
+  end
+end

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -37,6 +37,11 @@ class ArtistUrl < ApplicationRecord
     q = q.search_text_attribute(:url, params)
     q = q.search_text_attribute(:normalized_url, params)
 
+    if params[:artist_name].present?
+      q = q.joins(:artist).where("artists.name = ?", params[:artist_name])
+    end
+
+    # Legacy param?
     q = q.artist_matches(params[:artist])
     q = q.url_matches(params[:url_matches])
     q = q.normalized_url_matches(params[:normalized_url_matches])

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -136,6 +136,15 @@ class TagRelationship < ApplicationRecord
         q = q.status_matches(params[:status])
       end
 
+      if params[:antecedent_tag_category].present?
+        q = q.joins(:antecedent_tag).where("tags.category": params[:antecedent_tag_category])
+      end
+
+      if params[:consequent_tag_category].present?
+        q = q.joins(:consequent_tag).where("tags.category": params[:consequent_tag])
+      end
+
+      # Legacy params?
       q = q.tag_matches(:antecedent_name, params[:antecedent_tag])
       q = q.tag_matches(:consequent_name, params[:consequent_tag])
 

--- a/app/views/admin/staff_notes/_search.html.erb
+++ b/app/views/admin/staff_notes/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: admin_staff_notes_path, always_display: true do |f| %>
+<%= form_search path: admin_staff_notes_path, always_display: true do |f| %>
   <%= f.input :creator_name, label: "Creator Name", input_html: {data: {autocomplete: "user"}} %>
   <%= f.input :user_name, label: "User Name", input_html: {data: {autocomplete: "user"}} %>
   <%= f.input :body_matches, label: "Body" %>

--- a/app/views/application/_form_search.erb
+++ b/app/views/application/_form_search.erb
@@ -1,0 +1,7 @@
+<% if hideable %>
+  <a href="#" id="search-form-show-link" <% if show_on_load %>style="display:none;"<% end %>>Show Search Options</a>
+  <a href="#" id="search-form-hide-link" <% unless show_on_load %>style="display:none;"<% end %>>Hide Search Options</a>
+<% end %>
+<div class="section" id="searchform" <% unless show_on_load %>style="display:none;"<% end %>>
+  <%= simple_form_for(:search, :method => :get, url: path, defaults: {required: false}, html: {class: "inline-form"}, &block) %>
+</div>

--- a/app/views/application/_form_search.erb
+++ b/app/views/application/_form_search.erb
@@ -3,5 +3,10 @@
   <a href="#" id="search-form-hide-link" <% unless show_on_load %>style="display:none;"<% end %>>Hide Search Options</a>
 <% end %>
 <div class="section" id="searchform" <% unless show_on_load %>style="display:none;"<% end %>>
-  <%= simple_form_for(:search, :method => :get, url: path, defaults: {required: false}, html: {class: "inline-form"}, &block) %>
+  <%= simple_form_for(:search, method: :get,
+                               url: path,
+                               builder: SearchFormBuilder, search_params: params[:search],
+                               defaults: { required: false },
+                               html: { class: "inline-form" },
+                               &block) %>
 </div>

--- a/app/views/application/_hideable_form_search.erb
+++ b/app/views/application/_hideable_form_search.erb
@@ -1,5 +1,0 @@
-<a href="#" id="search-form-show-link" <% if show_on_load %>style="display:none;"<% end %>>Show Search Options</a>
-<a href="#" id="search-form-hide-link" <% unless show_on_load %>style="display:none;"<% end %>>Hide Search Options</a>
-<div class="section" id="searchform" <% unless show_on_load %>style="display:none;"<% end %>>
-  <%= simple_form_for(:search, :method => :get, url: path, defaults: {required: false}, html: {class: "inline-form"}, &block) %>
-</div>

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -1,9 +1,7 @@
 <div id="c-artist-urls">
   <div id="a-index">
     <%= simple_form_for(:search, url: artist_urls_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-      <%= f.simple_fields_for :artist do |fa| %>
-        <%= fa.input :name, label: "Artist Name", input_html: { value: params.dig(:search, :artist, :name), "data-autocomplete": "artist" } %>
-      <% end %>
+      <%= f.input :artist_name, label: "Artist Name", input_html: { value: params.dig(:search, :artist_name), "data-autocomplete": "artist" } %>
       <%= f.input :url_matches, label: "URL", input_html: { value: params.dig(:search, :url_matches) } %>
       <%= f.input :normalized_url_matches, label: "Normalized URL", input_html: { value: params.dig(:search, :normalized_url_matches) } %>
       <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params.dig(:search, :is_active) %>

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -1,11 +1,11 @@
 <div id="c-artist-urls">
   <div id="a-index">
-    <%= simple_form_for(:search, url: artist_urls_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-      <%= f.input :artist_name, label: "Artist Name", input_html: { value: params.dig(:search, :artist_name), "data-autocomplete": "artist" } %>
-      <%= f.input :url_matches, label: "URL", input_html: { value: params.dig(:search, :url_matches) } %>
-      <%= f.input :normalized_url_matches, label: "Normalized URL", input_html: { value: params.dig(:search, :normalized_url_matches) } %>
-      <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params.dig(:search, :is_active) %>
-      <%= f.input :order, collection: [["ID", "id"], ["Created", "created_at"], ["Updated", "updated_at"]], selected: params.dig(:search, :order) %>
+    <%= form_search(path: artist_urls_path) do |f| %>
+      <%= f.input :artist_name, label: "Artist Name", autocomplete: "artist" %>
+      <%= f.input :url_matches, label: "URL" %>
+      <%= f.input :normalized_url_matches, label: "Normalized URL" %>
+      <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+      <%= f.input :order, collection: [["ID", "id"], ["Created", "created_at"], ["Updated", "updated_at"]] %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/artist_versions/_search.html.erb
+++ b/app/views/artist_versions/_search.html.erb
@@ -1,5 +1,5 @@
-<%= simple_form_for(:search, url: artist_versions_path, method: :get, defaults: { required: false }) do |f| %>
-  <%= f.input :updater_name, label: "User", input_html: { data: { autocomplete: "user" } } %>
-  <%= f.input :name, input_html: { data: { autocomplete: "artist" } } %>
+<%= form_search(path: artist_versions_path) do |f| %>
+  <%= f.input :updater_name, label: "User", autocomplete: "user" %>
+  <%= f.input :name, autocomplete: "artist" %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/artist_versions/_search.html.erb
+++ b/app/views/artist_versions/_search.html.erb
@@ -1,0 +1,5 @@
+<%= simple_form_for(:search, url: artist_versions_path, method: :get, defaults: { required: false }) do |f| %>
+  <%= f.input :updater_name, label: "User", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :name, input_html: { data: { autocomplete: "artist" } } %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/artist_versions/index.html.erb
+++ b/app/views/artist_versions/index.html.erb
@@ -2,6 +2,7 @@
   <div id="a-index">
     <h1>Artist History</h1>
 
+    <%= render "search" %>
     <%= render "standard_listing" %>
     <%= numbered_paginator(@artist_versions, :search_count => params[:search]) %>
   </div>

--- a/app/views/artist_versions/search.html.erb
+++ b/app/views/artist_versions/search.html.erb
@@ -2,13 +2,7 @@
   <div id="a-search">
     <h1>Search Changes</h1>
 
-    <div id="search">
-      <%= form_tag(artist_versions_path, :method => :get, :class => "simple_form") do %>
-        <%= search_field "updater_name", :label => "User", :data => { autocomplete: "user" } %>
-        <%= search_field "name", :label => "Name", :data => { autocomplete: "artist" } %>
-        <%= submit_tag "Search" %>
-      <% end %>
-    </div>
+    <%= render "search" %>
   </div>
 </div>
 

--- a/app/views/artists/_search.html.erb
+++ b/app/views/artists/_search.html.erb
@@ -1,10 +1,10 @@
-<%= simple_form_for(:search, url: artists_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :any_name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :any_name_matches), data: { autocomplete: "artist" }} %>
-  <%= f.input :url_matches, label: "URL", as: "string", input_html: { value: params.dig(:search, :url_matches) } %>
-  <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name), data: { autocomplete: "user" } } %>
-  <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params.dig(:search, :is_active) %>
-  <%= f.input :has_tag, label: "Has tag?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params.dig(:search, :has_tag) %>
-  <%= f.input :is_linked, label: "Linked Only", as: :boolean, input_html: { checked: params.dig(:search, :is_linked).to_s.truthy? } %>
-  <%= f.input :order, collection: [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]], selected: params.dig(:search, :order) %>
+<%= form_search(path: artists_path) do |f| %>
+  <%= f.input :any_name_matches, label: "Name", hint: "Use * for wildcard", autocomplete: "artist" %>
+  <%= f.input :url_matches, label: "URL", as: :string %>
+  <%= f.input :creator_name, label: "Creator", autocomplete: "user" %>
+  <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :has_tag, label: "Has tag?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :is_linked, label: "Linked Only", as: :boolean %>
+  <%= f.input :order, collection: [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/bans/_search.html.erb
+++ b/app/views/bans/_search.html.erb
@@ -1,8 +1,8 @@
-<%= simple_form_for(:search, method: :get, url: bans_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :user_name, label: "User", input_html: { value: params.dig(:search, :user_name), data: { autocomplete: "user" } } %>
-  <%= f.input :banner_name, label: "Banner", input_html: { value: params.dig(:search, :banner_name), data: { autocomplete: "user" } } %>
-  <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :reason_matches) } %>
-  <%= f.input :expired, label: "Expired?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params.dig(:search, :expired) %>
-  <%= f.input :order, include_blank: false, collection: [%w[Created id_desc], %w[Expiration expires_at_desc]], selected: params.dig(:search, :order) %>
+<%= form_search(path: bans_path) do |f| %>
+  <%= f.input :user_name, label: "User", autocomplete: "user" %>
+  <%= f.input :banner_name, label: "Banner", autocomplete: "user" %>
+  <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard" %>
+  <%= f.input :expired, label: "Expired?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :order, include_blank: false, collection: [%w[Created id_desc], %w[Expiration expires_at_desc]] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/blips/_search.html.erb
+++ b/app/views/blips/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: blips_path do |f| %>
+<%= form_search path: blips_path do |f| %>
   <%= f.input :creator_name, label: "Blipper", input_html: {value: params.dig(:search, :creator_name), data: {autocomplete: "user"}} %>
   <%= f.input :body_matches, label: "Body", input_html: {value: params.dig(:search, :body_matches)} %>
   <%= f.input :response_to, label: "Parent Blip #", input_html: {value: params.dig(:search, :response_to)} %>

--- a/app/views/bulk_update_requests/_search.html.erb
+++ b/app/views/bulk_update_requests/_search.html.erb
@@ -1,9 +1,9 @@
-<%= simple_form_for(:search, url: bulk_update_requests_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :user_name, label: "Creator", input_html: { value: params.dig(:search, :user_name), data: { autocomplete: "user" } } %>
-  <%= f.input :approver_name, label: "Approver", input_html: { value: params.dig(:search, :approver_name), data: { autocomplete: "user" } } %>
-  <%= f.input :title_matches, label: "Title", input_html: { value: params.dig(:search, :title_matches) } %>
-  <%= f.input :script_matches, label: "Script", input_html: { value: params.dig(:search, :script_matches) } %>
-  <%= f.input :status, label: "Status", collection: %w[pending approved rejected], include_blank: true, selected: params.dig(:search, :status) %>
-  <%= f.input :order, collection: [%w[Status status_desc], %w[Last\ updated updated_at_desc], %w[Newest id_desc], %w[Oldest id_asc]], include_blank: false, selected: params.dig(:search, :order) %>
+<%= form_search(path: bulk_update_requests_path) do |f| %>
+  <%= f.input :user_name, label: "Creator", autocomplete: "user" %>
+  <%= f.input :approver_name, label: "Approver", autocomplete: "user" %>
+  <%= f.input :title_matches, label: "Title" %>
+  <%= f.input :script_matches, label: "Script" %>
+  <%= f.input :status, label: "Status", collection: %w[pending approved rejected], include_blank: true %>
+  <%= f.input :order, collection: [%w[Status status_desc], %w[Last\ updated updated_at_desc], %w[Newest id_desc], %w[Oldest id_asc]], include_blank: false %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/comment_votes/index.html.erb
+++ b/app/views/comment_votes/index.html.erb
@@ -1,15 +1,16 @@
 <div id="c-comment-votes">
   <div id="a-index">
-    <%= simple_form_for(:search, method: :get, html: { class: "inline-form" }) do |f| %>
-      <%= f.input :user_name, label: "Voter Username", input_html: { value: params.dig(:search, :user_name), data: { autocomplete: "user" }} %>
-      <%= f.input :comment_id, label: "Comment ID", input_html: { value: params.dig(:search, :comment_id) } %>
+    <%# path is a string here because of duplicate routes %>
+    <%= form_search(path: "comment_votes") do |f| %>
+      <%= f.input :user_name, label: "Voter Username", autocomplete: "user" %>
+      <%= f.input :comment_id, label: "Comment ID" %>
       <br>
-      <%= f.input :comment_creator_name, label: "Comment Creator Username", input_html: { value: params.dig(:search, :comment_creator_name), data: { autocomplete: "user" }} %>
-      <%= f.input :timeframe, label: "Timeframe", include_blank: true, collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]], selected: params[:search][:timeframe] %>
-      <%= f.input :score, label: "Type", include_blank: true, collection: [["Upvote", "1"], ["Locked", "0"], ["Downvote", "-1"]], selected: params[:search][:score] %>
-      <%= f.input :user_ip_addr, label: "IP Address", input_html: { value: params.dig(:search, :user_ip_addr) } %>
-      <%= f.input :duplicates_only, label: "Duplicates Only", as: :boolean, input_html: { checked: params.dig(:search, :duplicates_only).to_s.truthy? } %>
-      <%= f.input :order, collection: [["Created", "id"], ["IP Address", "ip_addr"]], selected: params[:search][:order] %>
+      <%= f.input :comment_creator_name, label: "Comment Creator Username", autocomplete: "user" %>
+      <%= f.input :timeframe, label: "Timeframe", include_blank: true, collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]] %>
+      <%= f.input :score, label: "Type", include_blank: true, collection: [["Upvote", "1"], ["Locked", "0"], ["Downvote", "-1"]] %>
+      <%= f.input :user_ip_addr, label: "IP Address" %>
+      <%= f.input :duplicates_only, label: "Duplicates Only", as: :boolean %>
+      <%= f.input :order, collection: [["Created", "id"], ["IP Address", "ip_addr"]] %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/comments/_search.html.erb
+++ b/app/views/comments/_search.html.erb
@@ -1,0 +1,14 @@
+<%= simple_form_for(:search, :method => :get, url: comments_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= hidden_field_tag "group_by", "comment", :id => "group_by_full" %>
+  <%= f.input :creator_name, label: "Commenter", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :body_matches, label: "Body" %>
+  <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
+  <% if CurrentUser.is_moderator? %>
+    <%= f.input :ip_addr, label: "Ip Address" %>
+    <%= f.input :is_hidden, label: "Hidden?", collection: [["Yes", true], ["No", false]] %>
+  <% end %>
+  <%= f.input :is_sticky, label: "Sticky?", collection: [["Yes", true], ["No", false]] %>
+  <%= f.input :do_not_bump_post, label: "Bumping?", collection: [["Yes", false], ["No", true]] %>
+  <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc), %w(Score score_desc), %w(Post post_id_desc)] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/comments/_search.html.erb
+++ b/app/views/comments/_search.html.erb
@@ -1,8 +1,8 @@
-<%= simple_form_for(:search, :method => :get, url: comments_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+<%= form_search(path: comments_path) do |f| %>
   <%= hidden_field_tag "group_by", "comment", :id => "group_by_full" %>
-  <%= f.input :creator_name, label: "Commenter", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :creator_name, label: "Commenter", autocomplete: "user" %>
   <%= f.input :body_matches, label: "Body" %>
-  <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
+  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
   <% if CurrentUser.is_moderator? %>
     <%= f.input :ip_addr, label: "Ip Address" %>
     <%= f.input :is_hidden, label: "Hidden?", collection: [["Yes", true], ["No", false]] %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -4,6 +4,7 @@
 
     <%= render "posts/partials/common/inline_blacklist" %>
 
+    <%= render "search" %>
     <% if params[:group_by] == "comment" %>
       <%= render "index_by_comment" %>
     <% else %>

--- a/app/views/comments/search.html.erb
+++ b/app/views/comments/search.html.erb
@@ -2,20 +2,7 @@
   <div id="a-search">
     <h1>Search Comments</h1>
 
-    <%= simple_form_for(:search, :method => :get, url: comments_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-      <%= hidden_field_tag "group_by", "comment", :id => "group_by_full" %>
-      <%= f.input :creator_name, label: "Commenter", input_html: { data: { autocomplete: "user" } } %>
-      <%= f.input :body_matches, label: "Body" %>
-      <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
-      <% if CurrentUser.is_moderator? %>
-        <%= f.input :ip_addr, label: "Ip Address" %>
-        <%= f.input :is_hidden, label: "Hidden?", collection: [["Yes", true], ["No", false]] %>
-      <% end %>
-      <%= f.input :is_sticky, label: "Sticky?", collection: [["Yes", true], ["No", false]] %>
-      <%= f.input :do_not_bump_post, label: "Bumping?", collection: [["Yes", false], ["No", true]] %>
-      <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc), %w(Score score_desc), %w(Post post_id_desc)] %>
-      <%= f.submit "Search" %>
-    <% end %>
+    <%= render "search" %>
   </div>
 </div>
 

--- a/app/views/dmails/_search.html.erb
+++ b/app/views/dmails/_search.html.erb
@@ -1,8 +1,8 @@
-<%= simple_form_for(:search, url: dmails_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+<%= form_search(path: dmails_path) do |f| %>
   <%= f.hidden_field :folder, value: params[:folder] %>
-  <%= f.input :title_matches, label: "Title", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :title_matches) } %>
-  <%= f.input :message_matches, label: "Message", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :messages_matches) } %>
-  <%= f.input :to_name, label: "To", input_html: { value: params.dig(:search, :to_name), data: { autocomplete: "user" } } %>
-  <%= f.input :from_name, label: "From", input_html: { value: params.dig(:search, :from_name), data: { autocomplete: "user" } } %>
+  <%= f.input :title_matches, label: "Title", hint: "Use * for wildcard" %>
+  <%= f.input :message_matches, label: "Message", hint: "Use * for wildcard" %>
+  <%= f.input :to_name, label: "To" %>
+  <%= f.input :from_name, label: "From", autocomplete: "user" %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/email_blacklists/_search.html.erb
+++ b/app/views/email_blacklists/_search.html.erb
@@ -1,6 +1,6 @@
-<%= simple_form_for(:search, url: email_blacklists_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :pattern, label: "Domain", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :domain)} %>
-  <%= f.input :reason, label: "Ban Reason", input_html: { value: params.dig(:search, :reason) } %>
-  <%= f.input :order, collection: [["Recently created", "id"], ["Last updated", "updated_at"], ["Domain", "domain"], ["Reason", "reason"]], selected: params.dig(:search, :order) %>
+<%= form_search(path: email_blacklists_path) do |f| %>
+  <%= f.input :pattern, label: "Domain", hint: "Use * for wildcard" %>
+  <%= f.input :reason, label: "Ban Reason" %>
+  <%= f.input :order, collection: [["Recently created", "id"], ["Last updated", "updated_at"], ["Domain", "domain"], ["Reason", "reason"]] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/forum_posts/_search.html.erb
+++ b/app/views/forum_posts/_search.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for(:search, url: forum_posts_path, method: :get, defaults: { required: false }) do |f| %>
+  <%= f.input :topic_title_matches, label: "Title" %>
+  <%= f.input :body_matches, label: "Body" %>
+  <%= f.input :creator_name, label: "Author", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :topic_category_id, label: "Category", collection: ForumCategory.visible.reverse_mapping, include_blank: true %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/forum_posts/_search.html.erb
+++ b/app/views/forum_posts/_search.html.erb
@@ -1,7 +1,7 @@
-<%= simple_form_for(:search, url: forum_posts_path, method: :get, defaults: { required: false }) do |f| %>
+<%= form_search(path: forum_posts_path) do |f| %>
   <%= f.input :topic_title_matches, label: "Title" %>
   <%= f.input :body_matches, label: "Body" %>
-  <%= f.input :creator_name, label: "Author", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :creator_name, label: "Author", autocomplete: "user" %>
   <%= f.input :topic_category_id, label: "Category", collection: ForumCategory.visible.reverse_mapping, include_blank: true %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/forum_posts/index.html.erb
+++ b/app/views/forum_posts/index.html.erb
@@ -1,5 +1,6 @@
 <div id="c-forum-posts">
   <div id="a-index">
+    <%= render "search" %>
     <table width="100%" class="striped">
       <thead>
         <tr>

--- a/app/views/forum_posts/search.html.erb
+++ b/app/views/forum_posts/search.html.erb
@@ -1,16 +1,8 @@
 <div id="c-forum-posts">
   <div id="a-search">
     <h1>Search Forum</h1>
-    <%= form_tag(forum_posts_path, :method => :get, :class => "simple_form") do %>
-      <%= search_field "topic_title_matches", :label => "Title" %>
-      <%= search_field "body_matches", :label => "Body" %>
-      <%= search_field "creator_name", :label => "Author", :data => { autocomplete: "user" } %>
-      <div class="input">
-        <label for="search_topic_category_id">Category</label>
-        <%= forum_topic_category_select("search", "topic_category_id", include_blank: true) %>
-      </div>
-      <%= submit_tag "Search" %>
-    <% end %>
+
+    <%= render "search" %>
   </div>
 </div>
 

--- a/app/views/mod_actions/_search.html.erb
+++ b/app/views/mod_actions/_search.html.erb
@@ -1,5 +1,5 @@
-<%= simple_form_for(:search, method: :get, url: mod_actions_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name), data: { autocomplete: "user" } } %>
-  <%= f.input :action, label: "Action", collection: ModAction::KnownActions.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true, selected: params.dig(:search, :action) %>
+<%= form_search(path: mod_actions_path) do |f| %>
+  <%= f.input :creator_name, label: "Creator", autocomplete: "user" %>
+  <%= f.input :action, label: "Action", collection: ModAction::KnownActions.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/moderator/ip_addrs/_search.html.erb
+++ b/app/views/moderator/ip_addrs/_search.html.erb
@@ -1,10 +1,10 @@
 <div class="box-section">
   It is possible to search for IP address wildcards using CIDR notation, but only if searching for a single IP addr. You probably want '/24' at the end for IPv4 wildcards.
 </div>
-<%= simple_form_for(:search, method: :get, url: moderator_ip_addrs_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :user_id, label: "User IDs", input_html: { value: params.dig(:search, :user_id) } %>
-  <%= f.input :user_name, label: "User Names", input_html: { value: params.dig(:search, :user_name) } %>
-  <%= f.input :ip_addr, label: "IP Addresses", input_html: { value: params.dig(:search, :ip_addr) } %>
-  <%= f.input :with_history, label: "With History", as: :boolean, input_html: { checked: params.dig(:search, :with_history).to_s.truthy? } %>
+<%= form_search(path: moderator_ip_addrs_path) do |f| %>
+  <%= f.input :user_id, label: "User IDs" %>
+  <%= f.input :user_name, label: "User Names", autocomplete: "user" %>
+  <%= f.input :ip_addr, label: "IP Addresses" %>
+  <%= f.input :with_history, label: "With History", as: :boolean %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/moderator/post/disapprovals/index.html.erb
+++ b/app/views/moderator/post/disapprovals/index.html.erb
@@ -2,14 +2,14 @@
   <div id="a-index">
     <h1>Disapprovals</h1>
 
-    <%= simple_form_for(:search, url: moderator_post_disapprovals_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-      <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
-      <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
-      <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
-      <%= f.input :message_matches, label: "Message", input_html: { value: params[:search][:message_matches] } %>
-      <%= f.input :reason, label: "Reason", collection: %w[borderline_quality borderline_relevancy other].map { |x| [x.humanize, x] }, include_blank: true, selected: params[:search][:reason] %>
-      <%= f.input :has_message, label: "Has Message?", collection: %w[Yes No], include_blank: true, selected: params[:search][:has_message] %>
-      <%= f.input :order, collection: [["ID", "id_desc"], ["Post ID", "post_id_desc"]], selected: params[:search][:order] %>
+    <%= form_search(path: moderator_post_disapprovals_path) do |f| %>
+      <%= f.input :creator_name, label: "Creator", autocomplete: "user" %>
+      <%= f.input :post_id, label: "Post ID" %>
+      <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
+      <%= f.input :message_matches, label: "Message" %>
+      <%= f.input :reason, label: "Reason", collection: %w[borderline_quality borderline_relevancy other].map { |x| [x.humanize, x] }, include_blank: true %>
+      <%= f.input :has_message, label: "Has Message?", collection: %w[Yes No], include_blank: true %>
+      <%= f.input :order, collection: [["ID", "id_desc"], ["Post ID", "post_id_desc"]] %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/notes/_quick_search.html.erb
+++ b/app/views/notes/_quick_search.html.erb
@@ -1,4 +1,3 @@
 <%= form_tag(notes_path, :method => :get) do %>
-  <%= hidden_field_tag "group_by", "note" %>
   <%= text_field "search", "body_matches", :id => "quick_search_body_matches", :placeholder => "Search notes" %>
 <% end %>

--- a/app/views/notes/_search.html.erb
+++ b/app/views/notes/_search.html.erb
@@ -1,8 +1,6 @@
-<%= simple_form_for(:search, url: notes_path, method: :get, defaults: { required: false }) do |f| %>
-  <%= f.hidden_field :group_by, value: "note" %>
-
+<%= form_search(path: notes_path) do |f| %>
   <%= f.input :body_matches, label: "Body" %>
-  <%= f.input :creator_name, label: "Author", input_html: { data: { autocomplete: "user" } } %>
-  <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
+  <%= f.input :creator_name, label: "Author", autocomplete: "user" %>
+  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/notes/_search.html.erb
+++ b/app/views/notes/_search.html.erb
@@ -1,0 +1,8 @@
+<%= simple_form_for(:search, url: notes_path, method: :get, defaults: { required: false }) do |f| %>
+  <%= f.hidden_field :group_by, value: "note" %>
+
+  <%= f.input :body_matches, label: "Body" %>
+  <%= f.input :creator_name, label: "Author", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -2,6 +2,7 @@
   <div id="a-index">
     <h1>Notes</h1>
 
+    <%= render "search" %>
     <table width="100%" class="striped autofit">
       <thead>
         <tr>

--- a/app/views/notes/search.html.erb
+++ b/app/views/notes/search.html.erb
@@ -2,14 +2,7 @@
   <div id="a-search">
     <h1>Search Notes</h1>
 
-    <%= simple_form_for(:search, url: notes_path, method: :get, defaults: { required: false }) do |f| %>
-      <%= f.hidden_field :group_by, value: "note" %>
-
-      <%= f.input :body_matches, label: "Body" %>
-      <%= f.input :creator_name, label: "Author", input_html: { data: { autocomplete: "user" } } %>
-      <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
-      <%= f.submit "Search" %>
-    <% end %>
+    <%= render "search" %>
   </div>
 </div>
 

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -3,9 +3,9 @@
     <h1>Approvals</h1>
     <%= render "posts/partials/common/inline_blacklist" %>
 
-    <%= simple_form_for(:search, url: post_approvals_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-      <%= f.input :user_name, label: "Approver", input_html: { value: params[:search][:user_name], data: { autocomplete: "user" } } %>
-      <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
+    <%= form_search(path: post_approvals_path) do |f| %>
+      <%= f.input :user_name, label: "Approver", autocomplete: "user" %>
+      <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/post_events/_search.html.erb
+++ b/app/views/post_events/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: post_events_path do |f| %>
+<%= form_search path: post_events_path do |f| %>
   <%= f.input :post_id, label: "Post #", input_html: {value: params.dig(:search, :post_id)} %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name), data: { autocomplete: "user" } } %>
   <%= f.input :action, label: "Action", collection: PostEvent.actions.keys.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true, selected: params.dig(:search, :action) %>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -1,12 +1,12 @@
-<%= simple_form_for(:search, url: post_flags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches", input_html: { value: params.dig(:search, :reason_matches) } %>
-  <%= f.input :post_tags_match, label: "Tags", input_html: { value: params.dig(:search, :post_tags_match), data: { autocomplete: "tag-query" } } %>
-  <%= f.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :post_id) } %>
+<%= form_search(path: post_flags_path) do |f| %>
+  <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches" %>
+  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
+  <%= f.input :post_id, label: "Post ID" %>
   <% if CurrentUser.is_janitor? %>
-    <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name), data: { autocomplete: "user" } } %>
-    <%= f.input :ip_addr, label: "Ip Address", input_html: { value: params.dig(:search, :ip_addr)} %>
+    <%= f.input :creator_name, label: "Creator", autocomplete: "user" %>
+    <%= f.input :ip_addr, label: "Ip Address" %>
   <% end %>
-  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params.dig(:search, :is_resolved) %>
-  <%= f.input :category, label: "Category", collection: ["normal", "unapproved", "deleted", "banned", "duplicate"], include_blank: true, selected: params.dig(:search, :category) %>
+  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :category, label: "Category", collection: ["normal", "unapproved", "deleted", "banned", "duplicate"], include_blank: true %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/post_replacements/_search.html.erb
+++ b/app/views/post_replacements/_search.html.erb
@@ -1,9 +1,9 @@
-<%= simple_form_for(:search, url: post_replacements_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :md5, label: "MD5", input_html: { value: params.dig(:search, :md5) } %>
-  <%= f.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :post_id) } %>
-  <%= f.input :creator_name, label: "Creator", input_html: { value: params.dig(:search, :creator_name), data: { autocomplete: "user" } } %>
-  <%= f.input :approver_name, label: "Approver", input_html: { value: params.dig(:search, :approver_name), data: { autocomplete: "user" } } %>
-  <%= f.input :uploader_name_on_approve, label: "Original Uploader", input_html: { value: params.dig(:search, :uploader_name_on_approve), data: { autocomplete: "user" } } %>
-  <%= f.input :status, label: "status", collection: ["pending", "rejected", "approved", "promoted"], include_blank: true, selected: params.dig(:search, :status) %>
+<%= form_search(path: post_replacements_path) do |f| %>
+  <%= f.input :md5, label: "MD5" %>
+  <%= f.input :post_id, label: "Post ID" %>
+  <%= f.input :creator_name, label: "Creator", autocomplete: "user" %>
+  <%= f.input :approver_name, label: "Approver", autocomplete: "user" %>
+  <%= f.input :uploader_name_on_approve, label: "Original Uploader", autocomplete: "user" %>
+  <%= f.input :status, label: "status", collection: ["pending", "rejected", "approved", "promoted"], include_blank: true %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/post_sets/_search.html.erb
+++ b/app/views/post_sets/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: post_sets_path do |f| %>
+<%= form_search path: post_sets_path do |f| %>
   <%= f.input :name, label: "Name", input_html: { value: params.dig(:search, :name) } %>
   <%= f.input :shortname, label: "Short Name", input_html: {value: params.dig(:search, :shortname)} %>
   <%= f.input :creator_name, label: "Username", input_html: {value: params.dig(:search, :creator_name), data: {autocomplete: 'users'}} %>

--- a/app/views/post_versions/_search.html.erb
+++ b/app/views/post_versions/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: post_versions_path do |f| %>
+<%= form_search path: post_versions_path do |f| %>
   <%= f.input :updater_name, label: "User", input_html: {value: params.dig(:search, :updater_name), data: {autocomplete: "user"}} %>
   <%= f.input :updater_id, label: "User ID", input_html: {value: params.dig(:search, :updater_id)} %>
   <%= f.input :post_id, label: "Post #", input_html: {value: params.dig(:search, :post_id)} %>

--- a/app/views/post_votes/index.html.erb
+++ b/app/views/post_votes/index.html.erb
@@ -1,14 +1,15 @@
 <div id="c-post-votes">
   <div id="a-index">
-    <%= simple_form_for(:search, method: :get, html: { class: "inline-form" }) do |f| %>
-      <%= f.input :user_name, label: "Username", input_html: { value: params.dig(:search, :user_name), data: { autocomplete: "user" } } %>
-      <%= f.input :post_id, label: "Post ID", input_html: { value: params.dig(:search, :post_id) } %>
+    <%# path is a string here because of duplicate routes %>
+    <%= form_search(path: "post_votes") do |f| %>
+      <%= f.input :user_name, label: "Username", autocomplete: "user" %>
+      <%= f.input :post_id, label: "Post ID" %>
       <br>
-      <%= f.input :timeframe, label: "Timeframe", include_blank: true, collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]], selected: params[:search][:timeframe] %>
-      <%= f.input :score, label: "Type", include_blank: true, collection: [["Upvote", "1"], ["Locked", "0"], ["Downvote", "-1"]], selected: params[:search][:score] %>
-      <%= f.input :user_ip_addr, label: "IP Address", input_html: { value: params.dig(:search, :user_ip_addr) } %>
-      <%= f.input :duplicates_only, label: "Duplicates Only", as: :boolean, input_html: { checked: params.dig(:search, :duplicates_only).to_s.truthy? } %>
-      <%= f.input :order, collection: [["Created", "id"], ["IP Address", "ip_addr"]], selected: params[:search][:order] %>
+      <%= f.input :timeframe, label: "Timeframe", include_blank: true, collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]] %>
+      <%= f.input :score, label: "Type", include_blank: true, collection: [["Upvote", "1"], ["Locked", "0"], ["Downvote", "-1"]] %>
+      <%= f.input :user_ip_addr, label: "IP Address" %>
+      <%= f.input :duplicates_only, label: "Duplicates Only", as: :boolean %>
+      <%= f.input :order, collection: [["Created", "id"], ["IP Address", "ip_addr"]] %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/tag_relationships/_search.html.erb
+++ b/app/views/tag_relationships/_search.html.erb
@@ -1,10 +1,10 @@
 <%# url %>
 
-<%= simple_form_for(:search, method: :get, url: url, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
-  <%= f.input :status, label: "Status", collection: %w[Approved Active Pending Deleted Retired Processing Queued], include_blank: true, selected: params[:search][:status] %>
-  <%= f.input :antecedent_tag_category, label: "From Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params.dig(:search, :antecedent_tag_category) %>
-  <%= f.input :consequent_tag_category, label: "To Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params.dig(:search, :consequent_tag_category) %>
-  <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]], selected: params[:search][:order] %>
+<%= form_search(path: url) do |f| %>
+  <%= f.input :name_matches, label: "Name", autocomplete: "tag" %>
+  <%= f.input :status, label: "Status", collection: %w[Approved Active Pending Deleted Retired Processing Queued], include_blank: true %>
+  <%= f.input :antecedent_tag_category, label: "From Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true %>
+  <%= f.input :consequent_tag_category, label: "To Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true %>
+  <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/tag_relationships/_search.html.erb
+++ b/app/views/tag_relationships/_search.html.erb
@@ -3,12 +3,8 @@
 <%= simple_form_for(:search, method: :get, url: url, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
   <%= f.input :status, label: "Status", collection: %w[Approved Active Pending Deleted Retired Processing Queued], include_blank: true, selected: params[:search][:status] %>
-  <%= f.simple_fields_for :antecedent_tag do |fa| %>
-    <%= fa.input :category, label: "From Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params.dig(:search, :antecedent_tag, :category) %>
-  <% end %>
-  <%= f.simple_fields_for :consequent_tag do |fa| %>
-    <%= fa.input :category, label: "To Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params.dig(:search, :consequent_tag, :category) %>
-  <% end %>
+  <%= f.input :antecedent_tag_category, label: "From Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params.dig(:search, :antecedent_tag_category) %>
+  <%= f.input :consequent_tag_category, label: "To Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params.dig(:search, :consequent_tag_category) %>
   <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]], selected: params[:search][:order] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/tag_type_versions/_search.html.erb
+++ b/app/views/tag_type_versions/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: tag_type_versions_path do |f| %>
+<%= form_search path: tag_type_versions_path do |f| %>
   <%= f.input :tag, label: "Tag", input_html: { value: params.dig(:search, :tag) } %>
   <%= f.input :user_name, label: "Username", input_html: {value: params.dig(:search, :user_name), data: {autocomplete: "user"}} %>
   <%= f.input :user_id, label: "User ID", input_html: {value: params.dig(:search, :user_id)} %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -1,9 +1,9 @@
-<%= simple_form_for(:search, url: tags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :name_matches), data: { autocomplete: "tag" } } %>
-  <%= f.input :category, label: "Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true,selected: params.dig(:search, :category) %>
-  <%= f.input :order, collection: [%w[Newest date], %w[Count count], %w[Name name]], include_blank: false, selected: params.dig(:search, :order) %>
-  <%= f.input :hide_empty, label: "Hide empty?", collection: %w[yes no], selected: params.dig(:search, :hide_empty) %>
-  <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true, selected: params.dig(:search, :has_wiki) %>
-  <%= f.input :has_artist, label: "Has artist?", collection: %w[yes no], include_blank: true, selected: params.dig(:search, :has_artist) %>
+<%= form_search(path: tags_path) do |f| %>
+  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", autocomplete: "tag" %>
+  <%= f.input :category, label: "Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true %>
+  <%= f.input :order, collection: [%w[Newest date], %w[Count count], %w[Name name]], include_blank: false %>
+  <%= f.input :hide_empty, label: "Hide empty?", collection: %w[yes no] %>
+  <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true %>
+  <%= f.input :has_artist, label: "Has artist?", collection: %w[yes no], include_blank: true %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/takedowns/_search.html.erb
+++ b/app/views/takedowns/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: path do |f| %>
+<%= form_search path: path do |f| %>
   <%= f.input :status, label: "Status", collection: [["Pending", "pending"],
                                                       ["Inactive", "inactive"],
                                                       ["Denied", "denied"],

--- a/app/views/tickets/_search.html.erb
+++ b/app/views/tickets/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: tickets_path do |f| %>
+<%= form_search path: tickets_path do |f| %>
   <% if CurrentUser.is_admin? %>
     <%= f.input :creator_name, label: "Reporter", input_html: {value: params.dig(:search, :creator_name)} %>
     <%= f.input :creator_id, label: "Reporter ID", input_html: {value: params.dig(:search, :creator_id)} %>

--- a/app/views/upload_whitelists/_search.html.erb
+++ b/app/views/upload_whitelists/_search.html.erb
@@ -1,7 +1,7 @@
-<%= simple_form_for(:search, url: upload_whitelists_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :pattern, label: "Pattern", hint: "Use * for wildcard", input_html: { value: params[:search][:pattern]} %>
-  <%= f.input :note, label: "Note", as: "string", input_html: { value: params[:search][:note] } %>
-  <%= f.input :reason, label: "Ban Reason", input_html: { value: params[:search][:reason] } %>
-  <%= f.input :order, collection: [["Recently created", "id"], ["Last updated", "updated_at"], ["Pattern", "pattern"], ["Note", "note"]], selected: params[:search][:order] %>
+<%= form_search(path: upload_whitelists_path) do |f| %>
+  <%= f.input :pattern, label: "Pattern", hint: "Use * for wildcard" %>
+  <%= f.input :note, label: "Note", as: :string %>
+  <%= f.input :reason, label: "Ban Reason" %>
+  <%= f.input :order, collection: [["Recently created", "id"], ["Last updated", "updated_at"], ["Pattern", "pattern"], ["Note", "note"]] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/uploads/_search.html.erb
+++ b/app/views/uploads/_search.html.erb
@@ -1,8 +1,8 @@
-<%= simple_form_for(:search, url: uploads_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :uploader_name, label: "Uploader", input_html: { value: params[:search][:uploader_name], data: { autocomplete: "user" } } %>
-  <%= f.input :post_tags_match, label: "Post Tags", input_html: { value: params[:search][:post_tags_match] } %>
-  <%= f.input :source_matches, label: "Source", input_html: { value: params[:search][:source_matches] } %>
-  <%= f.input :status, collection: [%w[Completed completed], %w[Processing processing], %w[Pending pending], %w[Duplicate *duplicate*], %w[Error error*]], include_blank: true, selected: params[:search][:status] %>
+<%= form_search(path: uploads_path) do |f| %>
+  <%= f.input :uploader_name, label: "Uploader", autocomplete: "user" %>
+  <%= f.input :post_tags_match, label: "Post Tags" %>
+  <%= f.input :source_matches, label: "Source" %>
+  <%= f.input :status, collection: [%w[Completed completed], %w[Processing processing], %w[Pending pending], %w[Duplicate *duplicate*], %w[Error error*]], include_blank: true %>
 
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/user_feedbacks/_search.html.erb
+++ b/app/views/user_feedbacks/_search.html.erb
@@ -1,6 +1,6 @@
-<%= simple_form_for(:search, :method => :get, url: user_feedbacks_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :user_name, label: "User", input_html: { data: { autocomplete: "user" } } %>
-  <%= f.input :creator_name, label: "Creator", input_html: { data: { autocomplete: "user" } } %>
+<%= form_search(path: user_feedbacks_path) do |f| %>
+  <%= f.input :user_name, label: "User", autocomplete: "user" %>
+  <%= f.input :creator_name, label: "Creator", autocomplete: "user" %>
   <%= f.input :body_matches, label: "Message" %>
   <%= f.input :category, collection: %w[positive negative neutral], include_blank: true %>
   <%= f.submit "Search" %>

--- a/app/views/user_feedbacks/_search.html.erb
+++ b/app/views/user_feedbacks/_search.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for(:search, :method => :get, url: user_feedbacks_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :user_name, label: "User", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :creator_name, label: "Creator", input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :body_matches, label: "Message" %>
+  <%= f.input :category, collection: %w[positive negative neutral], include_blank: true %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -2,6 +2,7 @@
   <div id="a-index">
     <h1>User Feedback</h1>
 
+    <%= render "search" %>
     <table class="striped" width="100%">
       <thead>
         <tr>

--- a/app/views/user_feedbacks/search.html.erb
+++ b/app/views/user_feedbacks/search.html.erb
@@ -2,20 +2,7 @@
   <div id="a-search">
     <h1>Search User Feedbacks</h1>
 
-    <%= form_tag(user_feedbacks_path, :method => :get, :class => "simple_form") do %>
-      <%= search_field "user_name", :label => "User", :data => { autocomplete: "user" } %>
-      <%= search_field "creator_name", :label => "Creator", :data => { autocomplete: "user" } %>
-      <%= search_field "body_matches", :label => "Message" %>
-
-      <div class="input">
-        <label for="search_category">Category</label>
-        <%= select "search", "category", %w(positive negative neutral), :include_blank => true %>
-      </div>
-
-      <div class="input">
-        <%= submit_tag "Search" %>
-      </div>
-    <% end %>
+    <%= render "search" %>
   </div>
 </div>
 

--- a/app/views/user_name_change_requests/_search.html.erb
+++ b/app/views/user_name_change_requests/_search.html.erb
@@ -1,4 +1,4 @@
-<%= hideable_form_search path: user_name_change_requests_path do |f| %>
+<%= form_search path: user_name_change_requests_path do |f| %>
   <%= f.input :current_name, label: "Current Name", input_html: {value: params.dig(:search, :current_name), data: {autocomplete: "user"}} %>
   <%= f.input :original_name, label: "Original Name", input_html: {value: params.dig(:search, :original_name)} %>
   <%= f.input :desired_name, label: "Desired Name", input_html: {value: params.dig(:search, :desired_name)} %>

--- a/app/views/users/_search.html.erb
+++ b/app/views/users/_search.html.erb
@@ -1,17 +1,17 @@
-<%= simple_form_for(:search, url: users_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :name_matches), data: { autocomplete: "user" } } %>
+<%= form_search(path: users_path) do |f| %>
+  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", autocomplete: "user" %>
 
   <% if CurrentUser.is_admin? %>
-    <%= f.input :email_matches, label: "Email", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :email_matches) }  %>
+    <%= f.input :email_matches, label: "Email", hint: "Use * for wildcard" %>
   <% end %>
 
-  <%= f.input :level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :level) %>
-  <%= f.input :min_level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :min_level) %>
-  <%= f.input :max_level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :max_level) %>
+  <%= f.input :level, collection: User.level_hash.to_a, include_blank: true %>
+  <%= f.input :min_level, collection: User.level_hash.to_a, include_blank: true %>
+  <%= f.input :max_level, collection: User.level_hash.to_a, include_blank: true %>
 
-  <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: true, selected: params.dig(:search, :can_upload_free) %>
-  <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: true, selected: params.dig(:search, :can_approve_posts) %>
+  <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: true %>
+  <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: true %>
 
-  <%= f.input :order, collection: [["Join date", "date"], ["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]], selected: params.dig(:search, :order) %>
+  <%= f.input :order, collection: [["Join date", "date"], ["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/users/_search.html.erb
+++ b/app/views/users/_search.html.erb
@@ -1,0 +1,17 @@
+<%= simple_form_for(:search, url: users_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :name_matches), data: { autocomplete: "user" } } %>
+
+  <% if CurrentUser.is_admin? %>
+    <%= f.input :email_matches, label: "Email", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :email_matches) }  %>
+  <% end %>
+
+  <%= f.input :level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :level) %>
+  <%= f.input :min_level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :min_level) %>
+  <%= f.input :max_level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :max_level) %>
+
+  <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: true, selected: params.dig(:search, :can_upload_free) %>
+  <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: true, selected: params.dig(:search, :can_approve_posts) %>
+
+  <%= f.input :order, collection: [["Join date", "date"], ["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]], selected: params.dig(:search, :order) %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,11 +2,7 @@
   <div id="a-index">
     <h1>Users</h1>
 
-    <% form_tag(users_path, :method => :get, :class => "simple_form") do %>
-      <%= search_field "name_matches", :label => "Name" %>
-      <%= submit_tag "Search" %>
-    <% end %>
-
+    <%= render "search" %>
     <table width="100%" class="striped">
       <thead>
         <tr>

--- a/app/views/users/search.html.erb
+++ b/app/views/users/search.html.erb
@@ -1,22 +1,8 @@
 <div id="c-users">
   <div id="a-search">
-    <%= simple_form_for(:search, url: users_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-      <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :name_matches), data: { autocomplete: "user" } } %>
-
-      <% if CurrentUser.is_admin? %>
-        <%= f.input :email_matches, label: "Email", hint: "Use * for wildcard", input_html: { value: params.dig(:search, :email_matches) }  %>
-      <% end %>
-
-      <%= f.input :level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :level) %>
-      <%= f.input :min_level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :min_level) %>
-      <%= f.input :max_level, collection: User.level_hash.to_a, include_blank: true, selected: params.dig(:search, :max_level) %>
-
-      <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: true, selected: params.dig(:search, :can_upload_free) %>
-      <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: true, selected: params.dig(:search, :can_approve_posts) %>
-
-      <%= f.input :order, collection: [["Join date", "date"], ["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]], selected: params.dig(:search, :order) %>
-      <%= f.submit "Search" %>
-    <% end %>
+    <h1>Search Users</h1>
+    
+    <%= render "search" %>
   </div>
 </div>
 

--- a/app/views/wiki_pages/_search.html.erb
+++ b/app/views/wiki_pages/_search.html.erb
@@ -1,0 +1,9 @@
+<%= simple_form_for(:search, url: wiki_pages_path, method: :get, defaults: { required: false }) do |f| %>
+  <%= f.input :title, label: "Title", hint: "Use * for wildcard searches", input_html: { data: { autocomplete: "wiki-page" } } %>
+  <%= f.input :creator_name, input_html: { data: { autocomplete: "user" } } %>
+  <%= f.input :other_names_match, label: "Other names", hint: "Use * for wildcard searches" %>
+  <%= f.input :other_names_present, collection: %w[Yes No], include_blank: true %>
+  <%= f.input :hide_deleted, collection: %w[Yes No] %>
+  <%= f.input :order, collection: [%w[Name title], %w[Date time], %w[Posts post_count]] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/wiki_pages/_search.html.erb
+++ b/app/views/wiki_pages/_search.html.erb
@@ -1,6 +1,6 @@
-<%= simple_form_for(:search, url: wiki_pages_path, method: :get, defaults: { required: false }) do |f| %>
-  <%= f.input :title, label: "Title", hint: "Use * for wildcard searches", input_html: { data: { autocomplete: "wiki-page" } } %>
-  <%= f.input :creator_name, input_html: { data: { autocomplete: "user" } } %>
+<%= form_search(path: wiki_pages_path) do |f| %>
+  <%= f.input :title, label: "Title", hint: "Use * for wildcard searches", autocomplete: "wiki-page" %>
+  <%= f.input :creator_name, autocomplete: "user" %>
   <%= f.input :other_names_match, label: "Other names", hint: "Use * for wildcard searches" %>
   <%= f.input :other_names_present, collection: %w[Yes No], include_blank: true %>
   <%= f.input :hide_deleted, collection: %w[Yes No] %>

--- a/app/views/wiki_pages/index.html.erb
+++ b/app/views/wiki_pages/index.html.erb
@@ -5,6 +5,7 @@
     <section id="content">
       <h1>Wiki</h1>
 
+      <%= render "search" %>
       <table class="striped" width="100%">
         <thead>
           <tr>

--- a/app/views/wiki_pages/search.html.erb
+++ b/app/views/wiki_pages/search.html.erb
@@ -1,28 +1,8 @@
 <div id="c-wiki-pages">
   <div id="a-search">
-    <%= form_tag(wiki_pages_path, :method => :get, :class => "simple_form") do %>
-      <%= search_field "title", :hint => "Use * for wildcard searches", :data => { :autocomplete => "wiki-page" } %>
-      <%= search_field "creator_name", :data => { :autocomplete => "user" } %>
-      <%= search_field "body_matches", :label => "Body" %>
-      <%= search_field "other_names_match", :label => "Other names", :hint => "Use * for wildcard searches" %>
+    <h1>Search Wiki</h1>
 
-      <div class="input">
-        <label for="search_other_names_present">Other names present?</label>
-        <%= select "search", "other_names_present", ["yes", "no"], :include_blank => true %>
-      </div>
-
-      <div class="input">
-        <label for="search_order">Order</label>
-        <%= select "search", "order", [%w[Name title], %w[Date time], %w[Posts post_count]] %>
-      </div>
-
-      <div class="input">
-        <label for="search_hide_deleted">Hide Deleted</label>
-        <%= select "search", "hide_deleted", ["Yes", "No"] %>
-      </div>
-
-      <%= submit_tag "Search" %>
-    <% end %>
+    <%= render "search" %>
   </div>
 </div>
 


### PR DESCRIPTION
Improves the way search form are currently build.
Adds a custom form builder which automatically sets the values from what is set in the url. Also adds a shorthand to set the autocomplete property. This has the positive side-effect that all form now do this, while most already did there were a few which didn't autofill. Two forms had nested params `search[a][b]` which I flattened because I didn't want to have the form builder support that.

I also was annoyed that there were a few pages which had dedicated search pages but no way to search directly on the index like on most other ones, so I moved these to partials and added them to the index as well. A few models modified the url parameters in their search function which caused them to be non-empty, this caused the search form to always be expanded on load. I removed these parameters, since I suspect they were only part of danbooru anyways.

212d6e3727f182533278d0f69a15f4c1fcdb7f1a is the main commit, the rest are preparations and fixes for that to happen.