### PR TITLE
[Bans]: Hide ban button for non-moderators

### DIFF
--- a/app/views/bans/_secondary_links.html.erb
+++ b/app/views/bans/_secondary_links.html.erb
@@ -1,4 +1,6 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "Listing", bans_path %>
-  <%= subnav_link_to "Ban", new_ban_path %>
+  <% if CurrentUser.is_moderator? %>
+    <%= subnav_link_to "Ban", new_ban_path %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
On the `/bans` index, the `Ban` button to create a new ban shows regardless of level. This changes it to only show for moderators or above.