### PR TITLE
[Posts] Locked tags for admins only in edit view

### DIFF
--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -26,7 +26,7 @@
 
     <div id="tag-string-editor"></div>
 
-    <%= f.input :locked_tags, label: "Locked Tags", autocomplete: "tag-edit", input_html: { value: (post.locked_tags || ""), spellcheck: false, size: "60x2", disabled: !CurrentUser.is_moderator? } %>
+    <%= f.input :locked_tags, label: "Locked Tags", autocomplete: "tag-edit", input_html: { value: (post.locked_tags || ""), spellcheck: false, size: "60x2", disabled: !CurrentUser.is_admin? } %>
   </div>
 
   <% if post.is_rating_locked? %>


### PR DESCRIPTION
This was missed in the previous commits, just came across it when trying to edit a post. The field being enabled sends the `locked_tags` parameter, resulting in `found unpermitted parameter: :locked_tag` error and moderators not being able to edit tags.