### PR TITLE
Relationship rejections

### DIFF
--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -1,5 +1,5 @@
 class TagAliasesController < ApplicationController
-  before_action :moderator_only, except: [:index, :show]
+  before_action :moderator_only, except: [:index, :show, :destroy]
   respond_to :html, :json, :js
 
   def show

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -1,5 +1,5 @@
 class TagImplicationsController < ApplicationController
-  before_action :moderator_only, except: [:index, :show]
+  before_action :moderator_only, except: [:index, :show, :destroy]
   respond_to :html, :json, :js
 
   def show

--- a/app/javascript/src/javascripts/tag_relationships.js
+++ b/app/javascript/src/javascripts/tag_relationships.js
@@ -1,62 +1,54 @@
 import Utility from './utility.js';
 
 class TagRelationships {
-  static typePlural(type) {
-    if (type === "alias") {
-      return "aliases";
-    }
-    return `${type}s`;
-  }
-  static approve(e, type) {
+  static approve(e) {
     e.preventDefault();
     const $e = $(e.target);
-    const parent = $e.parents(`.tag-${type}`)
-    const id = parent.data(`${type}-id`);
+    const parent = $e.parents(".tag-relationship");
+    const route = parent.data("relationship-route");
+    const human = parent.data("relationship-human");
+    const id = parent.data("relationship-id");
     $.ajax({
-      url: `/tag_${this.typePlural(type)}/${id}/approve.json`,
+      url: `/${route}/${id}/approve.json`,
       type: 'POST',
       dataType: 'json'
     }).done(function (data) {
-      Utility.notice(`Accepted ${type}.`);
+      Utility.notice(`Accepted ${human}.`);
       parent.slideUp('fast');
     }).fail(function (data) {
-      Utility.error(`Failed to accept ${type}.`);
+      Utility.error(`Failed to accept ${human}.`);
     });
   }
 
-  static reject(e, type) {
+  static reject(e) {
     e.preventDefault();
     const $e = $(e.target);
-    const parent = $e.parents(`.tag-${type}`)
-    const id = parent.data(`${type}-id`);
-    if(!confirm(`Are you sure you want to reject this ${type}?`))
+    const parent = $e.parents(".tag-relationship");
+    const route = parent.data("relationship-route");
+    const human = parent.data("relationship-human");
+    const id = parent.data("relationship-id");
+    if(!confirm(`Are you sure you want to reject this ${human}?`))
       return;
     $.ajax({
-      url: `/tag_${this.typePlural(type)}/${id}.json`,
+      url: `/${route}/${id}.json`,
       type: 'DELETE',
       dataType: 'json'
     }).done(function (data) {
-      Utility.notice(`Rejected ${type}.`);
+      Utility.notice(`Rejected ${human}.`);
       parent.slideUp('fast');
     }).fail(function (data) {
-      Utility.error(`Failed to reject ${type}.`);
+      Utility.error(`Failed to reject ${human}.`);
     });
   }
 }
 
 $(document).ready(function() {
-  $(".tag-alias-accept").on('click', e => {
-    TagRelationships.approve(e, 'alias');
+  $(".tag-relationship-accept").on('click', e => {
+    TagRelationships.approve(e);
   });
-  $(".tag-alias-reject").on('click', e => {
-    TagRelationships.reject(e, 'alias');
+  $(".tag-relationship-reject").on('click', e => {
+    TagRelationships.reject(e);
   });
-  $(".tag-implication-accept").on('click', e => {
-    TagRelationships.approve(e,'implication');
-  });
-  $(".tag-implication-reject").on('click', e => {
-    TagRelationships.reject(e,'implication');
-  })
 });
 
 export default TagRelationships

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -72,13 +72,16 @@ class TagRelationship < ApplicationRecord
     status =~ /\Aerror:/
   end
 
+  def approvable_by?(user)
+    is_pending? && user.is_moderator?
+  end
+
   def deletable_by?(user)
-    return true if user.is_moderator?
-    return false
+    user.is_moderator?
   end
 
   def editable_by?(user)
-    deletable_by?(user)
+    is_pending? && deletable_by?(user)
   end
 
   module SearchMethods

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -77,11 +77,11 @@ class TagRelationship < ApplicationRecord
   end
 
   def deletable_by?(user)
-    user.is_moderator?
+    user.is_moderator? || (is_pending? && creator.id == user.id)
   end
 
   def editable_by?(user)
-    is_pending? && deletable_by?(user)
+    is_pending? && user.is_moderator?
   end
 
   module SearchMethods

--- a/app/views/tag_aliases/_listing.html.erb
+++ b/app/views/tag_aliases/_listing.html.erb
@@ -12,7 +12,7 @@
   </thead>
   <tbody>
     <% tag_aliases.each do |tag_alias| %>
-      <tr id="tag-alias-<%= tag_alias.id %>" class="tag-alias" data-alias-id="<%= tag_alias.id %>">
+      <tr id="tag-alias-<%= tag_alias.id %>">
         <td class="category-<%= tag_alias.antecedent_tag.try(:category) %>"><%= link_to tag_alias.antecedent_name, show_or_new_wiki_pages_path(:title => tag_alias.antecedent_name) %> <span class="count"><%= tag_alias.antecedent_tag.post_count rescue 0 %></span></td>
         <td class="category-<%= tag_alias.consequent_tag.try(:category) %>"><%= link_to tag_alias.consequent_name, show_or_new_wiki_pages_path(:title => tag_alias.consequent_name) %> <span class="count"><%= tag_alias.consequent_tag.post_count rescue 0 %></span>
         <% if CurrentUser.is_member? && tag_alias.status == "pending" && tag_alias.has_transitives %><span class="redtext"> HAS TRANSITIVES</span><% end %></td>
@@ -27,21 +27,7 @@
           <%= tag_alias.status %>
         </td>
         <td>
-          <%= link_to "Show", tag_alias_path(tag_alias) %>
-
-          <% if CurrentUser.is_moderator? %>
-            <% if tag_alias.editable_by?(CurrentUser.user) %>
-              | <%= link_to "Edit", edit_tag_alias_path(tag_alias) %>
-            <% end %>
-
-            <% if tag_alias.deletable_by?(CurrentUser.user) %>
-              | <%= link_to "Reject", "#", class: "tag-alias-reject" %>
-            <% end %>
-
-            <% if tag_alias.is_pending? %>
-              | <%= link_to "Approve", "#", class: "tag-alias-accept" %>
-            <% end %>
-          <% end %>
+          <%= render "tag_relationships/command_buttons", tag_relation: tag_alias, with_show_link: true %>
         </td>
       </tr>
     <% end %>

--- a/app/views/tag_aliases/show.html.erb
+++ b/app/views/tag_aliases/show.html.erb
@@ -27,22 +27,10 @@
         <br>
       <% end %>
 
-      <% if CurrentUser.is_moderator? %>
-        <li>
-          <strong>Commands</strong>
-          <span class="tag-alias" data-alias-id="<%= @tag_alias.id %>">
-            <% if @tag_alias.is_pending? %>
-              <%= link_to "Approve", "#", class: "tag-alias-accept" %>
-            <% end %>
-            <% if @tag_alias.deletable_by?(CurrentUser.user) %>
-              | <%= link_to "Reject", "#", class: "tag-alias-reject" %>
-            <% end %>
-            <% if @tag_alias.editable_by?(CurrentUser.user) %>
-              | <%= link_to "Edit", edit_tag_alias_path(@tag_alias) %>
-            <% end %>
-          </span>
-        </li>
-      <% end %>
+      <li>
+        <strong>Commands</strong>
+        <%= render "tag_relationships/command_buttons", tag_relation: @tag_alias, with_show_link: false %>
+      </li>
     </ul>
   </div>
 </div>

--- a/app/views/tag_implications/_listing.html.erb
+++ b/app/views/tag_implications/_listing.html.erb
@@ -12,7 +12,7 @@
   </thead>
   <tbody>
     <% tag_implications.each do |tag_implication| %>
-      <tr class="tag-implication" id="tag-implication-<%= tag_implication.id %>" data-implication-id="<%= tag_implication.id %>">
+      <tr id="tag-implication-<%= tag_implication.id %>">
         <td class="category-<%= tag_implication.antecedent_tag.try(:category) %>"><%= link_to tag_implication.antecedent_name, show_or_new_wiki_pages_path(:title => tag_implication.antecedent_name) %> <span class="count"><%= tag_implication.antecedent_tag.post_count rescue 0 %></span></td>
         <td class="category-<%= tag_implication.consequent_tag.try(:category) %>"><%= link_to tag_implication.consequent_name, show_or_new_wiki_pages_path(:title => tag_implication.consequent_name) %> <span class="count"><%= tag_implication.consequent_tag.post_count rescue 0 %></span></td>
         <td>
@@ -24,21 +24,7 @@
         <td><%= link_to_user(tag_implication.approver) if tag_implication.approver %></td>
         <td id="tag-implication-status-for-<%= tag_implication.id %>"><%= tag_implication.status %></td>
         <td>
-          <%= link_to "Show", tag_implication_path(tag_implication) %>
-
-          <% if CurrentUser.is_moderator? %>
-            <% if tag_implication.is_pending? && tag_implication.editable_by?(CurrentUser.user) %>
-              | <%= link_to "Edit", edit_tag_implication_path(tag_implication) %>
-            <% end %>
-
-            <% if tag_implication.deletable_by?(CurrentUser.user) %>
-              | <%= link_to "Reject", "#", class: "tag-implication-reject" %>
-            <% end %>
-
-            <% if tag_implication.is_pending? %>
-              | <%= link_to "Approve", "#", class: "tag-implication-accept" %>
-            <% end %>
-          <% end %>
+          <%= render "tag_relationships/command_buttons", tag_relation: tag_implication, with_show_link: true %>
         </td>
       </tr>
     <% end %>

--- a/app/views/tag_implications/show.html.erb
+++ b/app/views/tag_implications/show.html.erb
@@ -15,22 +15,10 @@
       <% end %>
       <li><strong>Status</strong>: <%= @tag_implication.status %></li>
 
-      <% if CurrentUser.is_moderator? %>
-        <li>
-          <strong>Commands</strong>
-          <span class="tag-implication" data-implication-id="<%= @tag_implication.id %>">
-            <% if @tag_implication.is_pending? %>
-              <%= link_to "Approve", "#", class: "tag-implication-accept" %>
-            <% end %>
-            <% if @tag_implication.deletable_by?(CurrentUser.user) %>
-              | <%= link_to "Reject", "#", class: "tag-implication-reject" %>
-            <% end %>
-            <% if @tag_implication.is_pending? && @tag_implication.editable_by?(CurrentUser.user) %>
-              | <%= link_to "Edit", edit_tag_implication_path(@tag_implication) %>
-            <% end %>
-          </span>
-        </li>
-      <% end %>
+      <li>
+        <strong>Commands</strong>
+        <%= render "tag_relationships/command_buttons", tag_relation: @tag_implication, with_show_link: false %>
+      </li>
     </ul>
   </div>
 </div>

--- a/app/views/tag_relationships/_command_buttons.html.erb
+++ b/app/views/tag_relationships/_command_buttons.html.erb
@@ -1,0 +1,18 @@
+<span class="tag-relationship" data-relationship-route="<%= tag_relation.model_name.route_key %>"
+                               data-relationship-human="<%= tag_relation.model_name.singular.titleize %>"
+                               data-relationship-id="<%= tag_relation.id %>">
+  <% links = [] %>
+  <% if with_show_link %>
+    <% links.push link_to("Show", action: "show", controller: tag_relation.model_name.route_key, id: tag_relation.id) %>
+  <% end %>
+  <% if tag_relation.approvable_by?(CurrentUser.user) %>
+    <% links.push link_to("Approve", "#", class: "tag-relationship-accept") %>
+  <% end %>
+  <% if tag_relation.deletable_by?(CurrentUser.user) %>
+    <% links.push link_to("Reject", "#", class: "tag-relationship-reject") %>
+  <% end %>
+  <% if tag_relation.editable_by?(CurrentUser.user) %>
+    <% links.push link_to("Edit", action: "edit", controller: tag_relation.model_name.route_key, id: tag_relation.id) %>
+  <% end %>
+  <%= safe_join(links, " | ") %>
+</span>


### PR DESCRIPTION
Allow users to reject their own pending requests.

* The first commit makes sure that the aprove/reject,... links get properly generated for users of any level. They come from a central location now, which is nice.
* The second one basically just adds `is_pending? && creator == current_user` as a condition to `deletable_by`. The controllers already did access checks against that method, in addition to `moderator_only` which I now removed, so I didn't have to change anything more.