### PR TITLE
[PostSets] Don't require wildcard for name search

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -69,9 +69,10 @@ class ApplicationRecord < ActiveRecord::Base
         PostQueryBuilder.new(nil).add_range_relation(parsed_range, qualified_column, self)
       end
 
-      def text_attribute_matches(attribute, value)
+      def text_attribute_matches(attribute, value, convert_to_wildcard: false)
         column = column_for_attribute(attribute)
         qualified_column = "#{table_name}.#{column.name}"
+        value = "*#{value}*" if convert_to_wildcard && value.exclude?("*")
 
         if value =~ /\*/
           where("lower(#{qualified_column}) LIKE :value ESCAPE E'\\\\'", value: value.downcase.to_escaped_for_sql_like)

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -52,12 +52,6 @@ class Pool < ApplicationRecord
       reorder(Arel.sql("(case pools.id when #{current_pool_id} then 0 else 1 end), pools.name"))
     end
 
-    def name_matches(name)
-      name = normalize_name_for_search(name)
-      name = "*#{name}*" unless name =~ /\*/
-      where("lower(pools.name) like ? escape E'\\\\'", name.to_escaped_for_sql_like)
-    end
-
     def default_order
       order(updated_at: :desc)
     end
@@ -66,7 +60,7 @@ class Pool < ApplicationRecord
       q = super
 
       if params[:name_matches].present?
-        q = q.name_matches(params[:name_matches])
+        q = q.attribute_matches(:name, normalize_name(params[:name_matches]), convert_to_wildcard: true)
       end
 
       q = q.attribute_matches(:description, params[:description_matches])
@@ -143,15 +137,11 @@ class Pool < ApplicationRecord
     name.gsub(/[_[:space:]]+/, "_").gsub(/\A_|_\z/, "")
   end
 
-  def self.normalize_name_for_search(name)
-    normalize_name(name).downcase
-  end
-
   def self.find_by_name(name)
     if name =~ /\A\d+\z/
       where("pools.id = ?", name.to_i).first
     elsif name
-      where("lower(pools.name) = ?", normalize_name_for_search(name)).first
+      where("lower(pools.name) = ?", normalize_name(name).downcase).first
     else
       nil
     end

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -308,6 +308,12 @@ class PostSet < ApplicationRecord
       joins(:maintainers).where('(post_set_maintainers.user_id = ? AND post_set_maintainers.status = ?) OR creator_id = ?', user_id, 'approved', user_id)
     end
 
+    def name_matches(name)
+      name = normalize_name_for_search(name)
+      name = "*#{name}*" unless name =~ /\*/
+      where("lower(post_sets.name) like ? escape E'\\\\'", name.to_escaped_for_sql_like)
+    end
+
     def search(params)
       q = super
 
@@ -318,7 +324,7 @@ class PostSet < ApplicationRecord
 
       q = q.attribute_exact_matches(:creator_id, params[:creator_id])
       if params[:name].present?
-        q = q.where_ilike(:name, params[:name])
+        q = q.name_matches(params[:name])
       end
       if params[:shortname].present?
         q = q.where_ilike(:shortname, params[:shortname])
@@ -347,6 +353,15 @@ class PostSet < ApplicationRecord
   end
 
   extend SearchMethods
+
+  def self.normalize_name(name)
+    name.gsub(/[_[:space:]]+/, "_").gsub(/\A_|_\z/, "")
+  end
+
+  def self.normalize_name_for_search(name)
+    normalize_name(name).downcase
+  end
+
   include ValidationMethods
   include AccessMethods
   include PostMethods

--- a/app/views/post_sets/_search.html.erb
+++ b/app/views/post_sets/_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_search path: post_sets_path do |f| %>
   <%= f.input :name, label: "Name" %>
   <%= f.input :shortname, label: "Short Name" %>
-  <%= f.input :creator_name, label: "Username", autocomplete: "users" %>
+  <%= f.input :creator_name, label: "Username", autocomplete: "user" %>
   <% if CurrentUser.is_moderator? %>
     <%= f.input :is_public, label: "Public?", collection: [["Yes", true], ["No", false]], include_blank: true %>
   <% end %>


### PR DESCRIPTION
Don't require wildcards when searching post sets, this behavior matches the pool search. Also fix a typo in the search partial that prevented any autocompletion for usernames.

[topic #37381](https://e621.net/forum_topics/37381)