### PR TITLE
[Pools] Use the same search as other pages + add a heading

### DIFF
--- a/app/views/pools/_search.html.erb
+++ b/app/views/pools/_search.html.erb
@@ -2,7 +2,7 @@
   <%= f.input :name_matches, label: "Name", :value => params.dig(:search, :name_matches), autocomplete: "pool" %>
   <%= f.input :description_matches, label: "Description", :value => params.dig(:search, :description_matches) %>
   <%= f.input :creator_name, label: "Creator", :value => params.dig(:search, :creator_name), autocomplete: "user" %>
-  <%= f.input :is_active, label: "Status", collection: [["Active", "true"], ["Inactive", "false"]], :selected => params.dig(:search, :is_active) %>
+  <%= f.input :is_active, label: "Status", collection: [["Active", "true"], ["Inactive", "false"]], :selected => params.dig(:search, :is_active), :include_blank => true %>
   <%= f.input :category, label: "Category", collection: [["Series", "series"], ["Collection", "collection"]], :selected => params.dig(:search, :category), :include_blank => true %>
   <%= f.input :order, label: "Order", collection: [["Last updated", "updated_at"], ["Name", "name"], ["Recently created", "created_at"], ["Post count", "post_count"]], :selected => params.dig(:search, :order), :include_blank => true %>
   <%= f.submit "Search" %>

--- a/app/views/pools/_search.html.erb
+++ b/app/views/pools/_search.html.erb
@@ -1,63 +1,9 @@
-<table class="search">
-  <tbody>
-    <%= form_tag path, :method => :get, :class => "simple_form" do %>
-      <tr>
-        <th><label for="search_name_matches">Name</label></th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "name_matches", :value => params.dig(:search, :name_matches), :data => { autocomplete: "pool" } %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_description_matches">Description</label></th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "description_matches", :value => params.dig(:search, :description_matches) %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_creator_name">Creator</th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "creator_name", :value => params.dig(:search, :creator_name), :data => { autocomplete: "pool" } %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_is_active">Status</th>
-        <td>
-          <div class="input">
-            <%= select "search", "is_active", ["", ["Active", "true"], ["Inactive", "false"]], :selected => params.dig(:search, :is_active) %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_category">Category</th>
-        <td>
-          <div class="input">
-            <%= select "search", "category", [["Series", "series"], ["Collection", "collection"]], :selected => params.dig(:search, :category), :include_blank => true %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_order">Order</th>
-        <td>
-          <div class="input">
-            <%= select "search", "order", [["Last updated", "updated_at"], ["Name", "name"], ["Recently created", "created_at"], ["Post count", "post_count"]], :selected => params.dig(:search, :order), :include_blank => true %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <td><%= submit_tag "Search" %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= form_search(path: request.path) do |f| %>
+  <%= f.input :name_matches, label: "Name", :value => params.dig(:search, :name_matches), autocomplete: "pool" %>
+  <%= f.input :description_matches, label: "Description", :value => params.dig(:search, :description_matches) %>
+  <%= f.input :creator_name, label: "Creator", :value => params.dig(:search, :creator_name), autocomplete: "user" %>
+  <%= f.input :is_active, label: "Status", collection: [["Active", "true"], ["Inactive", "false"]], :selected => params.dig(:search, :is_active) %>
+  <%= f.input :category, label: "Category", collection: [["Series", "series"], ["Collection", "collection"]], :selected => params.dig(:search, :category), :include_blank => true %>
+  <%= f.input :order, label: "Order", collection: [["Last updated", "updated_at"], ["Name", "name"], ["Recently created", "created_at"], ["Post count", "post_count"]], :selected => params.dig(:search, :order), :include_blank => true %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/pools/_search.html.erb
+++ b/app/views/pools/_search.html.erb
@@ -1,9 +1,9 @@
 <%= form_search(path: request.path) do |f| %>
-  <%= f.input :name_matches, label: "Name", :value => params.dig(:search, :name_matches), autocomplete: "pool" %>
-  <%= f.input :description_matches, label: "Description", :value => params.dig(:search, :description_matches) %>
-  <%= f.input :creator_name, label: "Creator", :value => params.dig(:search, :creator_name), autocomplete: "user" %>
-  <%= f.input :is_active, label: "Status", collection: [["Active", "true"], ["Inactive", "false"]], :selected => params.dig(:search, :is_active), :include_blank => true %>
-  <%= f.input :category, label: "Category", collection: [["Series", "series"], ["Collection", "collection"]], :selected => params.dig(:search, :category), :include_blank => true %>
-  <%= f.input :order, label: "Order", collection: [["Last updated", "updated_at"], ["Name", "name"], ["Recently created", "created_at"], ["Post count", "post_count"]], :selected => params.dig(:search, :order), :include_blank => true %>
+  <%= f.input :name_matches, label: "Name", autocomplete: "pool" %>
+  <%= f.input :description_matches, label: "Description" %>
+  <%= f.input :creator_name, label: "Creator", autocomplete: "user" %>
+  <%= f.input :is_active, label: "Status", collection: [["Active", "true"], ["Inactive", "false"]], :include_blank => true %>
+  <%= f.input :category, label: "Category", collection: [["Series", "series"], ["Collection", "collection"]], :include_blank => true %>
+  <%= f.input :order, label: "Order", collection: [["Last updated", "updated_at"], ["Name", "name"], ["Recently created", "created_at"], ["Post count", "post_count"]], :include_blank => true %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/pools/gallery.html.erb
+++ b/app/views/pools/gallery.html.erb
@@ -1,8 +1,10 @@
 <div id="c-pools">
   <div id="a-gallery">
-    <%= render "search", :path => gallery_pools_path %>
+    <%= render partial: "search", locals: {path: gallery_pools_path} %>
 
     <%= render "posts/partials/common/inline_blacklist" %>
+
+    <h2>Pools</h2>
 
     <section>
       <%= @post_set.presenter.post_previews_html(self) %>

--- a/app/views/pools/index.html.erb
+++ b/app/views/pools/index.html.erb
@@ -1,6 +1,7 @@
 <div id="c-pools">
   <div id="a-index">
-    <%= render "search", :path => pools_path %>
+    <%= render partial: "search", locals: {path: pools_path} %>
+    <h2>Pools</h2>
     <table class="striped" width="100%">
       <thead>
         <tr>


### PR DESCRIPTION
The search form used on the pools page has been different to the other pages and it's been bothering me - so this PR brings it up to date with the other ones. This also fixes a bug where "Creator" currently uses pool autocomplete.

Also added a `<h2>` tag to the page, just like the post sets page.

![image](https://user-images.githubusercontent.com/102884856/163096100-d5486aad-0291-471e-bbd7-69a8f7aae88d.png)
![image](https://user-images.githubusercontent.com/102884856/163096146-2e3ae753-522a-4d7d-893d-3de8213493d1.png)
