### PR TITLE
Correctly Truncate Artist Other Names & URLs To 25

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -213,7 +213,7 @@ class Artist < ApplicationRecord
       self.urls = string.to_s.scan(/[^[:space:]]+/).map do |url|
         is_active, url = ArtistUrl.parse_prefix(url)
         self.urls.find_or_initialize_by(url: url, is_active: is_active)
-      end.uniq(&:url)[0..MAX_URLS_PER_ARTIST - 1]
+      end.uniq(&:url).first(MAX_URLS_PER_ARTIST)
 
       self.url_string_changed = (url_string_was != url_string)
     end
@@ -254,6 +254,7 @@ class Artist < ApplicationRecord
   module NameMethods
     extend ActiveSupport::Concern
 
+    MAX_OTHER_NAMES_PER_ARTIST = 25
     module ClassMethods
       def normalize_name(name)
         name.to_s.downcase.strip.gsub(/ /, '_').to_s
@@ -271,7 +272,7 @@ class Artist < ApplicationRecord
     def normalize_other_names
       self.other_names = other_names.map { |x| Artist.normalize_name(x) }.uniq
       self.other_names -= [name]
-      self.other_names = other_names[0..24].map { |other_name| other_name[0..99] }
+      self.other_names = other_names.first(MAX_OTHER_NAMES_PER_ARTIST).map { |other_name| other_name.first(100) }
     end
   end
 

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -213,7 +213,7 @@ class Artist < ApplicationRecord
       self.urls = string.to_s.scan(/[^[:space:]]+/).map do |url|
         is_active, url = ArtistUrl.parse_prefix(url)
         self.urls.find_or_initialize_by(url: url, is_active: is_active)
-      end.uniq(&:url)[0..MAX_URLS_PER_ARTIST]
+      end.uniq(&:url)[0..MAX_URLS_PER_ARTIST - 1]
 
       self.url_string_changed = (url_string_was != url_string)
     end
@@ -271,7 +271,7 @@ class Artist < ApplicationRecord
     def normalize_other_names
       self.other_names = other_names.map { |x| Artist.normalize_name(x) }.uniq
       self.other_names -= [name]
-      self.other_names = other_names[0..25].map { |other_name| other_name[0..99] }
+      self.other_names = other_names[0..24].map { |other_name| other_name[0..99] }
     end
   end
 


### PR DESCRIPTION
This is a really nitpicky one, but I noticed artists allowed 26 other names & urls when testing them. I was unsure if I should subtract one from the `MAX_URLS_PER_ARTIST` constant when using it, or inline the number. I've gone with subtracting one to leave as little a footprint as possible.