### PR TITLE
[Posts]: Hide disabled comments info better

### DIFF
--- a/app/decorators/posts_decorator.rb
+++ b/app/decorators/posts_decorator.rb
@@ -72,7 +72,7 @@ class PostsDecorator < ApplicationDecorator
     post_score_icon = "#{"&uarr;" if post.score > 0}#{"&darr;" if post.score < 0}#{"&varr;" if post.score == 0}"
     score = t.tag.span("#{post_score_icon}#{post.score}".html_safe, class: "post-score-score " + score_class(post.score))
     favs =  t.tag.span("&hearts;#{post.fav_count}".html_safe, class: 'post-score-faves')
-    comments = t.tag.span "C#{CurrentUser.is_moderator? || !post.is_comment_disabled ? post.comment_count : 0}", class: 'post-score-comments'
+    comments = t.tag.span "C#{post.visible_comment_count(CurrentUser)}", class: 'post-score-comments'
     rating =  t.tag.span(post.rating.upcase, class: "post-score-rating")
     status = t.tag.span(status_flags.join(''), class: 'post-score-extras')
     t.tag.div score + favs + comments + rating + status, class: 'post-score', id: "post-score-#{post.id}"

--- a/app/decorators/posts_decorator.rb
+++ b/app/decorators/posts_decorator.rb
@@ -72,7 +72,7 @@ class PostsDecorator < ApplicationDecorator
     post_score_icon = "#{"&uarr;" if post.score > 0}#{"&darr;" if post.score < 0}#{"&varr;" if post.score == 0}"
     score = t.tag.span("#{post_score_icon}#{post.score}".html_safe, class: "post-score-score " + score_class(post.score))
     favs =  t.tag.span("&hearts;#{post.fav_count}".html_safe, class: 'post-score-faves')
-    comments = t.tag.span "C#{post.comment_count}", class: 'post-score-comments'
+    comments = t.tag.span "C#{CurrentUser.is_moderator? || !post.is_comment_disabled ? post.comment_count : 0}", class: 'post-score-comments'
     rating =  t.tag.span(post.rating.upcase, class: "post-score-rating")
     status = t.tag.span(status_flags.join(''), class: 'post-score-extras')
     t.tag.div score + favs + comments + rating + status, class: 'post-score', id: "post-score-#{post.id}"

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -91,7 +91,7 @@ module PostsHelper
     post_score_icon = "#{"&uarr;" if post.score > 0}#{"&darr;" if post.score < 0}#{"&varr;" if post.score == 0}"
     score = tag.span("#{post_score_icon}#{post.score}".html_safe, class: "post-score-score " + score_class(post.score))
     favs =  tag.span("&hearts;#{post.fav_count}".html_safe, class: 'post-score-faves')
-    comments = tag.span "C#{post.comment_count}", class: 'post-score-comments'
+    comments = tag.span "C#{post.visible_comment_count(CurrentUser)}", class: 'post-score-comments'
     rating =  tag.span(post.rating.upcase, class: "post-score-rating")
     status = tag.span(status_flags.join(''), class: 'post-score-extras')
     tag.div score + favs + comments + rating + status, class: 'post-score', id: "post-score-#{post.id}"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1772,6 +1772,10 @@ class Post < ApplicationRecord
   def flaggable_for_guidelines?
     return true if is_pending?
     return true if CurrentUser.is_privileged? && !has_tag?("grandfathered_content") && created_at.after?("2015-01-01")
-    return false
+    false
+  end
+
+  def visible_comment_count(user)
+    (user.is_moderator? || !is_comment_disabled) ? comment_count : 0
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1776,6 +1776,6 @@ class Post < ApplicationRecord
   end
 
   def visible_comment_count(user)
-    (user.is_moderator? || !is_comment_disabled) ? comment_count : 0
+    user.is_moderator? || !is_comment_disabled ? comment_count : 0
   end
 end

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -48,6 +48,9 @@ class PostEvent < ApplicationRecord
   def self.search(params)
     q = super
 
+    unless CurrentUser.is_moderator?
+      q = q.where.not(action: [actions[:comment_disabled], actions[:comment_enabled]])
+    end
     if params[:post_id].present?
       q = q.where("post_id = ?", params[:post_id].to_i)
     end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -169,7 +169,7 @@ class PostPresenter < Presenter
         created_at: post.created_at,
         updated_at: post.updated_at,
         fav_count: post.fav_count,
-        comment_count: post.comment_count,
+        comment_count: post.visible_comment_count(CurrentUser),
         change_seq: post.change_seq,
         uploader_id: post.uploader_id,
         description: post.description,

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -99,7 +99,6 @@ class PostSerializer < ActiveModel::Serializer
         note_locked: nullable_to_truthy(object.is_note_locked),
         status_locked: nullable_to_truthy(object.is_status_locked),
         rating_locked: nullable_to_truthy(object.is_rating_locked),
-        comment_disabled: CurrentUser.is_moderator? ? nullable_to_truthy(object.is_comment_disabled) : false,
         deleted: object.is_deleted
     }
   end
@@ -138,8 +137,7 @@ class PostSerializer < ActiveModel::Serializer
   end
 
   def comment_count
-    return 0 unless CurrentUser.is_moderator? || !nullable_to_truthy(object.is_comment_disabled)
-    object.comment_count
+    object.visible_comment_count(CurrentUser)
   end
 
   attributes :id, :created_at, :updated_at, :file, :preview, :sample, :score, :tags, :locked_tags, :change_seq, :flags,

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -99,7 +99,7 @@ class PostSerializer < ActiveModel::Serializer
         note_locked: nullable_to_truthy(object.is_note_locked),
         status_locked: nullable_to_truthy(object.is_status_locked),
         rating_locked: nullable_to_truthy(object.is_rating_locked),
-        comment_disabled: nullable_to_truthy(object.is_comment_disabled),
+        comment_disabled: CurrentUser.is_moderator? ? nullable_to_truthy(object.is_comment_disabled) : false,
         deleted: object.is_deleted
     }
   end
@@ -135,6 +135,11 @@ class PostSerializer < ActiveModel::Serializer
 
   def duration
     object.duration ? object.duration.to_f : nil
+  end
+
+  def comment_count
+    return 0 unless CurrentUser.is_moderator? || !nullable_to_truthy(object.is_comment_disabled)
+    object.comment_count
   end
 
   attributes :id, :created_at, :updated_at, :file, :preview, :sample, :score, :tags, :locked_tags, :change_seq, :flags,


### PR DESCRIPTION
Currently, there's a bit of a mix between making disabled comments hard to find, and making them easy to find, as well as leaking a bit of information disabling comments should hide.

This pr:
- Hides the number of comments for non moderators (shows 0), both in the posts list, as well as in the json api
- Removes the comment_disabled flag in api responses
- Excludes the `comment_disabled` and `comment_enabled` post events from non-moderators, as this makes it very easy to find posts with disabled comments

In theory the comment count can still be sniffed out with a brute force `id:(...) comment_count:`, but I don't think there should really be any concern over that.