### PR TITLE
Add searching by disapprovals

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -99,6 +99,7 @@ Autocomplete.initialize_tag_autocomplete = function() {
         return;
       case "user":
       case "approver":
+      case "disapprover":
       case "commenter":
       case "comm":
       case "noter":

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -10,10 +10,10 @@ class TagQuery
   ].freeze
 
   NEGATABLE_METATAGS = %w[
-    id filetype type rating description parent user user_id approver flagger deletedby delreason
+    id filetype type rating description parent user user_id approver disapprover flagger deletedby delreason
     source status pool set fav favoritedby note locked upvote votedup downvote voteddown voted
     width height mpixels ratio filesize duration score favcount date age change tagcount
-    commenter comm noter noteupdater
+    commenter comm noter noteupdater disapprovals
   ] + TagCategory::SHORT_NAME_LIST.map { |tag_name| "#{tag_name}tags" }
 
   METATAGS = %w[
@@ -142,6 +142,14 @@ class TagQuery
           id_or_invalid(user_id)
         end
 
+      when "disapprover", "-disapprover", "~disapprover"
+        if CurrentUser.can_approve_posts
+          add_to_query(type, :disapprover_ids, any_none_key: :disapprover, value: g2) do
+            user_id = User.name_or_id_to_id(g2)
+            id_or_invalid(user_id)
+          end
+        end
+
       when "commenter", "-commenter", "~commenter", "comm", "-comm", "~comm"
         add_to_query(type, :commenter_ids, any_none_key: :commenter, value: g2) do
           user_id = User.name_or_id_to_id(g2)
@@ -163,6 +171,11 @@ class TagQuery
       when "pool", "-pool", "~pool"
         add_to_query(type, :pool_ids, any_none_key: :pool, value: g2) do
           Pool.name_to_id(g2)
+        end
+
+      when "disapprovals", "-disapprovals", "~disapprovals"
+        if CurrentUser.can_approve_posts
+          add_to_query(type, :disa_count, any_none_key: :disapprover, value: g2) { ParseValue.range(g2) }
         end
 
       when "set", "-set", "~set"

--- a/app/models/post_disapproval.rb
+++ b/app/models/post_disapproval.rb
@@ -5,6 +5,9 @@ class PostDisapproval < ApplicationRecord
   validates :post_id, uniqueness: { :scope => [:user_id], :message => "have already hidden this post" }
   validates :reason, inclusion: { :in => %w(borderline_quality borderline_relevancy other) }
 
+  after_create -> { post.update_index }
+  after_destroy -> { post.update_index }
+
   scope :with_message, -> { where("message is not null and message <> ''") }
   scope :without_message, -> { where("message is null or message = ''") }
   scope :poor_quality, -> { where(:reason => "borderline_quality") }

--- a/db/fixes/117_1_add_elasticsearch_disapproval_index.rb
+++ b/db/fixes/117_1_add_elasticsearch_disapproval_index.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+client = Post.document_store.client
+client.indices.put_mapping index: Post.document_store.index_name, body: { properties: { disapprover: { type: "integer" } } }
+client.indices.put_mapping index: Post.document_store.index_name, body: { properties: { dis_count: { type: "integer" } } }

--- a/db/fixes/117_2_add_elasticsearch_disapproval_data.rb
+++ b/db/fixes/117_2_add_elasticsearch_disapproval_data.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+Post.find_each do |post|
+  puts post.id
+  post.document_store.client.update(index: Post.document_store.index_name, id: post.id, body: { doc: { disapprover: post.disapprovals.pluck(:user_id) || nil } })
+  post.document_store.client.update(index: Post.document_store.index_name, id: post.id, body: { doc: { dis_count: post.disapprovals.count } })
+end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1660,6 +1660,78 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match([posts[1]], "commenter:none")
     end
 
+    should "Return posts for the disapprover:<name> metatag" do
+      posts = create_list(:post, 3, is_pending: true)
+      @alice = create(:moderator_user, name: "alice")
+      @zach = create(:moderator_user, name: "zach")
+      @john = create(:member_user, name: "john")
+      disapproval1 = create(:post_disapproval, user: @alice, post: posts[0], reason: "borderline_quality")
+      disapproval2 = create(:post_disapproval, user: @zach, post: posts[1], reason: "borderline_quality")
+      disapproval0 = create(:post_disapproval, user: @zach, post: posts[0], reason: "borderline_quality")
+
+      CurrentUser.user = @john
+      assert_tag_match(posts.reverse, "disapprover:alice") # refuse to filter for non-approvers
+      CurrentUser.user = @alice
+      assert_tag_match([posts[0]], "disapprover:alice") # TODO: !NONE
+    end
+
+    should "Return posts for the disapprover:<any|none> metatag" do
+      posts = create_list(:post, 3, is_pending: true)
+      @alice = create(:moderator_user, name: "alice")
+      @zach = create(:moderator_user, name: "zach")
+      @john = create(:member_user, name: "john")
+      disapproval1 = create(:post_disapproval, user: @alice, post: posts[0], reason: "borderline_quality")
+      disapproval2 = create(:post_disapproval, user: @zach, post: posts[1], reason: "borderline_quality")
+      disapproval0 = create(:post_disapproval, user: @zach, post: posts[0], reason: "borderline_quality")
+
+      CurrentUser.user = @john
+      assert_tag_match(posts.reverse, "disapprover:any")
+      assert_tag_match(posts.reverse, "disapprover:none")
+
+      CurrentUser.user = @alice
+      assert_tag_match([posts[2]], "disapprover:none") # TODO: !All
+      assert_tag_match([posts[1], posts[0]], "disapprover:any") # TODO: !none
+    end
+
+    should "Return posts for the disapprovals:<n> metatag" do
+      posts = create_list(:post, 3, is_pending: true)
+      @alice = create(:moderator_user, name: "alice")
+      @zach = create(:moderator_user, name: "zach")
+      @john = create(:member_user, name: "john")
+      disapproval1 = create(:post_disapproval, user: @alice, post: posts[0], reason: "borderline_quality")
+      disapproval2 = create(:post_disapproval, user: @zach, post: posts[1], reason: "borderline_quality")
+      disapproval0 = create(:post_disapproval, user: @zach, post: posts[0], reason: "borderline_quality")
+
+      CurrentUser.user = @john
+      assert_tag_match(posts.reverse, "disapprovals:1")
+      assert_tag_match(posts.reverse, "disapprovals:2")
+      assert_tag_match(posts.reverse, "disapprovals:0")
+      assert_tag_match(posts.reverse, "disapprovals:>=1")
+      CurrentUser.user = @alice
+      assert_tag_match([posts[1]], "disapprovals:1") # TODO: !none
+      assert_tag_match([posts[0]], "disapprovals:2") # TODO: !none
+      assert_tag_match([posts[2]], "disapprovals:0") # TODO: !none
+      assert_tag_match([posts[1], posts[0]], "disapprovals:>=1") # TODO: !none
+    end
+
+    should "Return posts for the disapprovals:<any|none> metatag" do
+      posts = create_list(:post, 3, is_pending: true)
+      @alice = create(:moderator_user, name: "alice")
+      @zach = create(:moderator_user, name: "zach")
+      @john = create(:member_user, name: "john")
+      disapproval1 = create(:post_disapproval, user: @alice, post: posts[0], reason: "borderline_quality")
+      disapproval2 = create(:post_disapproval, user: @zach, post: posts[1], reason: "borderline_quality")
+      disapproval0 = create(:post_disapproval, user: @zach, post: posts[0], reason: "borderline_quality")
+
+      CurrentUser.user = @john
+      assert_tag_match(posts.reverse, "disapprovals:any")
+      assert_tag_match(posts.reverse, "disapprovals:none")
+
+      CurrentUser.user = @alice
+      assert_tag_match([posts[2]], "disapprovals:none") # TODO: !posts
+      assert_tag_match([posts[1], posts[0]], "disapprovals:any") # TODO: !none
+    end
+
     should "return posts for the noter:<name> metatag" do
       users = create_list(:user, 2)
       posts = create_list(:post, 2)
@@ -1865,6 +1937,7 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts.reverse, "order:change")
       assert_tag_match(posts.reverse, "order:comment")
       assert_tag_match(posts.reverse, "order:comment_bumped")
+      assert_tag_match(posts.reverse, "order:disapproval_desc")
       assert_tag_match(posts.reverse, "order:note")
       assert_tag_match(posts.reverse, "order:mpixels")
       assert_tag_match(posts.reverse, "order:portrait")
@@ -1886,6 +1959,7 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts, "order:change_asc")
       assert_tag_match(posts, "order:comment_asc")
       assert_tag_match(posts, "order:comment_bumped_asc")
+      assert_tag_match(posts, "order:disapproval_asc")
       assert_tag_match(posts, "order:note_asc")
       assert_tag_match(posts, "order:mpixels_asc")
       assert_tag_match(posts, "order:landscape")


### PR DESCRIPTION
CHANGES: 
- Added `disapprover:<name|any|none>` metatag - where user has disapproved a post
- Added `disapprovals:<n|any|none>` metatag - where there is a number of disprovals on a post
- Added `order:disapprovals` term, as well as `asc` and `desc` versions - orders by the number of disapprovals on a post, then ID
- Added Unit tests for metatags
- Added post index fields 
- Added DB Fix for post index fields
- Added autocomplete for users 

