### PR TITLE
Theme support for related tags, autocompletion and backtraces

### DIFF
--- a/app/javascript/src/styles/common/jquery_ui_custom.scss
+++ b/app/javascript/src/styles/common/jquery_ui_custom.scss
@@ -89,6 +89,9 @@ div.ui-dialog {
 .ui-widget-content {
   border: 1px solid $widget-border;
   background-color: $widget-background;
+  @include themable {
+    background-color: themed("color-section");
+  }
   color: $widget-color;
 }
 

--- a/app/javascript/src/styles/specific/error.scss
+++ b/app/javascript/src/styles/specific/error.scss
@@ -5,6 +5,9 @@ ul.backtrace {
   font-size: 1.2em;
   list-style-type: none;
   background: $section-background;
+  @include themable {
+    background: themed('color-section');
+  }
   padding: 1em;
   margin-bottom: 1em;
 }

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -4,6 +4,9 @@ div.related-tags {
   width: 100%;
   margin-bottom: 1em;
   background: $related-tags-background;
+  @include themable {
+    background: rgba(lighten( themed("color-section"), 10%), 0.7);
+  }
   overflow: hidden;
   border-radius: $border-radius-half;
   display: flex;


### PR DESCRIPTION
While using the hotdog theme on April Fools', something hurt my eyes more than the contract between the red and the yellow - the fact parts of the website still show in the default blue. A before and after example is shown below.

![e6](https://user-images.githubusercontent.com/102884856/161406599-796a5916-1387-4219-b0ef-05f3131d6b5d.PNG)

I also did the same for the autocompletion widget and backtraces. This is my first PR so I'm sorry if I did anything wrong :)