### PR TITLE
[UserFeedback] Add Updater

### DIFF
--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -2,6 +2,7 @@ class UserFeedback < ApplicationRecord
   self.table_name = "user_feedback"
   belongs_to :user
   belongs_to_creator
+  belongs_to_updater
   validates :body, :category, presence: true
   validates :category, inclusion: { in: %w[positive negative neutral] }
   validates :body, length: { minimum: 1, maximum: Danbooru.config.user_feedback_max_size }
@@ -75,7 +76,7 @@ class UserFeedback < ApplicationRecord
     return unless should_send
 
     action = saved_change_to_id? ? "created" : "updated"
-    body = %(#{creator_name} #{action} a "#{category} record":/user_feedbacks?search[user_id]=#{user_id} for your account:\n\n#{self.body})
+    body = %(#{updater_name} #{action} a "#{category} record":/user_feedbacks?search[user_id]=#{user_id} for your account:\n\n#{self.body})
     Dmail.create_automated(to_id: user_id, title: "Your user record has been updated", body: body)
   end
 

--- a/db/migrate/20240101042716_user_feedback_add_updater_id.rb
+++ b/db/migrate/20240101042716_user_feedback_add_updater_id.rb
@@ -1,0 +1,6 @@
+class UserFeedbackAddUpdaterId < ActiveRecord::Migration[7.0]
+  def change
+    add_column :user_feedback, :updater_id, :integer
+    add_foreign_key :user_feedback, :users, column: :updater_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2096,7 +2096,8 @@ CREATE TABLE public.user_feedback (
     body text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    creator_ip_addr inet
+    creator_ip_addr inet,
+    updater_id integer
 );
 
 
@@ -4438,6 +4439,14 @@ ALTER TABLE ONLY public.tickets
 
 
 --
+-- Name: user_feedback fk_rails_9329a36823; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_feedback
+    ADD CONSTRAINT fk_rails_9329a36823 FOREIGN KEY (updater_id) REFERENCES public.users(id);
+
+
+--
 -- Name: mascots fk_rails_9901e810fa; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4743,6 +4752,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230513074838'),
 ('20230517155547'),
 ('20230518182034'),
-('20230531080817');
+('20230531080817'),
+('20240101042716');
 
 


### PR DESCRIPTION
This pr adds an updater to user feedbacks, as currently they do not store this information. This results in odd things like the update dmail claiming the original record creator updated the record, even if they were not the updater.

A relevant test has been included.

![image](https://github.com/e621ng/e621ng/assets/17226394/430b4573-345d-4975-94a3-b1ae422517ef)
![image](https://github.com/e621ng/e621ng/assets/17226394/1026f476-7771-4e0d-ae9f-e3696e3a8ee2)
