### PR TITLE
[Posts] Don't hide page nubers of pools behind title attribute

### DIFF
--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -26,7 +26,7 @@ $darken-background-50: rgba(0,0,0,0.5);
 // Links
 $link-color: #b4c7d9;
 $link-hover-color: #2e76b4;
-$link-last-page-color: #3e9e49;
+$link-page-number-color: #3e9e49;
 $highlight-color: lighten($link-color, 45%);
 
 // Sections
@@ -189,7 +189,7 @@ $keyboard-key-background: #333;
 $keyboard-key-color: white;
 $keyboard-key-border: #333;
 $inline-inactive-color: #aaa;
-$inline-last-page-color: #666;
+$inline-page-number-color: #666;
 
 // JQUI
 $widget-link-color: $link-color;

--- a/app/javascript/src/styles/base/_links.scss
+++ b/app/javascript/src/styles/base/_links.scss
@@ -21,14 +21,14 @@ a:active {
   text-decoration: none;
 }
 
-a.last-page {
+a.page-number {
   @include themable {
-    color: themed('color-link-last-page');
+    color: themed('color-link-page-number');
   }
 }
-a.last-page:hover {
+a.page-number:hover {
   @include themable {
-    color: themed('color-link-last-page-hover');
+    color: themed('color-link-page-number-hover');
   }
 }
 

--- a/app/javascript/src/styles/common/inline.scss
+++ b/app/javascript/src/styles/common/inline.scss
@@ -31,6 +31,6 @@ span.inactive {
   color: $inline-inactive-color;
 }
 
-td a.last-page {
-  color: $inline-last-page-color;
+td a.page-number {
+  color: $inline-page-number-color;
 }

--- a/app/javascript/src/styles/specific/pools.scss
+++ b/app/javascript/src/styles/specific/pools.scss
@@ -1,4 +1,4 @@
-a.pool-category-series, .pool-category-series a:not(.last-page) {
+a.pool-category-series, .pool-category-series a:not(.page-number) {
   color: $pool-series-link-color;
 
   &:hover {
@@ -6,7 +6,7 @@ a.pool-category-series, .pool-category-series a:not(.last-page) {
   }
 }
 
-a.pool-category-collection, .pool-category-collection a:not(.last-page) {
+a.pool-category-collection, .pool-category-collection a:not(.page-number) {
   color: $pool-collection-link-color;
 
   &:hover {

--- a/app/javascript/src/styles/specific/pools.scss
+++ b/app/javascript/src/styles/specific/pools.scss
@@ -1,4 +1,4 @@
-a.pool-category-series, .pool-category-series a {
+a.pool-category-series, .pool-category-series a:not(.last-page) {
   color: $pool-series-link-color;
 
   &:hover {
@@ -6,7 +6,7 @@ a.pool-category-series, .pool-category-series a {
   }
 }
 
-a.pool-category-collection, .pool-category-collection a {
+a.pool-category-collection, .pool-category-collection a:not(.last-page) {
   color: $pool-collection-link-color;
 
   &:hover {

--- a/app/javascript/src/styles/themes/_theme_bloodlust.scss
+++ b/app/javascript/src/styles/themes/_theme_bloodlust.scss
@@ -23,8 +23,8 @@ $theme_bloodlust: (
   "color-link-active":            #ffffff,
   "color-button-active":          #e8c446,
 
-  "color-link-last-page":         $bloodlust-color-text-muted,
-  "color-link-last-hover":        $bloodlust-color-link-hover,
+  "color-link-page-number":       $bloodlust-color-text-muted,
+  "color-link-page-number-hover": $bloodlust-color-link-hover,
 
   "color-success":                darkgreen,
   "color-danger":                 maroon,

--- a/app/javascript/src/styles/themes/_theme_hexagon.scss
+++ b/app/javascript/src/styles/themes/_theme_hexagon.scss
@@ -27,8 +27,8 @@ $theme_hexagon: (
   "color-link-active":            #e8c446,
   "color-button-active":          #e8c446,
 
-  "color-link-last-page":         $hexagon-color-text-muted,
-  "color-link-last-hover":        $hexagon-color-link-hover,
+  "color-link-page-number":       $hexagon-color-text-muted,
+  "color-link-page-number-hover": $hexagon-color-link-hover,
 
   "color-success":                darkgreen,
   "color-danger":                 maroon,

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -346,6 +346,10 @@ class Pool < ApplicationRecord
     (post_count / CurrentUser.user.per_page.to_f).ceil
   end
 
+  def page_index(post_id)
+    (page_number(post_id) / CurrentUser.user.per_page.to_f).ceil
+  end
+
   def method_attributes
     super + [:creator_name, :post_count]
   end

--- a/app/views/forum_topics/_listing.html.erb
+++ b/app/views/forum_topics/_listing.html.erb
@@ -22,7 +22,7 @@
           <%= link_to topic.title, forum_topic_path(topic), class: "forum-post-link" %>
 
           <% if topic.response_count > Danbooru.config.posts_per_page %>
-            <%= link_to "page #{topic.last_page}", forum_topic_path(topic, :page => topic.last_page), :class => "last-page" %>
+            <%= link_to "page #{topic.last_page}", forum_topic_path(topic, :page => topic.last_page), :class => "page-number" %>
           <% end %>
 
           <% if topic.is_locked? %>

--- a/app/views/pools/index.html.erb
+++ b/app/views/pools/index.html.erb
@@ -20,7 +20,7 @@
               <%= link_to pool.pretty_name, pool_path(pool) %>
 
               <% if pool.post_count > CurrentUser.user.per_page %>
-                <%= link_to "page #{pool.last_page}", pool_path(pool, :page => pool.last_page), :class => "last-page" %>
+                <%= link_to "page #{pool.last_page}", pool_path(pool, :page => pool.last_page), :class => "page-number" %>
               <% end %>
             </td>
             <td>

--- a/app/views/posts/partials/show/_pool_list_item.html.erb
+++ b/app/views/posts/partials/show/_pool_list_item.html.erb
@@ -15,6 +15,7 @@
 
   <span class="pool-name">
     <%= link_to("Pool: #{pool.pretty_name}", pool_path(pool), title: "page #{pool.page_number(post.id)}/#{pool.post_count}") -%>
+    <%= link_to("page #{pool.page_number(post.id)}/#{pool.post_count}", pool_path(pool, page: pool.page_index(post.id)), class: "last-page") -%>
   </span>
 
   <% pool.next_post_id(post.id).tap do |next_post_id| -%>

--- a/app/views/posts/partials/show/_pool_list_item.html.erb
+++ b/app/views/posts/partials/show/_pool_list_item.html.erb
@@ -15,7 +15,7 @@
 
   <span class="pool-name">
     <%= link_to("Pool: #{pool.pretty_name}", pool_path(pool), title: "page #{pool.page_number(post.id)}/#{pool.post_count}") -%>
-    <%= link_to("page #{pool.page_number(post.id)}/#{pool.post_count}", pool_path(pool, page: pool.page_index(post.id)), class: "last-page") -%>
+    <%= link_to("page #{pool.page_number(post.id)}/#{pool.post_count}", pool_path(pool, page: pool.page_index(post.id)), class: "page-number") -%>
   </span>
 
   <% pool.next_post_id(post.id).tap do |next_post_id| -%>


### PR DESCRIPTION
This has been annoying me ever since Firefox "Daylight" for Android stopped displaying the title of links and called it a "feature".

## Features

This PR adds the page number of a post in a pool next to the pool links above the post. Previously the page numbers were hidden behind the `title` attribute of the pool link.

Clicking on the page number will take you to the page in the pool gallery that contains the post.

## How it looks

on desktop:
![image](https://user-images.githubusercontent.com/114746666/193276187-e5067261-a015-49ba-ae92-b41245b11fbc.png)

on mobile:
![image](https://user-images.githubusercontent.com/114746666/193276306-acc28151-98e0-4986-87c1-49ed2a5494a5.png)

I reused and renamed the `last-page` css rule for styling this. As a bonus the `:hover` color of these links will actually show now, because it previously used the wrong css variable name.

## Tests

I barely tested this and couldn't find any UI tests in this repo. I hope i didn't break any CSS elsewhere.
The link may or may not actually take you to the correct page.