### PR TITLE
[Tags] Use template for MetaSearch relation tables

### DIFF
--- a/app/views/meta_searches/tags.html.erb
+++ b/app/views/meta_searches/tags.html.erb
@@ -47,34 +47,7 @@
       <% if @meta_search.tag_aliases.blank? %>
         <p>No results</p>
       <% else %>
-        <table class="striped">
-          <thead>
-            <tr>
-              <th>From</th>
-              <th>To</th>
-              <th></th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <% @meta_search.tag_aliases.each do |tag_alias| %>
-              <tr>
-                <td><%= tag_alias.antecedent_name %></td>
-                <td><%= tag_alias.consequent_name %></td>
-                <td>
-                  <%= link_to "Show", tag_alias_path(tag_alias) %>
-                  <% if tag_alias.deletable_by?(CurrentUser.user) %>
-                    | <%= link_to "Delete", tag_alias_path(tag_alias), :method => :delete, :data => {:confirm => "Are you sure you want to delete this alias?"} %>
-                  <% end %>
-
-                  <% if CurrentUser.is_admin? && tag_alias.is_pending? %>
-                    | <%= link_to "Approve", approve_tag_alias_path(tag_alias), :method => :post %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <%= render "tag_relationships/listing", tag_relations: @meta_search.tag_aliases %>
       <% end %>
     </section>
 
@@ -83,33 +56,7 @@
       <% if @meta_search.tag_implications.blank? %>
         <p>No results</p>
       <% else %>
-        <table class="striped">
-          <thead>
-            <tr>
-              <th>From</th>
-              <th>To</th>
-              <th></th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <% @meta_search.tag_implications.each do |tag_implication| %>
-              <tr>
-                <td><%= tag_implication.antecedent_name %></td>
-                <td><%= tag_implication.consequent_name %></td>
-                <td>
-                  <%= link_to "Show", tag_implication_path(tag_implication) %>
-                  <% if tag_implication.deletable_by?(CurrentUser.user) %>
-                    | <%= link_to "Delete", tag_implication_path(tag_implication), :method => :delete, :data => {:confirm => "Are you sure you want to delete this implication?"} %>
-                  <% end %>
-                  <% if CurrentUser.user.is_admin? && tag_implication.is_pending? %>
-                    | <%= link_to "Approve", approve_tag_implication_path(tag_implication), :method => :post %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <%= render "tag_relationships/listing", tag_relations: @meta_search.tag_implications %>
       <% end %>
     </section>
   </div>


### PR DESCRIPTION
I hadn't previously realised that the MetaSearch page didn't only include active relationships, but also the pending and deleted aliases - which makes the data really misleading with no way to tell the status.

I was originally going to just add the status column, but realised I can just use this template that already exists and save a bunch of code duplication. All the additional columns added by the template are probably reasonable to include on the MetaSearch too.