### PR TITLE
[PostSets] require post_ids[] for adding/removing posts

### DIFF
--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -86,7 +86,7 @@ class PostSetsController < ApplicationController
   def destroy
     @post_set = PostSet.find(params[:id])
     check_settings_edit_access(@post_set)
-    if @post_set.creator != CurrentUser.user 
+    if @post_set.creator != CurrentUser.user
       ModAction.log(:set_delete, {set_id: @post_set.id, user_id: @post_set.creator_id})
     end
     @post_set.destroy
@@ -108,8 +108,7 @@ class PostSetsController < ApplicationController
   def add_posts
     @post_set = PostSet.find(params[:id])
     check_post_edit_access(@post_set)
-    return render_expected_error(422, "post_ids[] is required") if params[:post_ids].blank?
-    @post_set.add(params[:post_ids].map(&:to_i))
+    @post_set.add(add_remove_posts_params.map(&:to_i))
     @post_set.save
     respond_with(@post_set)
   end
@@ -117,8 +116,7 @@ class PostSetsController < ApplicationController
   def remove_posts
     @post_set = PostSet.find(params[:id])
     check_post_edit_access(@post_set)
-    return render_expected_error(422, "post_ids[] is required") if params[:post_ids].blank?
-    @post_set.remove(params[:post_ids].map(&:to_i))
+    @post_set.remove(add_remove_posts_params.map(&:to_i))
     @post_set.save
     respond_with(@post_set)
   end
@@ -149,6 +147,10 @@ class PostSetsController < ApplicationController
 
   def update_posts_params
     params.require(:post_set).permit([:post_ids_string])
+  end
+
+  def add_remove_posts_params
+    params.except(:id, :format).permit(post_ids: []).require(:post_ids)
   end
 
   def search_params

--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -108,6 +108,7 @@ class PostSetsController < ApplicationController
   def add_posts
     @post_set = PostSet.find(params[:id])
     check_post_edit_access(@post_set)
+    return render_expected_error(422, "post_ids[] is required") if params[:post_ids].blank?
     @post_set.add(params[:post_ids].map(&:to_i))
     @post_set.save
     respond_with(@post_set)
@@ -116,6 +117,7 @@ class PostSetsController < ApplicationController
   def remove_posts
     @post_set = PostSet.find(params[:id])
     check_post_edit_access(@post_set)
+    return render_expected_error(422, "post_ids[] is required") if params[:post_ids].blank?
     @post_set.remove(params[:post_ids].map(&:to_i))
     @post_set.save
     respond_with(@post_set)


### PR DESCRIPTION
This corrects the error of attempting to map `params[:post_ids]` before verifying it's actually present in `add_posts` & `remove_posts` of the post sets controller.
![image](https://github.com/e621ng/e621ng/assets/17226394/dabee96c-7757-4765-b6a6-31585d2f45fb)
![image](https://github.com/e621ng/e621ng/assets/17226394/64f50455-26a6-4981-ae82-9b42be081bec)

