### PR TITLE
[Artists] Respond with json for name lookup & deletion

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -61,12 +61,9 @@ class ArtistsController < ApplicationController
       raise User::PrivilegeError
     end
     @artist.update_attribute(:is_active, false)
-    respond_to do |format|
+    respond_with(@artist) do |format|
       format.html do
         redirect_to(artist_path(@artist), notice: "Artist deleted")
-      end
-      format.json do
-        head 204
       end
     end
   end


### PR DESCRIPTION
Fixes #503

This makes `GET /artists/{name}` return a proper 404 json response as it should, as well as returning a json response when deleting an artist.