### PR TITLE
[Uploader] Remove cub from contentious examples

### DIFF
--- a/app/javascript/src/javascripts/uploader/uploader.vue.erb
+++ b/app/javascript/src/javascripts/uploader/uploader.vue.erb
@@ -101,7 +101,7 @@
                     <div class="col2">
           <textarea class="tag-textarea" v-model="tagEntries.theme" id="post_themes" rows="2"
                     data-autocomplete="tag-edit"
-                    placeholder="Ex: cub young gore scat watersports diaper my_little_pony vore not_furry rape hyper etc."></textarea>
+                    placeholder="Ex: young gore scat watersports diaper my_little_pony vore not_furry rape hyper etc."></textarea>
                     </div>
                 </div>
             </template>


### PR DESCRIPTION
The cub tag is [being aliased into young](https://e621.net/forum_topics/41659), so there's no need to list it in the examples list for contentious content.