### PR TITLE
[Notes] Improve search UI for notes and note changes

### DIFF
--- a/app/controllers/note_versions_controller.rb
+++ b/app/controllers/note_versions_controller.rb
@@ -11,7 +11,7 @@ class NoteVersionsController < ApplicationController
   private
 
   def search_params
-    permitted_params = %i[updater_id post_id note_id is_active body_matches]
+    permitted_params = %i[updater_id updater_name post_id note_id is_active body_matches]
     permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params
   end

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -10,6 +10,10 @@ class NoteVersion < ApplicationRecord
       q = q.where(updater_id: params[:updater_id].split(",").map(&:to_i))
     end
 
+    if params[:updater_name]
+      q = q.where(updater_id: User.name_to_id(params[:updater_name]))
+    end
+
     if params[:post_id]
       q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
     end

--- a/app/views/note_versions/_search.html.erb
+++ b/app/views/note_versions/_search.html.erb
@@ -1,0 +1,7 @@
+<%= form_search(path: note_versions_path) do |f| %>
+  <%= f.input :body_matches, label: "Body" %>
+  <%= f.input :updater_name, label: "User", autocomplete: "user" %>
+  <%= f.input :post_id, label: "Post #"%>
+  <%= f.input :note_id, label: "Note #"%>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/note_versions/index.html.erb
+++ b/app/views/note_versions/index.html.erb
@@ -2,6 +2,8 @@
   <div id="a-index">
     <h1>Note Changes</h1>
 
+    <%= render "search" %>
+
     <% if params.dig(:search, :post_id).present? || params.dig(:search, :note_id).present? %>
       <%= render "revert_listing" %>
     <% else %>

--- a/app/views/notes/_search.html.erb
+++ b/app/views/notes/_search.html.erb
@@ -1,6 +1,8 @@
 <%= form_search(path: notes_path) do |f| %>
   <%= f.input :body_matches, label: "Body" %>
   <%= f.input :creator_name, label: "Author", autocomplete: "user" %>
+  <%= f.input :post_id, label: "Post #"%>
   <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
+  <%= f.input :is_active, label: "Status", collection: [["Active", "true"], ["Deleted", "false"]], :include_blank => true %>
   <%= f.submit "Search" %>
 <% end %>


### PR DESCRIPTION
Adds some additional search options to the notes and note changes pages, that already worked but weren't exposed in the UI.

**Note changes**
![image](https://user-images.githubusercontent.com/102884856/216841800-06153dbc-a9d6-4977-8fc8-fc170f1da374.png)
Previously had no UI-exposed search despite accepting the parameters. I intentionally excluded `is_active` because the results will likely confuse users - deleted notes still appear in the search because they were active at the time they were updated.

Also added the ability to search note changes by username, see `app/models/note_version.rb` because I'm not convinced that was the best solution. Doesn't support being comma-separated like other values on this page, but I don't see any other pages allowing to search for comma-separated usernames either.

**Notes**
![image](https://user-images.githubusercontent.com/102884856/216842121-f0f1a9fe-5e1f-4ddf-b88a-f2d3e0076e09.png)
Nothing major here, just added `post_id` and `is_active` to the search UI.


Original suggestion: [forum #37234](https://e621.net/forum_topics/37234)
