### PR TITLE
[Pools Gallery] Default to any category when none is selected

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -28,7 +28,7 @@ class PoolsController < ApplicationController
 
   def gallery
     params[:limit] ||= CurrentUser.user.per_page
-    search = search_params.presence || ActionController::Parameters.new(category: "series")
+    search = search_params.presence || ActionController::Parameters.new(category: "any")
 
     @pools = Pool.search(search).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     @post_set = PostSets::PoolGallery.new(@pools)

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -28,9 +28,8 @@ class PoolsController < ApplicationController
 
   def gallery
     params[:limit] ||= CurrentUser.user.per_page
-    search = search_params.presence || ActionController::Parameters.new(category: "any")
 
-    @pools = Pool.search(search).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @pools = Pool.search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     @post_set = PostSets::PoolGallery.new(@pools)
   end
 


### PR DESCRIPTION
Mentioned in [topic #25734 - post #303846](https://e621.net/forum_topics/25734?page=17#forum_post_303846) and [topic #34432](https://e621.net/forum_topics/34432) that by default the pools gallery only shows series when the search isn't used. 

This is contradictory to how it works when using the search - leaving the category as blank while searching will return both series and collections but the index page without any searching only returns series. This doesn't match up with the behaviour of the regular (non-gallery) listing of pools which shows both collections and series at the same time.

Without this, as far as I can tell, there's no way of viewing both series and collections at the same time without filtering any out, apart from manually altering the URL to `category=any`.