### PR TITLE
Add daily janitor reports

### DIFF
--- a/app/logical/janitor_report_generator.rb
+++ b/app/logical/janitor_report_generator.rb
@@ -1,0 +1,47 @@
+class JanitorReportGenerator
+  extend ActiveSupport::NumberHelper
+
+  def self.run!
+    return if Danbooru.config.janitor_reports_webhook.nil?
+
+    current_stats = stats
+    previous_queue_size = Cache.redis.get("janitor_reports:previous_queue_size") || current_stats[:queue_size]
+    Cache.redis.set("janitor_reports:previous_queue_size", current_stats[:queue_size])
+
+    diff = current_stats[:queue_size] - previous_queue_size.to_i
+    content = <<~REPORT.chomp
+      Janitor report for <t:#{Time.now.to_i}:D>
+      Currently, there are #{number_to_delimited(current_stats[:queue_size])} pending posts. There were #{number_to_delimited(previous_queue_size)} pending posts yesterday.
+      That is #{number_to_delimited(diff)} #{diff >= 0 ? 'more' : 'less'} than the day before.
+
+      #{number_to_delimited(current_stats[:posts])} posts were added yesterday.
+
+      #{number_to_delimited(current_stats[:approvals] + current_stats[:deletions][:total])} posts were processed.
+      Approvals: #{number_to_delimited(current_stats[:approvals])}
+      Deletions: #{number_to_delimited(current_stats[:deletions][:total])} (#{number_to_delimited(current_stats[:deletions][:automod] - current_stats[:deletions][:takedowns])} automated, #{number_to_delimited(current_stats[:deletions][:takedowns])} takedown, #{number_to_delimited(current_stats[:deletions][:total] - current_stats[:deletions][:automod])} manual)
+    REPORT
+
+    HTTParty.post(Danbooru.config.janitor_reports_webhook,
+                  body: {
+                    content: content,
+                    flags: 4096,
+                  }.to_json,
+                  headers: {
+                    "Content-Type" => "application/json",
+                  })
+  end
+
+  def self.stats
+    deletions = PostFlag.where(is_deletion: true).where("created_at >= ?", 1.day.ago)
+    {
+      queue_size: Post.pending.count,
+      deletions: {
+        total: deletions.count,
+        automod: deletions.where(creator_id: User.system.id).count,
+        takedowns: deletions.where("reason LIKE ?", "takedown #%").count,
+      },
+      approvals: PostApproval.where("created_at >= ?", 1.day.ago).count,
+      posts: Post.where("created_at >= ? ", 1.day.ago).count,
+    }
+  end
+end

--- a/app/logical/janitor_report_generator.rb
+++ b/app/logical/janitor_report_generator.rb
@@ -2,7 +2,7 @@ class JanitorReportGenerator
   extend ActiveSupport::NumberHelper
 
   def self.run!
-    return if Danbooru.config.janitor_reports_webhook.nil?
+    return if Danbooru.config.janitor_reports_discord_webhook_url.blank?
 
     current_stats = stats
     previous_queue_size = Cache.redis.get("janitor_reports:previous_queue_size") || current_stats[:queue_size]
@@ -21,14 +21,16 @@ class JanitorReportGenerator
       Deletions: #{number_to_delimited(current_stats[:deletions][:total])} (#{number_to_delimited(current_stats[:deletions][:automod] - current_stats[:deletions][:takedowns])} automated, #{number_to_delimited(current_stats[:deletions][:takedowns])} takedown, #{number_to_delimited(current_stats[:deletions][:total] - current_stats[:deletions][:automod])} manual)
     REPORT
 
-    HTTParty.post(Danbooru.config.janitor_reports_webhook,
-                  body: {
-                    content: content,
-                    flags: 4096,
-                  }.to_json,
-                  headers: {
-                    "Content-Type" => "application/json",
-                  })
+    HTTParty.post(
+      Danbooru.config.janitor_reports_discord_webhook_url,
+      body: {
+        content: content,
+        flags: 4096,
+      }.to_json,
+      headers: {
+        "Content-Type" => "application/json",
+      },
+    )
   end
 
   def self.stats

--- a/app/logical/maintenance.rb
+++ b/app/logical/maintenance.rb
@@ -12,6 +12,7 @@ module Maintenance
     ignoring_exceptions { Ban.prune! }
     ignoring_exceptions { UserPasswordResetNonce.prune! }
     ignoring_exceptions { StatsUpdater.run! }
+    ignoring_exceptions { JanitorReportGenerator.run! }
   end
 
   def ignoring_exceptions(&block)

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -768,6 +768,10 @@ module Danbooru
     def enable_visitor_metrics?
       false
     end
+
+    def janitor_reports_webhook
+      nil
+    end
   end
 
   class EnvironmentConfiguration

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -769,7 +769,7 @@ module Danbooru
       false
     end
 
-    def janitor_reports_webhook
+    def janitor_reports_discord_webhook_url
       nil
     end
   end


### PR DESCRIPTION
Adds a daily report for janitors, sent via a webhook, as [requested by some janitors](https://canary.discord.com/channels/431908090883997698/1099477233032253440/1122551709219180554).