### PR TITLE
Add warning tags to artist exclusions

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -479,7 +479,7 @@ module Danbooru
           "header" => 'Artists',
           "humanized" => {
             "slice" => 0,
-            "exclusion" => %w(avoid_posting conditional_dnp),
+            "exclusion" => %w(avoid_posting conditional_dnp epilepsy_warning sound_warning),
             "regexmap" => //,
             "formatstr" => "created by %s"
           },


### PR DESCRIPTION
Add `epilepsy_warning` and `sound_warning` to the artist exclusions for the humanized tag list. Because stuff like this just looks dumb:

![image](https://user-images.githubusercontent.com/102884856/218924721-b556a2bd-a1c0-4fa6-87c8-bf3d6ba692d0.png)
