### PR TITLE
[HelpPages] Add default value for related & title

### DIFF
--- a/db/migrate/20230316084945_help_pages_add_default_values.rb
+++ b/db/migrate/20230316084945_help_pages_add_default_values.rb
@@ -1,0 +1,8 @@
+class HelpPagesAddDefaultValues < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :help_pages, :related, false
+    change_column_default :help_pages, :related, from: nil, to: ""
+    change_column_null :help_pages, :title, false
+    change_column_default :help_pages, :title, from: nil, to: ""
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -863,8 +863,8 @@ CREATE TABLE public.help_pages (
     updated_at timestamp without time zone NOT NULL,
     name character varying NOT NULL,
     wiki_page character varying NOT NULL,
-    related character varying,
-    title character varying
+    related character varying DEFAULT ''::character varying NOT NULL,
+    title character varying DEFAULT ''::character varying NOT NULL
 );
 
 
@@ -4627,6 +4627,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230221153458'),
 ('20230226152600'),
 ('20230312103728'),
-('20230314170352');
+('20230314170352'),
+('20230316084945');
 
 


### PR DESCRIPTION
While messing around with various json routes in my never ending quest to break everything I normally can't touch, I came across this little bug. Not providing `related` or `title` when creating a help page results in null values being inserted, which then breaks displaying any help pages. Not providing `name` also results in an exception being thrown due to attempting to normalize a nil value. 

This pr:
- makes `related` & `title` non-nullable
- fixes the presence check for `name`
- adds presence checks for `related` & `title`