### PR TITLE
[Tickets] Display post report reason

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -2,6 +2,7 @@ class Ticket < ApplicationRecord
   belongs_to_creator
   belongs_to :claimant, class_name: "User", optional: true
   belongs_to :handler, class_name: "User", optional: true
+  belongs_to :post_report_reason, foreign_key: "report_reason", optional: true
   before_validation :initialize_fields, on: :create
   after_initialize :validate_type
   after_initialize :classify
@@ -15,7 +16,6 @@ class Ticket < ApplicationRecord
   validate :validate_creator_is_not_limited, on: :create
 
   scope :for_creator, ->(uid) {where('creator_id = ?', uid)}
-  has_one :post_report_reason, foreign_key: "id", primary_key: "report_reason"
 
   attr_accessor :record_type, :send_update_dmail
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -15,6 +15,7 @@ class Ticket < ApplicationRecord
   validate :validate_creator_is_not_limited, on: :create
 
   scope :for_creator, ->(uid) {where('creator_id = ?', uid)}
+  has_one :post_report_reason, foreign_key: "id", primary_key: "report_reason"
 
   attr_accessor :record_type, :send_update_dmail
 

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -65,7 +65,7 @@
           <td><span class='title'>Reason</span></td>
           <td class="dtext-container">
             <% if @ticket.qtype == "post" && @ticket.post_report_reason.present? %>
-                <%= @ticket.post_report_reason.description %>
+                <%= @ticket.post_report_reason.reason %>
              <% end %>
             <%= format_text(@ticket.reason) %>
           </td>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -63,7 +63,12 @@
 
         <tr>
           <td><span class='title'>Reason</span></td>
-          <td class="dtext-container"><%= format_text(@ticket.reason) %></td>
+          <td class="dtext-container">
+            <% if @ticket.qtype == "post" && !@ticket.post_report_reason.nil? %>
+                <%= @ticket.post_report_reason.description %>
+             <% end %>
+            <%= format_text(@ticket.reason) %>
+          </td>
         </tr>
 
         <% if(!@ticket.response.blank?) %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -65,8 +65,8 @@
           <td><span class='title'>Reason</span></td>
           <td class="dtext-container">
             <% if @ticket.qtype == "post" && @ticket.post_report_reason.present? %>
-                <%= @ticket.post_report_reason.reason %>
-             <% end %>
+              <p><%= @ticket.post_report_reason.reason %></p>
+            <% end %>
             <%= format_text(@ticket.reason) %>
           </td>
         </tr>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -64,7 +64,7 @@
         <tr>
           <td><span class='title'>Reason</span></td>
           <td class="dtext-container">
-            <% if @ticket.qtype == "post" && !@ticket.post_report_reason.nil? %>
+            <% if @ticket.qtype == "post" && @ticket.post_report_reason.present? %>
                 <%= @ticket.post_report_reason.description %>
              <% end %>
             <%= format_text(@ticket.reason) %>


### PR DESCRIPTION
This prepends the Report Reason used when reporting a post to the ticket reason. I didn't feel this required its own field to be shown in, and I feel it's been unshown for far too long.