### PR TITLE
[Autocomplete] Global replace _ for users

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -394,7 +394,7 @@ Autocomplete.user_source = function(term, resp, prefix) {
         return {
           id: user.id,
           type: "user",
-          label: user.name.replace(/_/, " "),
+          label: user.name.replace(/_/g, " "),
           value: prefix + user.name,
           level: user.level_string
         };


### PR DESCRIPTION
Came across the fact that only the first underscore was being replaced in usernames
![image](https://github.com/e621ng/e621ng/assets/102884856/72a7fdd5-58c1-4154-a7d6-e5655d75afd9)

Every other autocomplete already uses `/_/g`, so I'm not sure how it was missing from the user autocomplete for all these years.

![image](https://github.com/e621ng/e621ng/assets/102884856/a45eeb28-5f01-4c3c-a3de-5fb60008c140)

Now that's much nicer.