### PR TITLE
[Posts] Use will-change: transform; when using vertical/horizontal fit

### DIFF
--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -491,10 +491,12 @@ textarea[data-autocomplete="tag-edit"] {
 #image {
   &.fit-window {
     max-width: 100%;
+    will-change: transform;
   }
   &.fit-window-vertical {
     max-width: 100%;
     max-height: 95vh;
+    will-change: transform;
   }
 }
 


### PR DESCRIPTION
Fixes poor image scaling on Chrome/Edge, and probably every other Chromium based browser. See also [forum #33513](https://e621.net/forum_topics/33513).

This probably isn't the most elegant solution, but it seems to fix the issue in Chromium-based browsers and doesn't seem to cause any issues in other browsers. Safari on iOS and OS X has not been tested


**Examples**
Left is original, right is with `will-change: transform;`. Make sure it's viewed at 100% size to actually see a difference.
![examples](https://user-images.githubusercontent.com/102884856/166930812-8a0096df-5bef-4d83-8513-0bd64de01576.png)
(image credit: [post #2042556](https://e926.net/posts/2042556), [post #692610](https://e926.net/posts/692610), [post #864033](https://e926.net/posts/864033), [post #896454](https://e926.net/posts/896454))