### PR TITLE
[Tags] Disallow é in tag names

### DIFF
--- a/app/logical/tag_name_validator.rb
+++ b/app/logical/tag_name_validator.rb
@@ -38,7 +38,7 @@ class TagNameValidator < ActiveModel::EachValidator
       record.errors.add(attribute, "'#{value}' cannot begin with '#{$1}:'")
     end
 
-    if normalized =~ /[^[:ascii:]é]/ && !options[:disable_ascii_check] == true
+    if normalized =~ /[^[:ascii:]]/ && !options[:disable_ascii_check] == true
       record.errors.add(attribute,  "'#{value}' must consist of only ASCII characters")
     end
   end

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -219,7 +219,6 @@ class TagTest < ActiveSupport::TestCase
       should allow_value(" foo ").for(:name).on(:create)
       should allow_value("foo bar").for(:name).on(:create)
       should allow_value("FOO").for(:name).on(:create)
-      should allow_value("café").for(:name).on(:create)
 
       should_not allow_value("").for(:name).on(:create)
       should_not allow_value("___").for(:name).on(:create)
@@ -231,6 +230,7 @@ class TagTest < ActiveSupport::TestCase
       should_not allow_value("foo*bar").for(:name).on(:create)
       should_not allow_value("foo,bar").for(:name).on(:create)
       should_not allow_value("foo\abar").for(:name).on(:create)
+      should_not allow_value("café").for(:name).on(:create)
       should_not allow_value("東方").for(:name).on(:create)
       should_not allow_value("FAV:blah").for(:name).on(:create)
 


### PR DESCRIPTION
This exception was originally made for `pokémon` tags, which have now mostly been aliased away to their `pokemon` variants, [but tags are still being created using é](https://e926.net/tags?commit=Search&search%5Bhide_empty%5D=1&search%5Bname_matches%5D=%2A%C3%A9%2A&search%5Border%5D=date) because of this exception.

There's no reason to give é special treatment anymore when no other accented characters are allowed.