### PR TITLE
[Uploader] Correct path to user upload limit

### DIFF
--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -27,7 +27,7 @@
   <% elsif CurrentUser.post_upload_throttle <= 5 %>
     <div id="post-uploads-remaining" class="section<% if CurrentUser.post_upload_throttle <= 0 %> sect_red<% end %>" style="width:640px;">
       You have <span class="post-uploads-remaining-count"><%= CurrentUser.post_upload_throttle %></span> uploads remaining this hour.
-      See <%= link_to "here", help_page_path(id: "upload_limit") %> for more details.
+      See <%= link_to "here", upload_limit_users_path %> for more details.
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Reported at [forum #334620](https://e621.net/forum_topics/25734?page=24#forum_post_334620). 

In one case the uploader will link to a non-existent help page rather than the users upload limit path, this PR fixes it.