### PR TITLE
[Tickets] Fix paths for sets and pools

### DIFF
--- a/app/views/tickets/new_types/_pool.html.erb
+++ b/app/views/tickets/new_types/_pool.html.erb
@@ -1,7 +1,7 @@
 <% @pool = @ticket.content %>
 <h4>You are reporting the following pool:</h4>
-<div class='page'><%= fast_link_to(@pool.name, controller: "pools", id: @pool.id) %></div>
+<div class='page'><%= fast_link_to(@pool.name, pool_path(id: @pool.id)) %></div>
 <div class='author'><%= link_to_user(@pool.creator) %></div>
 <span class="date" title="Created on <%= @pool.created_at.strftime("%b %d, %Y %I:%M %p") %>">
-  <%= time_ago_in_words(@pool.created_at) %>ago
+  <%= time_ago_in_words(@pool.created_at) %> ago
 </span>

--- a/app/views/tickets/new_types/_set.html.erb
+++ b/app/views/tickets/new_types/_set.html.erb
@@ -1,5 +1,5 @@
 <% @set = @ticket.content %>
 <h4>You are reporting the following set:</h4>
-<div class='page'><%= fast_link_to(@set.name, controller: "set", action: "show", id: @set.id) %></div>
+<div class='page'><%= fast_link_to(@set.name, post_set_path(id: @set.id)) %></div>
 <div class='author'><%= link_to_user(@set.creator) %></div>
 <span class="date" title="Created on <%= @set.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@set.created_at) %> ago</span>

--- a/app/views/tickets/types/_pool.html.erb
+++ b/app/views/tickets/types/_pool.html.erb
@@ -1,6 +1,6 @@
 <% if @ticket.content %>
     <tr>
       <td><span class='title'>Reported Pool</span></td>
-      <td><%= fast_link_to(@ticket.content.name, controller: "pools", id: @ticket.content.id) %></td>
+      <td><%= fast_link_to(@ticket.content.name, pool_path(id: @ticket.content.id)) %></td>
     </tr>
 <% end %>

--- a/app/views/tickets/types/_set.html.erb
+++ b/app/views/tickets/types/_set.html.erb
@@ -1,6 +1,6 @@
 <% if @ticket.content %>
     <tr>
       <td><span class='title'>Reported Set</span></td>
-      <td><%= fast_link_to(@ticket.content.name, controller: "set", action: "show", id: @ticket.content.id) %></td>
+      <td><%= fast_link_to(@ticket.content.name, post_set_path(id: @ticket.content.id)) %></td>
     </tr>
 <% end %>


### PR DESCRIPTION
Fixes the path used on sets and pools when displaying a ticket.

* The link on a set report ticket currently goes to `/set/show/id`, resulting in a 404.
* The link on a pool report ticket currently goes to `/pools//id`, which does actually work, but looks bad.

These changes instead result in the ticket linking to `/post_sets/id` and `/pools/id` respectively.

Also, added a space after the time ago on the new pool ticket to prevent this happening:
![image](https://user-images.githubusercontent.com/102884856/208324596-0e657ab0-00b3-49f9-8a12-95e66b8dfa58.png)