### PR TITLE
[Artists] Correct bsky domain for priority list

### DIFF
--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -94,7 +94,7 @@ class ArtistUrl < ApplicationRecord
     "skeb.jp",
     "pillowfort.social",
     "reddit.com",
-    "bsky.social",
+    "bsky.app",
     "youtube.com",
     "t.me",
     "instagram.com",


### PR DESCRIPTION
https://github.com/e621ng/e621ng/commit/61a0a6518adab6e3e0db3ba79c3988a868d13852#comments

"The domain for bluesky should be bsky.app rather than bsky.social - the .app domain is the actual web interface where the .social domain is only used for the username handles. E.g. https://bsky.app/profile/12345.bsky.social"