### PR TITLE
[Related Tags] Switch default blue on active tag for a themed color

### DIFF
--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -42,7 +42,9 @@ div.related-tags {
   }
 
   .tag-active {
-    background: rgb(0, 111, 250);
+    @include themable {
+      background: themed("color-active-tag");
+    }
     color: white;
   }
 

--- a/app/javascript/src/styles/themes/_theme_bloodlust.scss
+++ b/app/javascript/src/styles/themes/_theme_bloodlust.scss
@@ -33,6 +33,8 @@ $theme_bloodlust: (
   "color-score-positive":         #3e9e49,
   "color-score-negative":         #e45f5f,
 
+  "color-active-tag":             #222222,
+
   // Detail Colors
   "color-detail-quote":           #67717b,
   "color-detail-code":            #ffe380,

--- a/app/javascript/src/styles/themes/_theme_hexagon.scss
+++ b/app/javascript/src/styles/themes/_theme_hexagon.scss
@@ -41,6 +41,8 @@ $theme_hexagon: (
   "color-score-positive":         #3e9e49,
   "color-score-negative":         #e45f5f,
 
+  "color-active-tag":             #006ffa,
+
   // Detail Colors
   "color-detail-quote":           #b4c7d9,
   "color-detail-code":            #ffe380,

--- a/app/javascript/src/styles/themes/_theme_hotdog.scss
+++ b/app/javascript/src/styles/themes/_theme_hotdog.scss
@@ -21,6 +21,8 @@ $theme_hotdog: (
   "color-score-positive":         #3e9e49,
   "color-score-negative":         #e45f5f,
 
+  "color-active-tag":             #ff0000,
+
   // Detail Colors
   "color-detail-quote":           #67717b,
   "color-detail-code":            #ffe380,

--- a/app/javascript/src/styles/themes/_theme_pony.scss
+++ b/app/javascript/src/styles/themes/_theme_pony.scss
@@ -22,6 +22,8 @@ $theme_pony: (
   "color-score-positive":         #3e9e49,
   "color-score-negative":         #e45f5f,
 
+  "color-active-tag":             #6f36da,
+
   // Detail Colors
   "color-detail-quote":           #67717b,
   "color-detail-code":      #ffe380,

--- a/app/javascript/src/styles/themes/_theme_serpent.scss
+++ b/app/javascript/src/styles/themes/_theme_serpent.scss
@@ -22,6 +22,8 @@ $theme_serpent: (
   "color-score-positive":         #3e9e49,
   "color-score-negative":         #e45f5f,
 
+  "color-active-tag":             #44a544,
+
   // Detail Colors
   "color-detail-quote":           #67717b,
   "color-detail-code":            #ffe380,


### PR DESCRIPTION
Use a more theme appropriate color with the highlighted tags on the related tags menu, rather than the default blue.

![Active tag](https://user-images.githubusercontent.com/102884856/169415551-3235d129-012f-46f6-bb40-f8c2f5be598f.png)
