### PR TITLE
EditHistories overhaul & search

### DIFF
--- a/app/concerns/user_warnable.rb
+++ b/app/concerns/user_warnable.rb
@@ -12,11 +12,11 @@ module UserWarnable
   end
 
   def user_warned!(type, user)
-    update({ warning_type: type, warning_user_id: user })
+    update(warning_type: type, warning_user_id: user.id)
   end
 
   def remove_user_warning!
-    update_columns({ warning_type: nil, warning_user_id: nil })
+    update(warning_type: nil, warning_user_id: nil)
   end
 
   def was_warned?

--- a/app/concerns/user_warnable.rb
+++ b/app/concerns/user_warnable.rb
@@ -13,10 +13,12 @@ module UserWarnable
 
   def user_warned!(type, user)
     update(warning_type: type, warning_user_id: user.id)
+    save_version("mark_#{type}")
   end
 
   def remove_user_warning!
     update(warning_type: nil, warning_user_id: nil)
+    save_version("unmark")
   end
 
   def was_warned?
@@ -26,11 +28,11 @@ module UserWarnable
   def warning_type_string
     case warning_type
     when "warning"
-      "User received a warning for the contents of this message."
+      "User received a warning for the contents of this message"
     when "record"
-      "User received a record for the contents of this message."
+      "User received a record for the contents of this message"
     when "ban"
-      "User was banned for the contents of this message."
+      "User was banned for the contents of this message"
     else
       "[This is a bug with the website. Woo!]"
     end

--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -40,20 +40,13 @@ class BlipsController < ApplicationController
   def hide
     @blip = Blip.find(params[:id])
     check_hide_privilege(@blip)
-
-    Blip.transaction do
-      @blip.update(is_hidden: true)
-      ModAction.log(:blip_hide, { blip_id: @blip.id, user_id: @blip.creator_id }) if CurrentUser.user != @blip.creator
-    end
+    @blip.hide!
     respond_with(@blip)
   end
 
   def unhide
     @blip = Blip.find(params[:id])
-    Blip.transaction do
-      @blip.update(is_hidden: false)
-      ModAction.log(:blip_unhide, {blip_id: @blip.id, user_id: @blip.creator_id})
-    end
+    @blip.unhide!
     respond_with(@blip)
   end
 

--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -29,10 +29,7 @@ class BlipsController < ApplicationController
   def update
     @blip = Blip.find(params[:id])
     check_edit_privilege(@blip)
-    Blip.transaction do
-      @blip.update(blip_params(:update))
-      ModAction.log(:blip_update, { blip_id: @blip.id, user_id: @blip.creator_id }) if CurrentUser.user != @blip.creator
-    end
+    @blip.update(blip_params(:update))
     flash[:notice] = 'Blip updated'
     respond_with(@blip)
   end
@@ -52,8 +49,6 @@ class BlipsController < ApplicationController
 
   def destroy
     @blip = Blip.find(params[:id])
-
-    ModAction.log(:blip_delete, {blip_id: @blip.id, user_id: @blip.creator_id})
     @blip.destroy
     flash[:notice] = 'Blip deleted'
     respond_with(@blip) do |format|

--- a/app/controllers/edit_histories_controller.rb
+++ b/app/controllers/edit_histories_controller.rb
@@ -3,7 +3,7 @@ class EditHistoriesController < ApplicationController
   before_action :moderator_only
 
   def index
-    @edit_history = EditHistory.includes(:user).paginate(params[:page], limit: params[:limit])
+    @edit_history = EditHistory.search(search_params).includes(:user).paginate(params[:page], limit: params[:limit])
     respond_with(@edit_history)
   end
 
@@ -11,5 +11,11 @@ class EditHistoriesController < ApplicationController
     @edit_history = EditHistory.includes(:user).where(versionable_id: params[:id], versionable_type: params[:type]).paginate(params[:page], limit: params[:limit])
     @content_edits = @edit_history.select(&:is_contentful?)
     respond_with(@edit_history)
+  end
+
+  def search_params
+    permitted_params = %i[versionable_type versionable_id edit_type user_id user_name]
+    permitted_params += %i[ip_addr] if CurrentUser.is_admin?
+    permit_search_params permitted_params
   end
 end

--- a/app/controllers/edit_histories_controller.rb
+++ b/app/controllers/edit_histories_controller.rb
@@ -9,6 +9,7 @@ class EditHistoriesController < ApplicationController
 
   def show
     @edit_history = EditHistory.includes(:user).where(versionable_id: params[:id], versionable_type: params[:type]).paginate(params[:page], limit: params[:limit])
+    @original = EditHistory.includes(:user).where(versionable_id: params[:id], versionable_type: params[:type]).original
     @content_edits = @edit_history.select(&:is_contentful?)
     respond_with(@edit_history)
   end

--- a/app/controllers/edit_histories_controller.rb
+++ b/app/controllers/edit_histories_controller.rb
@@ -8,7 +8,8 @@ class EditHistoriesController < ApplicationController
   end
 
   def show
-    @edits = EditHistory.includes(:user).where('versionable_id = ? AND versionable_type = ?', params[:id], params[:type]).order(:id)
-    respond_with(@edits)
+    @edit_history = EditHistory.includes(:user).where(versionable_id: params[:id], versionable_type: params[:type]).paginate(params[:page], limit: params[:limit])
+    @content_edits = @edit_history.select(&:is_contentful?)
+    respond_with(@edit_history)
   end
 end

--- a/app/controllers/edit_histories_controller.rb
+++ b/app/controllers/edit_histories_controller.rb
@@ -8,7 +8,7 @@ class EditHistoriesController < ApplicationController
   end
 
   def show
-    @edit_history = EditHistory.includes(:user).where(versionable_id: params[:id], versionable_type: params[:type]).paginate(params[:page], limit: params[:limit])
+    @edit_history = EditHistory.includes(:user).where(versionable_id: params[:id], versionable_type: params[:type]).order(id: :asc).paginate(params[:page], limit: params[:limit])
     @original = EditHistory.includes(:user).where(versionable_id: params[:id], versionable_type: params[:type]).original
     @content_edits = @edit_history.select(&:is_contentful?)
     respond_with(@edit_history)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -239,21 +239,17 @@ class ApplicationRecord < ActiveRecord::Base
             save_version(type)
           end
 
-          def safe_saved_change_to?(attr)
-            respond_to?("saved_change_to_#{attr}?") && send("saved_change_to_#{attr}?")
-          end
-
           define_method :should_create_edited_history do
-            return true if versioning_subject_column && safe_saved_change_to?(versioning_subject_column)
-            safe_saved_change_to?(versioning_body_column)
+            return true if versioning_subject_column && saved_change_to_attribute?(versioning_subject_column)
+            saved_change_to_attribute?(versioning_body_column)
           end
 
           define_method :should_create_hidden_history do
-            safe_saved_change_to?(versioning_is_hidden_column)
+            saved_change_to_attribute?(versioning_is_hidden_column)
           end
 
           define_method :should_create_stickied_history do
-            safe_saved_change_to?(versioning_is_sticky_column)
+            saved_change_to_attribute?(versioning_is_sticky_column)
           end
 
           define_method :save_original_version do

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -239,42 +239,64 @@ class ApplicationRecord < ActiveRecord::Base
             save_version(type)
           end
 
+          def safe_saved_change_to?(attr)
+            respond_to?("saved_change_to_#{attr}?") && send("saved_change_to_#{attr}?")
+          end
+
           define_method :should_create_edited_history do
-            return true if versioning_subject_column && send("saved_change_to_#{versioning_subject_column}?")
-            send "saved_change_to_#{versioning_body_column}?"
+            return true if versioning_subject_column && safe_saved_change_to?(versioning_subject_column)
+            safe_saved_change_to?(versioning_body_column)
           end
 
           define_method :should_create_hidden_history do
-            respond_to?("saved_change_to_#{versioning_is_hidden_column}?") && send("saved_change_to_#{versioning_is_hidden_column}?")
+            safe_saved_change_to?(versioning_is_hidden_column)
           end
 
           define_method :should_create_stickied_history do
-            respond_to?("saved_change_to_#{versioning_is_sticky_column}?") && send("saved_change_to_#{versioning_is_sticky_column}?")
+            safe_saved_change_to?(versioning_is_sticky_column)
+          end
+
+          define_method :save_original_version do
+            if is_a?(ForumTopic)
+              body = original_post.body
+            else
+              body = send "#{versioning_body_column}_before_last_save"
+              body = send versioning_body_column if body.nil?
+            end
+
+            subject = nil
+            if versioning_subject_column
+              subject = send "#{versioning_subject_column}_before_last_save"
+              subject = send versioning_subject_column if subject.nil?
+            end
+            new = EditHistory.new
+            new.versionable = self
+            new.version = 1
+            new.ip_addr = send(versioning_ip_column)
+            new.body = body
+            new.user_id = send(versioning_user_column)
+            new.subject = subject
+            new.created_at = created_at
+            new.save!
           end
 
           define_method :save_version do |edit_type = "edit"|
             EditHistory.transaction do
               our_next_version = next_version
               if our_next_version == 0
+                save_original_version
                 our_next_version += 1
-                body = send "#{versioning_body_column}_before_last_save"
-                body = send versioning_body_column if body.nil?
-                new = EditHistory.new
-                new.versionable = self
-                new.version = 1
-                new.ip_addr = send versioning_ip_column
-                new.body = body
-                new.user_id = send versioning_user_column
-                new.subject = send "#{versioning_subject_column}_before_last_save" if versioning_subject_column
-                new.created_at = created_at
-                new.save!
               end
+
+              body = send(versioning_body_column)
+              subject = versioning_subject_column ? send(versioning_subject_column) : nil
 
               version = EditHistory.new
               version.version = our_next_version + 1
               version.versionable = self
               version.ip_addr = CurrentUser.ip_addr
-              version.body = send versioning_body_column
+              version.body = body
+              version.subject = subject
               version.user_id = CurrentUser.id
               version.edit_type = edit_type
               version.save!

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -257,12 +257,8 @@ class ApplicationRecord < ActiveRecord::Base
           end
 
           define_method :save_original_version do
-            if is_a?(ForumTopic)
-              body = original_post.body
-            else
-              body = send "#{versioning_body_column}_before_last_save"
-              body = send versioning_body_column if body.nil?
-            end
+            body = send "#{versioning_body_column}_before_last_save"
+            body = send versioning_body_column if body.nil?
 
             subject = nil
             if versioning_subject_column

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -219,18 +219,23 @@ class ApplicationRecord < ActiveRecord::Base
   concerning :SimpleVersioningMethods do
     class_methods do
       def simple_versioning(options = {})
-        cattr_accessor :versioning_body_column, :versioning_ip_column, :versioning_user_column, :versioning_subject_column, :versioning_is_hidden_column
+        cattr_accessor :versioning_body_column, :versioning_ip_column, :versioning_user_column, :versioning_subject_column, :versioning_is_hidden_column, :versioning_is_sticky_column
         self.versioning_body_column = options[:body_column] || "body"
         self.versioning_subject_column = options[:subject_column]
         self.versioning_ip_column = options[:ip_column] || "creator_ip_addr"
         self.versioning_user_column = options[:user_column] || "creator_id"
         self.versioning_is_hidden_column = options[:is_hidden_column] || "is_hidden"
+        self.versioning_is_sticky_column = options[:is_sticky_column] || "is_sticky"
 
         class_eval do
           has_many :versions, class_name: "EditHistory", as: :versionable
           after_update :save_version, if: :should_create_edited_history
           after_save(if: :should_create_hidden_history) do |rec|
             type = rec.send("#{versioning_is_hidden_column}?") ? "hide" : "unhide"
+            save_version(type)
+          end
+          after_save(if: :should_create_stickied_history) do |rec|
+            type = rec.send("#{versioning_is_sticky_column}?") ? "stick" : "unstick"
             save_version(type)
           end
 
@@ -241,6 +246,10 @@ class ApplicationRecord < ActiveRecord::Base
 
           define_method :should_create_hidden_history do
             respond_to?("saved_change_to_#{versioning_is_hidden_column}?") && send("saved_change_to_#{versioning_is_hidden_column}?")
+          end
+
+          define_method :should_create_stickied_history do
+            respond_to?("saved_change_to_#{versioning_is_sticky_column}?") && send("saved_change_to_#{versioning_is_sticky_column}?")
           end
 
           define_method :save_version do |edit_type = "edit"|

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -12,7 +12,7 @@ class Blip < ApplicationRecord
     ModAction.log(:blip_update, { blip_id: rec.id, user_id: rec.creator_id })
   end
   after_destroy do |rec|
-    ModAction.log(:blip_delete, {blip_id: rec.id, user_id: rec.creator_id})
+    ModAction.log(:blip_delete, { blip_id: rec.id, user_id: rec.creator_id })
   end
   after_save(if: ->(rec) { rec.saved_change_to_is_hidden? && CurrentUser.id != rec.creator_id }) do |rec|
     action = rec.is_hidden? ? :blip_hide : :blip_unhide

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -107,15 +107,15 @@ class Blip < ApplicationRecord
 
   def hidden_at
     return nil unless is_hidden?
-    versions.select { |v| v.edit_type == "hide" }.last&.created_at
+    versions.hidden.last&.created_at
   end
 
   def warned_at
     return nil unless was_warned?
-    versions.select { |v| v.edit_type.starts_with?("mark_") }.last&.created_at
+    versions.marked.last&.created_at
   end
 
   def edited_at
-    versions.select { |v| v.edit_type == "edit" }.last&.created_at
+    versions.edited.last&.created_at
   end
 end

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -104,4 +104,18 @@ class Blip < ApplicationRecord
   include PermissionsMethods
   extend SearchMethods
   include ApiMethods
+
+  def hidden_at
+    return nil unless is_hidden?
+    versions.select { |v| v.edit_type == "hide" }.last&.created_at
+  end
+
+  def warned_at
+    return nil unless was_warned?
+    versions.select { |v| v.edit_type.starts_with?("mark_") }.last&.created_at
+  end
+
+  def edited_at
+    versions.select { |v| v.edit_type == "edit" }.last&.created_at
+  end
 end

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -6,6 +6,7 @@ class Blip < ApplicationRecord
   user_status_counter :blip_count
   validates :body, presence: true
   belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
+  belongs_to :warning_user, class_name: "User", optional: true
   has_many :responses, class_name: "Blip", foreign_key: "response_to"
   validates :body, length: { minimum: 5, maximum: Danbooru.config.blip_max_size }
   validate :validate_parent_exists, :on => :create

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -3,19 +3,26 @@ class Blip < ApplicationRecord
   simple_versioning
   belongs_to_creator
   belongs_to_updater optional: true
-  user_status_counter :blip_count
-  validates :body, presence: true
-  belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
-  belongs_to :warning_user, class_name: "User", optional: true
-  has_many :responses, class_name: "Blip", foreign_key: "response_to"
-  validates :body, length: { minimum: 5, maximum: Danbooru.config.blip_max_size }
   validate :validate_parent_exists, :on => :create
   validate :validate_creator_is_not_limited, :on => :create
+  validates :body, presence: true
+  validates :body, length: { minimum: 5, maximum: Danbooru.config.blip_max_size }
+
+  after_update(if: ->(rec) { !rec.saved_change_to_is_hidden? && CurrentUser.id != rec.creator_id }) do |rec|
+    ModAction.log(:blip_update, { blip_id: rec.id, user_id: rec.creator_id })
+  end
+  after_destroy do |rec|
+    ModAction.log(:blip_delete, {blip_id: rec.id, user_id: rec.creator_id})
+  end
   after_save(if: ->(rec) { rec.saved_change_to_is_hidden? && CurrentUser.id != rec.creator_id }) do |rec|
     action = rec.is_hidden? ? :blip_hide : :blip_unhide
     ModAction.log(action, { blip_id: rec.id, user_id: rec.creator_id })
   end
 
+  user_status_counter :blip_count
+  belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
+  belongs_to :warning_user, class_name: "User", optional: true
+  has_many :responses, class_name: "Blip", foreign_key: "response_to"
   def response?
     parent.present?
   end

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -2,6 +2,7 @@ class Blip < ApplicationRecord
   include UserWarnable
   simple_versioning
   belongs_to_creator
+  belongs_to_updater optional: true
   user_status_counter :blip_count
   validates :body, presence: true
   belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,6 +8,7 @@ class Comment < ApplicationRecord
   validate :post_not_comment_disabled, on: :create
   validates :body, presence: { message: "has no content" }
   validates :body, length: { minimum: 1, maximum: Danbooru.config.comment_max_size }
+  belongs_to :warning_user, class_name: "User", optional: true
 
   after_create :update_last_commented_at_on_create
   after_update(if: ->(rec) { !rec.saved_change_to_is_hidden? && CurrentUser.id != rec.creator_id }) do |rec|

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -214,15 +214,15 @@ class Comment < ApplicationRecord
 
   def hidden_at
     return nil unless is_hidden?
-    versions.select { |v| v.edit_type == "hide" }.last&.created_at
+    versions.hidden.last&.created_at
   end
 
   def warned_at
     return nil unless was_warned?
-    versions.select { |v| v.edit_type.starts_with?("mark_") }.last&.created_at
+    versions.marked.last&.created_at
   end
 
   def edited_at
-    versions.select { |v| v.edit_type == "edit" }.last&.created_at
+    versions.edited.last&.created_at
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -11,7 +11,7 @@ class Comment < ApplicationRecord
   belongs_to :warning_user, class_name: "User", optional: true
 
   after_create :update_last_commented_at_on_create
-  after_update(if: ->(rec) { !rec.saved_change_to_is_hidden? && !rec.saved_change_to_is_sticky? && CurrentUser.id != rec.creator_id }) do |rec|
+  after_update(if: ->(rec) { !rec.saved_change_to_is_hidden? && (rec.saved_change_to_is_sticky? || CurrentUser.id != rec.creator_id) }) do |rec|
     ModAction.log(:comment_update, { comment_id: rec.id, user_id: rec.creator_id })
   end
   after_destroy :update_last_commented_at_on_destroy

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -23,10 +23,6 @@ class Comment < ApplicationRecord
     action = rec.is_hidden? ? :comment_hide : :comment_unhide
     ModAction.log(action, { comment_id: rec.id, user_id: rec.creator_id })
   end
-  after_save(if: ->(rec) { rec.saved_change_to_is_sticky? }) do |rec|
-    type = rec.is_sticky? ? "stick" : "unstick"
-    save_version(type)
-  end
 
   user_status_counter :comment_count
   belongs_to :post, counter_cache: :comment_count

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -54,6 +54,12 @@ class EditHistory < ApplicationRecord
     %w[original edit].include?(edit_type)
   end
 
+  def page(limit = 20)
+    limit = limit.to_i
+    return 1 if limit <= 0
+    (version / limit).ceil + 1
+  end
+
   module SearchMethods
     def hidden
       where(edit_type: "hide")

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -106,7 +106,7 @@ class EditHistory < ApplicationRecord
         q = q.where("ip_addr <<= ?", params[:ip_addr])
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -67,6 +67,10 @@ class EditHistory < ApplicationRecord
       where(edit_type: "edit")
     end
 
+    def original
+      where(edit_type: "original", version: 1).first
+    end
+
     def search(params)
       q = super
 

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -40,6 +40,7 @@ class EditHistory < ApplicationRecord
     versions[index - 1]
   end
 
+  # rubocop:disable Rails/OutputSafety
   def text_content
     if is_contentful?
       return subject if subject.present?
@@ -47,6 +48,7 @@ class EditHistory < ApplicationRecord
     end
     "<b>#{EDIT_MAP[edit_type.to_sym] || pretty_edit_type}</b>".html_safe
   end
+  # rubocop:enable Rails/OutputSafety
 
   def is_contentful?
     %w[original edit].include?(edit_type)

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -43,9 +43,9 @@ class EditHistory < ApplicationRecord
   def text_content
     if is_contentful?
       return subject if subject.present?
-      body
+      return body
     end
-    EDIT_MAP[edit_type.to_sym] || pretty_edit_type
+    "<b>#{EDIT_MAP[edit_type.to_sym] || pretty_edit_type}</b>".html_safe
   end
 
   def is_contentful?

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -3,12 +3,6 @@ class EditHistory < ApplicationRecord
   belongs_to :versionable, polymorphic: true
   belongs_to :user
 
-  TYPE_MAP = {
-    comment: "Comment",
-    forum: "ForumPost",
-    blip: "Blip",
-  }.freeze
-
   EDIT_MAP = {
     hide: "Hidden",
     unhide: "Unhidden",
@@ -47,6 +41,10 @@ class EditHistory < ApplicationRecord
   end
 
   def text_content
+    if is_contentful?
+      return subject if subject.present?
+      body
+    end
     EDIT_MAP[edit_type.to_sym] || pretty_edit_type
   end
 

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -1,11 +1,56 @@
 class EditHistory < ApplicationRecord
-  self.table_name = 'edit_histories'
+  self.table_name = "edit_histories"
   belongs_to :versionable, polymorphic: true
   belongs_to :user
 
   TYPE_MAP = {
-      comment: 'Comment',
-      forum: 'ForumPost',
-      blip: 'Blip'
-  }
+    comment: "Comment",
+    forum: "ForumPost",
+    blip: "Blip",
+  }.freeze
+
+  EDIT_MAP = {
+    hide: "Hidden",
+    unhide: "Unhidden",
+    stick: "Stickied",
+    unstick: "Unstickied",
+    mark_warning: "Marked For Warning",
+    wark_record: "Marked For Record",
+    mark_ban: "Marked For Ban",
+    unmark: "Unmarked",
+  }.freeze
+
+  KNOWN_TYPES = %i[
+    comment
+    forum_post
+    blip
+  ].freeze
+
+  KNOWN_EDIT_TYPES = %i[
+    hide
+    unhide
+    stick
+    unstick
+    mark_warning
+    mark_record
+    mark_ban
+    unmark
+  ].freeze
+
+  def pretty_edit_type
+    edit_type.titleize
+  end
+
+  def previous_version(versions)
+    return nil if version == 1 || (index = versions.index(self)) < 1
+    versions[index - 1]
+  end
+
+  def text_content
+    EDIT_MAP[edit_type.to_sym] || pretty_edit_type
+  end
+
+  def is_contentful?
+    %w[original edit].include?(edit_type)
+  end
 end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -29,7 +29,7 @@ class ForumPost < ApplicationRecord
   after_update(if: ->(rec) { rec.saved_change_to_is_hidden? }) do |rec|
     ModAction.log(rec.is_hidden ? :forum_post_hide : :forum_post_unhide, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
-  after_destroy(if: ->(rec) { rec.updater_id != rec.creator_id }) do |rec|
+  after_destroy do |rec|
     ModAction.log(:forum_post_delete, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
 

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -23,14 +23,14 @@ class ForumPost < ApplicationRecord
   validate :validate_creator_is_not_limited, on: :create
   before_destroy :validate_topic_is_unlocked
   after_save :delete_topic_if_original_post
-  after_update(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
-    ModAction.log(:forum_post_update, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+  after_update(if: ->(rec) { !rec.saved_change_to_is_hidden? && rec.updater_id != rec.creator_id }) do |rec|
+    ModAction.log(:forum_post_update, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
-  after_update(:if => ->(rec) {rec.saved_change_to_is_hidden?}) do |rec|
-    ModAction.log(rec.is_hidden ? :forum_post_hide : :forum_post_unhide, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+  after_update(if: ->(rec) { rec.saved_change_to_is_hidden? }) do |rec|
+    ModAction.log(rec.is_hidden ? :forum_post_hide : :forum_post_unhide, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
-  after_destroy(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
-    ModAction.log(:forum_post_delete, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+  after_destroy(if: ->(rec) { rec.updater_id != rec.creator_id }) do |rec|
+    ModAction.log(:forum_post_delete, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
 
   attr_accessor :bypass_limits

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -224,15 +224,15 @@ class ForumPost < ApplicationRecord
 
   def hidden_at
     return nil unless is_hidden?
-    versions.select { |v| v.edit_type == "hide" }.last&.created_at
+    versions.hidden.last&.created_at
   end
 
   def warned_at
     return nil unless was_warned?
-    versions.select { |v| v.edit_type.starts_with?("mark_") }.last&.created_at
+    versions.marked.last&.created_at
   end
 
   def edited_at
-    versions.select { |v| v.edit_type == "edit" }.last&.created_at
+    versions.edited.last&.created_at
   end
 end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -221,4 +221,18 @@ class ForumPost < ApplicationRecord
 
     true
   end
+
+  def hidden_at
+    return nil unless is_hidden?
+    versions.select { |v| v.edit_type == "hide" }.last&.created_at
+  end
+
+  def warned_at
+    return nil unless was_warned?
+    versions.select { |v| v.edit_type.starts_with?("mark_") }.last&.created_at
+  end
+
+  def edited_at
+    versions.select { |v| v.edit_type == "edit" }.last&.created_at
+  end
 end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -10,6 +10,7 @@ class ForumPost < ApplicationRecord
   has_one :tag_alias
   has_one :tag_implication
   has_one :bulk_update_request
+  belongs_to :warning_user, class_name: "User", optional: true
   before_validation :initialize_is_hidden, :on => :create
   after_create :update_topic_updated_at_on_create
   after_destroy :update_topic_updated_at_on_destroy

--- a/app/views/application/_update_notice.html.erb
+++ b/app/views/application/_update_notice.html.erb
@@ -2,6 +2,6 @@
 
 <% if record.respond_to?(:updater) && record.updater != record.creator  %>
   <p class="info">Updated by <%= link_to_user record.updater %> <%= time_ago_in_words_tagged(record.updated_at) %></p>
-<% elsif record.updated_at - record.created_at > 5.minutes %>
+<% elsif CurrentUser.is_moderator? || record.updated_at - record.created_at > 5.minutes %>
   <p class="info">Updated <%= time_ago_in_words_tagged(record.updated_at) %></p>
 <% end %>

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -6,7 +6,7 @@
         <h4 class="author-name"><%= link_to_user blip.creator %></h4>
         <%= blip.creator.level_string %>
         <% if blip.is_hidden? %>
-          (hidden)
+          <span<% if blip.hidden_at.present? %> title="<%= time_ago_in_words(blip.hidden_at) %> ago"<% end %>>(hidden)</span>
         <% end %>
       </div>
       <div class="avatar">
@@ -23,11 +23,14 @@
       <div class="body dtext-container">
         <%= format_text(blip.body, allow_color: blip.creator.is_privileged?) %>
       </div>
-      <%= render "application/update_notice", record: blip %>
-      <% if blip.was_warned? %>
+      <% if blip.edited_at.present? %>
+        <%= render "application/update_notice", record: blip, timestamp: blip.edited_at %>
+      <% end %>
+      <% if blip.was_warned? && blip.warned_at.present? %>
         <div class="user-warning">
           <hr>
-          <em><%= blip.warning_type_string %></em>
+          <em><%= blip.warning_type_string %><% if blip.warning_user.present? %> by <%= link_to_user(blip.warning_user) %><% end %>.</em>
+          <span class="info"><%= time_ago_in_words_tagged(blip.warned_at) %></span>
         </div>
       <% end %>
       <div class="content-menu">

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -23,6 +23,7 @@
       <div class="body dtext-container">
         <%= format_text(blip.body, allow_color: blip.creator.is_privileged?) %>
       </div>
+      <%= render "application/update_notice", record: blip %>
       <% if blip.was_warned? %>
         <div class="user-warning">
           <hr>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -8,7 +8,7 @@
         <h4 class="author-name"><%= link_to_user comment.creator %></h4>
         <%= comment.creator.level_string %>
         <% if comment.is_hidden? %>
-          (hidden)
+          <span<% if comment.hidden_at.present? %> title="<%= time_ago_in_words(comment.hidden_at) %> ago"<% end %>>(hidden)</span>
         <% end %>
       </div>
       <div class="avatar">
@@ -22,11 +22,14 @@
       <div class="body dtext-container">
         <%= format_text(comment.body, allow_color: comment.creator.is_privileged?) %>
       </div>
-      <%= render "application/update_notice", record: comment %>
-      <% if comment.was_warned? %>
+      <% if comment.edited_at.present? %>
+        <%= render "application/update_notice", record: comment, timestamp: comment.edited_at %>
+      <% end %>
+      <% if comment.was_warned? && comment.warned_at.present? %>
         <div class="user-warning">
           <hr>
-          <em><%= comment.warning_type_string %></em>
+          <em><%= comment.warning_type_string %><% if comment.warning_user.present? %> by <%= link_to_user(comment.warning_user) %><% end %>.</em>
+          <span class="info"><%= time_ago_in_words_tagged(comment.warned_at) %></span>
         </div>
       <% end %>
         <div class="content-menu">

--- a/app/views/edit_histories/_search.erb
+++ b/app/views/edit_histories/_search.erb
@@ -1,0 +1,10 @@
+<%= form_search(path: edit_histories_path) do |f| %>
+  <%= f.input :versionable_type, label: "Versionable Type", collection: EditHistory::KNOWN_TYPES.map { |k| [k.to_s.titleize, k.to_s.titleize.tr(" ", "")] }, include_blank: true %>
+  <%= f.input :versionable_id, label: "Versionable ID" %>
+  <%= f.input :edit_type, label: "Edit Type", collection: EditHistory::KNOWN_EDIT_TYPES.map { |k| [k.to_s.titleize, k.to_s] }, include_blank: true %>
+  <%= f.input :user_name, label: "Updater", autocomplete: "user" %>
+  <%= f.input :user_id, label: "Updater ID" %>
+  <% if CurrentUser.is_admin? %>
+    <%= f.input :ip_addr, label: "IP Address" %>
+  <% end %>
+<% end %>

--- a/app/views/edit_histories/_secondary_links.html.erb
+++ b/app/views/edit_histories/_secondary_links.html.erb
@@ -1,0 +1,3 @@
+<% content_for(:secondary_links) do %>
+  <%= subnav_link_to "Listing", edit_histories_path %>
+<% end %>

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -23,7 +23,7 @@
       <tbody>
       <% @edit_history.each do |edit| %>
         <tr id="edit-<%= edit.id %>" class="edit-<%= edit.edit_type.tr("_", "-") %>">
-          <td><%= link_to "Show", action: "show", id: edit.versionable_id, type: edit.versionable_type %></td>
+          <td><%= link_to "Show", action: "show", id: edit.versionable_id, type: edit.versionable_type, anchor: "edit-#{edit.id}" %></td>
           <td><%= edit.versionable_type %></td>
           <td><%= edit.pretty_edit_type %></td>
           <td><%= compact_time edit.updated_at %></td>

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -23,7 +23,7 @@
       <tbody>
       <% @edit_history.each do |edit| %>
         <tr id="edit-<%= edit.id %>" class="edit-<%= edit.edit_type.tr("_", "-") %>">
-          <td><%= link_to "Show", action: "show", id: edit.versionable_id, type: edit.versionable_type, anchor: "edit-#{edit.id}" %></td>
+          <td><%= link_to "Show", action: "show", id: edit.versionable_id, type: edit.versionable_type, page: edit.page, anchor: "edit-#{edit.id}" %></td>
           <td><%= edit.versionable_type %></td>
           <td><%= edit.pretty_edit_type %></td>
           <td><%= compact_time edit.updated_at %></td>

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -32,7 +32,7 @@
           <% end %>
           <td><%= link_to_user edit.user %></td>
           <td><%= edit.body[0..30] %></td>
-          <td><%= (edit.subject&[0..30]) || "" %></td>
+          <td><%= (edit.subject || "")[0..30] %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -2,6 +2,8 @@
   <div id="a-index">
     <h1>Recent Edits</h1>
 
+    <%= render "search" %>
+
     <table class="striped">
       <thead>
       <tr>
@@ -39,6 +41,8 @@
     <%= numbered_paginator(@edit_history) %>
   </div>
 </div>
+
+<%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
   Edit Histories

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -7,6 +7,7 @@
       <tr>
         <th></th>
         <th>Type</th>
+        <th>Edit Type</th>
         <th>Date</th>
         <% if CurrentUser.is_admin? %>
           <th>IP Address</th>
@@ -19,16 +20,17 @@
 
       <tbody>
       <% @edit_history.each do |edit| %>
-        <tr id="edit-<%= edit.id %>">
+        <tr id="edit-<%= edit.id %>" class="edit-<%= edit.edit_type.tr("_", "-") %>">
           <td><%= link_to "Show", action: "show", id: edit.versionable_id, type: edit.versionable_type %></td>
           <td><%= edit.versionable_type %></td>
+          <td><%= edit.pretty_edit_type %></td>
           <td><%= compact_time edit.updated_at %></td>
           <% if CurrentUser.is_admin? %>
             <td><%= link_to_ip edit.ip_addr %></td>
           <% end %>
           <td><%= link_to_user edit.user %></td>
           <td><%= edit.body[0..30] %></td>
-          <td><%= edit.subject&[0..30] %></td>
+          <td><%= (edit.subject&[0..30]) || "" %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -33,6 +33,8 @@
   </div>
 </div>
 
+<%= render "secondary_links" %>
+
 <% content_for(:page_title) do %>
   Edit History
 <% end %>

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -1,10 +1,21 @@
 <div id="c-edit-history">
   <div id="a-show">
-    <h1>Edits for <%= h params[:type] %> #<%= h params[:id] %></h1>
+    <% if @edit_history.length < 1 %>
+      <h1>Edits for <%= h params[:type] %> #<%= h params[:id] %></h1>
+    <% else %>
+      <% case @edit_history.original.versionable_type %>
+      <% when "Blip" %>
+        <h1>Edits for <%= link_to "Blip ##{@edit_history.original.versionable_id}", blip_path, id: @edit_history.original.versionable_id %></h1>
+      <% when "Comment" %>
+        <h1>Edits for <%= link_to "Comment ##{@edit_history.original.versionable_id}", comment_path, id: @edit_history.original.versionable_id %></h1>
+      <% when "ForumPost" %>
+        <h1>Edits for <%= link_to "ForumPost ##{@edit_history.original.versionable_id}", forum_post_path, id: @edit_history.original.versionable_id %></h1>
+      <% end %>
+    <% end %>
 
     <div class="response-list" id="edit-history">
       <% @edit_history.each do |edit| %>
-        <div class="edit-item box-section edit-<%= edit.edit_type.tr("_", "-") %>">
+        <div class="edit-item box-section edit-<%= edit.edit_type.tr("_", "-") %>" id="edit-<%= edit.id %>">
           <div class="author">
             <h6><%= link_to_user edit.user %></h6>
             <%= compact_time edit.created_at %>
@@ -33,7 +44,7 @@
   </div>
 </div>
 
-<%= render "secondary_links" %>
+<%= render "secondary_links", record: @edit_history&.original %>
 
 <% content_for(:page_title) do %>
   Edit History

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -3,8 +3,8 @@
     <h1>Edits for <%= h params[:type] %> #<%= h params[:id] %></h1>
 
     <div class="response-list" id="edit-history">
-      <% @edits.each_with_index do |edit, idx| %>
-        <div class="edit-item box-section">
+      <% @edit_history.each do |edit| %>
+        <div class="edit-item box-section edit-<%= edit.edit_type.tr("_", "-") %>">
           <div class="author">
             <h6><%= link_to_user edit.user %></h6>
             <%= compact_time edit.created_at %>
@@ -14,10 +14,16 @@
           </div>
           <div class="content">
             <div class="body">
-              <% if edit.version > 1 %>
-                <%= lcs_diff(@edits[idx-1].body, edit.body) %>
+              <% if edit.is_contentful? %>
+                <% if (previous = edit.previous_version(@content_edits)) %>
+                  <%= lcs_diff(previous.body, edit.body) %>
+                <% else %>
+                  <%= edit.body %>
+                <% end %>
               <% else %>
-                <%= edit.body %>
+                <b>
+                  <%= edit.text_content %>
+                </b>
               <% end %>
             </div>
           </div>

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -10,6 +10,8 @@
         <h1>Edits for <%= link_to "Comment ##{@original.versionable_id}", comment_path, id: @original.versionable_id %></h1>
       <% when "ForumPost" %>
         <h1>Edits for <%= link_to "ForumPost ##{@original.versionable_id}", forum_post_path, id: @original.versionable_id %></h1>
+      <% else %>
+        <h1>Edits for <%= h params[:type] %> #<%= h params[:id] %></h1>
       <% end %>
     <% end %>
 
@@ -18,19 +20,15 @@
         <div class="edit-item box-section edit-<%= edit.edit_type.tr("_", "-") %>" id="edit-<%= edit.id %>">
           <div class="author">
             <h6><%= link_to_user edit.user %></h6>
-            <%= compact_time edit.created_at %>
+            <%= link_to compact_time(edit.created_at), url_for(anchor: "edit-#{edit.id}") %>
             <% if CurrentUser.is_admin? %>
               <div><%= link_to_ip edit.ip_addr %></div>
             <% end %>
           </div>
           <div class="content">
             <div class="body">
-              <% if edit.is_contentful? %>
-                <% if (previous = edit.previous_version(@content_edits)) %>
-                  <%= lcs_diff(previous.body, edit.body) %>
-                <% else %>
-                  <%= edit.body %>
-                <% end %>
+              <% if edit.is_contentful? && (previous = edit.previous_version(@content_edits)) %>
+                <%= lcs_diff(previous.text_content, edit.text_content) %>
               <% else %>
                 <b>
                   <%= edit.text_content %>

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -1,15 +1,15 @@
 <div id="c-edit-history">
   <div id="a-show">
-    <% if @edit_history.length < 1 %>
+    <% if @edit_history.empty? %>
       <h1>Edits for <%= h params[:type] %> #<%= h params[:id] %></h1>
     <% else %>
-      <% case @edit_history.original.versionable_type %>
+      <% case @original.versionable_type %>
       <% when "Blip" %>
-        <h1>Edits for <%= link_to "Blip ##{@edit_history.original.versionable_id}", blip_path, id: @edit_history.original.versionable_id %></h1>
+        <h1>Edits for <%= link_to "Blip ##{@original.versionable_id}", blip_path, id: @original.versionable_id %></h1>
       <% when "Comment" %>
-        <h1>Edits for <%= link_to "Comment ##{@edit_history.original.versionable_id}", comment_path, id: @edit_history.original.versionable_id %></h1>
+        <h1>Edits for <%= link_to "Comment ##{@original.versionable_id}", comment_path, id: @original.versionable_id %></h1>
       <% when "ForumPost" %>
-        <h1>Edits for <%= link_to "ForumPost ##{@edit_history.original.versionable_id}", forum_post_path, id: @edit_history.original.versionable_id %></h1>
+        <h1>Edits for <%= link_to "ForumPost ##{@original.versionable_id}", forum_post_path, id: @original.versionable_id %></h1>
       <% end %>
     <% end %>
 
@@ -43,6 +43,8 @@
     </div>
   </div>
 </div>
+
+<%= numbered_paginator(@edit_history) %>
 
 <%= render "secondary_links", record: @edit_history&.original %>
 

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -44,7 +44,7 @@
 
 <%= numbered_paginator(@edit_history) %>
 
-<%= render "secondary_links", record: @edit_history&.original %>
+<%= render "secondary_links" %>
 
 <% content_for(:page_title) do %>
   Edit History

--- a/app/views/edit_histories/show.html.erb
+++ b/app/views/edit_histories/show.html.erb
@@ -30,9 +30,7 @@
               <% if edit.is_contentful? && (previous = edit.previous_version(@content_edits)) %>
                 <%= lcs_diff(previous.text_content, edit.text_content) %>
               <% else %>
-                <b>
-                  <%= edit.text_content %>
-                </b>
+                <%= edit.text_content %>
               <% end %>
             </div>
           </div>

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -8,7 +8,7 @@
         <h4 class="author-name"><%= link_to_user forum_post.creator %></h4>
         <%= forum_post.creator.level_string %>
         <% if forum_post.is_hidden? %>
-          (hidden)
+          <span<% if forum_post.hidden_at.present? %> title="<%= time_ago_in_words(forum_post.hidden_at) %> ago"<% end %>>(hidden)</span>
         <% end %>
       </div>
       <div class="avatar">
@@ -22,11 +22,14 @@
       <div class="dtext-container">
         <%= format_text(parse_embedded_tag_request_text(forum_post.body), allow_color: forum_post.creator.is_privileged?) %>
       </div>
-      <%= render "application/update_notice", record: forum_post %>
-      <% if forum_post.was_warned? %>
+      <% if forum_post.edited_at.present? %>
+        <%= render "application/update_notice", record: forum_post, timestamp: forum_post.edited_at %>
+      <% end %>
+      <% if forum_post.was_warned? && forum_post.warned_at.present? %>
         <div class="user-warning">
           <hr>
-          <em><%= forum_post.warning_type_string %></em>
+          <em><%= forum_post.warning_type_string %><% if forum_post.warning_user.present? %> by <%= link_to_user(forum_post.warning_user) %><% end %>.</em>
+          <span class="info"><%= time_ago_in_words_tagged(forum_post.warned_at) %></span>
         </div>
       <% end %>
       <div class="content-menu">

--- a/app/views/forum_posts/index.html.erb
+++ b/app/views/forum_posts/index.html.erb
@@ -20,7 +20,9 @@
               </td>
               <td class="forum-post-excerpt">
                 <%= link_to truncate(forum_post.body, :length => 50), forum_post_path(forum_post) %>
-                <%= "(hidden)" if forum_post.is_hidden? %>
+                <% if forum_post.is_hidden? %>
+                  <span<% if forum_post.hidden_at.present? %> title="<%= time_ago_in_words(forum_post.hidden_at) %> ago"<% end %>>(hidden)</span>
+                <% end %>
               </td>
               <td><%= link_to_user forum_post.creator %></td>
               <td><%= time_ago_in_words_tagged forum_post.created_at %></td>

--- a/app/views/moderator/dashboards/_activity_comment.html.erb
+++ b/app/views/moderator/dashboards/_activity_comment.html.erb
@@ -14,7 +14,7 @@
         <td>
           <%= link_to activity.comment.body, post_path(activity.comment.post_id) %>
           <% if activity.comment.is_hidden? %>
-            <span class="inactive">(hidden)</span>
+            <span class="inactive"<% if activity.comment.hidden_at.present? %> title="<%= time_ago_in_words(activity.comment.hidden_at) %> ago"<% end %>>(hidden)</span>
           <% end %>
         </td>
         <td><%= link_to_user(activity.comment.creator) %></td>

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -23,7 +23,7 @@
               <div class="dtext-container">
                 <%= format_text(feedback.body) %>
               </div>
-              <%= render "application/update_notice", record: feedback %>
+              <%= render "application/update_notice", record: feedback, timestamp: feedback.updated_at %>
             </td>
             <td>
               <% if feedback.editable_by?(CurrentUser.user) %>

--- a/app/views/user_name_change_requests/show.html.erb
+++ b/app/views/user_name_change_requests/show.html.erb
@@ -8,7 +8,7 @@
           <th>Date</th>
           <td>
             <%= compact_time @change_request.created_at %>
-            <%= render "application/update_notice", record: @change_request %>
+            <%= render "application/update_notice", record: @change_request, timestamp: @change_request.updated_at %>
           </td>
         </tr>
         <tr>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -59,6 +59,9 @@
         <span>
           <%= presenter.forum_post_count(self) %>
           (<%= link_to "mentions", forum_posts_path(search: { body_matches: user.name }) %>)
+          <% if CurrentUser.is_moderator? %>
+            (<%= link_to "edits", edit_histories_path(search: { versionable_type: EditHistory::TYPE_MAP[:forum], user_id: user.id }) %>)
+          <% end %>
         </span>
 
         <span>Comments</span>
@@ -67,6 +70,7 @@
           (<%= link_to "mentions", comments_path(group_by: :comment, search:{ body_matches: user.name }) %>)
           <% if CurrentUser.is_moderator? %>
             (<%= link_to "votes", action: "index", controller: "comment_votes", search: { user_name: user.name } %>)
+            (<%= link_to "edits", edit_histories_path(search: { versionable_type: EditHistory::TYPE_MAP[:comment], user_id: user.id }) %>)
           <% end %>
         </span>
 

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -60,7 +60,7 @@
           <%= presenter.forum_post_count(self) %>
           (<%= link_to "mentions", forum_posts_path(search: { body_matches: user.name }) %>)
           <% if CurrentUser.is_moderator? %>
-            (<%= link_to "edits", edit_histories_path(search: { versionable_type: EditHistory::TYPE_MAP[:forum], user_id: user.id }) %>)
+            (<%= link_to "edits", edit_histories_path(search: { versionable_type: "ForumPost", user_id: user.id }) %>)
           <% end %>
         </span>
 
@@ -70,7 +70,7 @@
           (<%= link_to "mentions", comments_path(group_by: :comment, search:{ body_matches: user.name }) %>)
           <% if CurrentUser.is_moderator? %>
             (<%= link_to "votes", action: "index", controller: "comment_votes", search: { user_name: user.name } %>)
-            (<%= link_to "edits", edit_histories_path(search: { versionable_type: EditHistory::TYPE_MAP[:comment], user_id: user.id }) %>)
+            (<%= link_to "edits", edit_histories_path(search: { versionable_type: "Comment", user_id: user.id }) %>)
           <% end %>
         </span>
 

--- a/db/fixes/110_edit_histories_edit_types.rb
+++ b/db/fixes/110_edit_histories_edit_types.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+# blips don't store an updater id
+blip_updater = User.find(1)
+# blips & fourm posts don't store an updater ip
+ip_addr = "127.0.0.1"
+
+# the default is original, so we need to update everything that isn't version=1
+EditHistory.where.not(version: 1).find_each do |edit_history|
+  edit_history.update_columns(edit_type: "edit")
+end
+
+Blip.where("is_hidden = TRUE OR warning_type IS NOT NULL").find_each do |blip|
+  # blips have no updater information, so we're pretty well forced to leave everything anonymous
+  CurrentUser.scoped(blip_updater, ip_addr) do
+    blip.save_version("hide") if blip.is_hidden?
+    blip.save_version("mark_#{blip.warning_type}") if blip.was_warned?
+  end
+end
+
+Comment.where("is_hidden = TRUE OR is_sticky = TRUE OR warning_type IS NOT NULL").find_each do |comment|
+  updater = User.find(comment.updater_id)
+  CurrentUser.scoped(updater, comment.updater_ip_addr) do
+    comment.save_version("hide") if comment.is_hidden?
+    comment.save_version("stick") if comment.is_sticky?
+    comment.save_version("mark_#{comment.warning_type}") if comment.was_warned?
+  end
+
+  # warning_user_id has never been set - we're updating it with the current updater_id, as that's likely to be the one who added the warning
+  if comment.was_warned? && comment.warning_user_id.nil?
+    comment.update_columns(warning_user_id: comment.updater_id)
+  end
+end
+
+ForumPost.where("is_hidden = TRUE OR warning_type IS NOT NULL").find_each do |forum_post|
+  updater = User.find(forum_post.updater_id)
+  CurrentUser.scoped(updater, ip_addr) do
+    forum_post.save_version("hide") if forum_post.is_hidden?
+    forum_post.save_version("mark_#{forum_post.warning_type}") if forum_post.was_warned?
+  end
+
+  # warning_user_id has never been set - we're updating it with the current updater_id, as that's likely to be the one who added the warning
+  if forum_post.was_warned? && forum_post.warning_user_id.nil?
+    forum_post.update_columns(warning_user_id: forum_post.updater_id)
+  end
+end

--- a/db/migrate/20230531080817_add_blips_updater_id.rb
+++ b/db/migrate/20230531080817_add_blips_updater_id.rb
@@ -1,0 +1,6 @@
+class AddBlipsUpdaterId < ActiveRecord::Migration[7.0]
+  def change
+    add_column :blips, :updater_id, :integer
+    add_foreign_key :blips, :users, column: :updater_id
+  end
+end

--- a/db/migrate/20230531081706_add_edit_histories_edit_type.rb
+++ b/db/migrate/20230531081706_add_edit_histories_edit_type.rb
@@ -1,0 +1,5 @@
+class AddEditHistoriesEditType < ActiveRecord::Migration[7.0]
+  def change
+    add_column :edit_histories, :edit_type, :text, null: false, default: "original"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -251,7 +251,8 @@ CREATE TABLE public.blips (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     warning_type integer,
-    warning_user_id integer
+    warning_user_id integer,
+    updater_id integer
 );
 
 
@@ -4421,6 +4422,14 @@ ALTER TABLE ONLY public.staff_audit_logs
 
 
 --
+-- Name: blips fk_rails_23e7479aac; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.blips
+    ADD CONSTRAINT fk_rails_23e7479aac FOREIGN KEY (updater_id) REFERENCES public.users(id);
+
+
+--
 -- Name: tickets fk_rails_45cd696dba; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4733,6 +4742,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230506161827'),
 ('20230513074838'),
 ('20230517155547'),
-('20230518182034');
+('20230518182034'),
+('20230531080817');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -516,7 +516,8 @@ CREATE TABLE public.edit_histories (
     versionable_id integer NOT NULL,
     version integer NOT NULL,
     ip_addr inet NOT NULL,
-    user_id integer NOT NULL
+    user_id integer NOT NULL,
+    edit_type text DEFAULT 'original'::text NOT NULL
 );
 
 
@@ -4743,6 +4744,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230513074838'),
 ('20230517155547'),
 ('20230518182034'),
-('20230531080817');
+('20230531080817'),
+('20230531081706');
 
 

--- a/test/factories/blip.rb
+++ b/test/factories/blip.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory(:blip) do
-    creator
     creator_ip_addr { "127.0.0.1" }
     sequence(:body) { |n| "blip_body_#{n}" }
   end

--- a/test/unit/blip_test.rb
+++ b/test/unit/blip_test.rb
@@ -1,0 +1,183 @@
+require "test_helper"
+
+class BlipTest < ActiveSupport::TestCase
+  context "A blip" do
+    setup do
+      @user = create(:user)
+      CurrentUser.user = @user
+    end
+
+    context "created by a limited user" do
+      setup do
+        Danbooru.config.stubs(:disable_throttles?).returns(false)
+      end
+
+      should "fail creation" do
+        blip = build(:blip)
+        blip.save
+        assert_equal(["Creator can not yet perform this action. Account is too new"], blip.errors.full_messages)
+      end
+    end
+
+    context "created by an unlimited user" do
+      setup do
+        Danbooru.config.stubs(:blip_limit).returns(100)
+      end
+
+      should "be created" do
+        blip = build(:blip)
+        blip.save
+        assert(blip.errors.empty?, blip.errors.full_messages.join(", "))
+      end
+
+      should "be searchable" do
+        b1 = create(:blip, body: "aaa bbb ccc")
+        b2 = create(:blip, body: "aaa ddd")
+
+        matches = Blip.search(body_matches: "aaa")
+        assert_equal(2, matches.count)
+        assert_equal(b2.id, matches.all[0].id)
+        assert_equal(b1.id, matches.all[1].id)
+      end
+
+      should "default to id_desc order when searched with no options specified" do
+        blips = create_list(:blip, 3)
+        matches = Blip.search({})
+
+        assert_equal([blips[2].id, blips[1].id, blips[0].id], matches.map(&:id))
+      end
+
+      context "that is edited by a moderator" do
+        setup do
+          @blip = create(:blip)
+          @mod = create(:moderator_user)
+          CurrentUser.user = @mod
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @blip.update(body: "nopearino")
+          end
+        end
+
+        should "credit the moderator as the updater" do
+          @blip.update(body: "testing")
+          assert_equal(@mod.id, @blip.updater_id)
+        end
+      end
+
+      context "that is hidden by a moderator" do
+        setup do
+          @blip = create(:blip)
+          @mod = create(:moderator_user)
+          CurrentUser.user = @mod
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @blip.update(is_hidden: true)
+          end
+        end
+
+        should "credit the moderator as the updater" do
+          @blip.update(is_hidden: true)
+          assert_equal(@mod.id, @blip.updater_id)
+        end
+      end
+
+      context "that is deleted" do
+        setup do
+          @blip = create(:blip)
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @blip.destroy
+          end
+        end
+      end
+    end
+
+    context "during validation" do
+      subject { build(:blip) }
+      should_not allow_value(" ").for(:body)
+    end
+
+    context "when modified" do
+      setup do
+        @blip = create(:blip)
+        original_body = @blip.body
+        @blip.class_eval do
+          after_save do
+            if @body_history.nil?
+              @body_history = [original_body]
+            end
+            @body_history.push(body)
+          end
+
+          define_method :body_history do
+            @body_history
+          end
+        end
+      end
+
+      instance_exec do
+        define_method :verify_history do |history, blip, edit_type, user = blip.creator_id|
+          throw "history is nil (#{blip.id}:#{edit_type}:#{user}:#{blip.creator_id})" if history.nil?
+          assert_equal(blip.body_history[history.version - 1], history.body, "history body did not match")
+          assert_equal(edit_type, history.edit_type, "history edit_type did not match")
+          assert_equal(user, history.user_id, "history user_id did not match")
+        end
+      end
+
+      should "create edit histories when body is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 3) do
+          @blip.update(body: "testing")
+          as(@mod) { @blip.update(body: "another test") }
+
+          original, edit, edit2 = EditHistory.where(versionable_id: @blip.id).order(version: :asc)
+          verify_history(original, @blip, "original", @user.id)
+          verify_history(edit, @blip, "edit", @user.id)
+          verify_history(edit2, @blip, "edit", @mod.id)
+        end
+      end
+
+      should "create edit histories when hidden is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 3) do
+          @blip.hide!
+          as(@mod) { @blip.unhide! }
+
+          original, hide, unhide = EditHistory.where(versionable_id: @blip.id).order(version: :asc)
+          verify_history(original, @blip, "original")
+          verify_history(hide, @blip, "hide")
+          verify_history(unhide, @blip, "unhide", @mod.id)
+        end
+      end
+
+      should "create edit histories when warning is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 7) do
+          as(@mod) do
+            @blip.user_warned!("warning", @mod)
+            @blip.remove_user_warning!
+            @blip.user_warned!("record", @mod)
+            @blip.remove_user_warning!
+            @blip.user_warned!("ban", @mod)
+            @blip.remove_user_warning!
+
+            original, warn, unmark1, record, unmark2, ban, unmark3 = EditHistory.where(versionable_id: @blip.id).order(version: :asc)
+            verify_history(original, @blip, "original")
+            verify_history(warn, @blip, "mark_warning", @mod.id)
+            verify_history(unmark1, @blip, "unmark", @mod.id)
+            verify_history(record, @blip, "mark_record", @mod.id)
+            verify_history(unmark2, @blip, "unmark", @mod.id)
+            verify_history(ban, @blip, "mark_ban", @mod.id)
+            verify_history(unmark3, @blip, "unmark", @mod.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -1,10 +1,10 @@
-require 'test_helper'
+require "test_helper"
 
 class CommentTest < ActiveSupport::TestCase
   context "A comment" do
     setup do
-      user = create(:user)
-      CurrentUser.user = user
+      @user = create(:user)
+      CurrentUser.user = @user
     end
 
     context "created by a limited user" do
@@ -234,6 +234,97 @@ class CommentTest < ActiveSupport::TestCase
     context "during validation" do
       subject { build(:comment) }
       should_not allow_value(" ").for(:body)
+    end
+
+    context "when modified" do
+      setup do
+        @post = create(:post)
+        @comment = create(:comment, post_id: @post.id)
+        original_body = @comment.body
+        @comment.class_eval do
+          after_save do
+            if @body_history.nil?
+              @body_history = [original_body]
+            end
+            @body_history.push(body)
+          end
+
+          define_method :body_history do
+            @body_history
+          end
+        end
+      end
+
+      instance_exec do
+        define_method :verify_history do |history, comment, edit_type, user = comment.creator_id|
+          throw "history is nil (#{comment.id}:#{edit_type}:#{user}:#{comment.creator_id})" if history.nil?
+          assert_equal(comment.body_history[history.version - 1], history.body, "history body did not match")
+          assert_equal(edit_type, history.edit_type, "history edit_type did not match")
+          assert_equal(user, history.user_id, "history user_id did not match")
+        end
+      end
+
+      should "create edit histories when body is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 3) do
+          @comment.update(body: "test")
+          as(@mod) { @comment.update(body: "test2") }
+
+          original, edit, edit2 = EditHistory.where(versionable_id: @comment.id).order(version: :asc)
+          verify_history(original, @comment, "original", @user.id)
+          verify_history(edit, @comment, "edit", @user.id)
+          verify_history(edit2, @comment, "edit", @mod.id)
+        end
+      end
+
+      should "create edit histories when hidden is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 3) do
+          @comment.hide!
+          as(@mod) { @comment.unhide! }
+
+          original, hide, unhide = EditHistory.where(versionable_id: @comment.id).order(version: :asc)
+          verify_history(original, @comment, "original")
+          verify_history(hide, @comment, "hide")
+          verify_history(unhide, @comment, "unhide", @mod.id)
+        end
+      end
+
+      should "create edit histories when sticky is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 3) do
+          as(@mod) { @comment.update(is_sticky: true) }
+
+          as(@mod) { @comment.update(is_sticky: false) }
+          original, stick, unstick = EditHistory.where(versionable_id: @comment.id).order(version: :asc)
+          verify_history(original, @comment, "original")
+          verify_history(stick, @comment, "stick", @mod.id)
+          verify_history(unstick, @comment, "unstick", @mod.id)
+        end
+      end
+
+      should "create edit histories when warning is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 7) do
+          as(@mod) do
+            @comment.user_warned!("warning", @mod)
+            @comment.remove_user_warning!
+            @comment.user_warned!("record", @mod)
+            @comment.remove_user_warning!
+            @comment.user_warned!("ban", @mod)
+            @comment.remove_user_warning!
+
+            original, warn, unmark1, record, unmark2, ban, unmark3 = EditHistory.where(versionable_id: @comment.id).order(version: :asc)
+            verify_history(original, @comment, "original")
+            verify_history(warn, @comment, "mark_warning", @mod.id)
+            verify_history(unmark1, @comment, "unmark", @mod.id)
+            verify_history(record, @comment, "mark_record", @mod.id)
+            verify_history(unmark2, @comment, "unmark", @mod.id)
+            verify_history(ban, @comment, "mark_ban", @mod.id)
+            verify_history(unmark3, @comment, "unmark", @mod.id)
+          end
+        end
+      end
     end
   end
 end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -188,13 +188,63 @@ class CommentTest < ActiveSupport::TestCase
 
         should "create a mod action" do
           assert_difference("ModAction.count") do
-            @comment.update(:body => "nope")
+            @comment.update(body: "nope")
           end
         end
 
         should "credit the moderator as the updater" do
           @comment.update(body: "test")
           assert_equal(@mod.id, @comment.updater_id)
+        end
+      end
+
+      context "that is hidden by a moderator" do
+        setup do
+          @comment = create(:comment)
+          @mod = create(:moderator_user)
+          CurrentUser.user = @mod
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @comment.update(is_hidden: true)
+          end
+        end
+
+        should "credit the moderator as the updater" do
+          @comment.update(is_hidden: true)
+          assert_equal(@mod.id, @comment.updater_id)
+        end
+      end
+
+      context "that is stickied by a moderator" do
+        setup do
+          @comment = create(:comment)
+          @mod = create(:moderator_user)
+          CurrentUser.user = @mod
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @comment.update(is_sticky: true)
+          end
+        end
+
+        should "credit the moderator as the updater" do
+          @comment.update(is_sticky: true)
+          assert_equal(@mod.id, @comment.updater_id)
+        end
+      end
+
+      context "that is deleted" do
+        setup do
+          @comment = create(:comment)
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @comment.destroy
+          end
         end
       end
 

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ForumPostTest < ActiveSupport::TestCase
   context "A forum post" do
@@ -109,6 +109,83 @@ class ForumPostTest < ActiveSupport::TestCase
       should "record its updater" do
         @post.update(:body => "abc")
         assert_equal(@second_user.id, @post.updater_id)
+      end
+    end
+
+    context "when modified" do
+      setup do
+        @forum_post = create(:forum_post, topic_id: @topic.id)
+        original_body = @forum_post.body
+        @forum_post.class_eval do
+          after_save do
+            if @body_history.nil?
+              @body_history = [original_body]
+            end
+            @body_history.push(body)
+          end
+
+          define_method :body_history do
+            @body_history
+          end
+        end
+      end
+
+      instance_exec do
+        define_method :verify_history do |history, forum_post, edit_type, user = forum_post.creator_id|
+          throw "history is nil (#{forum_post.id}:#{edit_type}:#{user}:#{forum_post.creator_id})" if history.nil?
+          assert_equal(forum_post.body_history[history.version - 1], history.body, "history body did not match")
+          assert_equal(edit_type, history.edit_type, "history edit_type did not match")
+          assert_equal(user, history.user_id, "history user_id did not match")
+        end
+      end
+
+      should "create edit histories when body is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 3) do
+          @forum_post.update(body: "test")
+          as(@mod) { @forum_post.update(body: "test2") }
+
+          original, edit, edit2 = EditHistory.where(versionable_id: @forum_post.id).order(version: :asc)
+          verify_history(original, @forum_post, "original", @user.id)
+          verify_history(edit, @forum_post, "edit", @user.id)
+          verify_history(edit2, @forum_post, "edit", @mod.id)
+        end
+      end
+
+      should "create edit histories when hidden is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 3) do
+          @forum_post.hide!
+          as(@mod) { @forum_post.unhide! }
+
+          original, hide, unhide = EditHistory.where(versionable_id: @forum_post.id).order(version: :asc)
+          verify_history(original, @forum_post, "original")
+          verify_history(hide, @forum_post, "hide")
+          verify_history(unhide, @forum_post, "unhide", @mod.id)
+        end
+      end
+
+      should "create edit histories when warning is changed" do
+        @mod = create(:moderator_user)
+        assert_difference("EditHistory.count", 7) do
+          as(@mod) do
+            @forum_post.user_warned!("warning", @mod)
+            @forum_post.remove_user_warning!
+            @forum_post.user_warned!("record", @mod)
+            @forum_post.remove_user_warning!
+            @forum_post.user_warned!("ban", @mod)
+            @forum_post.remove_user_warning!
+
+            original, warn, unmark1, record, unmark2, ban, unmark3 = EditHistory.where(versionable_id: @forum_post.id).order(version: :asc)
+            verify_history(original, @forum_post, "original")
+            verify_history(warn, @forum_post, "mark_warning", @mod.id)
+            verify_history(unmark1, @forum_post, "unmark", @mod.id)
+            verify_history(record, @forum_post, "mark_record", @mod.id)
+            verify_history(unmark2, @forum_post, "unmark", @mod.id)
+            verify_history(ban, @forum_post, "mark_ban", @mod.id)
+            verify_history(unmark3, @forum_post, "unmark", @mod.id)
+          end
+        end
       end
     end
   end

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -99,16 +99,53 @@ class ForumPostTest < ActiveSupport::TestCase
       assert_equal(@user.id, post.creator_id)
     end
 
-    context "updated by a second user" do
+    context "that is edited by a moderator" do
       setup do
         @post = create(:forum_post, topic_id: @topic.id)
-        @second_user = create(:user)
-        CurrentUser.user = @second_user
+        @mod = create(:moderator_user)
+        CurrentUser.user = @mod
       end
 
-      should "record its updater" do
-        @post.update(:body => "abc")
-        assert_equal(@second_user.id, @post.updater_id)
+      should "create a mod action" do
+        assert_difference("ModAction.count") do
+          @post.update(body: "nope")
+        end
+      end
+
+      should "credit the moderator as the updater" do
+        @post.update(body: "test")
+        assert_equal(@mod.id, @post.updater_id)
+      end
+    end
+
+    context "that is hidden by a moderator" do
+      setup do
+        @post = create(:forum_post, topic_id: @topic.id)
+        @mod = create(:moderator_user)
+        CurrentUser.user = @mod
+      end
+
+      should "create a mod action" do
+        assert_difference("ModAction.count") do
+          @post.update(is_hidden: true)
+        end
+      end
+
+      should "credit the moderator as the updater" do
+        @post.update(is_hidden: true)
+        assert_equal(@mod.id, @post.updater_id)
+      end
+    end
+
+    context "that is deleted" do
+      setup do
+        @post = create(:forum_post, topic_id: @topic.id)
+      end
+
+      should "create a mod action" do
+        assert_difference("ModAction.count") do
+          @post.destroy
+        end
       end
     end
 

--- a/test/unit/paginator_test.rb
+++ b/test/unit/paginator_test.rb
@@ -9,6 +9,11 @@ class PaginatorTest < ActiveSupport::TestCase
   end
 
   { active_record: Blip, elasticsearch: Post }.each do |name, model| # rubocop:disable Metrics/BlockLength
+    setup do
+      @user = create(:user)
+      CurrentUser.user = @user
+    end
+
     context name do
       context "sequential pagination (before)" do
         should "return the correct set of records" do


### PR DESCRIPTION
### Changes
* [EditHistories] Adds a new `edit_type` column to EditHistory entries. Currently, there's:
  * `original` - `version=1`, nothing special
  * `edit` - any content change
  * `hide`/`unhide` - hiding or unhiding
  * `stick`/`unstick` - sticking and unsticking
  * `mark_warning`/`mark_record`/`mark_ban` - marking for a warning/record/ban
  * `unmark` - removing any mark
* [EditHistoriesController] Adds searching to `/edit_histories` (`versionable_type`, `versionable_id`, `edit_type`, `user_id`, `user_name`, `ip_addr` (admin))
  * `edit_type=original` is excluded, unless searching for a specific edit type (`original` is still not included in the dropdown)
* [Blips/Comments/ForumPosts] Add timestamp for hiding to the "(hidden)" text (`title` attribute, shown when hovering)
  * This does remove the abilitiy of users immediately seeing who hid their comment, though they can still find out by looking at the modactions
  * [Example](https://github.com/e621ng/e621ng/assets/17226394/bc282c9f-06e7-431b-b7ff-c72627428853)
* [EditHistories] Add "Listing" link to "secondary links" to return to index
* [EditHistories#index] Add `|| ""` to subject column to fix `false` spam
* [EditHistories#index] Change "Show" link to actually link directly to that edit (via anchor)
* [EditHistories#show] Add link to "Edits for X #0" header (e.g. "Edits for [Comment #0](http://localhost:3000/comments/0)")
  * This is messy currently, it could potentially be cleaned up if paths can be referenced within models
* [EditHistories#show] Add an `id` to divs (`edit-0`) for linking
* [EditHistories#show] Make time clickable for link, similar to how comments and such behave
* [EditHistories#show] Add numbered paginator
* [WarningNotice] Display timestamp & user inline (when known)
  * [Known Example](https://user-images.githubusercontent.com/17226394/242752573-76a1171f-883d-4309-ac09-eee5eb982cad.png)
  * [Unknown Example](https://user-images.githubusercontent.com/17226394/242752721-c4c6e8c0-42a7-4f55-a6fc-e8117eacda08.png)
  * "Unknown" should only happen on blips marked before this pr, due to `warning_user_id` never being set, and blips not having an `updater_id` we can use for assumptions
* [UserStatistics] Adds link to list forum post/comment edits on user profile

### Tests
* Remove `creator` default from blip factory - this causes mismatches due to `CurrentUser` not being used unless explicitly provided
* Add blip tests - mirrored and trimmed down from comment tests
* Add hide/stick/delete modaction tests to comments & forum posts
* Extensive tests on blips/comments/forum posts to ensure edit histories are being created correctly ([sub]If tests can be shared between files/templated, these could possibly be condensed down)

### General Cleanup
* [EditHistory] Removed `TYPE_MAP`, seems unused
* [ApplicationRecord] Moved creation of `original` histories to `save_original_version` (`save_version` method was over 30 lines)
* [ApplicationRecord] Use `saved_change_to_attribute?` instead of `send`, this won't error if columns don't exist

### Tangentially Related
These are not directly related to edit histories, but including them here can save headaches and possible merge conflicts in the future.
* [UpdateNotice] Changes edited timestamps to always show to Moderators and higher (0f70ecb40a0de4d4c0add4178d9aad311acd171c)
* [UserWarnable] Fixes a bug where `warning_user_id` is never set (6cda2238b30da5c4ba3db163589de1e1d7780ad5)
* [Blips] Adds an `updater_id` field to blips, and adds an update notice to them (d29b239141fb213276daeae6c857beb9616df442)
* [Blips] Add `hide!` & `unhide!` methods to blips (this is the way comments & forum posts are) (8340beab5fcdafecece4ac40c7eaf8ecbbf024ea)
* [Blips] Move modaction generation logic into rails callbacks (8340beab5fcdafecece4ac40c7eaf8ecbbf024ea, db66b3ce55754695a6e3349577ee2caed7dbd063)
* [ForumPosts] Disable creating an edit modaction when hiding forum posts (8693454dea47fd33f10bba97d969b66501a98b8c)
* [ForumPosts] Remove `updater_id != creator_id` check on destroy (66e9b344fd00d3634bce2bb9a8c079abf511efbb)
* [Comments] Always create edit modaction when sticking/unsticking comments (dd4315b10cb6cd800e0c39d7841ebb36e0b0377c)

<details>
<summary><h3>Current Concerns</h3></summary>

The only thing I'm entirely sure needs to changed is the way the non-content edits are displayed within the edit histories. Right now there's just some bold text printed out. This could probably use some different background coloring at the least.
![image](https://github.com/e621ng/e621ng/assets/17226394/b822f856-3543-4c77-af00-e003bd308653)
<hr>
I excluded sticking a comment from creating a modlog action, though this pr adds an edit history entry for sticking & unsticking/
https://github.com/e621ng/e621ng/blob/d1478383b7a99fea115e83ef7f4c5ab0a4d8987c/app/models/comment.rb#L14
</details>



Side tangent, editing (`PATCH /{type}/{id}`) with `is_hidden` doesn't create a "hide"/"unhide" mod action, it only creates an "edited" action. Doing this to other's posts is only available to admins, and not available within normal usage, so it shouldn't be too much of a concern. They will also still get an edit history for whatever has been done.

### TODO
After this is merged, open pull request for including forum topics: subject, locking, hiding, etc.