### PR TITLE
Iqdb upgrade take 2

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 server: bin/rails server -p 9000 -b 0.0.0.0
 # server: bundle exec unicorn -c config/unicorn/development.rb
-jobs: SIDEKIQ_QUEUES="low_prio:1;tags:2;default:3;high_prio:5" bundle exec sidekiq
+jobs: SIDEKIQ_QUEUES="low_prio:1;iqdb_new:1;tags:2;default:3;high_prio:5" bundle exec sidekiq
 cron: run-parts /etc/periodic/daily && crond -f

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -40,18 +40,22 @@ class IqdbQueriesController < ApplicationController
 
   def new_version
     if params[:file]
-      @matches = IqdbProxyNew.query_file(params[:file].tempfile)
+      @matches = iqdb_proxy(:query_file, params[:file].tempfile)
     elsif params[:url].present?
       parsed_url = Addressable::URI.heuristic_parse(params[:url]) rescue nil
       raise User::PrivilegeError, "Invalid URL" unless parsed_url
       whitelist_result = UploadWhitelist.is_whitelisted?(parsed_url)
       raise User::PrivilegeError, "Not allowed to request content from this URL" unless whitelist_result[0]
-      @matches = IqdbProxyNew.query_url(params[:url])
+      @matches = iqdb_proxy(:query_url, params[:url])
     elsif params[:post_id]
-      @matches = IqdbProxyNew.query_post(Post.find(params[:post_id]))
+      @matches = iqdb_proxy(:query_post, Post.find(params[:post_id]))
     elsif params[:hash]
-      @matches = IqdbProxyNew.query_hash(params[:hash])
+      @matches = iqdb_proxy(:query_hash, params[:hash])
     end
+  end
+
+  def iqdb_proxy(method, value)
+    IqdbProxyNew.send(method, value, params[:score_cutoff])
   end
 
   def throttle

--- a/app/jobs/iqdb_remove_job_new.rb
+++ b/app/jobs/iqdb_remove_job_new.rb
@@ -1,0 +1,7 @@
+class IqdbRemoveJobNew < ApplicationJob
+  queue_as :iqdb_new
+
+  def perform(post_id)
+    IqdbProxyNew.remove_post(post_id)
+  end
+end

--- a/app/jobs/iqdb_update_job_new.rb
+++ b/app/jobs/iqdb_update_job_new.rb
@@ -1,0 +1,10 @@
+class IqdbUpdateJobNew < ApplicationJob
+  queue_as :iqdb_new
+
+  def perform(post_id)
+    post = Post.find_by id: post_id
+    return unless post
+
+    IqdbProxyNew.update_post(post)
+  end
+end

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -1,26 +1,30 @@
 module FileMethods
   def is_image?
-    file_ext =~ /jpg|jpeg|gif|png/i
+    is_png? || is_jpg? || is_gif?
   end
 
   def is_png?
-    file_ext =~ /png/i
+    file_ext == "png"
+  end
+
+  def is_jpg?
+    file_ext == "jpg"
   end
 
   def is_gif?
-    file_ext =~ /gif/i
+    file_ext == "gif"
   end
 
   def is_flash?
-    file_ext =~ /swf/i
+    file_ext == "swf"
   end
 
   def is_webm?
-    file_ext =~ /webm/i
+    file_ext == "webm"
   end
 
   def is_mp4?
-    file_ext =~ /mp4/i
+    file_ext == "mp4"
   end
 
   def is_video?

--- a/app/logical/iqdb_proxy_new.rb
+++ b/app/logical/iqdb_proxy_new.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module IqdbProxyNew
+  class Error < StandardError; end
+
+  IQDB_NUM_PIXELS = 128
+
+  module_function
+
+  def make_request(path, request_type, params = {})
+    url = URI.parse(Danbooru.config.iqdb_server)
+    url.path = path
+    HTTParty.send(request_type, url, { body: params.to_json, headers: { "Content-Type" => "application/json" } })
+  rescue Errno::ECONNREFUSED, Errno::EADDRNOTAVAIL
+    raise Error, "This service is temporarily unavailable. Please try again later."
+  end
+
+  def update_post(post)
+    return unless post.has_preview?
+
+    thumb = generate_thumbnail(post.preview_file_path)
+    raise Error, "failed to generate thumb for #{post.id}" unless thumb
+
+    response = make_request("/images/#{post.id}", :post, get_channels_data(thumb))
+    raise Error, "iqdb request failed" if response.code != 200
+  end
+
+  def remove_post(post_id)
+    response = make_request("/images/#{post_id}", :delete)
+    raise Error, "iqdb request failed" if response.code != 200
+  end
+
+  def query_url(image_url)
+    file, _strategy = Downloads::File.new(image_url).download!
+    query_file(file)
+  end
+
+  def query_post(post)
+    return [] unless post.has_preview?
+
+    File.open(post.preview_file_path) do |f|
+      query_file(f)
+    end
+  end
+
+  def query_file(file)
+    thumb = generate_thumbnail(file.path)
+    return [] unless thumb
+
+    response = make_request("/query", :post, get_channels_data(thumb))
+    return [] if response.code != 200
+
+    process_iqdb_result(response.parsed_response)
+  end
+
+  def query_hash(hash)
+    response = make_request "/query", :post, { hash: hash }
+    return [] if response.code != 200
+
+    process_iqdb_result(response.parsed_response)
+  end
+
+  def process_iqdb_result(json, score_cutoff = 80)
+    raise Error, "Server returned an error. Most likely the url is not found." unless json.is_a?(Array)
+
+    json.filter! { |entry| (entry["score"] || 0) >= score_cutoff }
+    json.map do |x|
+      x["post"] = Post.find(x["post_id"])
+      x
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end.compact
+  end
+
+  def generate_thumbnail(file_path)
+    Vips::Image.thumbnail(file_path, IQDB_NUM_PIXELS, height: IQDB_NUM_PIXELS, size: :force)
+  rescue Vips::Error
+    nil
+  end
+
+  def get_channels_data(thumbnail)
+    r = []
+    g = []
+    b = []
+    is_grayscale = thumbnail.bands == 1
+    thumbnail.to_a.each do |data|
+      data.each do |rgb|
+        r << rgb[0]
+        g << (is_grayscale ? rgb[0] : rgb[1])
+        b << (is_grayscale ? rgb[0] : rgb[2])
+      end
+    end
+    { channels: { r: r, g: g, b: b } }
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1551,14 +1551,15 @@ class Post < ApplicationRecord
       def remove_iqdb(post_id)
         if iqdb_enabled?
           IqdbRemoveJob.perform_async(post_id)
+          IqdbRemoveJobNew.perform_later(post_id)
         end
       end
     end
 
     def update_iqdb_async
       if Post.iqdb_enabled? && has_preview?
-        # IqdbUpdateJob.perform_async(id, preview_file_url)
         IqdbUpdateJob.perform_async(id, "md5:#{md5}.jpg")
+        IqdbUpdateJobNew.perform_later(id)
       end
     end
 

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -723,6 +723,9 @@ module Danbooru
     def iqdbs_server
     end
 
+    def iqdb_server
+    end
+
     def elasticsearch_host
       '127.0.0.1'
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ x-environment: &common-env
   DANBOORU_ELASTICSEARCH_HOST: elastic
   DANBOORU_MEMCACHED_SERVERS: memcached
   DANBOORU_IQDBS_SERVER: http://iqdb:4567
+  DANBOORU_IQDB_SERVER: http://iqdb_new:5588
   # These are just development secrets, do not use them in production
   SECRET_TOKEN: 1c58518a891eff4520cadc59afa9e378a9325f1247544ff258096e497f095f45
   SESSION_SECRET_KEY: 44b4f44e9f253c406cbe727d403d500c1cecff943e4d2aea8f5447f28846fffe
@@ -121,6 +122,12 @@ services:
       - redis
     volumes:
       - post_data:/data
+      - iqdb_data:/iqdb
+
+  iqdb_new:
+    image: ghcr.io/e621ng/iqdb:d4fed9d9a51184e72d2f14d4ec461d7830bd177a 
+    command: iqdb http 0.0.0.0 5588 /iqdb/e621_v2.db
+    volumes:
       - iqdb_data:/iqdb
 
   # Useful for development

--- a/test/functional/moderator/post/posts_controller_test.rb
+++ b/test/functional/moderator/post/posts_controller_test.rb
@@ -67,7 +67,7 @@ module Moderator
 
             post_auth move_favorites_moderator_post_post_path(@child.id), @admin, params: { commit: "Submit" }
             assert_redirected_to(@child)
-            perform_enqueued_jobs
+            perform_enqueued_jobs(only: TransferFavoritesJob)
             @parent.reload
             @child.reload
             as(@admin) do


### PR DESCRIPTION
Fixes #313, previously attempted in #368.

This will run both the old and new version in parallel. The old version will still be the default, the new one will only be used when appending `v2=1` as a parameter. When the results and performance looks good I will switch it over and remove the old version entirely.

This significantly simplifies the current iqdb setup. No more separate sidekiq process, no extra http server. It's all one package now. The sqlite db should also be more resilient that the custom db from before which tended to occasionally vanish.