### PR TITLE
[Posts] Show file extension in iqdb search

### DIFF
--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -73,6 +73,7 @@ class PostPresenter < Presenter
 
     if options[:size]
       locals[:size] = post.file_size
+      locals[:file_ext] = post.file_ext
     else
       locals[:size] = nil
     end

--- a/app/views/posts/partials/index/_preview.html.erb
+++ b/app/views/posts/partials/index/_preview.html.erb
@@ -23,7 +23,7 @@
   <% end -%>
   <% if size -%>
     <p class="desc">
-      <%= number_to_human_size(size) %> (<%= width %>x<%= height %>)
+      <%= number_to_human_size(size) %>  <%= file_ext.upcase %> (<%= width %>x<%= height %>)
     </p>
   <% end -%>
 <% end -%>


### PR DESCRIPTION
Shows the file extension in the reverse image search results, because while the filesize can be an indicator whether the image is JPG or PNG, it's not *always* a good way to tell.

![image](https://github.com/e621ng/e621ng/assets/102884856/cf9fe05a-6b98-4988-93fc-6d1bf241619b)

Apparently I made this PR about 4 months ago and forgot to actually submit it, so that's why the commit is so old.