### PR TITLE
[Search] Allow ascending order for IDs

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -102,8 +102,15 @@ class ApplicationRecord < ActiveRecord::Base
         end
       end
 
-      def apply_default_order(params)
-        return default_order
+      def apply_basic_order(params)
+        case params[:order]
+        when "id_asc"
+          order(id: :asc)
+        when "id_desc"
+          order(id: :desc)
+        else
+          default_order
+        end
       end
 
       def default_order

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -495,7 +495,7 @@ class Artist < ApplicationRecord
       when "post_count"
         q = q.includes(:tag).order("tags.post_count desc nulls last").order("artists.name").references(:tags)
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -51,7 +51,7 @@ class ArtistUrl < ApplicationRecord
       dir = $2 || :desc
       q = q.order($1 => dir).order(id: :desc)
     else
-      q = q.apply_default_order(params)
+      q = q.apply_basic_order(params)
     end
 
     q

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -44,7 +44,7 @@ class ArtistVersion < ApplicationRecord
       if params[:order] == "name"
         q = q.order("artist_versions.name").default_order
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -47,7 +47,7 @@ class Ban < ApplicationRecord
     when "expires_at_desc"
       q = q.order("bans.expires_at desc")
     else
-      q = q.apply_default_order(params)
+      q = q.apply_basic_order(params)
     end
 
     q

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -102,7 +102,7 @@ class Blip < ApplicationRecord
       when "updated_at", "updated_at_desc"
         q = q.order("blips.updated_at DESC")
       else
-        q = q.order('id DESC')
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -73,16 +73,12 @@ class BulkUpdateRequest < ApplicationRecord
 
       params[:order] ||= "status_desc"
       case params[:order]
-      when "id_desc"
-        q = q.order(id: :desc)
-      when "id_asc"
-        q = q.order(id: :asc)
       when "updated_at_desc"
         q = q.order(updated_at: :desc)
       when "updated_at_asc"
         q = q.order(updated_at: :asc)
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -113,7 +113,7 @@ class Comment < ApplicationRecord
         if %i[body_matches creator_name creator_id].any? { |key| params[key].present? }
           q = q.order(created_at: :desc)
         else
-          q = q.apply_default_order(params)
+          q = q.apply_basic_order(params)
         end
       end
 

--- a/app/models/email_blacklist.rb
+++ b/app/models/email_blacklist.rb
@@ -43,7 +43,7 @@ class EmailBlacklist < ApplicationRecord
     when "domain"
       q = q.order("email_blacklists.domain")
     else
-      q = q.apply_default_order(params)
+      q = q.apply_basic_order(params)
     end
 
     q

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -48,6 +48,6 @@ class ExceptionLog < ApplicationRecord
       q = q.where("class_name != 'ActiveRecord::QueryCanceled'")
     end
 
-    q.apply_default_order(params)
+    q.apply_basic_order(params)
   end
 end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -85,7 +85,7 @@ class ForumPost < ApplicationRecord
 
       q = q.attribute_matches(:is_hidden, params[:is_hidden])
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -83,7 +83,7 @@ class ForumTopic < ApplicationRecord
       when "sticky"
         q = q.sticky_first
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/ip_ban.rb
+++ b/app/models/ip_ban.rb
@@ -27,7 +27,7 @@ class IpBan < ApplicationRecord
 
     q = q.attribute_matches(:reason, params[:reason])
 
-    q.apply_default_order(params)
+    q.apply_basic_order(params)
   end
 
   def validate_ip_addr

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -96,7 +96,7 @@ class ModAction < ApplicationRecord
       q = q.where('action = ?', params[:action])
     end
 
-    q.apply_default_order(params)
+    q.apply_basic_order(params)
   end
 
   def hidden_attributes

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -53,7 +53,7 @@ class Note < ApplicationRecord
         q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -29,7 +29,7 @@ class NoteVersion < ApplicationRecord
       q = q.where("updater_ip_addr <<= ?", params[:ip_addr])
     end
 
-    q.apply_default_order(params)
+    q.apply_basic_order(params)
   end
 
   def previous

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -89,7 +89,7 @@ class Pool < ApplicationRecord
       when "post_count"
         q = q.order(Arel.sql("cardinality(post_ids) desc")).default_order
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -32,7 +32,7 @@ class PoolVersion < ApplicationRecord
         q = q.where("updater_ip_addr <<= ?", params[:ip_addr])
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 

--- a/app/models/post_approval.rb
+++ b/app/models/post_approval.rb
@@ -34,7 +34,7 @@ class PostApproval < ApplicationRecord
         q = q.attribute_matches(:user_id, params[:user_id])
         q = q.attribute_matches(:post_id, params[:post_id])
 
-        q.apply_default_order(params)
+        q.apply_basic_order(params)
       end
     end
   end

--- a/app/models/post_disapproval.rb
+++ b/app/models/post_disapproval.rb
@@ -38,10 +38,10 @@ class PostDisapproval < ApplicationRecord
         when "post_id", "post_id_desc"
           q = q.order(post_id: :desc, id: :desc)
         else
-          q = q.apply_default_order(params)
+          q = q.apply_basic_order(params)
         end
 
-        q.apply_default_order(params)
+        q
       end
     end
   end

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -68,6 +68,6 @@ class PostEvent < ApplicationRecord
       q = q.where('action = ?', actions[params[:action]])
     end
 
-    q.apply_default_order(params)
+    q.apply_basic_order(params)
   end
 end

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -82,7 +82,7 @@ class PostFlag < ApplicationRecord
         q = q.where(is_deletion: true)
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 

--- a/app/models/staff_note.rb
+++ b/app/models/staff_note.rb
@@ -42,7 +42,7 @@ class StaffNote < ApplicationRecord
         q = q.where.not(creator: User.system)
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
 
     def default_order

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1040,7 +1040,7 @@ class Tag < ApplicationRecord
       when "similarity"
         q = q.order_similarity(params[:fuzzy_name_matches]) if params[:fuzzy_name_matches].present?
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -169,7 +169,7 @@ class TagRelationship < ApplicationRecord
       when "tag_count"
         q = q.join_consequent.order("consequent_tag.post_count desc, antecedent_name asc, consequent_name asc")
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/takedown.rb
+++ b/app/models/takedown.rb
@@ -252,7 +252,7 @@ class Takedown < ApplicationRecord
       when 'post_count'
         q = q.order('post_count DESC')
       else
-        q = q.order('id DESC')
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -138,7 +138,7 @@ class Upload < ApplicationRecord
         q = q.where("uploads.tag_string LIKE ? ESCAPE E'\\\\'", params[:tag_string].to_escaped_for_sql_like)
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 

--- a/app/models/upload_whitelist.rb
+++ b/app/models/upload_whitelist.rb
@@ -47,7 +47,7 @@ class UploadWhitelist < ApplicationRecord
       when "created_at"
         q = q.order("id desc")
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -842,7 +842,7 @@ class User < ApplicationRecord
       when "post_update_count"
         q = q.order("user_statuses.post_update_count desc")
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -68,7 +68,7 @@ class UserFeedback < ApplicationRecord
         q = q.where("category = ?", params[:category])
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -36,7 +36,7 @@ class UserNameChangeRequest < ApplicationRecord
       q = q.where_ilike(:desired_name, User.normalize_name(params[:desired_name]))
     end
 
-    q.apply_default_order(params)
+    q.apply_basic_order(params)
   end
 
   def rejected?

--- a/app/models/user_vote.rb
+++ b/app/models/user_vote.rb
@@ -91,7 +91,7 @@ class UserVote < ApplicationRecord
       if params[:order] == "ip_addr" && allow_complex_params
         q = q.order(:user_ip_addr)
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
       q
     end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -117,7 +117,7 @@ class WikiPage < ApplicationRecord
       when "post_count"
         q = q.includes(:tag).order("tags.post_count desc nulls last").references(:tags)
       else
-        q = q.apply_default_order(params)
+        q = q.apply_basic_order(params)
       end
 
       q

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -33,7 +33,7 @@ class WikiPageVersion < ApplicationRecord
         q = q.where("updater_ip_addr <<= ?", params[:ip_addr])
       end
 
-      q.apply_default_order(params)
+      q.apply_basic_order(params)
     end
   end
 


### PR DESCRIPTION
This MR allows specifying the direction of ordering for IDs on any search endpoint that supports ordering.