### PR TITLE
[VoteManager]: Make links work

### DIFF
--- a/app/javascript/src/javascripts/vote_manager.js
+++ b/app/javascript/src/javascripts/vote_manager.js
@@ -11,6 +11,7 @@ class VoteManager {
     const self = this;
     self.lastSelected = 0;
     $("#votes").on('click', 'tbody tr', function (evt) {
+      if ($(evt.target).is("a")) return;
       evt.preventDefault();
       if (evt.shiftKey) {
         self.toggleRowsBetween([self.lastSelected, this.rowIndex]);


### PR DESCRIPTION
This simply ignores clicking on the row if the element we're clicking on is a link, making the links on `/post_votes` & `/comment_votes` work flawlessly.