### PR TITLE
Fix deprecation warning during pagination code

### DIFF
--- a/app/indexes/post_version_index.rb
+++ b/app/indexes/post_version_index.rb
@@ -2,7 +2,7 @@
 
 module PostVersionIndex
   def self.included(base)
-    base.settings index: {number_of_shards: 8, number_of_replicas: 1} do
+    base.settings index: { number_of_shards: 8, number_of_replicas: 1, max_result_window: 250_000 } do
       mappings dynamic: false do
         indexes :id, type: 'integer'
         indexes :post_id, type: 'integer'

--- a/app/logical/danbooru/paginator/active_record_extension.rb
+++ b/app/logical/danbooru/paginator/active_record_extension.rb
@@ -6,35 +6,11 @@ module Danbooru
       extend ActiveSupport::Concern
 
       module ClassMethods
+        include BaseExtension
+
         def paginate(page, options = {})
-          @paginator_options = options
-
-          validate_page_number(page)
-          if use_sequential_paginator?(page)
-            paginate_sequential(page)
-          else
-            paginate_numbered(page)
-          end
-        end
-
-        def validate_page_number(page)
-          return if page.is_a? Numeric
-          return if page.blank?
-          raise ::Danbooru::Paginator::PaginationError.new("Invalid page number.") unless page =~ /\A[ab]?\d+\z/i
-        end
-
-        def use_sequential_paginator?(page)
-          page =~ /[ab]\d+/i
-        end
-
-        def paginate_sequential(page)
-          if page =~ /b(\d+)/
-            paginate_sequential_before($1)
-          elsif page =~ /a(\d+)/
-            paginate_sequential_after($1)
-          else
-            paginate_sequential_before
-          end
+          paginated, _mode = paginate_base(page, options)
+          paginated
         end
 
         def paginate_sequential_before(before_id = nil)
@@ -58,11 +34,7 @@ module Danbooru
         end
 
         def paginate_numbered(page)
-          page = [page.to_i, 1].max
-
-          if page > Danbooru.config.max_numbered_pages
-            raise ::Danbooru::Paginator::PaginationError.new("You cannot go beyond page #{Danbooru.config.max_numbered_pages}. Please narrow your search terms.")
-          end
+          page = validate_numbered_page(page)
 
           extending(NumberedCollectionExtension).limit(records_per_page).offset((page - 1) * records_per_page).tap do |obj|
             if records_per_page > 0
@@ -71,37 +43,6 @@ module Danbooru
               obj.total_pages = 1
             end
             obj.current_page = page
-          end
-        end
-
-        def records_per_page
-          option_for(:limit).to_i
-        end
-
-        # When paginating large tables, we want to avoid doing an expensive count query
-        # when the result won't even be used. So when calling paginate you can pass in
-        # an optional :search_count key which points to the search params. If these params
-        # exist, then assume we're doing a search and don't override the default count
-        # behavior. Otherwise, just return some large number so the paginator skips the
-        # count.
-        def option_for(key)
-          case key
-          when :limit
-            limit = @paginator_options.try(:[], :limit) || Danbooru.config.posts_per_page
-            if limit.to_i > 320
-              limit = 320
-            end
-            limit
-
-          when :count
-            if @paginator_options.has_key?(:search_count) && @paginator_options[:search_count].blank?
-              1_000_000
-            elsif @paginator_options[:count]
-              @paginator_options[:count]
-            else
-              nil
-            end
-
           end
         end
 

--- a/app/logical/danbooru/paginator/active_record_extension.rb
+++ b/app/logical/danbooru/paginator/active_record_extension.rb
@@ -34,8 +34,6 @@ module Danbooru
         end
 
         def paginate_numbered(page)
-          page = validate_numbered_page(page)
-
           extending(NumberedCollectionExtension).limit(records_per_page).offset((page - 1) * records_per_page).tap do |obj|
             if records_per_page > 0
               obj.total_pages = (obj.total_count.to_f / records_per_page).ceil

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -5,6 +5,8 @@ module Danbooru
         @paginator_options = options
 
         if use_numbered_paginator?(page)
+          validate_numbered_page(page)
+          page = [page.to_i, 1].max
           [paginate_numbered(page), :numbered]
         elsif use_sequential_paginator?(page)
           [paginate_sequential(page), :sequential]
@@ -14,11 +16,8 @@ module Danbooru
       end
 
       def validate_numbered_page(page)
-        page = [page.to_i, 1].max
-        if page > Danbooru.config.max_numbered_pages
-          raise Danbooru::Paginator::PaginationError, "You cannot go beyond page #{Danbooru.config.max_numbered_pages}. Please narrow your search terms."
-        end
-        page
+        return if page.to_i <= Danbooru.config.max_numbered_pages
+        raise Danbooru::Paginator::PaginationError, "You cannot go beyond page #{Danbooru.config.max_numbered_pages}. Please narrow your search terms."
       end
 
       def use_numbered_paginator?(page)

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -1,0 +1,74 @@
+module Danbooru
+  module Paginator
+    module BaseExtension
+      def paginate_base(page, options)
+        @paginator_options = options
+
+        validate_page_number(page)
+        if use_sequential_paginator?(page)
+          [paginate_sequential(page), :sequential]
+        else
+          [paginate_numbered(page), :numbered]
+        end
+      end
+
+      def validate_page_number(page)
+        return if page.is_a? Numeric
+        return if page.blank?
+        raise Danbooru::Paginator::PaginationError, "Invalid page number." unless page =~ /\A[ab]?\d+\z/i
+      end
+
+      def validate_numbered_page(page)
+        page = [page.to_i, 1].max
+        if page > Danbooru.config.max_numbered_pages
+          raise Danbooru::Paginator::PaginationError, "You cannot go beyond page #{Danbooru.config.max_numbered_pages}. Please narrow your search terms."
+        end
+        page
+      end
+
+      def use_sequential_paginator?(page)
+        page =~ /[ab]\d+/i
+      end
+
+      def paginate_sequential(page)
+        if page =~ /b(\d+)/
+          paginate_sequential_before($1)
+        elsif page =~ /a(\d+)/
+          paginate_sequential_after($1)
+        else
+          paginate_sequential_before
+        end
+      end
+
+      def records_per_page
+        option_for(:limit).to_i
+      end
+
+      # When paginating large tables, we want to avoid doing an expensive count query
+      # when the result won't even be used. So when calling paginate you can pass in
+      # an optional :search_count key which points to the search params. If these params
+      # exist, then assume we're doing a search and don't override the default count
+      # behavior. Otherwise, just return some large number so the paginator skips the
+      # count.
+      def option_for(key)
+        case key
+        when :limit
+          limit = @paginator_options.try(:[], :limit) || Danbooru.config.posts_per_page
+          if limit.to_i > 320
+            limit = 320
+          end
+          limit
+
+        when :count
+          if @paginator_options.key?(:search_count) && @paginator_options[:search_count].blank?
+            1_000_000
+          elsif @paginator_options[:count]
+            @paginator_options[:count]
+          else
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -4,18 +4,13 @@ module Danbooru
       def paginate_base(page, options)
         @paginator_options = options
 
-        validate_page_number(page)
-        if use_sequential_paginator?(page)
+        if use_numbered_paginator?(page)
+          [paginate_numbered(page), :numbered]
+        elsif use_sequential_paginator?(page)
           [paginate_sequential(page), :sequential]
         else
-          [paginate_numbered(page), :numbered]
+          raise Danbooru::Paginator::PaginationError, "Invalid page number."
         end
-      end
-
-      def validate_page_number(page)
-        return if page.is_a? Numeric
-        return if page.blank?
-        raise Danbooru::Paginator::PaginationError, "Invalid page number." unless page =~ /\A[ab]?\d+\z/i
       end
 
       def validate_numbered_page(page)
@@ -26,8 +21,12 @@ module Danbooru
         page
       end
 
+      def use_numbered_paginator?(page)
+        page.blank? || page.to_s =~ /\A\d+\z/
+      end
+
       def use_sequential_paginator?(page)
-        page =~ /[ab]\d+/i
+        page =~ /\A[ab]\d+\z/i
       end
 
       def paginate_sequential(page)

--- a/app/logical/danbooru/paginator/elasticsearch_extensions.rb
+++ b/app/logical/danbooru/paginator/elasticsearch_extensions.rb
@@ -51,20 +51,14 @@ module Danbooru
     end
 
     module ElasticsearchExtensions
-      attr_reader :records_per_page, :total_entries, :current_page, :sequential_paginator_mode
+      include BaseExtension
+
+      attr_reader :total_entries, :current_page, :sequential_paginator_mode
 
       def paginate(page, options = {})
-        @paginator_options = options
+        paginated, mode = paginate_base(page, options)
 
-        validate_page_number(page)
-        sequential = use_sequential_paginator?(page)
-        paginated = if sequential
-                      paginate_sequential(page)
-                    else
-                      paginate_numbered(page)
-                    end
-
-        new_opts = {mode: (sequential ? :sequential : :numbered), seq_mode: sequential_paginator_mode,
+        new_opts = {mode: mode, seq_mode: sequential_paginator_mode,
                     per_page: records_per_page, total: total_count, current_page: current_page}
         if options[:results] == :results
           PaginatedArray.new(paginated.results, new_opts)
@@ -73,30 +67,9 @@ module Danbooru
         end
       end
 
-      def validate_page_number(page)
-        return if page.is_a? Numeric
-        return if page.blank?
-        raise ::Danbooru::Paginator::PaginationError.new("Invalid page number.") unless page =~ /\A[ab]?\d+\z/i
-      end
-
-      def use_sequential_paginator?(page)
-        page =~ /[ab]\d+/i
-      end
-
-      def paginate_sequential(page)
-        if page =~ /b(\d+)/
-          paginate_sequential_before($1)
-        elsif page =~ /a(\d+)/
-          paginate_sequential_after($1)
-        else
-          paginate_sequential_before
-        end
-      end
-
       def paginate_sequential_before(before_id = nil)
         search.definition.update(size: records_per_page + 1, track_total_hits: records_per_page+1)
         search.definition[:body].update(sort: [{id: :desc}])
-
 
         if before_id.to_i > 0
           search.definition[:body][:query][:bool][:must] << ({range: {id: {lt: before_id.to_i}}})
@@ -117,51 +90,16 @@ module Danbooru
       end
 
       def paginate_numbered(page)
-        page = [page.to_i, 1].max
-
-        if page > Danbooru.config.max_numbered_pages
-          raise ::Danbooru::Paginator::PaginationError.new("You cannot go beyond page #{Danbooru.config.max_numbered_pages}. Please narrow your search terms.")
-        end
-
+        page = validate_numbered_page(page)
         search.definition.update(size: records_per_page, from: (page - 1) * records_per_page, track_total_hits: Danbooru.config.max_numbered_pages * records_per_page + 1)
         @current_page = page
 
         self
       end
 
-      def records_per_page
-        option_for(:limit).to_i
-      end
-
       def limit(count)
         search.definition.update(size: count)
         self
-      end
-
-      # When paginating large tables, we want to avoid doing an expensive count query
-      # when the result won't even be used. So when calling paginate you can pass in
-      # an optional :search_count key which points to the search params. If these params
-      # exist, then assume we're doing a search and don't override the default count
-      # behavior. Otherwise, just return some large number so the paginator skips the
-      # count.
-      def option_for(key)
-        case key
-        when :limit
-          limit = @paginator_options.try(:[], :limit) || Danbooru.config.posts_per_page
-          if limit.to_i > 320
-            limit = 320
-          end
-          limit
-
-        when :count
-          if @paginator_options.has_key?(:search_count) && @paginator_options[:search_count].blank?
-            1_000_000
-          elsif @paginator_options[:count]
-            @paginator_options[:count]
-          else
-            nil
-          end
-        end
       end
 
       def total_count

--- a/app/logical/danbooru/paginator/elasticsearch_extensions.rb
+++ b/app/logical/danbooru/paginator/elasticsearch_extensions.rb
@@ -90,7 +90,6 @@ module Danbooru
       end
 
       def paginate_numbered(page)
-        page = validate_numbered_page(page)
         search.definition.update(size: records_per_page, from: (page - 1) * records_per_page, track_total_hits: Danbooru.config.max_numbered_pages * records_per_page + 1)
         @current_page = page
 


### PR DESCRIPTION
Noticed during tests, which occasionally printed `deprecated Object#=~ is called on Integer; it always returns nil` during pagination code. I assume this only happends during tests since all query parameters are strings, but they seem to be passed as is when doing `get posts_path, params: { page: 1 }`. It's slightly annoying seeing that message pop up every once in a while.

I took the opportunity and consolidated a bit of code between both elastic and active_record so I don't have to fix it twice.
Somehow two bugfixes managed two sneak in. Fixing page validation for pages larger than what fits in an integer for elastic, and PostVersion not having its result window adjusted like Post already has.