### PR TITLE
[UserWarnable] Fix warning_user_id and add inline user/timestamp

### DIFF
--- a/app/concerns/user_warnable.rb
+++ b/app/concerns/user_warnable.rb
@@ -26,11 +26,11 @@ module UserWarnable
   def warning_type_string
     case warning_type
     when "warning"
-      "User received a warning for the contents of this message."
+      "User received a warning for the contents of this message"
     when "record"
-      "User received a record for the contents of this message."
+      "User received a record for the contents of this message"
     when "ban"
-      "User was banned for the contents of this message."
+      "User was banned for the contents of this message"
     else
       "[This is a bug with the website. Woo!]"
     end

--- a/app/concerns/user_warnable.rb
+++ b/app/concerns/user_warnable.rb
@@ -16,7 +16,7 @@ module UserWarnable
   end
 
   def remove_user_warning!
-    update(warning_type: type, warning_user_id: nil)
+    update(warning_type: nil, warning_user_id: nil)
   end
 
   def was_warned?

--- a/app/concerns/user_warnable.rb
+++ b/app/concerns/user_warnable.rb
@@ -12,11 +12,11 @@ module UserWarnable
   end
 
   def user_warned!(type, user)
-    update({ warning_type: type, warning_user_id: user })
+    update(warning_type: type, warning_user_id: user.id)
   end
 
   def remove_user_warning!
-    update_columns({ warning_type: nil, warning_user_id: nil })
+    update(warning_type: type, warning_user_id: nil)
   end
 
   def was_warned?

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -2,13 +2,15 @@ class Blip < ApplicationRecord
   include UserWarnable
   simple_versioning
   belongs_to_creator
-  user_status_counter :blip_count
   validates :body, presence: true
-  belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
-  has_many :responses, class_name: "Blip", foreign_key: "response_to"
   validates :body, length: { minimum: 5, maximum: Danbooru.config.blip_max_size }
-  validate :validate_parent_exists, :on => :create
-  validate :validate_creator_is_not_limited, :on => :create
+  validate :validate_parent_exists, on: :create
+  validate :validate_creator_is_not_limited, on: :create
+  
+  user_status_counter :blip_count
+  belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
+  belongs_to :warning_user, class_name: "User", optional: true
+  has_many :responses, class_name: "Blip", foreign_key: "response_to"
 
   def response?
     parent.present?

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -6,7 +6,7 @@ class Blip < ApplicationRecord
   validates :body, length: { minimum: 5, maximum: Danbooru.config.blip_max_size }
   validate :validate_parent_exists, on: :create
   validate :validate_creator_is_not_limited, on: :create
-  
+
   user_status_counter :blip_count
   belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
   belongs_to :warning_user, class_name: "User", optional: true

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -25,6 +25,7 @@ class Comment < ApplicationRecord
 
   user_status_counter :comment_count
   belongs_to :post, counter_cache: :comment_count
+  belongs_to :warning_user, class_name: "User", optional: true
   has_many :votes, :class_name => "CommentVote", :dependent => :destroy
 
   module SearchMethods

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -6,6 +6,7 @@ class ForumPost < ApplicationRecord
   belongs_to_updater
   user_status_counter :forum_post_count
   belongs_to :topic, :class_name => "ForumTopic"
+  belongs_to :warning_user, class_name: "User", optional: true
   has_many :votes, class_name: "ForumPostVote"
   has_one :tag_alias
   has_one :tag_implication

--- a/app/views/application/_warned_notice.html.erb
+++ b/app/views/application/_warned_notice.html.erb
@@ -1,0 +1,6 @@
+<% if record.was_warned? %>
+  <div class="user-warning">
+    <hr>
+    <em><%= record.warning_type_string %>.</em>
+  </div>
+<% end %>

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -26,7 +26,8 @@
       <% if blip.was_warned? %>
         <div class="user-warning">
           <hr>
-          <em><%= blip.warning_type_string %></em>
+          <em><%= blip.warning_type_string %><% if blip.warning_user.present? %> by <%= link_to_user(blip.warning_user) %><% end %>.</em>
+          <span class="info"><%= time_ago_in_words_tagged(blip.updated_at) %></span>
         </div>
       <% end %>
       <div class="content-menu">

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -23,13 +23,7 @@
       <div class="body dtext-container">
         <%= format_text(blip.body, allow_color: blip.creator.is_privileged?) %>
       </div>
-      <% if blip.was_warned? %>
-        <div class="user-warning">
-          <hr>
-          <em><%= blip.warning_type_string %><% if blip.warning_user.present? %> by <%= link_to_user(blip.warning_user) %><% end %>.</em>
-          <span class="info"><%= time_ago_in_words_tagged(blip.updated_at) %></span>
-        </div>
-      <% end %>
+      <%= render "application/warned_notice", record: blip %>
       <div class="content-menu">
         <menu>
           <% if CurrentUser.is_member? %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -23,13 +23,7 @@
         <%= format_text(comment.body, allow_color: comment.creator.is_privileged?) %>
       </div>
       <%= render "application/update_notice", record: comment %>
-      <% if comment.was_warned? %>
-        <div class="user-warning">
-          <hr>
-          <em><%= comment.warning_type_string %><% if comment.warning_user.present? %> by <%= link_to_user(comment.warning_user) %><% end %>.</em>
-          <span class="info"><%= time_ago_in_words_tagged(comment.updated_at) %></span>
-        </div>
-      <% end %>
+      <%= render "application/warned_notice", record: comment %>
         <div class="content-menu">
           <menu>
             <% if post && !comment.is_sticky %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -26,7 +26,8 @@
       <% if comment.was_warned? %>
         <div class="user-warning">
           <hr>
-          <em><%= comment.warning_type_string %></em>
+          <em><%= comment.warning_type_string %><% if comment.warning_user.present? %> by <%= link_to_user(comment.warning_user) %><% end %>.</em>
+          <span class="info"><%= time_ago_in_words_tagged(comment.updated_at) %></span>
         </div>
       <% end %>
         <div class="content-menu">

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -26,7 +26,8 @@
       <% if forum_post.was_warned? %>
         <div class="user-warning">
           <hr>
-          <em><%= forum_post.warning_type_string %></em>
+          <em><%= forum_post.warning_type_string %><% if forum_post.warning_user.present? %> by <%= link_to_user(forum_post.warning_user) %><% end %>.</em>
+          <span class="info"><%= time_ago_in_words_tagged(forum_post.updated_at) %></span>
         </div>
       <% end %>
       <div class="content-menu">

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -23,13 +23,7 @@
         <%= format_text(parse_embedded_tag_request_text(forum_post.body), allow_color: forum_post.creator.is_privileged?) %>
       </div>
       <%= render "application/update_notice", record: forum_post %>
-      <% if forum_post.was_warned? %>
-        <div class="user-warning">
-          <hr>
-          <em><%= forum_post.warning_type_string %><% if forum_post.warning_user.present? %> by <%= link_to_user(forum_post.warning_user) %><% end %>.</em>
-          <span class="info"><%= time_ago_in_words_tagged(forum_post.updated_at) %></span>
-        </div>
-      <% end %>
+      <%= render "application/warned_notice", record: forum_post %>
       <div class="content-menu">
         <menu>
           <% if CurrentUser.is_member? && @forum_topic && params[:controller] != "forum_posts" %>

--- a/db/fixes/111_missing_warning_user_id.rb
+++ b/db/fixes/111_missing_warning_user_id.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+# warning_user_id has never been set - we're updating it with the current updater_id, as they are very likely to be the one that added the warning
+Comment.where("warning_type IS NOT NULL").find_each do |comment|
+  if comment.was_warned? && comment.warning_user_id.nil?
+    comment.update_columns(warning_user_id: comment.updater_id)
+  end
+end
+
+ForumPost.where("warning_type IS NOT NULL").find_each do |forum_post|
+  if forum_post.was_warned? && forum_post.warning_user_id.nil?
+    forum_post.update_columns(warning_user_id: forum_post.updater_id)
+  end
+end

--- a/db/fixes/111_missing_warning_user_id.rb
+++ b/db/fixes/111_missing_warning_user_id.rb
@@ -3,13 +3,13 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
 
 # warning_user_id has never been set - we're updating it with the current updater_id, as they are very likely to be the one that added the warning
-Comment.where("warning_type IS NOT NULL").find_each do |comment|
+Comment.where.not(warning_type: nil).find_each do |comment|
   if comment.was_warned? && comment.warning_user_id.nil?
     comment.update_columns(warning_user_id: comment.updater_id)
   end
 end
 
-ForumPost.where("warning_type IS NOT NULL").find_each do |forum_post|
+ForumPost.where.not(warning_type: nil).find_each do |forum_post|
   if forum_post.was_warned? && forum_post.warning_user_id.nil?
     forum_post.update_columns(warning_user_id: forum_post.updater_id)
   end

--- a/db/fixes/111_missing_warning_user_id.rb
+++ b/db/fixes/111_missing_warning_user_id.rb
@@ -3,14 +3,12 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
 
 # warning_user_id has never been set - we're updating it with the current updater_id, as they are very likely to be the one that added the warning
-Comment.where.not(warning_type: nil).find_each do |comment|
-  if comment.was_warned? && comment.warning_user_id.nil?
-    comment.update_columns(warning_user_id: comment.updater_id)
+def update(model)
+  model.where(warning_user_id: nil).where.not(warning_type: nil).find_each do |record|
+    if record.was_warned? && record.warning_user_id != record.updater_id
+      record.update_columns(warning_user_id: record.updater_id)
+    end
   end
 end
 
-ForumPost.where.not(warning_type: nil).find_each do |forum_post|
-  if forum_post.was_warned? && forum_post.warning_user_id.nil?
-    forum_post.update_columns(warning_user_id: forum_post.updater_id)
-  end
-end
+[Comment, ForumPost].each { |model| update(model) }


### PR DESCRIPTION
Extracted from #526

Ideally, this should be merged alongside #540 & #542. Though none of them depend on eachother, changes further up the pipeline may depend on code spread across prs/cause nasty merge conflicts if merged later.

* Fixed `warning_user_id` never being set
* Add inline user and timestamp

![](https://user-images.githubusercontent.com/17226394/242752573-76a1171f-883d-4309-ac09-eee5eb982cad.png)
![](https://user-images.githubusercontent.com/17226394/242752721-c4c6e8c0-42a7-4f55-a6fc-e8117eacda08.png)

The provided fixer makes an assumption for comments and forum posts that `updater_id` will be the one that marked it - this will almost always be true (it should always be true, unless an admin edited the comment after the fact or a mod hid it). No fixer can be made for blips due to them not having an `updater_id` to assume from.