### PR TITLE
[Posts] Switch arrow direction for implications in final tag preview

### DIFF
--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -5,7 +5,7 @@
   </span>
   <span v-else-if="tag.type === 'implication'" class="tag-preview tag-preview-implication">
     <tag-link :name="tag.a" :tagType="tag.tagTypeA"></tag-link>
-    ⇐ <tag-link :name="tag.b" :tagType="tag.tagTypeB"></tag-link>
+    ⇒ <tag-link :name="tag.b" :tagType="tag.tagTypeB"></tag-link>
   </span>
   <span v-else class="tag-preview">
     <tag-link :name="tag.a" :tagType="tag.tagTypeA"></tag-link>


### PR DESCRIPTION
Swaps the direction the arrow is facing for implications in the "Final tag preview" when editing post tags. The current way the arrow is facing is misleading, making it look like the implied tag is actually the one doing the implying. It also brings it into line with the same way the arrow for aliased tags faces.

Before:
![image](https://user-images.githubusercontent.com/102884856/229006069-a718e1cc-f360-4e52-9bb4-845e711f5b18.png)

After:
![image](https://user-images.githubusercontent.com/102884856/229005201-3a95d6a5-2e43-42b3-b607-3f5c6b3049b5.png)



[topic #31595](https://e621.net/forum_topics/31595)
[forum #350310](https://e621.net/forum_posts/350310)