### PR TITLE
Added the count of replaced posts to the user page

### DIFF
--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -88,6 +88,10 @@ class UserPresenter
     template.link_to(user.post_replacement_rejected_count, template.post_replacements_path(search: { creator_id: user.id, status: "rejected" }))
   end
 
+  def approved_replacements_count(template)
+    template.link_to(PostReplacement.approved.count, template.post_replacements_path(search: { creator_id: user.id, status: "approved" }))
+  end
+
   def favorite_count(template)
     template.link_to(user.favorite_count, template.favorites_path(user_id: user.id))
   end

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -124,6 +124,12 @@
           <% end %>
         </span>
 
+        <span>Replaced Posts</span>
+        <span>
+          <%= presenter.approved_replacements_count(self) %>
+          [<%= link_to "pending", post_replacements_path(search: { creator_id: user.id, status: "pending" }) %>]
+        </span>
+
         <span>Wiki Page Changes</span>
         <span><%= presenter.wiki_page_version_count(self) %></span>
 


### PR DESCRIPTION
As suggested by @DonovanDMC in #569 it would be great to see approved and pending replacements created by a user on their page.
With this change, a new replaced post counter will be added to the user stats:
![image](https://github.com/e621ng/e621ng/assets/63162984/e475b717-1e74-4697-9642-faef607b59f9)
