### PR TITLE
[Tickets] Profile Links & Pending Count

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -214,10 +214,6 @@ class Ticket < ApplicationRecord
   end
 
   module SearchMethods
-    def for_user(user_id)
-      where(creator_id: user_id)
-    end
-
     def for_accused(user_id)
       where(accused_id: user_id)
     end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,5 +1,6 @@
 class Ticket < ApplicationRecord
   belongs_to_creator
+  user_status_counter :ticket_count
   belongs_to :claimant, class_name: "User", optional: true
   belongs_to :handler, class_name: "User", optional: true
   belongs_to :accused, class_name: "User", optional: true
@@ -213,6 +214,18 @@ class Ticket < ApplicationRecord
   end
 
   module SearchMethods
+    def for_user(user_id)
+      where(creator_id: user_id)
+    end
+
+    def for_accused(user_id)
+      where(accused_id: user_id)
+    end
+
+    def active
+      where(status: %w[pending partial])
+    end
+
     def search(params)
       q = super.includes(:creator).includes(:claimant)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -766,8 +766,7 @@ class User < ApplicationRecord
           post_count: Post.for_user(id).count,
           post_deleted_count: Post.for_user(id).deleted.count,
           post_update_count: PostVersion.for_user(id).count,
-          note_count: NoteVersion.for_user(id).count,
-          ticket_count: Ticket.for_user(id).count,
+          note_count: NoteVersion.where(updater_id: id).count
         )
       end
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -732,6 +732,10 @@ class User < ApplicationRecord
       user_status.post_flag_count
     end
 
+    def ticket_count
+      user_status.ticket_count
+    end
+
     def positive_feedback_count
       feedback.positive.count
     end
@@ -762,7 +766,8 @@ class User < ApplicationRecord
           post_count: Post.for_user(id).count,
           post_deleted_count: Post.for_user(id).deleted.count,
           post_update_count: PostVersion.for_user(id).count,
-          note_count: NoteVersion.where(updater_id: id).count
+          note_count: NoteVersion.for_user(id).count,
+          ticket_count: Ticket.for_user(id).count,
         )
       end
     end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -69,11 +69,11 @@ class UserPresenter
   end
 
   def upload_count(template)
-    template.link_to(user.post_upload_count, template.posts_path(:tags => "user:#{user.name}"))
+    template.link_to(user.post_upload_count, template.posts_path(tags: "user:#{user.name}"))
   end
 
   def active_upload_count(template)
-    template.link_to(user.post_upload_count - user.post_deleted_count, template.posts_path(:tags => "user:#{user.name}"))
+    template.link_to(user.post_upload_count - user.post_deleted_count, template.posts_path(tags: "user:#{user.name}"))
   end
 
   def deleted_upload_count(template)
@@ -89,53 +89,57 @@ class UserPresenter
   end
 
   def favorite_count(template)
-    template.link_to(user.favorite_count, template.favorites_path(:user_id => user.id))
+    template.link_to(user.favorite_count, template.favorites_path(user_id: user.id))
   end
 
   def comment_count(template)
-    template.link_to(user.comment_count, template.comments_path(:search => {:creator_id => user.id}, :group_by => "comment"))
+    template.link_to(user.comment_count, template.comments_path(search: { creator_id: user.id }, group_by: "comment"))
   end
 
   def commented_posts_count(template)
     count = CurrentUser.without_safe_mode { Post.fast_count("commenter:#{user.name}") }
-    template.link_to(count, template.posts_path(:tags => "commenter:#{user.name} order:comment_bumped"))
+    template.link_to(count, template.posts_path(tags: "commenter:#{user.name} order:comment_bumped"))
   end
 
   def post_version_count(template)
-    template.link_to(user.post_update_count, template.post_versions_path(:lr => user.id, :search => {:updater_id => user.id}))
+    template.link_to(user.post_update_count, template.post_versions_path(lr: user.id, search: { updater_id: user.id }))
   end
 
   def note_version_count(template)
-    template.link_to(user.note_version_count, template.note_versions_path(:search => {:updater_id => user.id}))
+    template.link_to(user.note_version_count, template.note_versions_path(search: { updater_id: user.id }))
   end
 
   def noted_posts_count(template)
     count = CurrentUser.without_safe_mode { Post.fast_count("noteupdater:#{user.name}") }
-    template.link_to(count, template.posts_path(:tags => "noteupdater:#{user.name} order:note"))
+    template.link_to(count, template.posts_path(tags: "noteupdater:#{user.name} order:note"))
   end
 
   def wiki_page_version_count(template)
-    template.link_to(user.wiki_page_version_count, template.wiki_page_versions_path(:search => {:updater_id => user.id}))
+    template.link_to(user.wiki_page_version_count, template.wiki_page_versions_path(search: { updater_id: user.id }))
   end
 
   def artist_version_count(template)
-    template.link_to(user.artist_version_count, template.artist_versions_path(:search => {:updater_id => user.id}))
+    template.link_to(user.artist_version_count, template.artist_versions_path(search: { updater_id: user.id }))
   end
 
   def forum_post_count(template)
-    template.link_to(user.forum_post_count, template.forum_posts_path(:search => {:creator_id => user.id}))
+    template.link_to(user.forum_post_count, template.forum_posts_path(search: { creator_id: user.id }))
   end
 
   def pool_version_count(template)
-    template.link_to(user.pool_version_count, template.pool_versions_path(:search => {:updater_id => user.id}))
+    template.link_to(user.pool_version_count, template.pool_versions_path(search: { updater_id: user.id }))
   end
 
   def flag_count(template)
     template.link_to(user.flag_count, template.post_flags_path(search: { creator_id: user.id }))
   end
 
+  def ticket_count(template)
+    template.link_to(user.ticket_count, template.tickets_path(search: { creator_id: user.id }))
+  end
+
   def approval_count(template)
-    template.link_to(Post.where("approver_id = ?", user.id).count, template.posts_path(:tags => "approver:#{user.name}"))
+    template.link_to(Post.where("approver_id = ?", user.id).count, template.posts_path(tags: "approver:#{user.name}"))
   end
 
   def feedbacks

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -50,8 +50,8 @@
             <% end %>
 
             <td class="<%= ticket.status %>-ticket"><%= pretty_ticket_status(ticket) %></td>
-            <td style="cursor:help;" title="<%= ticket.updated_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(ticket.updated_at) %> ago</td>
-            <td style="cursor:help;" title="<%= ticket.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(ticket.created_at) %> ago</td>
+            <td style="cursor:help;" title="<%= ticket.updated_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(ticket.updated_at) %> ago</td>
+            <td style="cursor:help;" title="<%= ticket.created_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(ticket.created_at) %> ago</td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -50,8 +50,8 @@
             <% end %>
 
             <td class="<%= ticket.status %>-ticket"><%= pretty_ticket_status(ticket) %></td>
-            <td style="cursor:help;" title="<%= ticket.updated_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(ticket.updated_at) %> ago</td>
-            <td style="cursor:help;" title="<%= ticket.created_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(ticket.created_at) %> ago</td>
+            <td style="cursor:help;"><%= time_ago_in_words_tagged(ticket.updated_at) %></td>
+            <td style="cursor:help;"><%= time_ago_in_words_tagged(ticket.created_at) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -83,7 +83,7 @@
         <% unless @ticket.response.blank? %>
           <tr>
             <td><span class='title'>Handled by</span></td>
-            <% if !@ticket.handler.nil? %>
+            <% if @ticket.handler.present? %>
               <td><%= link_to_user @ticket.handler %></td>
             <% else %>
               <td>Unknown</td>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -13,12 +13,14 @@
             </td>
           </tr>
         <% end %>
-        <% if @ticket.accused_id.present? && CurrentUser.is_moderator? %>
+        <% if @ticket.accused.present? && CurrentUser.is_moderator? %>
           <tr>
-            <td><span class='title'>Accused</span></td>
+            <td><span class="title">Accused</span></td>
             <td>
               <%= link_to_user @ticket.accused %>
-              (<%= link_to "#{Ticket.active.for_accused(@ticket.accused.id).count} Pending", tickets_path(search: { accused_id: @ticket.accused.id, search: { status: "pending" } }) %>)
+              <% if (pending_accused_count = Ticket.active.for_accused(@ticket.accused.id).count) >= 2 %>
+                (<%= link_to "#{pending_accused_count} Pending", tickets_path(search: { accused_id: @ticket.accused.id, status: "pending" }) %>)
+              <% end %>
             </td>
           </tr>
         <% end %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -13,13 +13,22 @@
             </td>
           </tr>
         <% end %>
+        <% if @ticket.accused_id.present? && CurrentUser.is_moderator? %>
+          <tr>
+            <td><span class='title'>Accused</span></td>
+            <td>
+              <%= link_to_user @ticket.accused %>
+              (<%= link_to "#{Ticket.active.for_accused(@ticket.accused.id).count} Pending", tickets_path(search: { accused_id: @ticket.accused.id, search: { status: "pending" } }) %>)
+            </td>
+          </tr>
+        <% end %>
         <tr>
           <td><span class="title">Created</span></td>
-          <td style="cursor:help;" title="<%= @ticket.created_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@ticket.created_at) %> ago</td>
+          <td style="cursor:help;" title="<%= @ticket.created_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(@ticket.created_at) %> ago</td>
         </tr>
         <tr>
           <td><span class="title">Updated</span></td>
-          <td style="cursor:help;" title="<%= @ticket.updated_at.strftime("%b %d, %Y %I:%M %p") %>"><%= time_ago_in_words(@ticket.updated_at) %> ago</td>
+          <td style="cursor:help;" title="<%= @ticket.updated_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(@ticket.updated_at) %> ago</td>
         </tr>
         <% if CurrentUser.is_moderator? %>
           <tr>
@@ -71,10 +80,10 @@
           </td>
         </tr>
 
-        <% if(!@ticket.response.blank?) %>
+        <% unless @ticket.response.blank? %>
           <tr>
             <td><span class='title'>Handled by</span></td>
-            <% if (!@ticket.handler.nil?)%>
+            <% if !@ticket.handler.nil? %>
               <td><%= link_to_user @ticket.handler %></td>
             <% else %>
               <td>Unknown</td>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -80,7 +80,7 @@
           </td>
         </tr>
 
-        if @ticket.response.present?
+        <% if @ticket.response.present? %>
           <tr>
             <td><span class='title'>Handled by</span></td>
             <% if @ticket.handler.present? %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -80,7 +80,7 @@
           </td>
         </tr>
 
-        <% unless @ticket.response.blank? %>
+        if @ticket.response.present?
           <tr>
             <td><span class='title'>Handled by</span></td>
             <% if @ticket.handler.present? %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -24,11 +24,11 @@
         <% end %>
         <tr>
           <td><span class="title">Created</span></td>
-          <td style="cursor:help;" title="<%= @ticket.created_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(@ticket.created_at) %> ago</td>
+          <td style="cursor:help;"><%= time_ago_in_words_tagged(@ticket.created_at) %></td>
         </tr>
         <tr>
           <td><span class="title">Updated</span></td>
-          <td style="cursor:help;" title="<%= @ticket.updated_at.strftime("%Y-%m-%dT%H:%M%:z") %>"><%= time_ago_in_words(@ticket.updated_at) %> ago</td>
+          <td style="cursor:help;"><%= time_ago_in_words_tagged(@ticket.updated_at) %></td>
         </tr>
         <% if CurrentUser.is_moderator? %>
           <tr>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -37,7 +37,7 @@
             [<%= link_to "sample", posts_path(:tags => "user:#{user.name} order:random limit:300 status:deleted") %>]
           <% end %>
         </span>
-        
+
         <span>Replaced</span>
         <span>
           <%= presenter.replaced_upload_count(self) %>
@@ -140,6 +140,17 @@
           <span>Flags</span>
           <span><%= presenter.flag_count(self) %></span>
         <% end %>
+
+        <% if CurrentUser.user.id == user.id || CurrentUser.is_moderator? %>
+            <span>Tickets</span>
+            <span>
+              <%= presenter.ticket_count(self) %>
+              <% if CurrentUser.is_moderator? %>
+                [<%= link_to "pending", tickets_path(creator_id: user.id,  search: { status: "pending" }) %>]
+                [<%= link_to "accused", tickets_path(accused_id: user.id,  search: { status: "pending" }) %>]
+              <% end %>
+            </span>
+          <% end %>
 
         <% if CurrentUser.id == user.id %>
           <span>API Key</span>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -146,8 +146,8 @@
             <span>
               <%= presenter.ticket_count(self) %>
               <% if CurrentUser.is_moderator? %>
-                [<%= link_to "pending", tickets_path(creator_id: user.id, search: { status: "pending" }) %>]
-                [<%= link_to "accused", tickets_path(accused_id: user.id, search: { status: "pending" }) %>]
+                [<%= link_to "pending", tickets_path(search: { creator_id: user.id, status: "pending" }) %>]
+                [<%= link_to "accused", tickets_path(search: { accused_id: user.id, status: "pending" }) %>]
               <% end %>
             </span>
           <% end %>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -146,8 +146,8 @@
             <span>
               <%= presenter.ticket_count(self) %>
               <% if CurrentUser.is_moderator? %>
-                [<%= link_to "pending", tickets_path(creator_id: user.id,  search: { status: "pending" }) %>]
-                [<%= link_to "accused", tickets_path(accused_id: user.id,  search: { status: "pending" }) %>]
+                [<%= link_to "pending", tickets_path(creator_id: user.id, search: { status: "pending" }) %>]
+                [<%= link_to "accused", tickets_path(accused_id: user.id, search: { status: "pending" }) %>]
               <% end %>
             </span>
           <% end %>

--- a/db/fixes/109_user_status_ticket_count.rb
+++ b/db/fixes/109_user_status_ticket_count.rb
@@ -3,5 +3,5 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
 
 UserStatus.find_each do |user_status|
-  user_status.update(ticket_count: Ticket.for_user(user_status.user_id).count)
+  user_status.update(ticket_count: Ticket.where(creator_id: user_status.user_id).count)
 end

--- a/db/fixes/109_user_status_ticket_count.rb
+++ b/db/fixes/109_user_status_ticket_count.rb
@@ -3,5 +3,5 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
 
 UserStatus.find_each do |user_status|
-  user_status.update_column(:ticket_count, Ticket.for_user(user_status.user_id).count)
+  user_status.update(ticket_count: Ticket.for_user(user_status.user_id).count)
 end

--- a/db/fixes/109_user_status_ticket_count.rb
+++ b/db/fixes/109_user_status_ticket_count.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+UserStatus.find_each do |user_status|
+  user_status.update_column(:ticket_count, Ticket.for_user(user_status.user_id).count)
+end

--- a/db/fixes/109_user_status_ticket_count.rb
+++ b/db/fixes/109_user_status_ticket_count.rb
@@ -2,6 +2,6 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
 
-UserStatus.find_each do |user_status|
-  user_status.update(ticket_count: Ticket.where(creator_id: user_status.user_id).count)
+User.find_each do |user|
+  UserStatus.for_user(user.id).update_all(ticket_count: Ticket.where(creator_id: user.id).count)
 end

--- a/db/migrate/20230513074838_add_user_statuses_ticket_count.rb
+++ b/db/migrate/20230513074838_add_user_statuses_ticket_count.rb
@@ -1,0 +1,5 @@
+class AddUserStatusesTicketCount < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_statuses, :ticket_count, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2214,7 +2214,8 @@ CREATE TABLE public.user_statuses (
     artist_edit_count integer DEFAULT 0 NOT NULL,
     own_post_replaced_count integer DEFAULT 0,
     own_post_replaced_penalize_count integer DEFAULT 0,
-    post_replacement_rejected_count integer DEFAULT 0
+    post_replacement_rejected_count integer DEFAULT 0,
+    ticket_count integer DEFAULT 0 NOT NULL
 );
 
 
@@ -4638,6 +4639,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230312103728'),
 ('20230314170352'),
 ('20230316084945'),
-('20230506161827');
+('20230506161827'),
+('20230513074838');
 
 


### PR DESCRIPTION
This pr:
* Adds a ticket count to user's profile, visible to them and moderator+ (along with pending & accused links)
* Displays the "Accused" user within tickets, along with a count of the "active" tickets against them (pending + partial)
* Replaces the timestamps with the standard `time_ago_in_words_tagged`

Also due to editor magic ✨, I've fixed all of the `Style/HashSyntax` issues in the user presenter. (..it's almost too tempting to go around fixing every tiny error)
The important lines are 137-139.