### PR TITLE
Allow Privileged+ To Bypass Rating Locks

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1590,11 +1590,8 @@ class Post < ApplicationRecord
     end
 
     def updater_can_change_rating
-      if rating_changed? && is_rating_locked?
-        # Don't forbid changes if the rating lock was just now set in the same update.
-        if !is_rating_locked_changed?
-          errors.add(:rating, "is locked and cannot be changed. Unlock the post first.")
-        end
+      if !CurrentUser.user.is_privileged? && rating_changed? && is_rating_locked?
+        errors.add(:rating, "is locked and cannot be changed.")
       end
     end
 

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -29,7 +29,7 @@
     <%= f.input :locked_tags, label: "Locked Tags", autocomplete: "tag-edit", input_html: { value: (post.locked_tags || ""), spellcheck: false, size: "60x2", disabled: !CurrentUser.is_moderator? } %>
   </div>
 
-  <% if post.is_rating_locked? %>
+  <% if !CurrentUser.user.is_privileged? && post.is_rating_locked?  %>
     <div class="input">
       This post is rating locked.
     </div>

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -29,11 +29,12 @@
     <%= f.input :locked_tags, label: "Locked Tags", autocomplete: "tag-edit", input_html: { value: (post.locked_tags || ""), spellcheck: false, size: "60x2", disabled: !CurrentUser.is_moderator? } %>
   </div>
 
-  <% if !CurrentUser.user.is_privileged? && post.is_rating_locked?  %>
+  <% if post.is_rating_locked?  %>
     <div class="input">
       This post is rating locked.
     </div>
-  <% else %>
+  <% end %>
+  <% unless CurrentUser.user.is_privileged? || post.is_rating_locked? %>
     <%= f.input :rating, as: :button_select, collection: rating_collection.reverse %>
   <% end %>
 


### PR DESCRIPTION
As the title says, this allows privileged+ users to edit the rating of a post even if it has been locked. As I see it, the necessity to unlock then relock the rating (if needed) is an unnecessary burden that could be forgone.

As far as I tested, this should make no difference in functionality beyond allowing Privileged+ to bypass rating locks. This also changes the error to a more informative "is locked and cannot be changed.", as only users who cannot lock ratings would have the possibility of seeing it.

I also want to make a sidenote that editing a rating locked post via api methods produces no error, and the result looks as if the change has succeeded (the result has the provided rating, but nothing was actually changed).