### PR TITLE
[Posts] Fix the "Borderline Relevancy" detailed disapproval option

### DIFF
--- a/app/views/post_disapprovals/_detailed_rejection_dialog.html.erb
+++ b/app/views/post_disapprovals/_detailed_rejection_dialog.html.erb
@@ -3,7 +3,7 @@
 
   <%= custom_form_for(PostDisapproval.new, url: moderator_post_disapprovals_path, id: "detailed-rejection-form") do |f| %>
     <%= f.hidden_field :post_id, value: "x" %>
-    <%= f.input :reason, collection: [["Borderline Relevant", "borderline_relevant"], ["Borderline Quality", "borderline_quality"], ["Other", "other"]] %>
+    <%= f.input :reason, collection: [["Borderline Relevancy", "borderline_relevancy"], ["Borderline Quality", "borderline_quality"], ["Other", "other"]] %>
     <%= f.input :message, as: :string %>
   <% end %>
 </div>


### PR DESCRIPTION
In the "Detailed Disapproval" dropdown, selecting the "Borderline Relevant" option wouldn't do anything.
That option's value was invalid and would be rejected by validation down the line.

![deletion](https://user-images.githubusercontent.com/1503448/222991107-8b134251-3a53-47e6-bf44-fee053f918f1.png)
