### PR TITLE
[ModActions] Revise report_reason_update & user_feedback_update

### DIFF
--- a/app/controllers/post_report_reasons_controller.rb
+++ b/app/controllers/post_report_reasons_controller.rb
@@ -38,9 +38,9 @@ class PostReportReasonsController < ApplicationController
     @reason = PostReportReason.find(params[:id])
     PostReportReason.transaction do
       @reason.update(reason_params)
-      ModAction.log(:report_reason_update, {reason: @reason.reason, reason_was: @reason.reason_before_last_save}) if @reason.valid?
+      ModAction.log(:report_reason_update, { reason: @reason.reason, reason_was: @reason.reason_before_last_save, description: @reason.description, description_was: @reason.description_before_last_save }) if @reason.valid?
     end
-    flash[:notice] = @reason.valid? ? 'Post report reason updated' : @reason.errors.full_messages.join('; ')
+    flash[:notice] = @reason.valid? ? "Post report reason updated" : @reason.errors.full_messages.join("; ")
     redirect_to post_report_reasons_path
   end
 

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -96,7 +96,18 @@ class ModActionDecorator < ApplicationDecorator
     when "user_feedback_create"
       "Created #{vals['type'].capitalize} record ##{vals['record_id']} for #{user} with reason: #{vals['reason']}"
     when "user_feedback_update"
-      "Edited #{vals['type']} record ##{vals['record_id']} for #{user} to: #{vals['reason']}"
+      if vals["reason_was"].present? || vals["type_was"].present?
+        text = "Edited record ##{vals['record_id']} for #{user}"
+        if vals["type"] != vals["type_was"]
+          text += "\nchanged type from #{vals['type_was']} to #{vals['type']}"
+        end
+        if vals["reason"] != vals["reason_was"]
+          text += "\nchanged reason from \"#{vals['reason_was']}\" to \"#{vals['reason']}\""
+        end
+        text
+      else
+        "Edited #{vals['type']} record ##{vals['record_id']} for #{user} to: #{vals['reason']}"
+      end
     when "user_feedback_delete"
       "Deleted #{vals['type']} record ##{vals['record_id']} for #{user} with reason: #{vals['reason']}"
       ### Legacy User Record ###

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -69,7 +69,7 @@ class ModActionDecorator < ApplicationDecorator
       if vals['duration'].is_a?(Numeric) && vals['duration'] < 0
         "Banned #{user} permanently"
       elsif vals['duration']
-        "Banned #{user} for #{vals['duration']} #{vals['duration'] == 1 ? "day" : "days"}"
+        "Banned #{user} for #{vals['duration']} #{vals['duration'] == 1 ? 'day' : 'days'}"
       else
         "Banned #{user}"
       end
@@ -251,7 +251,14 @@ class ModActionDecorator < ApplicationDecorator
     when "report_reason_create"
       "Created post report reason #{vals['reason']}"
     when "report_reason_update"
-      "Edited post report reason #{vals['reason_was']} to #{vals['reason']}"
+      text = "Edited post report reason #{vals['reason']}"
+      if vals["reason"] != vals["reason_was"]
+        text += "\nchanged reason from \"#{vals['reason_was']}\" to \"#{vals['reason']}\""
+      end
+      if vals["description"] != vals["description_was"]
+        text += "\nchanged description from \"#{vals['description_was']}\" to \"#{vals['description']}\""
+      end
+      text
     when "report_reason_delete"
       "Deleted post report reason #{vals['reason']} by #{user}"
 

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -99,10 +99,10 @@ class ModActionDecorator < ApplicationDecorator
       if vals["reason_was"].present? || vals["type_was"].present?
         text = "Edited record ##{vals['record_id']} for #{user}"
         if vals["type"] != vals["type_was"]
-          text += "\nchanged type from #{vals['type_was']} to #{vals['type']}"
+          text += "\nChanged type from #{vals['type_was']} to #{vals['type']}"
         end
         if vals["reason"] != vals["reason_was"]
-          text += "\nchanged reason from \"#{vals['reason_was']}\" to \"#{vals['reason']}\""
+          text += "\nChanged reason: [section=Old]#{vals['reason_was']}[/section] [section=New]#{vals['reason']}[/section]"
         end
         text
       else
@@ -264,10 +264,10 @@ class ModActionDecorator < ApplicationDecorator
     when "report_reason_update"
       text = "Edited post report reason #{vals['reason']}"
       if vals["reason"] != vals["reason_was"]
-        text += "\nchanged reason from \"#{vals['reason_was']}\" to \"#{vals['reason']}\""
+        text += "\nChanged reason from \"#{vals['reason_was']}\" to \"#{vals['reason']}\""
       end
       if vals["description"] != vals["description_was"]
-        text += "\nchanged description from \"#{vals['description_was']}\" to \"#{vals['description']}\""
+        text += "\nChanged description from \"#{vals['description_was']}\" to \"#{vals['description']}\""
       end
       text
     when "report_reason_delete"

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -11,7 +11,7 @@ class UserFeedback < ApplicationRecord
     ModAction.log(:user_feedback_create, { user_id: rec.user_id, reason: rec.body, type: rec.category, record_id: rec.id })
   end
   after_update do |rec|
-    ModAction.log(:user_feedback_update, { user_id: rec.user_id, reason: rec.body, type: rec.category, record_id: rec.id })
+    ModAction.log(:user_feedback_update, { user_id: rec.user_id, reason: rec.body, reason_was: rec.body_before_last_save, type: rec.category, type_was: rec.category_before_last_save, record_id: rec.id })
   end
   after_destroy do |rec|
     ModAction.log(:user_feedback_delete, { user_id: rec.user_id, reason: rec.body, type: rec.category, record_id: rec.id })


### PR DESCRIPTION
Fixes #488

This pr:
* Adds more detailed logging for the `report_reason_update` action
* Clarifies details for the `user_feedback_update` action (showing type changes & reason changes separately)

<details>
<summary><code>report_reason_update</code> Example</summary>

![image](https://github.com/e621ng/e621ng/assets/17226394/48d7c84a-a1ee-494f-9ed2-6e6f8db5e931)
</details> 

<details>
<summary><code>user_feedback_update</code> Example</summary>

![image](https://github.com/e621ng/e621ng/assets/17226394/dbac6c38-74df-40c5-afd0-cba43abf61b5)

Entries without `reason_was` or `type_was` are assumed to be legacy, and use the original format.
</details>