### PR TITLE
[Artists] Show error when changing notes with locked wiki page

### DIFF
--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -15,6 +15,9 @@
   <%= f.input :group_name %>
   <%= f.input :url_string, :label => "URLs", as: :text, input_html: { size: "80x10", value: params.dig(:artist, :url_string) || @artist.urls.join("\n")}, hint: "You can prefix a URL with - to mark it as dead." %>
 
-  <%= f.input :notes, as: :dtext, limit: Danbooru.config.wiki_page_max_size %>
+  <% if @artist.is_note_locked? %>
+    <p>Artist is note locked. Notes cannot be edited.</p>
+  <% end %>
+  <%= f.input :notes, as: :dtext, limit: Danbooru.config.wiki_page_max_size, disabled: @artist.is_note_locked? %>
   <%= f.button :submit, "Submit" %>
 <% end %>

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -266,21 +266,21 @@ class ArtistTest < ActiveSupport::TestCase
         @artist = create(:artist, url_string: "http://foo.com")
       end
 
-      should "create a new version when an url is added" do
+      should "create a new version when a url is added" do
         assert_difference("ArtistVersion.count") do
           @artist.update(url_string: "http://foo.com http://bar.com")
           assert_equal(%w[http://bar.com http://foo.com], @artist.versions.last.urls)
         end
       end
 
-      should "create a new version when an url is removed" do
+      should "create a new version when a url is removed" do
         assert_difference("ArtistVersion.count") do
           @artist.update(url_string: "")
           assert_equal(%w[], @artist.versions.last.urls)
         end
       end
 
-      should "create a new version when an url is marked inactive" do
+      should "create a new version when a url is marked inactive" do
         assert_difference("ArtistVersion.count") do
           @artist.update(url_string: "-http://foo.com")
           assert_equal(%w[-http://foo.com], @artist.versions.last.urls)
@@ -373,6 +373,24 @@ class ArtistTest < ActiveSupport::TestCase
 
         @artist.reload
         assert_equal("https://e621.net", @artist.url_string)
+      end
+
+      should "not change notes when locked" do
+        @artist.notes = "abababab"
+        as(create(:user)) { @artist.save }
+
+        assert_equal("abababab", @artist.wiki_page.body)
+
+        @artist.wiki_page.update_column(:is_locked, true)
+
+        @artist.notes = "babababa"
+        assert_no_difference(-> { ArtistVersion.count }) do
+          as(create(:user)) { @artist.save }
+        end
+
+        assert_equal("abababab", @artist.wiki_page.body)
+
+        assert_equal(["Wiki page is locked"], @artist.errors.full_messages)
       end
     end
   end


### PR DESCRIPTION
This pr makes an actual error show when editing an artist that has a locked wiki page instead of silently discarding the contents.
![image](https://github.com/e621ng/e621ng/assets/17226394/64cb7efb-59c9-41be-8217-0bc9da262152)

Includes a test to both ensure the wiki page is not modified, and that the error is generated.