### PR TITLE
Add hide/delete modaction tests to comments & forum posts/minor forum posts modactions cleanup

### DIFF
--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -23,13 +23,13 @@ class ForumPost < ApplicationRecord
   before_destroy :validate_topic_is_unlocked
   after_save :delete_topic_if_original_post
   after_update(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
-    ModAction.log(:forum_post_update, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+    ModAction.log(:forum_post_update, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
   after_update(:if => ->(rec) {rec.saved_change_to_is_hidden?}) do |rec|
-    ModAction.log(rec.is_hidden ? :forum_post_hide : :forum_post_unhide, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+    ModAction.log(rec.is_hidden ? :forum_post_hide : :forum_post_unhide, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
-  after_destroy(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
-    ModAction.log(:forum_post_delete, {forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id})
+  after_destroy do |rec|
+    ModAction.log(:forum_post_delete, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
 
   attr_accessor :bypass_limits

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -22,10 +22,10 @@ class ForumPost < ApplicationRecord
   validate :validate_creator_is_not_limited, on: :create
   before_destroy :validate_topic_is_unlocked
   after_save :delete_topic_if_original_post
-  after_update(:if => ->(rec) {rec.updater_id != rec.creator_id}) do |rec|
+  after_update(:if => ->(rec) { !rec.saved_change_to_is_hidden? && rec.updater_id != rec.creator_id }) do |rec|
     ModAction.log(:forum_post_update, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
-  after_update(:if => ->(rec) {rec.saved_change_to_is_hidden?}) do |rec|
+  after_update(:if => ->(rec) { rec.saved_change_to_is_hidden? }) do |rec|
     ModAction.log(rec.is_hidden ? :forum_post_hide : :forum_post_unhide, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
   end
   after_destroy do |rec|

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -206,7 +206,7 @@ class CommentTest < ActiveSupport::TestCase
         end
 
         should "create a mod action" do
-          assert_difference("ModAction.count") do
+          assert_difference(-> { ModAction.count }, 1) do
             @comment.update(is_hidden: true)
           end
         end
@@ -225,7 +225,7 @@ class CommentTest < ActiveSupport::TestCase
         end
 
         should "create a mod action" do
-          assert_difference("ModAction.count") do
+          assert_difference(-> { ModAction.count }, 1) do
             @comment.update(is_sticky: true)
           end
         end
@@ -242,7 +242,7 @@ class CommentTest < ActiveSupport::TestCase
         end
 
         should "create a mod action" do
-          assert_difference("ModAction.count") do
+          assert_difference(-> { ModAction.count }, 1) do
             @comment.destroy
           end
         end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -1,10 +1,10 @@
-require 'test_helper'
+require "test_helper"
 
 class CommentTest < ActiveSupport::TestCase
   context "A comment" do
     setup do
-      user = create(:user)
-      CurrentUser.user = user
+      @user = create(:user)
+      CurrentUser.user = @user
     end
 
     context "created by a limited user" do
@@ -188,13 +188,63 @@ class CommentTest < ActiveSupport::TestCase
 
         should "create a mod action" do
           assert_difference("ModAction.count") do
-            @comment.update(:body => "nope")
+            @comment.update(body: "nope")
           end
         end
 
         should "credit the moderator as the updater" do
           @comment.update(body: "test")
           assert_equal(@mod.id, @comment.updater_id)
+        end
+      end
+
+      context "that is hidden by a moderator" do
+        setup do
+          @comment = create(:comment)
+          @mod = create(:moderator_user)
+          CurrentUser.user = @mod
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @comment.update(is_hidden: true)
+          end
+        end
+
+        should "credit the moderator as the updater" do
+          @comment.update(is_hidden: true)
+          assert_equal(@mod.id, @comment.updater_id)
+        end
+      end
+
+      context "that is stickied by a moderator" do
+        setup do
+          @comment = create(:comment)
+          @mod = create(:moderator_user)
+          CurrentUser.user = @mod
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @comment.update(is_sticky: true)
+          end
+        end
+
+        should "credit the moderator as the updater" do
+          @comment.update(is_sticky: true)
+          assert_equal(@mod.id, @comment.updater_id)
+        end
+      end
+
+      context "that is deleted" do
+        setup do
+          @comment = create(:comment)
+        end
+
+        should "create a mod action" do
+          assert_difference("ModAction.count") do
+            @comment.destroy
+          end
         end
       end
 

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -107,7 +107,7 @@ class ForumPostTest < ActiveSupport::TestCase
       end
 
       should "create a mod action" do
-        assert_difference("ModAction.count") do
+        assert_difference(-> { ModAction.count }, 1) do
           @post.update(body: "nope")
         end
       end
@@ -126,7 +126,7 @@ class ForumPostTest < ActiveSupport::TestCase
       end
 
       should "create a mod action" do
-        assert_difference("ModAction.count") do
+        assert_difference(-> { ModAction.count }, 1) do
           @post.update(is_hidden: true)
         end
       end
@@ -143,7 +143,7 @@ class ForumPostTest < ActiveSupport::TestCase
       end
 
       should "create a mod action" do
-        assert_difference("ModAction.count") do
+        assert_difference(-> { ModAction.count }, 1) do
           @post.destroy
         end
       end

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require "test_helper"
 
 class ForumPostTest < ActiveSupport::TestCase
   context "A forum post" do
@@ -99,17 +99,59 @@ class ForumPostTest < ActiveSupport::TestCase
       assert_equal(@user.id, post.creator_id)
     end
 
-    context "updated by a second user" do
+    context "that is edited by a moderator" do
       setup do
         @post = create(:forum_post, topic_id: @topic.id)
-        @second_user = create(:user)
-        CurrentUser.user = @second_user
+        @mod = create(:moderator_user)
+        CurrentUser.user = @mod
       end
 
-      should "record its updater" do
-        @post.update(:body => "abc")
-        assert_equal(@second_user.id, @post.updater_id)
+      should "create a mod action" do
+        assert_difference("ModAction.count") do
+          @post.update(body: "nope")
+        end
       end
+
+      should "credit the moderator as the updater" do
+        @post.update(body: "test")
+        assert_equal(@mod.id, @post.updater_id)
+      end
+    end
+
+    context "that is hidden by a moderator" do
+      setup do
+        @post = create(:forum_post, topic_id: @topic.id)
+        @mod = create(:moderator_user)
+        CurrentUser.user = @mod
+      end
+
+      should "create a mod action" do
+        assert_difference("ModAction.count") do
+          @post.update(is_hidden: true)
+        end
+      end
+
+      should "credit the moderator as the updater" do
+        @post.update(is_hidden: true)
+        assert_equal(@mod.id, @post.updater_id)
+      end
+    end
+
+    context "that is deleted" do
+      setup do
+        @post = create(:forum_post, topic_id: @topic.id)
+      end
+
+      should "create a mod action" do
+        assert_difference("ModAction.count") do
+          @post.destroy
+        end
+      end
+    end
+
+    context "during validation" do
+      subject { build(:forum_post) }
+      should_not allow_value(" ").for(:body)
     end
   end
 end


### PR DESCRIPTION
Extracted from #526

Ideally, this should be merged alongside #540 & #541. Though none of them depend on eachother, changes further up the pipeline may depend on code spread across prs/cause nasty merge conflicts if merged later.

* Add hide & delete modaction tests to comments and forum posts
* Remove forum posts' user id check on destroy (always create modaction regardless of actor)
* Ignore forum post update modaction if changing is_hidden (mirrors comments)