### PR TITLE
[UserRevert] Fix error when user has uploaded a post

### DIFF
--- a/app/logical/user_revert.rb
+++ b/app/logical/user_revert.rb
@@ -22,7 +22,7 @@ class UserRevert
 
   def revert_post_changes
     PostVersion.where(updater_id: user_id).find_each do |x|
-      x.undo!
+      x.undo! if x.can_undo?(CurrentUser)
     end
   end
 


### PR DESCRIPTION
Currently, when performing a user revert, it will throw an error if any of the changes are an upload. This makes use of the `can_undo?` method post versions have to avoid this.