### PR TITLE
[Uploader] Add trio to upload form

### DIFF
--- a/app/javascript/src/javascripts/uploader.vue
+++ b/app/javascript/src/javascripts/uploader.vue
@@ -323,6 +323,7 @@
   const char_count_checks = [
     {name: 'Solo'},
     {name: 'Duo'},
+    {name: 'Trio'},
     {name: 'Group'},
     {name: 'Zero Pictured'}];
 


### PR DESCRIPTION
It's been [at least a year](https://e621.net/forum_topics/27724) since the trio tag became a thing, and while it has over 45,000 usages it's currently underused due to the fact people select "group" on the upload form.

![Trio](https://user-images.githubusercontent.com/102884856/162204937-f8277c18-4594-412b-98d4-3df228cf900b.PNG)

