### PR TITLE
[Themes] more changes to theming including widgets, navbar and user edit

### DIFF
--- a/app/javascript/src/styles/common/jquery_ui_custom.scss
+++ b/app/javascript/src/styles/common/jquery_ui_custom.scss
@@ -90,12 +90,14 @@ div.ui-dialog {
   border: 1px solid $widget-border;
   background-color: $widget-background;
   @include themable {
-    background-color: themed("color-section");
+    background-color: lighten( themed("color-section"), 10%);
+    color: themed("color-text");
   }
-  color: $widget-color;
 }
 
 .ui-widget-header {
-  background-color: $widget-header-background;
-  color: $widget-header-color;
+  @include themable {
+    background-color: themed("color-background");
+    color: themed("color-text");
+  }
 }

--- a/app/javascript/src/styles/common/page_header.scss
+++ b/app/javascript/src/styles/common/page_header.scss
@@ -63,6 +63,8 @@ header#top {
   }
 
   menu:only-child {
-    border-bottom: 2px solid $menu-background;
+    @include themable {
+      border-bottom: 2px solid themed("color-foreground");
+    }
   }
 }

--- a/app/javascript/src/styles/specific/users.scss
+++ b/app/javascript/src/styles/specific/users.scss
@@ -106,7 +106,9 @@ div#c-users {
     }
 
     .active {
-      color: black;
+      @include themable {
+        color: themed("color-link-active");
+      }
     }
   }
 


### PR DESCRIPTION
Another theming request, this time making some more parts of the site themable, plus a fix to a mistake I made in the previous PR.

**Nav bar**
The border on the navbar (only shown when there's no subnav) was always blue, but now matches the subnav background.
![TopBar](https://user-images.githubusercontent.com/102884856/161630772-8ae3d4c0-2bd3-48e3-b223-7596e0190573.png)
 
**User settings**
Navigation links in the user settings were hardcoded to black when active, which was not the correct color for any theme. It also made it impossible to tell which link was active in the hotdog theme.
![HotdogSettings](https://user-images.githubusercontent.com/102884856/161630811-b1bc92ed-19e8-46b6-9daa-6e87e6a92866.png)
 
**Widgets**
The light border on the widget window was accidentally removed in PR #387  - it's now back.
![Pool](https://user-images.githubusercontent.com/102884856/161630971-8479039a-0e9c-4198-8227-3ccbc9240f63.PNG)

The header and text colors also now change depending on theme.
![AddToPool](https://user-images.githubusercontent.com/102884856/161631005-5e57ea47-ec26-4b28-931b-5bcd936f3024.png)

 



