### PR TITLE
Fixed replacements pending link not filtering with the pending status

### DIFF
--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -41,7 +41,7 @@
         <span>Replaced</span>
         <span>
           <%= presenter.replaced_upload_count(self) %>
-          [<%= link_to "pending", post_replacements_path(search: { creator_name: user.name }) %>]
+          [<%= link_to "pending", post_replacements_path(search: { creator_name: user.name, status: "pending" }) %>]
         </span>
 
         <span>Rejected</span>


### PR DESCRIPTION
Fixed the "[Pending]" link for replaced posts, so it now correctly filters the "Pending" status of replaced posts.
Before, the link simply displayed all replaced posts, and didn't set the status filter:
![image](https://github.com/e621ng/e621ng/assets/63162984/df688109-a958-41d3-af61-6b7b734b022f)

After the fix, the link correctly includes the pending status filter in order to only display pending replaced posts:
![image](https://github.com/e621ng/e621ng/assets/63162984/0daebb09-8d6e-4e84-b8b7-bf8db0ffb5ad)
