### PR TITLE
[Posts] Fix post toolbar styles on mobile devices

### DIFF
--- a/app/javascript/src/javascripts/favorites.js
+++ b/app/javascript/src/javascripts/favorites.js
@@ -5,13 +5,13 @@ import {SendQueue} from './send_queue'
 let Favorite = {};
 
 Favorite.initialize_actions = function () {
-  $("#add-to-favorites, #add-fav-button").on('click', e => {
+  $("#add-to-favorites, #add-fav-button").on("click", e => {
     e.preventDefault();
-    Favorite.create($(e.target).data('pid'));
+    Favorite.create($(e.target).closest("button").data("pid"));
   });
-  $("#remove-from-favorites, #remove-fav-button").on('click', e => {
+  $("#remove-from-favorites, #remove-fav-button").on("click", e => {
     e.preventDefault();
-    Favorite.destroy($(e.target).data('pid'));
+    Favorite.destroy($(e.target).closest("button").data("pid"));
   });
 };
 

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -432,12 +432,9 @@ textarea[data-autocomplete="tag-edit"] {
 
 section#image-extra-controls {
   display: flex;
-  align-items: center;
-  div {
-    margin-top: 0.5em;
-    margin-bottom: 0.5em;
-    margin-right: 0.5em;
-  }
+  flex-wrap: wrap;
+  gap: 0.5em;
+  margin: 0.5em 0;
 }
 
 section#tag-list {

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -186,10 +186,6 @@ div#c-posts {
   .fav-buttons {
     font-size: 14pt;
 
-    i {
-      margin-right: 0.1em;
-    }
-
     button.ui-button {
       padding: 0.25em 0.75em;
     }
@@ -201,6 +197,29 @@ div#c-posts {
 
   .fav-buttons-false #remove-fav-button {
     display: none;
+  }
+
+  .fav-buttons,
+  #image-download-link {
+    .button > i {
+      display: none;
+    }
+  }
+
+  @media only screen and (max-width: 500px) {
+    #image-extra-controls {
+      justify-content: center;
+    }
+    
+    .fav-buttons,
+    #image-download-link {
+      .button > i {
+        display: inline-block;
+      }
+      .button > span {
+        display: none;
+      }
+    }
   }
 
   div.parent-children {

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -101,29 +101,38 @@
             <%= post_vote_block(@post, @post.own_vote, buttons: true) %>
           </div>
           <%= tag.div(class: "fav-buttons fav-buttons-#{@post.is_favorited?}") do %>
-            <%= button_tag "+Favorite", id: 'add-fav-button', class: "button btn-success", 'data-pid': @post.id %>
-            <%= button_tag "-Favorite", id: 'remove-fav-button', class: "button btn-danger", 'data-pid': @post.id %>
+            <%= button_tag id: "add-fav-button", class: "button btn-success", "data-pid": @post.id do %>
+              <%= tag.i(class: "fa-regular fa-star") %>
+              <span>Favorite</span>
+            <% end %>
+            <%= button_tag id: "remove-fav-button", class: "button btn-danger", "data-pid": @post.id do %>
+              <%= tag.i(class: "fa-solid fa-star") %>
+              <span>Unfavorite</span>
+            <% end %>
           <% end %>
         <% end %>
         <% if @post.visible? %>
           <div id="image-download-link">
-            <%= link_to "Download", @post.file_url, class: "button btn-warn" %>
+            <%= link_to @post.file_url, class: "button btn-warn" do %>
+              <%= tag.i(class: "fa-solid fa-right-to-bracket fa-rotate-90") %>
+              <span>Download</span>
+            <% end %>
           </div>
         <% end %>
         <% if !@post.force_original_size? %>
           <div>
-            | <select id="image-resize-selector" class="button btn-neutral">
-                <option value="original">Original</option>
-                <option value="fit">Fit (Horizontal)</option>
-                <option value="fitv">Fit (Vertical)</option>
-                <% if !@post.is_video? %>
-                  <option value="large">Sample (<%= Danbooru.config.large_image_width %>px)</option>
-                <% end %>
-                <% Danbooru.config.video_rescales.keys.each do |size| %>
-                  <% next unless @post.has_sample_size?(size) %>
-                  <option value="<%= size %>">Sample (<%= size %>)</option>
-                <% end %>
-              </select>
+            <select id="image-resize-selector" class="button btn-neutral">
+              <option value="original">Original</option>
+              <option value="fit">Fit (Horizontal)</option>
+              <option value="fitv">Fit (Vertical)</option>
+              <% if !@post.is_video? %>
+                <option value="large">Sample (<%= Danbooru.config.large_image_width %>px)</option>
+              <% end %>
+              <% Danbooru.config.video_rescales.keys.each do |size| %>
+                <% next unless @post.has_sample_size?(size) %>
+                <option value="<%= size %>">Sample (<%= size %>)</option>
+              <% end %>
+          </select>
           </div>
         <% end %>
       </section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -94,7 +94,7 @@
         <% end %>
       </div>
 
-      <section id="image-extra-controls" style="display: flex;">
+      <section id="image-extra-controls">
 
         <% if CurrentUser.is_member? %>
           <div class="image-vote-buttons">


### PR DESCRIPTION
Fixed the broken post toolbar on mobile devices.
The favorite and download buttons had been replaced with icons on mobile too, to minimize the chances of linebreaking.

Before:
![before](https://github.com/e621ng/e621ng/assets/132787557/dbb599da-a81e-4384-b288-d91c69bf89b0)

After:
![toolbar](https://github.com/e621ng/e621ng/assets/132787557/fb9acffb-0c75-4ec2-9435-6693f91e81fd)
