### PR TITLE
Reveal artist summary to unregistered users

### DIFF
--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -6,37 +6,35 @@
     <li><strong>User</strong> <%= link_to_user(artist.linked_user) %></li>
   <% end %>
 
-  <% if CurrentUser.is_member? %>
-    <% if artist.other_names.present? %>
-      <li><strong>Other Names</strong> <%= link_to_artists(artist.other_names) %></li>
-    <% end %>
-    <% if artist.group_name.present? %>
-      <li><strong>Group</strong> <%= link_to_artist(artist.group_name) %></li>
-    <% end %>
-    <% if artist.group_name.present? && artist.members.present? %>
-      <li><strong>Members</strong> <%= link_to_artists(artist.members.limit(25).map(&:name)) %></li>
-    <% end %>
-    <% if artist.domains.any? %>
-      <li><strong>Domains</strong></li>
-      <ul>
-        <% artist.domains.each do |url, count| %>
-          <li><%= url %>: <%= count %></li>
-        <% end %>
-      </ul>
-    <% end %>
-    <% if artist.urls.present? %>
-      <li><strong>URLs</strong></li>
-      <ul>
-        <% artist.sorted_urls.each do |url| %>
-          <li>
-            <% if url.is_active? %>
-              <%= link_to h(url.to_s), h(url) %>
-            <% else %>
-              <del><%= h(url.url) %></del>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
+  <% if artist.other_names.present? %>
+    <li><strong>Other Names</strong> <%= link_to_artists(artist.other_names) %></li>
+  <% end %>
+  <% if artist.group_name.present? %>
+    <li><strong>Group</strong> <%= link_to_artist(artist.group_name) %></li>
+  <% end %>
+  <% if artist.group_name.present? && artist.members.present? %>
+    <li><strong>Members</strong> <%= link_to_artists(artist.members.limit(25).map(&:name)) %></li>
+  <% end %>
+  <% if artist.domains.any? %>
+    <li><strong>Domains</strong></li>
+    <ul>
+      <% artist.domains.each do |url, count| %>
+        <li><%= url %>: <%= count %></li>
+      <% end %>
+    </ul>
+  <% end %>
+  <% if artist.urls.present? %>
+    <li><strong>URLs</strong></li>
+    <ul>
+      <% artist.sorted_urls.each do |url| %>
+        <li>
+          <% if url.is_active? %>
+            <%= link_to h(url.to_s), h(url) %>
+          <% else %>
+            <del><%= h(url.url) %></del>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
   <% end %>
 </ul>


### PR DESCRIPTION
It seems wrong to hide artist URLs from unregistered users and I see no reason to hide the rest either.

Registered vs unregistered user example
![image](https://user-images.githubusercontent.com/102884856/188267728-19724ec5-793b-4f40-9b4a-59031959fb43.png)

Makes sense to me that everybody should be able to see this - registered or not. I only realised this wasn't visible when I asked an artist whether there were any additional links to include on their artist page and they replied saying they couldn't see any.