### PR TITLE
Show all users upload whitelist on sitemap, add "Requests" and "Help" to the secondary links on the upload whitelist page.

### DIFF
--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -120,10 +120,10 @@
           <li><%= link_to("Alias & Implication Import", new_admin_alias_and_implication_import_path) %></li>
           <li><%= link_to("Danger Zone", admin_danger_zone_index_path) %></li>
         <% end %>
-          <li><%= link_to("Upload Whitelist", upload_whitelists_path) %></li>
         <% if CurrentUser.is_moderator? %>
           <li><%= link_to("IP Bans", ip_bans_path) %></li>
         <% end %>
+        <li><%= link_to("Upload Whitelist", upload_whitelists_path) %></li>
         <li><%= link_to("Mod Actions", mod_actions_path) %></li>
         <li><%= link_to("Bulk Update Requests", bulk_update_requests_path) %></li>
         <li><%= link_to("Takedowns", takedowns_path) %></li>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -116,11 +116,11 @@
         <% if CurrentUser.is_admin? %>
           <li><%= link_to("Admin Dashboard", admin_dashboard_path) %></li>
           <li><%= link_to("Email Blacklist", email_blacklists_path) %></li>
-          <li><%= link_to("Upload Whitelist", upload_whitelists_path) %></li>
           <li><%= link_to("Post Report Reasons", post_report_reasons_path) %></li>
           <li><%= link_to("Alias & Implication Import", new_admin_alias_and_implication_import_path) %></li>
           <li><%= link_to("Danger Zone", admin_danger_zone_index_path) %></li>
         <% end %>
+          <li><%= link_to("Upload Whitelist", upload_whitelists_path) %></li>
         <% if CurrentUser.is_moderator? %>
           <li><%= link_to("IP Bans", ip_bans_path) %></li>
         <% end %>

--- a/app/views/upload_whitelists/_secondary_links.html.erb
+++ b/app/views/upload_whitelists/_secondary_links.html.erb
@@ -3,9 +3,8 @@
     <%= subnav_link_to "Listing", upload_whitelists_path %>
     <% if CurrentUser.is_admin? %>
       <%= subnav_link_to "New", new_upload_whitelist_path %>
-    <% else %>
-      <%= subnav_link_to "Request", forum_topic_path(id: 22269) %>
     <% end %>
+    <%= subnav_link_to "Requests", forum_topic_path(id: 22269) %>
     <%= subnav_link_to "Help", help_page_path(id: "upload_whitelist") %>
   </menu>
 <% end %>

--- a/app/views/upload_whitelists/_secondary_links.html.erb
+++ b/app/views/upload_whitelists/_secondary_links.html.erb
@@ -3,6 +3,9 @@
     <%= subnav_link_to "Listing", upload_whitelists_path %>
     <% if CurrentUser.is_admin? %>
       <%= subnav_link_to "New", new_upload_whitelist_path %>
+    <% else %>
+      <%= subnav_link_to "Request", forum_topic_path(id: 22269) %>
     <% end %>
+    <%= subnav_link_to "Help", help_page_path(id: "upload_whitelist") %>
   </menu>
 <% end %>


### PR DESCRIPTION
Sitemap
* The upload whitelist link has been moved outside the `if CurrentUser.is_admin?` block so regular users can see the link too.

Upload whitelist
* A "Requests" subnav link, which links to the upload whitelist request forum.
* A "Help" link is also added, which links to the relevant help page.

This closes #420 