### PR TITLE
[Artists] Add (view all) to recent posts header

### DIFF
--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -16,7 +16,7 @@
     <%= yield %>
 
     <div class="recent-posts">
-      <h1>Recent Posts (<%= link_to "view all", posts_path(:tags => @artist.name) %>)</h1>
+      <h1>Recent Posts (<%= link_to "view all", posts_path(tags: @artist.name) %>)</h1>
 
       <%= render "posts/partials/common/inline_blacklist" %>
 

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -16,7 +16,7 @@
     <%= yield %>
 
     <div class="recent-posts">
-      <h1>Recent Posts</h1>
+      <h1>Recent Posts (<%= link_to "view all", posts_path(:tags => @artist.name) %>)</h1>
 
       <%= render "posts/partials/common/inline_blacklist" %>
 


### PR DESCRIPTION
A few artists that I've uploaded for have expressed confusion how to view the rest of the posts when I've linked them their artist page. This would make it much clearer than knowing they have to click the artist name on the main header, and creates a little more visual consistency with wiki pages as an additional bonus.

Before (top) and after (bottom)
![image](https://user-images.githubusercontent.com/102884856/209439864-88e0a3cb-9df1-4a40-8623-f81ad79fce85.png)

A wiki page, for comparison
![image](https://user-images.githubusercontent.com/102884856/209439893-85d73ae4-1604-4947-916b-483df69939a0.png)

