### PR TITLE
[Blips] Add json response for editing old blips

### DIFF
--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -116,10 +116,7 @@ class BlipsController < ApplicationController
         redirect_back(fallback_location: blips_path, flash: { notice: "You cannot edit blips more than 5 minutes old" })
       end
       format.json do
-        render json: {
-          success: false,
-          reason: "You cannot edit blips more than 5 minutes old",
-        }, status: 422
+       render_expected_error(422, "You cannot edit blips more than 5 minutes old")
       end
     end
   end

--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -116,7 +116,7 @@ class BlipsController < ApplicationController
         redirect_back(fallback_location: blips_path, flash: { notice: "You cannot edit blips more than 5 minutes old" })
       end
       format.json do
-       render_expected_error(422, "You cannot edit blips more than 5 minutes old")
+        render_expected_error(422, "You cannot edit blips more than 5 minutes old")
       end
     end
   end

--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -111,7 +111,17 @@ class BlipsController < ApplicationController
   end
 
   def blip_too_old
-    redirect_back(fallback_location: blips_path, flash: {notice: 'You cannot edit blips more than 5 minutes old'})
+    respond_to do |format|
+      format.html do
+        redirect_back(fallback_location: blips_path, flash: { notice: "You cannot edit blips more than 5 minutes old" })
+      end
+      format.json do
+        render json: {
+          success: false,
+          reason: "You cannot edit blips more than 5 minutes old",
+        }, status: 422
+      end
+    end
   end
 
   def check_visible(blip)


### PR DESCRIPTION
Fixes #502

This pr makes `PATCH /blips/{id}` return a json error instead of a 302 Found redirect when a blip is too old to edit.