### PR TITLE
[Uploader] remove "I am the source"

### DIFF
--- a/app/javascript/src/javascripts/uploader/sources.vue
+++ b/app/javascript/src/javascripts/uploader/sources.vue
@@ -9,7 +9,7 @@
   </div>
   <div>
     <label class="section-label"><input type="checkbox" id="no_source" v-model="noSource"/>
-      No available source / I am the source.
+      No available source.
     </label>
   </div>
 </template>


### PR DESCRIPTION
![image](https://github.com/e621ng/e621ng/assets/102884856/134dd280-762d-4782-b66d-e85c4c5f8f43)

This has came up more than a few times, with many people suspicious it's the reason so many artists/commissioners self-upload without providing any source links. 

I'm not convinced it's not just pure laziness on their part, but it wouldn't hurt to remove the ambiguity from the uploader. Being _the source_ doesn't exclude you from needing to provide source links, unless it's not available, which is already covered by "No available source"