### PR TITLE
[Posts] Make comment_disabled not hide comments

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -172,7 +172,7 @@ class PostsController < ApplicationController
     ]
     permitted_params += %i[is_rating_locked] if CurrentUser.is_privileged?
     permitted_params += %i[is_note_locked bg_color] if CurrentUser.is_janitor?
-    permitted_params += %i[is_status_locked is_comment_disabled locked_tags hide_from_anonymous hide_from_search_engines] if CurrentUser.is_admin?
+    permitted_params += %i[is_status_locked is_comment_locked locked_tags hide_from_anonymous hide_from_search_engines] if CurrentUser.is_admin?
 
     params.require(:post).permit(permitted_params)
   end

--- a/app/logical/vote_manager.rb
+++ b/app/logical/vote_manager.rb
@@ -90,6 +90,7 @@ class VoteManager
     begin
       raise UserVote::Error.new("Invalid vote") unless [1, -1].include?(score)
       raise UserVote::Error.new("You do not have permission to vote") unless user.is_member?
+      raise UserVote::Error.new("Comment section is disabled") if !user.is_moderator? && comment.post.is_comment_disabled?
       CommentVote.transaction(**ISOLATION) do
         CommentVote.uncached do
           score_modifier = score

--- a/app/logical/vote_manager.rb
+++ b/app/logical/vote_manager.rb
@@ -88,9 +88,9 @@ class VoteManager
     @vote = nil
     score = score.to_i
     begin
-      raise UserVote::Error.new("Invalid vote") unless [1, -1].include?(score)
-      raise UserVote::Error.new("You do not have permission to vote") unless user.is_member?
-      raise UserVote::Error.new("Comment section is disabled") if !user.is_moderator? && comment.post.is_comment_disabled?
+      raise UserVote::Error, "Invalid vote" unless [1, -1].include?(score)
+      raise UserVote::Error, "You do not have permission to vote" unless user.is_member?
+      raise UserVote::Error, "Comment section is locked" if comment.post.is_comment_locked?
       CommentVote.transaction(**ISOLATION) do
         CommentVote.uncached do
           score_modifier = score

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -183,12 +183,14 @@ class Comment < ApplicationRecord
 
   def editable_by?(user)
     return true if user.is_admin?
+    return false if !user.is_moderator? && post.is_comment_disabled?
     return false if was_warned?
     creator_id == user.id
   end
 
   def can_hide?(user)
     return true if user.is_moderator?
+    return false if post.is_comment_disabled?
     return false if was_warned?
     user.id == creator_id
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -137,7 +137,7 @@ class Comment < ApplicationRecord
   end
 
   def post_not_comment_disabled
-    errors.add(:base, "Post has comments disabled") if Post.find_by(id: post_id)&.is_comment_disabled
+    errors.add(:base, "Post has comments disabled") if !CurrentUser.is_moderator? && Post.find_by(id: post_id)&.is_comment_disabled?
   end
 
   def update_last_commented_at_on_create
@@ -173,6 +173,12 @@ class Comment < ApplicationRecord
 
   def below_threshold?(user = CurrentUser.user)
     score < user.comment_threshold
+  end
+
+  def can_reply?(user)
+    return false if is_sticky?
+    return false if !user.is_moderator? && post.is_comment_disabled?
+    true
   end
 
   def editable_by?(user)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,7 +5,7 @@ class Comment < ApplicationRecord
   belongs_to_updater
   validate :validate_post_exists, on: :create
   validate :validate_creator_is_not_limited, on: :create
-  validate :post_not_comment_disabled, on: :create
+  validate :post_not_comment_locked, on: :create
   validates :body, presence: { message: "has no content" }
   validates :body, length: { minimum: 1, maximum: Danbooru.config.comment_max_size }
 
@@ -136,8 +136,8 @@ class Comment < ApplicationRecord
     true
   end
 
-  def post_not_comment_disabled
-    errors.add(:base, "Post has comments disabled") if !CurrentUser.is_moderator? && Post.find_by(id: post_id)&.is_comment_disabled?
+  def post_not_comment_locked
+    errors.add(:base, "Post has comments locked") if !CurrentUser.is_moderator? && Post.find_by(id: post_id)&.is_comment_locked?
   end
 
   def update_last_commented_at_on_create
@@ -177,20 +177,19 @@ class Comment < ApplicationRecord
 
   def can_reply?(user)
     return false if is_sticky?
-    return false if !user.is_moderator? && post.is_comment_disabled?
+    return false if post.is_comment_locked? && !user.is_moderator?
     true
   end
 
   def editable_by?(user)
     return true if user.is_admin?
-    return false if !user.is_moderator? && post.is_comment_disabled?
+    return false if post.is_comment_locked? && !user.is_moderator?
     return false if was_warned?
     creator_id == user.id
   end
 
   def can_hide?(user)
     return true if user.is_moderator?
-    return false if post.is_comment_disabled?
     return false if was_warned?
     user.id == creator_id
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -56,6 +56,9 @@ class Post < ApplicationRecord
   attr_accessor :old_tag_string, :old_parent_id, :old_source, :old_rating,
                 :do_not_version_changes, :tag_string_diff, :source_diff, :edit_reason
 
+  # FIXME: Remove this
+  alias_attribute :is_comment_locked, :is_comment_disabled
+
   has_many :versions, -> {order("post_versions.id ASC")}, :class_name => "PostVersion", :dependent => :destroy
 
   IMAGE_TYPES = %i[original large preview crop]
@@ -1518,8 +1521,8 @@ class Post < ApplicationRecord
         action = is_note_locked? ? :note_locked : :note_unlocked
         PostEvent.add(id, CurrentUser.user, action)
       end
-      if saved_change_to_is_comment_disabled?
-        action = is_comment_disabled? ? :comment_disabled : :comment_enabled
+      if saved_change_to_is_comment_locked?
+        action = is_comment_locked? ? :comment_locked : :comment_unlocked
         PostEvent.add(id, CurrentUser.user, action)
       end
     end
@@ -1713,7 +1716,7 @@ class Post < ApplicationRecord
     false
   end
 
-  def visible_comment_count(user)
-    user.is_moderator? || !is_comment_disabled ? comment_count : 0
+  def visible_comment_count(_user)
+    comment_count
   end
 end

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -15,8 +15,8 @@ class PostEvent < ApplicationRecord
     status_unlocked: 11,
     note_locked: 12,
     note_unlocked: 13,
-    comment_disabled: 18,
-    comment_enabled: 19,
+    comment_locked: 18,
+    comment_unlocked: 19,
     replacement_accepted: 14,
     replacement_rejected: 15,
     replacement_promoted: 20,
@@ -24,8 +24,8 @@ class PostEvent < ApplicationRecord
     expunged: 17,
   }
   MOD_ONLY_ACTIONS = [
-    actions[:comment_disabled],
-    actions[:comment_enabled],
+    actions[:comment_locked],
+    actions[:comment_unlocked],
   ].freeze
 
   def self.add(post_id, creator, action, data = {})

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -23,6 +23,10 @@ class PostEvent < ApplicationRecord
     replacement_deleted: 16,
     expunged: 17,
   }
+  MOD_ONLY_ACTIONS = [
+    actions[:comment_disabled],
+    actions[:comment_enabled],
+  ].freeze
 
   def self.add(post_id, creator, action, data = {})
     create!(post_id: post_id, creator: creator, action: action.to_s, extra_data: data)
@@ -41,7 +45,7 @@ class PostEvent < ApplicationRecord
     q = super
 
     unless CurrentUser.is_moderator?
-      q = q.where.not(action: [actions[:comment_disabled], actions[:comment_enabled]])
+      q = q.where.not(action: MOD_ONLY_ACTIONS)
     end
     if params[:post_id].present?
       q = q.where("post_id = ?", params[:post_id].to_i)

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -1,38 +1,37 @@
 <div class="comments-for-post" data-post-id="<%= post.id %>">
-  <% if post.is_comment_disabled %>
+  <% if post.is_comment_disabled? %>
     Comment section has been disabled.
   <% end %>
-  <% if !post.is_comment_disabled || CurrentUser.is_moderator? %>
-    <div class="row notices">
-      <% if post.comments.hidden(CurrentUser.user).count > 0 || (params[:controller] == "comments" && post.comments.count > 6) %>
-        <span id="threshold-comments-notice-for-<%= post.id %>">
-          <%= link_to "Show all comments", comments_path(:post_id => post.id), 'data-pid': post.id, class: 'show-all-comments-for-post-link' %>
-        </span>
-      <% end %>
-    </div>
-
-    <div class="list-of-comments">
-      <% if comments.empty? %>
-        <% if post.last_commented_at.present? %>
-          <p>There are no visible comments.</p>
-        <% else %>
-          <p>There are no comments.</p>
-        <% end %>
-      <% else %>
-        <%= render partial: "comments/partials/show/comment", collection: comments, locals: { post: post } %>
-      <% end %>
-    </div>
-
-    <% if CurrentUser.is_member? %>
-      <div class="new-comment">
-        <% if !CurrentUser.is_anonymous? && !CurrentUser.user.is_janitor? %>
-          <h2>Before commenting, read the <%= link_to "how to comment guide", wiki_pages_path(:search => {:title => "howto:comment"}) %>.</h2>
-        <% end %>
-        <p><%= link_to "Post comment", new_comment_path(comment: { post_id: post.id }), :class => "expand-comment-response" %></p>
-        <%= render "comments/form", comment: post.comments.new, hidden: true %>
-      </div>
-    <% else %>
-      <h5 id="respond-link"><%= link_to "Login to respond »", new_session_path %></h5>
+  <div class="row notices">
+    <% if post.comments.hidden(CurrentUser.user).count > 0 || (params[:controller] == "comments" && post.comments.count > 6) %>
+      <span id="threshold-comments-notice-for-<%= post.id %>">
+        <%= link_to "Show all comments", comments_path(:post_id => post.id), 'data-pid': post.id, class: 'show-all-comments-for-post-link' %>
+      </span>
     <% end %>
+  </div>
+
+  <div class="list-of-comments">
+    <% if comments.empty? %>
+      <% if post.last_commented_at.present? %>
+        <p>There are no visible comments.</p>
+      <% else %>
+        <p>There are no comments.</p>
+      <% end %>
+    <% else %>
+      <%= render partial: "comments/partials/show/comment", collection: comments, locals: { post: post } %>
+    <% end %>
+  </div>
+
+  <% if !CurrentUser.is_moderator? && post.is_comment_disabled? %>
+  <% elsif CurrentUser.is_member? %>
+    <div class="new-comment">
+      <% if !CurrentUser.is_anonymous? && !CurrentUser.user.is_janitor? %>
+        <h2>Before commenting, read the <%= link_to "how to comment guide", wiki_pages_path(:search => {:title => "howto:comment"}) %>.</h2>
+      <% end %>
+      <p><%= link_to "Post comment", new_comment_path(comment: { post_id: post.id }), :class => "expand-comment-response" %></p>
+      <%= render "comments/form", comment: post.comments.new, hidden: true %>
+    </div>
+  <% else %>
+    <h5 id="respond-link"><%= link_to "Login to respond »", new_session_path %></h5>
   <% end %>
 </div>

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -1,6 +1,6 @@
 <div class="comments-for-post" data-post-id="<%= post.id %>">
-  <% if post.is_comment_disabled? %>
-    Comment section has been disabled.
+  <% if post.is_comment_locked? %>
+    Comment section has been locked.
   <% end %>
   <div class="row notices">
     <% if post.comments.hidden(CurrentUser.user).count > 0 || (params[:controller] == "comments" && post.comments.count > 6) %>
@@ -22,7 +22,7 @@
     <% end %>
   </div>
 
-  <% if !CurrentUser.is_moderator? && post.is_comment_disabled? %>
+  <% if post.is_comment_locked? && !CurrentUser.is_moderator? %>
   <% elsif CurrentUser.is_member? %>
     <div class="new-comment">
       <% if !CurrentUser.is_anonymous? && !CurrentUser.user.is_janitor? %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -31,7 +31,7 @@
       <% end %>
         <div class="content-menu">
           <menu>
-            <% if post && !comment.is_sticky %>
+            <% if post && comment.can_reply?(CurrentUser.user) %>
               <li><%= tag.a "Reply", href: '#', class: "reply-link comment-reply-link" %></li>
             <% end %>
             <% if comment.editable_by?(CurrentUser.user) %>

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -56,6 +56,7 @@
         <%= f.input :is_rating_locked, label: "Rating" %>
         <% if CurrentUser.is_admin? %>
           <%= f.input :is_status_locked, label: "Status" %>
+          <%= f.input :is_comment_locked, label: "Comments" %>
         <% end %>
       </fieldset>
     </div>
@@ -71,7 +72,6 @@
       <fieldset class="limits">
         <%= f.input :hide_from_anonymous, as: :boolean, label: "Hide from Anon" %>
         <%= f.input :hide_from_search_engines, as: :boolean, label: "Hide from search engines" %>
-        <%= f.input :is_comment_disabled, label: "Disable comments" %>
       </fieldset>
     </div>
   <% end %>

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -220,13 +220,13 @@ class CommentTest < ActiveSupport::TestCase
 
       context "on a comment locked post" do
         setup do
-          @post = create(:post, is_comment_disabled: true)
+          @post = create(:post, is_comment_locked: true)
         end
 
         should "prevent new comments" do
           comment = build(:comment, post: @post)
           comment.save
-          assert_equal(["Post has comments disabled"], comment.errors.full_messages)
+          assert_equal(["Post has comments locked"], comment.errors.full_messages)
         end
       end
     end

--- a/test/unit/post_event_test.rb
+++ b/test/unit/post_event_test.rb
@@ -70,13 +70,13 @@ class PostEventTest < ActiveSupport::TestCase
         @post.save
       end
 
-      assert_post_events_created(@admin, :comment_disabled) do
-        @post.is_comment_disabled = true
+      assert_post_events_created(@admin, :comment_locked) do
+        @post.is_comment_locked = true
         @post.save
       end
 
-      assert_post_events_created(@admin, :comment_enabled) do
-        @post.is_comment_disabled = false
+      assert_post_events_created(@admin, :comment_unlocked) do
+        @post.is_comment_locked = false
         @post.save
       end
 


### PR DESCRIPTION
Changes disabled comments to not hide comments. [Requested Internally](https://discord.com/channels/431908090883997698/1099361575116222656/1147340840767868938).

This pr also, through commits which have been labeled accordingly:
* Disallows voting on comments in locked/disabled comment sections.
* Disables users ability to edit & hide comments on disabled posts.