### PR TITLE
[CI] Upload log after test run

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,3 +53,10 @@ jobs:
 
       - name: Run Tests
         run: $DOCKER_RUN tests
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: log/test.log

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,13 +52,6 @@ class ApplicationController < ActionController::Base
     # If InvalidAuthenticityToken was raised, CurrentUser isn't set so we have to do it here manually.
     CurrentUser.user ||= User.anonymous
 
-    if Rails.env.test? && ENV["DEBUG"]
-      puts "---"
-      STDERR.puts("#{exception.class} exception thrown: #{exception.message}")
-      exception.backtrace.each {|x| STDERR.puts(x)}
-      puts "---"
-    end
-
     case exception
     when ProcessingError
       render_expected_error(400, exception)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
   config.eager_load = ENV["CI"].present?
+  config.log_level = :info
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
Should make it easier to understand why random failures are happening.
Remove the manual logging in the application controller. Just look in your logs instead.

This also reduces the log level for tests.
Log files are now 700KB instead of 28MB per run.