### PR TITLE
Short Circuit On Null updater_id In Pool Versions

### DIFF
--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -101,6 +101,7 @@ class PoolVersion < ApplicationRecord
   end
 
   def updater
+    return nil if updater_id.nil?
     User.find(updater_id)
   end
 

--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -101,8 +101,7 @@ class PoolVersion < ApplicationRecord
   end
 
   def updater
-    return nil if updater_id.nil?
-    User.find(updater_id)
+    User.find_by(id: updater_id)
   end
 
   def updater_name


### PR DESCRIPTION
When visiting a pool version with a null updater id, an exception will be thrown. This can be seen via [this](https://e621.net/pool_versions?limit=1&page=11&search%5Bpool_id%5D=1059) pool.

The exception can be seen below:
![](https://user-images.githubusercontent.com/17226394/218413511-0cc3813c-3645-4cc4-bc33-b6d4f5ea419c.png)

I've added a check for nil before we bother attempting to fetch anything to short circuit if the updater id is nil. As far as I can tell, this remedies the issue. Fixes #471.