### PR TITLE
[Themes/Comments] Theme stickied comments

### DIFF
--- a/app/javascript/src/styles/specific/comments.scss
+++ b/app/javascript/src/styles/specific/comments.scss
@@ -13,7 +13,9 @@ div.comments-for-post {
       }
 
       &[data-is-sticky="true"] {
-        background: $comment-sticky-background;
+        @include themable {
+          background: lighten(themed("color-section"), 10%);
+        }
       }
 
       &[data-is-deleted="true"] {


### PR DESCRIPTION
Somehow I've never encountered a sticky comment before now.

Before/after
![image](https://user-images.githubusercontent.com/102884856/225071886-0d0b133d-32df-45a8-a70c-5d80158fc368.png)

Uses lighten instead of saturate because of adverse effects on greyscale colours (Bloodlust)