### PR TITLE
Disable downvoting own comment

### DIFF
--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -4,7 +4,7 @@ module CommentsHelper
     vote_score = voted ? vote.score : 0
     comment_score = comment.score
 
-    if CurrentUser.is_member? && comment.creator != CurrentUser.user
+    if CurrentUser.is_member?
       up_tag = tag.li(tag.a('&#x25B2;'.html_safe, class: 'comment-vote-up-link', 'data-id': comment.id),
                       class: confirm_score_class(vote_score, 1, false),
                       id: "comment-vote-up-#{comment.id}")

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -4,7 +4,7 @@ module CommentsHelper
     vote_score = voted ? vote.score : 0
     comment_score = comment.score
 
-    if CurrentUser.is_member?
+    if CurrentUser.is_member? && comment.creator != CurrentUser.user
       up_tag = tag.li(tag.a('&#x25B2;'.html_safe, class: 'comment-vote-up-link', 'data-id': comment.id),
                       class: confirm_score_class(vote_score, 1, false),
                       id: "comment-vote-up-#{comment.id}")

--- a/app/models/comment_vote.rb
+++ b/app/models/comment_vote.rb
@@ -29,11 +29,8 @@ class CommentVote < ApplicationRecord
   end
 
   def validate_comment_can_be_down_voted
-    if is_positive? && comment.creator == CurrentUser.user
-      errors.add :base, "You cannot upvote your own comments"
-      false
-    elsif is_negative? && comment.creator == CurrentUser.user
-      errors.add :base, "You cannot downvote your own comments"
+    if (is_positive? || is_negative?) && comment.creator == CurrentUser.user
+      errors.add :base, "You cannot vote on your own comments"
       false
     else
       true

--- a/app/models/comment_vote.rb
+++ b/app/models/comment_vote.rb
@@ -32,6 +32,9 @@ class CommentVote < ApplicationRecord
     if is_positive? && comment.creator == CurrentUser.user
       errors.add :base, "You cannot upvote your own comments"
       false
+    elsif is_negative? && comment.creator == CurrentUser.user
+      errors.add :base, "You cannot downvote your own comments"
+      false
     else
       true
     end

--- a/test/functional/comment_votes_controller_test.rb
+++ b/test/functional/comment_votes_controller_test.rb
@@ -8,6 +8,10 @@ class CommentVotesControllerTest < ActionDispatch::IntegrationTest
       CurrentUser.user = @user
       CurrentUser.ip_addr = "127.0.0.1"
       @comment = create(:comment, post: @post)
+
+      @user = create(:user)
+      CurrentUser.user = @user
+      CurrentUser.ip_addr = "127.0.0.1"
     end
 
     teardown do

--- a/test/functional/moderator/dashboards_controller_test.rb
+++ b/test/functional/moderator/dashboards_controller_test.rb
@@ -81,7 +81,7 @@ module Moderator
           setup do
             @users = (0..5).map { create(:user) }
 
-            CurrentUser.as(@users[0]) do
+            CurrentUser.as( create(:user) ) do
               @comment = create(:comment)
             end
 

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -96,26 +96,33 @@ class CommentTest < ActiveSupport::TestCase
 
       should "not record the user id of the voter" do
         user = FactoryBot.create(:user)
+        user2 = FactoryBot.create(:user)
         post = FactoryBot.create(:post)
         c1 = FactoryBot.create(:comment, post: post)
-        VoteManager.comment_vote!(user: user, comment: c1, score: -1)
-        c1.reload
-        assert_not_equal(user.id, c1.updater_id)
+        
+        CurrentUser.scoped(user, "127.0.0.1") do
+          VoteManager.comment_vote!(user: user, comment: c1, score: -1)
+          c1.reload
+          assert_not_equal(user.id, c1.updater_id)
+        end
       end
 
       should "not allow duplicate votes" do
         user = FactoryBot.create(:user)
+        user2 = FactoryBot.create(:user)
         post = FactoryBot.create(:post)
         c1 = FactoryBot.create(:comment, post: post)
-
-        assert_nothing_raised { VoteManager.comment_vote!(user: user, comment: c1, score: -1) }
-        assert_equal(:need_unvote, VoteManager.comment_vote!(user: user, comment: c1, score: -1))
-        assert_equal(1, CommentVote.count)
-        assert_equal(-1, CommentVote.last.score)
-
         c2 = FactoryBot.create(:comment, post: post)
-        assert_nothing_raised { VoteManager.comment_vote!(user: user, comment: c2, score: -1) }
-        assert_equal(2, CommentVote.count)
+        
+        CurrentUser.scoped(user2, "127.0.0.1") do
+          assert_nothing_raised { VoteManager.comment_vote!(user: user2, comment: c1, score: -1) }
+          assert_equal(:need_unvote, VoteManager.comment_vote!(user: user2, comment: c1, score: -1))
+          assert_equal(1, CommentVote.count)
+          assert_equal(-1, CommentVote.last.score)
+
+          assert_nothing_raised { VoteManager.comment_vote!(user: user2, comment: c2, score: -1) }
+          assert_equal(2, CommentVote.count)
+        end
       end
 
       should "not allow upvotes by the creator" do
@@ -124,7 +131,7 @@ class CommentTest < ActiveSupport::TestCase
         c1 = FactoryBot.create(:comment, post: post)
 
         exception = assert_raises(ActiveRecord::RecordInvalid) { VoteManager.comment_vote!(user: user, comment: c1, score: 1) }
-        assert_equal("Validation failed: You cannot upvote your own comments", exception.message)
+        assert_equal("Validation failed: You cannot vote on your own comments", exception.message)
       end
       
       should "not allow downvotes by the creator" do
@@ -133,22 +140,21 @@ class CommentTest < ActiveSupport::TestCase
         c1 = FactoryBot.create(:comment, post: post)
 
         exception = assert_raises(ActiveRecord::RecordInvalid) { VoteManager.comment_vote!(user: user, comment: c1, score: -1) }
-        assert_equal("Validation failed: You cannot downvote your own comments", exception.message)
+        assert_equal("Validation failed: You cannot vote on your own comments", exception.message)
       end
 
       should "allow undoing of votes" do
         user = FactoryBot.create(:user)
-        user2 = FactoryBot.create(:user)
         post = FactoryBot.create(:post)
         comment = FactoryBot.create(:comment, post: post)
-        CurrentUser.scoped(user2, "127.0.0.1") do
-          VoteManager.comment_vote!(user: user2, comment: comment, score: 1)
+        CurrentUser.scoped(user, "127.0.0.1") do
+          VoteManager.comment_vote!(user: user, comment: comment, score: 1)
           comment.reload
           assert_equal(1, comment.score)
-          VoteManager.comment_unvote!(user: user2, comment: comment)
+          VoteManager.comment_unvote!(user: user, comment: comment)
           comment.reload
           assert_equal(0, comment.score)
-          assert_nothing_raised { VoteManager.comment_vote!(user: user2, comment: comment, score: -1) }
+          assert_nothing_raised { VoteManager.comment_vote!(user: user, comment: comment, score: -1) }
         end
       end
 

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -126,6 +126,15 @@ class CommentTest < ActiveSupport::TestCase
         exception = assert_raises(ActiveRecord::RecordInvalid) { VoteManager.comment_vote!(user: user, comment: c1, score: 1) }
         assert_equal("Validation failed: You cannot upvote your own comments", exception.message)
       end
+      
+      should "not allow downvotes by the creator" do
+        user = FactoryBot.create(:user)
+        post = FactoryBot.create(:post)
+        c1 = FactoryBot.create(:comment, post: post)
+
+        exception = assert_raises(ActiveRecord::RecordInvalid) { VoteManager.comment_vote!(user: user, comment: c1, score: -1) }
+        assert_equal("Validation failed: You cannot downvote your own comments", exception.message)
+      end
 
       should "allow undoing of votes" do
         user = FactoryBot.create(:user)

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -103,7 +103,7 @@ class CommentTest < ActiveSupport::TestCase
         CurrentUser.scoped(user2, "127.0.0.1") do
           VoteManager.comment_vote!(user: user2, comment: c1, score: -1)
           c1.reload
-          assert_not_equal(user.id, c1.updater_id)
+          assert_not_equal(user2.id, c1.updater_id)
         end
       end
 

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -100,8 +100,8 @@ class CommentTest < ActiveSupport::TestCase
         post = FactoryBot.create(:post)
         c1 = FactoryBot.create(:comment, post: post)
         
-        CurrentUser.scoped(user, "127.0.0.1") do
-          VoteManager.comment_vote!(user: user, comment: c1, score: -1)
+        CurrentUser.scoped(user2, "127.0.0.1") do
+          VoteManager.comment_vote!(user: user2, comment: c1, score: -1)
           c1.reload
           assert_not_equal(user.id, c1.updater_id)
         end
@@ -145,16 +145,17 @@ class CommentTest < ActiveSupport::TestCase
 
       should "allow undoing of votes" do
         user = FactoryBot.create(:user)
+        user2 = FactoryBot.create(:user)
         post = FactoryBot.create(:post)
         comment = FactoryBot.create(:comment, post: post)
-        CurrentUser.scoped(user, "127.0.0.1") do
-          VoteManager.comment_vote!(user: user, comment: comment, score: 1)
+        CurrentUser.scoped(user2, "127.0.0.1") do
+          VoteManager.comment_vote!(user: user2, comment: comment, score: 1)
           comment.reload
           assert_equal(1, comment.score)
-          VoteManager.comment_unvote!(user: user, comment: comment)
+          VoteManager.comment_unvote!(user: user2, comment: comment)
           comment.reload
           assert_equal(0, comment.score)
-          assert_nothing_raised { VoteManager.comment_vote!(user: user, comment: comment, score: -1) }
+          assert_nothing_raised { VoteManager.comment_vote!(user: user2, comment: comment, score: -1) }
         end
       end
 


### PR DESCRIPTION
Currently, users are not able to make upvote their own comments.
However, they _are_ able to downvote their own comment.

This behaviour seems inconsistent and does not make much sense, so I made a PR that also disabled the downvote button on your own comment, in order to make things more consistent.

I also made it so that the buttons are not shown on a user's own comment, because it doesn't make much sense to show the buttons if you are not able to use them.

P.S.
I was not able to perform unit tests because it complained that I had not set up the testing DB, and there were no instructions on how to do so.
I manually did testing via the localhost site though.