### PR TITLE
[UserNameChangeRequests] Allow moderators to view requestss

### DIFF
--- a/app/controllers/user_name_change_requests_controller.rb
+++ b/app/controllers/user_name_change_requests_controller.rb
@@ -33,7 +33,7 @@ class UserNameChangeRequestsController < ApplicationController
   private
 
   def check_privileges!(change_request)
-    return if CurrentUser.is_admin?
+    return if CurrentUser.is_moderator?
     raise User::PrivilegeError if change_request.user_id != CurrentUser.user.id
   end
 


### PR DESCRIPTION
The index is already viewable, this was missed when name change mod actions were removed in c51029ea1e116d6f5fb7419b265aead4bf805cc4