### PR TITLE
[Stats] Theme support for the stats page

### DIFF
--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -65,6 +65,7 @@
 @import "specific/sessions.scss";
 @import "specific/site_map.scss";
 @import "specific/staff_notes.scss";
+@import "specific/stats.scss";
 @import "specific/tags.scss";
 @import "specific/takedowns.scss";
 @import "specific/terms_of_service.scss";

--- a/app/javascript/src/styles/specific/stats.scss
+++ b/app/javascript/src/styles/specific/stats.scss
@@ -1,0 +1,65 @@
+.stats-column {
+  width:400px;
+  display:inline-block;
+  vertical-align:top;
+}
+
+.stats-chart {
+  display:inline-block;
+  width:300px;
+  height:300px;
+  }
+
+.stats-chart-container {
+  white-space:nowrap;
+}
+
+.stats-pct {
+  text-align:right;
+}
+
+#stats-column-1 table {
+  margin-bottom:60px;
+}
+
+#stats-column-2 table {
+  margin-bottom:19px;
+}
+
+#stats-column-3 table {
+    margin-bottom:5px;
+}
+
+.stats-column table:last-child {
+  margin-bottom:10px !important;
+}
+
+.stats-column table {
+  margin-bottom:2em;
+  padding:3px;
+  border-spacing:0;
+}
+
+.stats-rounded {
+  @include themable {
+    background-color: themed("color-section");
+    box-shadow:2px 2px 5px darken( themed("color-section"), 15%);
+  }
+  border-radius:8px;
+  overflow: hidden;
+}
+
+.stats-rounded tr:nth-child(even) {
+  @include themable {
+    background-color: lighten( themed("color-section"), 3%);
+  }
+}
+.stats-rounded tr:nth-child(even) td {
+  @include themable {
+    border-top:1px solid lighten( themed("color-section"), 10%);
+    border-bottom:1px solid lighten( themed("color-section"), 10%);
+  }
+}
+.stats-rounded tr:last-child td{ border-bottom:none !important; }
+.stats-rounded td { padding:2px 10px; vertical-align:top; }
+.stats-rounded th { font-weight:bold; text-align:left; vertical-align:top; padding:0.2em 0.5em; white-space:nowrap; }

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,69 +1,3 @@
-<style>
-  .stats-column {
-    width:400px;
-    display:inline-block;
-    vertical-align:top;
-  }
-
-  .stats-chart {
-    display:inline-block;
-    width:300px;
-    height:300px;
-  }
-
-  .stats-chart-container {
-    white-space:nowrap;
-  }
-
-  .stats-pct {
-    text-align:right;
-  }
-
-  #stats-column-1 table {
-    margin-bottom:60px;
-  }
-
-  #stats-column-2 table {
-    margin-bottom:19px;
-  }
-
-  #stats-column-3 table {
-    margin-bottom:5px;
-  }
-
-  .stats-column table:last-child {
-    margin-bottom:10px !important;
-  }
-
-
-  table {
-    margin-bottom:2em;
-    padding:3px;
-    border-spacing:0;
-  }
-  td { padding:1px 4px; vertical-align:top; }
-  th { font-weight:bold; text-align:left; vertical-align:top; padding:0.2em 0.5em; white-space:nowrap; }
-
-  tr.selected { background-color:#288233 !important; /* green */ }
-
-
-  .rounded {
-    background-color:#203f6c;
-    border-radius:8px;
-    box-shadow:2px 2px 5px #07162D;
-  }
-
-  .rounded th { border-bottom:2px solid #6388c3; padding: 2px 10px; }
-  .rounded tr:nth-child(even) { background-color:#204274; }
-  .rounded tr:nth-child(even) td { border-top:1px solid #255193; border-bottom:1px solid #255193; }
-  .rounded tr:last-child td{ border-bottom:0; }
-  .rounded td { padding:2px 10px; }
-
-  .rounded-even	{ background-color:#204274; }
-  .rounded-even td	{ border-top:1px solid #255193; border-bottom:1px solid #255193; }
-  .rounded-odd	{ background-color:transparent; }
-  .rounded-odd td	{ border-top:none; border-bottom:none; }
-</style>
 <%= javascript_tag nonce: true do -%>
   function pct(current,total) {
     return Math.round((current/total)*100) + "%"
@@ -185,7 +119,7 @@
   <p>Refreshed once a day.</p>
   <div class='stats-column' id='stats-column-1'>
     <h2>Site</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>Started</td>
         <td style='width:105px;'><%= @stats['started'] %></td>
@@ -213,7 +147,7 @@
     </table>
 
     <h2>Posts</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>Total posts</td>
         <td style='width:50px;'><%= del(@stats['total_posts']) %></td>
@@ -283,7 +217,7 @@
 
   <div class='stats-column' id='stats-column-2'>
     <h2>Image files</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>Total existing posts</td>
         <td style='width:50px;'><%= del(@stats['active_posts']+@stats['deleted_posts']) %></td>
@@ -320,7 +254,7 @@
       </tr>
     </table>
     <h2>Users</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>User count</td>
         <td style='width:50px;'><%= del(@stats['total_users']) %></td>
@@ -367,7 +301,7 @@
 
   <div class='stats-column' id='stats-column-3'>
     <h2>Comments</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>Comment count</td>
         <td style='width:50px;'><%= del(@stats['total_comments']) %></td>
@@ -388,7 +322,7 @@
     </table>
 
     <h2>Forum Posts</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>Thread count</td>
         <td style='width:100px;'><%= del(@stats['total_forum_threads']) %></td>
@@ -404,7 +338,7 @@
     </table>
 
     <h2>Blips</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>Blip count</td>
         <td style='width:50px;'><%= del(@stats['total_blips']) %></td>
@@ -425,7 +359,7 @@
     </table>
 
     <h2>Tags</h2>
-    <table class='rounded'>
+    <table class='stats-rounded'>
       <tr>
         <td style='width:250px;'>Tag count</td>
         <td style='width:50px;'><%= del(@stats['total_tags']) %></td>


### PR DESCRIPTION
PR to close #408 

* Move styling from a <style> tag to a scss file.
* `rounded` class has been renamed to `stats-rounded` to prevent conflicts with a small number of pages that also use a `rounded` class.
* Use the `color-section` color to theme the tables, contrast is now improved a little in the Hexagon theme too.
* Also fix the bottom corners not always being rounded. (thanks @mandorinn!)

### Hexagon (old)
![image](https://user-images.githubusercontent.com/102884856/169325062-280015dd-468b-4d60-8790-307857452f7d.png)

## Hexagon (new)
![image](https://user-images.githubusercontent.com/102884856/169325616-e07edc7f-a1c9-4e8f-adb1-627ec7ed1ee8.png)

### Bloodlust (old)
![image](https://user-images.githubusercontent.com/102884856/169325912-8c6f1a21-2e03-427c-a6ac-b1c7fb1216cc.png)


### Bloodlust (new)
![image](https://user-images.githubusercontent.com/102884856/169324897-eb498674-e82a-4a17-a3c5-d7575bda90db.png)
