### PR TITLE
[TIckets] Expand Accused Search

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -2,6 +2,7 @@ class Ticket < ApplicationRecord
   belongs_to_creator
   belongs_to :claimant, class_name: "User", optional: true
   belongs_to :handler, class_name: "User", optional: true
+  belongs_to :accused, class_name: "User", optional: true
   before_validation :initialize_fields, on: :create
   after_initialize :validate_type
   after_initialize :classify

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -195,6 +195,18 @@ class Ticket < ApplicationRecord
 
     def initialize_fields
       self.status = "pending"
+      case qtype
+      when "blip"
+        self.accused_id = Blip.find(disp_id).creator_id
+      when "forum"
+        self.accused_id = ForumPost.find(disp_id).creator_id
+      when "comment"
+        self.accused_id = Comment.find(disp_id).creator_id
+      when "dmail"
+        self.accused_id = Dmail.find(disp_id).from_id
+      when "user"
+        self.accused_id = disp_id
+      end
     end
   end
 
@@ -217,7 +229,11 @@ class Ticket < ApplicationRecord
 
       if params[:accused_name].present?
         user_id = User.name_to_id(params[:accused_name])
-        q = q.where('disp_id = ? and qtype = ?', user_id, 'user') if user_id
+        q = q.where('accused_id = ?', user_id) if user_id
+      end
+
+      if params[:accused_id].present?
+        q = q.where('accused_id = ?', params[:accused_id].to_i)
       end
 
       if params[:qtype].present?

--- a/app/views/tickets/_search.html.erb
+++ b/app/views/tickets/_search.html.erb
@@ -3,6 +3,7 @@
     <%= f.input :creator_name, label: "Reporter", autocomplete: "user" %>
     <%= f.input :creator_id, label: "Reporter ID" %>
     <%= f.input :accused_name, label: "Accused", autocomplete: "user" %>
+    <%= f.input :accused_id, label: "Accused ID" %>
     <%= f.input :reason %>
   <% end %>
   <%= f.input :qtype, label: "Type", collection: [

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -9,6 +9,7 @@
           <th style="width:5%">ID</th>
           <% if CurrentUser.is_moderator? %>
             <th style="width:10%">Reporter</th>
+            <th style="width:10%">Accused</th>
             <th style="width:10%">Claimed By</th>
           <% end %>
           <th style="width:15%">Type</th>
@@ -25,13 +26,18 @@
             <td><%= link_to ticket.id, ticket_path(ticket) %></td>
             <% if CurrentUser.is_moderator? %>
               <td><%= link_to_user ticket.creator %></td>
-            <td>
-            <% if ticket.claimant.nil? %>
-              <span class="redtext">Unclaimed</span>
-            <% else %>
-              <%= link_to_user ticket.claimant %>
-            <% end %>
-            </td>
+              <td>
+                <% if ticket.accused %>
+                  <%= link_to_user ticket.accused %>
+                <% end %>
+              </td>
+              <td>
+              <% if ticket.claimant.nil? %>
+                <span class="redtext">Unclaimed</span>
+              <% else %>
+                <%= link_to_user ticket.claimant %>
+              <% end %>
+              </td>
             <% end %>
             <td><%= link_to ticket.type_title, ticket_path(ticket) %></td>
 

--- a/db/fixes/108_ticket_accuser_id.rb
+++ b/db/fixes/108_ticket_accuser_id.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+Ticket.where(qtype: "blip").find_each do |ticket|
+  ticket.update_column(:accused_id, Blip.find_by(id: ticket.disp_id)&.creator_id)
+end
+
+Ticket.where(qtype: "forum").find_each do |ticket|
+  ticket.update_column(:accused_id, ForumPost.find_by(id: ticket.disp_id)&.creator_id)
+end
+
+Ticket.where(qtype: "comment").find_each do |ticket|
+  ticket.update_column(:accused_id, Comment.find_by(id: ticket.disp_id)&.creator_id)
+end
+
+Ticket.where(qtype: "dmail").find_each do |ticket|
+  ticket.update_column(:accused_id, DMail.find_by(id: ticket.disp_id)&.creator_id)
+end
+
+Ticket.where(qtype: "user").find_each do |ticket|
+  ticket.update_column(:accused_id, ticket.disp_id)
+end

--- a/db/fixes/108_ticket_accuser_id.rb
+++ b/db/fixes/108_ticket_accuser_id.rb
@@ -15,7 +15,7 @@ Ticket.where(qtype: "comment").find_each do |ticket|
 end
 
 Ticket.where(qtype: "dmail").find_each do |ticket|
-  ticket.update_column(:accused_id, DMail.find_by(id: ticket.disp_id)&.creator_id)
+  ticket.update_column(:accused_id, Dmail.find_by(id: ticket.disp_id)&.from_id)
 end
 
 Ticket.where(qtype: "user").find_each do |ticket|

--- a/db/migrate/20230506161827_add_ticket_user_id.rb
+++ b/db/migrate/20230506161827_add_ticket_user_id.rb
@@ -1,0 +1,6 @@
+class AddTicketUserId < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tickets, :accused_id, :integer
+    add_foreign_key :tickets, :users, column: :accused_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4329,11 +4329,11 @@ ALTER TABLE ONLY public.staff_audit_logs
 
 
 --
--- Name: tickets fk_rails_538a036fb9; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: tickets fk_rails_45cd696dba; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tickets
-    ADD CONSTRAINT fk_rails_538a036fb9 FOREIGN KEY (accused_id) REFERENCES public.users(id);
+    ADD CONSTRAINT fk_rails_45cd696dba FOREIGN KEY (accused_id) REFERENCES public.users(id);
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1977,7 +1977,8 @@ CREATE TABLE public.tickets (
     handler_id integer DEFAULT 0 NOT NULL,
     claimant_id integer,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    accused_id integer
 );
 
 
@@ -4328,6 +4329,14 @@ ALTER TABLE ONLY public.staff_audit_logs
 
 
 --
+-- Name: tickets fk_rails_538a036fb9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.tickets
+    ADD CONSTRAINT fk_rails_538a036fb9 FOREIGN KEY (accused_id) REFERENCES public.users(id);
+
+
+--
 -- Name: mascots fk_rails_9901e810fa; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4628,6 +4637,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230226152600'),
 ('20230312103728'),
 ('20230314170352'),
-('20230316084945');
+('20230316084945'),
+('20230506161827');
 
 


### PR DESCRIPTION
This pr:
* Expands the "Accused" search option to include the creator of Blips, Forum Posts, Comments & DMails
* Adds an "Accused ID" search field, and properly implements the option (it was an allowed parameter, but never implemented)

My best thought for doing this was a new `accused_id` field for tickets. For simplicity I've also done this for user tickets. I've included the migration, as well as my best attempt at a fixer script for prod.

Currently, it's being added to new tickets via the `initialize_fields` method, as that was the only place I could think of shoving it.