### PR TITLE
[Blacklist] Redesign and rework the blacklist

### DIFF
--- a/app/controllers/concerns/deferred_posts.rb
+++ b/app/controllers/concerns/deferred_posts.rb
@@ -7,7 +7,7 @@ module DeferredPosts
 
   def deferred_posts
     Post.includes(:uploader).where(id: deferred_post_ids.to_a).find_each.reduce({}) do |post_hash, p|
-      post_hash[p.id] = p.minimal_attributes
+      post_hash[p.id] = p.thumbnail_attributes
       post_hash
     end
   end

--- a/app/decorators/posts_decorator.rb
+++ b/app/decorators/posts_decorator.rb
@@ -16,32 +16,13 @@ class PostsDecorator < ApplicationDecorator
     klass << "post-rating-safe" if post.rating == 's'
     klass << "post-rating-questionable" if post.rating == 'q'
     klass << "post-rating-explicit" if post.rating == 'e'
-    klass << "post-no-blacklist" if options[:no_blacklist]
+    klass << "blacklistable" unless options[:no_blacklist]
     klass
   end
 
   def data_attributes
-    post = object
-    attributes = {
-        "data-id" => post.id,
-        "data-has-sound" => post.has_tag?("video_with_sound", "flash_with_sound"),
-        "data-tags" => post.tag_string,
-        "data-rating" => post.rating,
-        "data-flags" => post.status_flags,
-        "data-uploader-id" => post.uploader_id,
-        "data-uploader" => post.uploader_name,
-        "data-file-ext" => post.file_ext,
-        "data-score" => post.score,
-        "data-fav-count" => post.fav_count,
-        "data-is-favorited" => post.favorited_by?(CurrentUser.user.id)
-    }
-
-    if post.visible?
-      attributes["data-file-url"] = post.file_url
-      attributes["data-large-file-url"] = post.large_file_url
-      attributes["data-preview-file-url"] = post.preview_file_url
-    end
-
+    attributes = {}
+    object.thumbnail_attributes.each_pair { |key, value| attributes["data-#{key}"] = value }
     attributes
   end
 

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -1,381 +1,277 @@
-import Utility from './utility'
-import LS from './local_storage'
-import Post from './posts';
+import Filter from "./models/Filter";
+import Storage from "./storage";
+import Utility from "./utility";
 
 let Blacklist = {};
 
-Blacklist.post_count = 0;
+Blacklist.isAnonymous = false;
+Blacklist.filters = {};
+Blacklist.hiddenPosts = new Set();
+Blacklist.ui = [];
 
-Blacklist.entries = [];
+/** Import the anonymous blacklist from the LocalStorage */
+Blacklist.init_anonymous_blacklist = function () {
+  let metaTag = $("meta[name=blacklisted-tags]");
+  if (metaTag.length == 0)
+    metaTag = $("<meta>")
+      .attr({
+        name: "blacklisted-tags",
+        content: "[]",
+      })
+      .appendTo("head");
 
-Blacklist.entryGet = function (line) {
-  return $.grep(Blacklist.entries, function (e, i) {
-    return e.tags === line;
-  })[0];
-};
-
-Blacklist.entriesAllSet = function (enabled) {
-  LS.put("dab", enabled ? "0" : "1");
-  for (const entry of Blacklist.entries) {
-    entry.disabled = !enabled;
+  if ($("body").data("user-is-anonymous")) {
+    Blacklist.isAnonymous = true;
+    metaTag.attr("content", Storage.Blacklist.AnonymousBlacklist);
   }
 };
 
-Blacklist.lineToggle = function (line) {
-  const entry = Blacklist.entryGet(line);
-  if (!entry)
-    return;
-  entry.disabled = !entry.disabled;
-};
-
-Blacklist.lineSet = function (line, enabled) {
-  const entry = Blacklist.entryGet(line);
-  if (!entry)
-    return;
-  entry.disabled = !enabled;
-};
-
-Blacklist.entryParse = function (string) {
-  const fixInsanity = function(input) {
-    switch(input) {
-      case '=>':
-        return '>=';
-      case '=<':
-        return '<=';
-      case '=':
-        return '==';
-      case '':
-        return '==';
-      default:
-        return input;
-    }
-  };
-  const entry = {
-    "tags": string,
-    "require": [],
-    "exclude": [],
-    "optional": [],
-    "disabled": false,
-    "hits": 0,
-    "score_comparison": null,
-    "username": false,
-    "user_id": 0
-  };
-  const matches = string.match(/\S+/g) || [];
-  for (const tag of matches) {
-    if (tag.charAt(0) === '-') {
-      entry.exclude.push(tag.slice(1));
-    } else if (tag.charAt(0) === '~') {
-      entry.optional.push(tag.slice(1));
-    } else if (tag.match(/^score:[<=>]{0,2}-?\d+/)) {
-      const score = tag.match(/^score:([<=>]{0,2})(-?\d+)/);
-      entry.score_comparison = [fixInsanity(score[1]), parseInt(score[2], 10)];
-    } else {
-      entry.require.push(tag);
-    }
-  }
-  // Use negative lookahead so it doesn't match user:!123 here
-  const user_matches = string.match(/user:(?!!)([\S]+)/) || [];
-  if (user_matches.length === 2) {
-    entry.username = user_matches[1];
-  }
-  // Allow both userid:123 and user:!123
-  const userid_matches = string.match(/user(?:id)?:!?(\d+)/) || [];
-  if (userid_matches.length === 2) {
-    entry.user_id = parseInt(userid_matches[1], 10);
-  }
-  return entry;
-};
-
-Blacklist.entriesParse = function () {
-  Blacklist.entries = [];
-  let entries = JSON.parse(Utility.meta("blacklisted-tags") || "[]");
-  entries = entries.map(e => e.replace(/(rating:[qes])\w+/ig, "$1").toLowerCase());
-  entries = entries.filter(e => e.trim() !== "");
-
-  for (const tags of entries) {
-    const entry = Blacklist.entryParse(tags);
-    Blacklist.entries.push(entry);
-  }
-};
-
-Blacklist.domEntryToggle = function (e) {
-  e.preventDefault();
-  const tags = $(e.target).text();
-  Blacklist.lineToggle(tags);
-  Blacklist.apply();
-};
-
-Blacklist.postHide = function (post) {
-  const $post = $(post);
-  $post.addClass("blacklisted");
-
-  const $video = $post.find("video").get(0);
-  if ($video) {
-    $video.pause();
-    $video.currentTime = 0;
-  }
-};
-
-Blacklist.postShow = function (post) {
-  const $post = $(post);
-  $post.removeClass("blacklisted");
-  Post.resize_notes();
-};
-
-Blacklist.sidebarUpdate = function () {
-  if (LS.get("dab") === "1") {
-    $("#disable-all-blacklists").hide();
-    $("#re-enable-all-blacklists").show();
-  } else {
-    $("#disable-all-blacklists").show();
-    $("#re-enable-all-blacklists").hide();
-  }
-  $("#blacklist-list").html("");
-  if (Blacklist.post_count <= 0) {
-    $("#blacklist-box").hide();
-    return;
-  }
-  for (const entry of this.entries) {
-    if (entry.hits === 0) {
-      continue;
-    }
-
-    const item = $("<li/>");
-    const link = $("<a/>");
-    const count = $("<span/>");
-
-    link.text(entry.tags);
-    link.addClass("blacklist-toggle-link");
-    if (entry.disabled) {
-      link.addClass("entry-disabled");
-    }
-    link.attr("href", `/posts?tags=${encodeURIComponent(entry.tags)}`);
-    link.attr("title", entry.tags);
-    link.attr("rel", "nofollow");
-    link.on("click.danbooru", Blacklist.domEntryToggle);
-    count.html(entry.hits);
-    count.addClass("post-count");
-    item.append(link);
-    item.append(" ");
-    item.append(count);
-
-    $("#blacklist-list").append(item);
-  }
-  $("#blacklisted-count").text(`(${Blacklist.post_count})`);
-
-
-  $("#blacklist-box").show();
-}
-
-Blacklist.initialize_disable_all_blacklists = function () {
-  if (LS.get("dab") === "1") {
-    Blacklist.entriesAllSet(false);
-  }
-
-  $("#disable-all-blacklists").on("click.danbooru", function (e) {
-    e.preventDefault();
-    Blacklist.entriesAllSet(false);
-    Blacklist.apply();
+/** Set up the modal dialogue with the blacklist editor */
+Blacklist.init_blacklist_editor = function () {
+  $("#blacklist-edit-dialog").dialog({
+    autoOpen: false,
+    width: 400,
+    height: 400,
   });
 
-  $("#re-enable-all-blacklists").on("click.danbooru", function (e) {
-    e.preventDefault();
-    Blacklist.entriesAllSet(true);
-    Blacklist.apply();
-  });
-}
-
-Blacklist.apply = function () {
-  Blacklist.post_count = 0;
-  for (const entry of this.entries) {
-    entry.hits = 0;
-  }
-
-  for (const post of this.posts()) {
-    let post_count = 0;
-    for (const entry of Blacklist.entries) {
-      if (Blacklist.postMatch(post, entry)) {
-        entry.hits += 1;
-        if (!entry.disabled)
-          post_count += 1;
-        Blacklist.post_count += 1;
-      }
-    }
-    const $post = $(post);
-    if (post_count > 0) {
-      Blacklist.postHide($post);
-    } else {
-      Blacklist.postShow($post);
-    }
-  }
-
-  if (Utility.meta("blacklist-users") === "true") {
-    for (const entry of this.entries.filter(x => x.username !== false)) {
-      $(`article[data-creator="${entry.username}"]`).hide();
-    }
-    for (const entry of this.entries.filter(x => x.user_id !== 0)) {
-      $(`article[data-creator-id="${entry.user_id}"]`).hide();
-    }
-  }
-
-  Blacklist.sidebarUpdate();
-}
-
-Blacklist.posts = function () {
-  return $(".post-preview, #image-container, #c-comments .post, .post-thumbnail");
-}
-
-Blacklist.postMatch = function (post, entry) {
-  const $post = $(post);
-  if ($post.hasClass('post-no-blacklist'))
-    return false;
-  let post_data = {
-    id: $post.data('id'),
-    score: parseInt($post.data('score'), 10),
-    tags: $post.data('tags'),
-    rating: $post.data('rating'),
-    uploader_id: $post.data('uploader-id'),
-    user: $post.data('uploader').toString().toLowerCase(),
-    flags: $post.data('flags'),
-    is_fav: $post.data('is-favorited')
-  };
-  return Blacklist.postMatchObject(post_data, entry);
-};
-
-Blacklist.postMatchObject = function (post, entry) {
-  const rangeComparator = function (comparison, target) {
-    // Bad comparison, post matches score.
-    if (!Array.isArray(comparison) || typeof target === 'undefined' || comparison.length !== 2)
-      return true;
-    switch (comparison[0]) {
-      case '<':
-        return target < comparison[1];
-      case '<=':
-        return target <= comparison[1];
-      case '==':
-        return target == comparison[1];
-      case '>=':
-        return target >= comparison[1];
-      case '>':
-        return target > comparison[1];
-      default:
-        return true;
-    }
-  };
-  const score_test = rangeComparator(entry.score_comparison, post.score);
-  const tags = post.tags.match(/\S+/g) || [];
-  tags.push(`id:${post.id}`);
-  tags.push(`rating:${post.rating}`);
-  tags.push(`userid:${post.uploader_id}`);
-  tags.push(`user:!${post.uploader_id}`);
-  tags.push(`user:${post.user}`);
-  tags.push(`height:${post.height}`);
-  tags.push(`width:${post.width}`);
-  if(post.is_fav)
-    tags.push('fav:me');
-  $.each(post.flags.match(/\S+/g) || [], function (i, v) {
-    tags.push(`status:${v}`);
+  $("#blacklist-cancel").on("click", function () {
+    $("#blacklist-edit-dialog").dialog("close");
   });
 
-  return (Utility.is_subset(tags, entry.require) && score_test)
-    && (!entry.optional.length || Utility.intersect(tags, entry.optional).length)
-    && !Utility.intersect(tags, entry.exclude).length;
-}
-
-Blacklist.initialize_all = function () {
-  Blacklist.entriesParse();
-
-  Blacklist.initialize_disable_all_blacklists();
-  Blacklist.apply();
-  $("#blacklisted-hider").remove();
-}
-
-Blacklist.initialize_anonymous_blacklist = function () {
-  if ($(document.body).data('user-is-anonymous') !== true) {
-    return;
-  }
-
-  const anonBlacklist = LS.get('anonymous-blacklist');
-  if (anonBlacklist) {
-    $("meta[name=blacklisted-tags]").attr("content", anonBlacklist);
-  }
-}
-
-Blacklist.initialize_blacklist_editor = function () {
-  $("#blacklist-edit-dialog").dialog({ autoOpen: false });
-
-  $("#blacklist-cancel").on('click', function () {
-    $("#blacklist-edit-dialog").dialog('close');
-  });
-
-  $("#blacklist-save").on('click', function () {
+  $("#blacklist-save").on("click", function () {
     const blacklist_content = $("#blacklist-edit").val();
     const blacklist_json = JSON.stringify(blacklist_content.split(/\n\r?/));
-    if($(document.body).data('user-is-anonymous') === true) {
-      LS.put('anonymous-blacklist', blacklist_json);
+    if (Blacklist.isAnonymous) {
+      Storage.Blacklist.AnonymousBlacklist = blacklist_json;
     } else {
       $.ajax("/users/" + Utility.meta("current-user-id") + ".json", {
-        method: "PUT",
         data: {
-          "user[blacklisted_tags]": blacklist_content
-        }
-      }).done(function () {
-        Utility.notice("Blacklist updated");
-      }).fail(function (data, status, xhr) {
-        Utility.error("Failed to update blacklist");
-      });
+          "user[blacklisted_tags]": blacklist_content,
+        },
+        method: "PUT",
+      })
+        .done(function () {
+          Utility.notice("Blacklist updated");
+          // Clear disabled filters, just in case
+          Storage.Blacklist.FilterState = new Set();
+        })
+        .fail(function (data, status, xhr) {
+          Utility.error("Failed to update blacklist");
+        });
     }
 
-    $("#blacklist-edit-dialog").dialog('close');
+    $("#blacklist-edit-dialog").dialog("close");
     $("meta[name=blacklisted-tags]").attr("content", blacklist_json);
-    Blacklist.initialize_all();
+
+    // Start from scratch
+    Blacklist.regenerate_filters();
+    Blacklist.add_posts($(".blacklistable"));
+    Blacklist.update_visibility();
   });
 
-  $("#blacklist-edit-link").on('click', function (event) {
+  $("#blacklist-edit-link").on("click", function (event) {
     event.preventDefault();
     let entries = JSON.parse(Utility.meta("blacklisted-tags") || "[]");
-    entries = entries.map(e => e.replace(/(rating:[qes])\w+/ig, "$1").toLowerCase());
-    entries = entries.filter(e => e.trim() !== "");
-    $("#blacklist-edit").val(entries.join('\n'));
-    $("#blacklist-edit-dialog").dialog('open');
+    $("#blacklist-edit").val(entries.join("\n"));
+    $("#blacklist-edit-dialog").dialog("open");
   });
 };
 
-Blacklist.collapseGet = function () {
-  const lsValue = LS.get('bc') || '1';
-  return lsValue === '1';
-};
+/** Reveals the blacklisted post without disabling any filters */
+Blacklist.init_reveal_on_click = function() {
+  if(!$("#c-posts #a-show").length) return;
+  $("#image-container").on("click", (event) => {
+    $(event.currentTarget).removeClass("blacklisted");
+  });
+}
 
-Blacklist.collapseSet = function (collapsed) {
-  LS.put('bc', collapsed ? "1" : "0");
-};
+/** Import the blacklist from the meta tag */
+Blacklist.regenerate_filters = function () {
+  Blacklist.filters = {};
 
-Blacklist.collapseUpdate = function () {
-  if (Blacklist.collapseGet()) {
-    $('#blacklist-list').hide();
-    $('#blacklist-collapse').addClass('hidden');
-  } else {
-    $('#blacklist-list').show();
-    $('#blacklist-collapse').removeClass('hidden');
+  // Attempt to create filters from text
+  let blacklistText;
+  try {
+    blacklistText = JSON.parse(Utility.meta("blacklisted-tags") || "[]");
+  } catch(error) {
+    console.error(error);
+    blacklistText = [];
+  }
+
+  for (let entry of blacklistText) {
+    const line = Filter.create(entry);
+    if(line) Blacklist.filters[line.text] = line;
+  }
+
+  // Clear any FilterState entries that don't have a matching filter
+  const keys = Object.keys(Blacklist.filters);
+  for (const filterState of Storage.Blacklist.FilterState) {
+    if (keys.includes(filterState)) continue;
+    Storage.Blacklist.FilterState.delete(filterState);
   }
 };
 
-Blacklist.initialize_collapse = function () {
-  $("#blacklist-collapse").on('click', function (e) {
-    e.preventDefault();
-    const current = Blacklist.collapseGet();
-    Blacklist.collapseSet(!current);
-    Blacklist.collapseUpdate();
+/** Build the sidebar and inline blacklist toggles */
+Blacklist.init_blacklist_toggles = function () {
+  if (Blacklist.ui.length) return;
+
+  $(".blacklist-ui").each((index, element) => {
+    Blacklist.ui.push(new BlacklistUI($(element)));
   });
-  Blacklist.collapseUpdate();
 };
 
-$(document).ready(function () {
-  Blacklist.initialize_collapse();
-  Blacklist.initialize_anonymous_blacklist();
-  Blacklist.initialize_blacklist_editor();
-  Blacklist.initialize_all();
+/**
+ * Register posts in the system, and calculate which filters apply to them
+ * @param {JQuery<HTMLElement> | JQuery<HTMLElement>[]} $posts Posts to register
+ */
+Blacklist.add_posts = function ($posts) {
+  for (const filter of Object.values(Blacklist.filters))
+    filter.update($posts);
+};
+
+/**
+ * Recalculate hidden posts based on the current filters.
+ * Also applies or removed `blacklist` class wherever necessary.
+ */
+Blacklist.update_visibility = function () {
+  let oldPosts = [...this.hiddenPosts],
+    newPosts = [];
+
+  // Tally up the new blacklisted posts
+  for (const filter of Object.values(Blacklist.filters)) {
+    if (!filter.enabled) continue;
+    newPosts = [...newPosts, ...filter.matchIDs];
+  }
+
+  // Calculate diffs
+  // TODO I feel like this could be optimized.
+  this.hiddenPosts = new Set(newPosts.filter(n => n));
+  let added = [...this.hiddenPosts].filter((n) => !oldPosts.includes(n)),
+    removed = oldPosts.filter((n) => !this.hiddenPosts.has(n));
+
+  // Update the UI
+  for (const ui of Blacklist.ui) ui.rebuildFilters();
+
+  // Apply / remove classes
+  for (const postID of added)
+    $(`.blacklistable[data-id="${postID}"]`).addClass("blacklisted");
+  for (const postID of removed)
+    $(`.blacklistable[data-id="${postID}"]`).removeClass("blacklisted");
+};
+
+$(() => {
+  Blacklist.init_anonymous_blacklist();
+  Blacklist.init_blacklist_editor();
+  Blacklist.init_reveal_on_click();
+
+  Blacklist.regenerate_filters();
+  Blacklist.add_posts($(".blacklistable"));
+  Blacklist.update_visibility();
+  $("#blacklisted-hider").remove();
+
+  Blacklist.init_blacklist_toggles();
 });
 
-export default Blacklist
+/**
+ * Represents the list of toggles for the blacklist filters.
+ * Could be either in a sidebar or inline formats.
+ */
+class BlacklistUI {
+  /**
+   * Constructor.
+   * Should only be run on `.blacklist-ui` elements.
+   * @param {JQuery<HTMLDivElement>} $element
+   */
+  constructor($element) {
+    this.$element = $element;
+    this.$counter = $element.find(".blacklisted-count");
+
+    // Collapsable header
+    $element
+      .attr("collapsed", Storage.Blacklist.Collapsed)
+      .find(".blacklist-header")
+      .on("click", () => {
+        const newState = this.$element.attr("collapsed") !== "true";
+        this.$element.attr("collapsed", newState);
+        Storage.Blacklist.Collapsed = newState;
+      });
+
+    // Toggle All switch
+    this.$toggle = $element
+      .find(".blacklist-toggle-all")
+      .text("Disable All Filters")
+      .on("click", () => {
+        if (this.$toggle.attr("is-enabling") == "true") {
+          for (const filter of Object.values(Blacklist.filters))
+            filter._enabled = true;
+          Storage.Blacklist.FilterState.clear();
+        } else {
+          const filterList = new Set();
+          for (const filter of Object.values(Blacklist.filters)) {
+            filter._enabled = false;
+            filterList.add(filter.text);
+          }
+          Storage.Blacklist.FilterState = filterList;
+        }
+
+        for (const element of Blacklist.ui) element.rebuildFilters();
+        Blacklist.update_visibility();
+      });
+
+    // Filters
+    this.$container = $($element.find(".blacklist-filters"));
+    this.rebuildFilters();
+  }
+
+  /**
+   * Deletes and re-creates the filter list.
+   * Done automatically every time a filter gets turned on or off,
+   * so all instances are in sync no matter what.
+   */
+  rebuildFilters() {
+    this.$container.html("");
+
+    let activeFilters = 0,
+      inactiveFilters = 0;
+    for (const [name, filter] of Object.entries(Blacklist.filters)) {
+      if (filter.matchIDs.size == 0) continue;
+
+      activeFilters++;
+      if (!filter.enabled) inactiveFilters++;
+
+      const entry = $("<li>")
+        .attr("enabled", filter.enabled)
+        .on("click", () => {
+          // Actual toggling done elsewhere
+          filter.enabled = !filter.enabled;
+        })
+        .appendTo(this.$container);
+
+      const link = $("<a>")
+        .attr("href", "/posts?tags=" + encodeURIComponent(name))
+        .html(
+          name
+            .replace(/_/g, "&#8203;_") // Allow tags to linebreak on underscores
+            .replace(/ -/, " &#8209;") // Prevent linebreaking on negated tags
+        )
+        .on("click", (event) => {
+          event.preventDefault();
+          // Link is disabled, but could still be right-clicked
+        })
+        .appendTo(entry);
+
+      $("<span>").text(filter.matchIDs.size).appendTo(link);
+    }
+
+    // Update the total blacklist size
+    this.$element.attr("filters", activeFilters);
+    this.$counter.text("(" + Blacklist.hiddenPosts.size + ")");
+
+    // Change the toggle state accordingly
+    this.$toggle
+      .text(inactiveFilters ? "Enable All Filters" : "Disable All Filters")
+      .attr("is-enabling", inactiveFilters > 0);
+  }
+}
+
+export default Blacklist;

--- a/app/javascript/src/javascripts/models/Filter.js
+++ b/app/javascript/src/javascripts/models/Filter.js
@@ -1,0 +1,323 @@
+import Blacklist from "../blacklists";
+import Storage from "../storage";
+import PostCache from "./PostCache";
+
+/**
+ * Represents an individual line in the blacklist.  
+ * Contains one or more tokens, which are evaluated to
+ * determine whether the post should be hidden.
+ */
+export default class Filter {
+
+  /**
+   * Constructor. Should not normally be used – refer to `Filter.create()` instead.  
+   * Keep in mind that the input needs to be cleaned up beforehand:
+   * - No comments, inline or standalone
+   * - No trailing or leading whitespace
+   * - No linebreaks
+   * - All lowercase
+   * @param {string} text Blacklist line
+   */
+  constructor(text) {
+    this.text = text;
+    this._enabled = !Storage.Blacklist.FilterState.has(text);
+    this.matchIDs = new Set();
+
+    this.tokens = [];
+    this.optional = [];
+
+    // Tokenize the filter parts
+    for (let word of new Set(this.text.split(" ").filter((e) => e.trim() !== ""))) {
+      let token = new FilterToken(word);
+      if (token.optional) this.optional.push(token);
+      else this.tokens.push(token);
+    }
+  }
+
+  /**
+   * Creates a new Filter based on the provided text.  
+   * Normalizes the text before passing it on to the constructor,
+   * and discards any lines that are guaranteed to be invalid.
+   * @param {string} text Blacklist line
+   * @returns Filter, or null if none was created
+   */
+  static create(text) {
+    text = text.trim();
+    
+    // Get rid of comments
+    if (!text || text.startsWith("#")) return null;
+    text = text.toLowerCase().replace(/ #.*$/, "");
+
+    return new Filter(text);
+  }
+
+  /** @returns {boolean} Filter state */
+  get enabled() {
+    return this._enabled;
+  }
+  set enabled(value) {
+    this._enabled = value == true;
+
+    if (this._enabled) Storage.Blacklist.FilterState.delete(this.text);
+    else Storage.Blacklist.FilterState.add(this.text);
+
+    for (const element of Blacklist.ui) element.rebuildFilters();
+    Blacklist.update_visibility();
+  }
+
+  /**
+   * Checks if the provided post matches the filter
+   * @param {JQuery<HTMLElement>} $post Post to check
+   * @returns True if the post matches the filter, false otherwise
+   */
+  update($post) {
+    if ($post.length == 0) return false;
+    else if (Array.isArray($post))
+      $post = $post[0]; // Deferred posts return an array
+    else if ($post.length > 1) {
+      // Batch update
+      for (const $one of $post)
+        this.update($($one));
+      return;
+    }
+
+    const post = PostCache.fromThumbnail($post);
+
+    // Check if the post matches the filter
+    let tokensMatch = false;
+    for (const token of this.tokens) {
+      tokensMatch = token.test(post);
+      if (token.inverted) tokensMatch = !tokensMatch;
+      if (!tokensMatch) break;
+    }
+
+    // No need to check optional tokens if rest of don't match
+    if (tokensMatch && this.optional.length) {
+      let optionalTokensMatch = false;
+      for (const token of this.optional) {
+        optionalTokensMatch = token.test(post);
+        if (token.inverted) optionalTokensMatch = !optionalTokensMatch;
+        if (optionalTokensMatch) break;
+      }
+
+      // If none of the optional tokens match, consider overall match a failure
+      if (!optionalTokensMatch) tokensMatch = false;
+    }
+
+    if (tokensMatch === true) this.matchIDs.add(post.id);
+    else if (tokensMatch === false) this.matchIDs.delete(post.id);
+  }
+}
+
+/**
+ * Represents a single word in the filter.
+ * Could be a tag, a metatag, a comparison, etc.
+ */
+class FilterToken {
+  /**
+   * Constructor.
+   * Provided data should not contain spaces.
+   * @param {string} raw Single filter word
+   */
+  constructor(raw) {
+    raw = raw.trim().toLowerCase();
+
+    // Optional
+    this.optional = raw.startsWith("~");
+    if (this.optional) raw = raw.substring(1);
+
+    // Inverted
+    // This allows for both ~ and - to be present
+    // Not sure if that's something we want to maintain
+    this.inverted = raw.startsWith("-");
+    if (this.inverted) raw = raw.substring(1);
+
+    // Get filter type: tag, id, score, rating, etc.
+    this.type = FilterUtils.getFilterType(raw);
+    if (this.type !== "tag") raw = raw.substring(this.type.length + 1);
+
+    // Get comparison methods: equals, smaller then, etc
+    this.comparison = FilterUtils.getComparison(raw);
+    if (this.comparison !== "=" && this.comparison !== "..")
+      raw = raw.substring(this.comparison.length);
+
+    // Convert data if necessary
+    switch (this.type) {
+      case "rating":
+        this.value = FilterUtils.parseRating(raw);
+        break;
+      case "sound":
+        this.value = FilterUtils.parseYesNo(raw);
+        break;
+      case "filesize":
+        this.value = FilterUtils.parseFilesize(raw);
+        break;
+      default:
+        this.value = raw;
+    }
+  }
+
+  /**
+   * Checks if the filter token is applicable to the specified post
+   * @param {any} post Post to test
+   * @returns true if the filter token matches
+   */
+  test(post) {
+    return FilterUtils.FilterTests[this.type](this, post);
+  }
+}
+
+/** Various utilities for the blacklist filters */
+let FilterUtils = {
+
+  /**
+   * Tests for various filter types.
+   * Each entry should return a `(token, post) => bool` function.
+   */
+  FilterTests: {
+    tag: (token, post) => FilterUtils.tagsMatchesFilter(post, token.value),
+    tagcount: (token, post) => FilterUtils.compare(post.tagcount, token),
+
+    id: (token, post) => FilterUtils.compare(post.id, token),
+    status: (token, post) => post.flags.indexOf(token.value) >= 0,
+    rating: (token, post) => post.rating === token.value,
+    type: (token, post) => post.file_ext === token.value,
+
+    width: (token, post) => FilterUtils.compare(post.width, token),
+    height: (token, post) => FilterUtils.compare(post.height, token),
+    filesize: (token, post) => FilterUtils.compare(post.size, token),
+
+    score: (token, post) => FilterUtils.compare(post.score, token),
+    favcount: (token, post) => FilterUtils.compare(post.fav_count, token),
+    fav: (token, post) => post.is_favorited,
+
+    uploader: (token, post) => FilterUtils.FilterTests.user(token, post),
+    user: (token, post) => {
+      // Funky userid: alternative
+      if (token.value.startsWith("!"))
+        return post.uploader_id === parseInt(token.value.substring(1));
+      return post.uploader === token.value;
+    },
+    userid: (token, post) => FilterUtils.compare(post.uploader_id, token),
+    username: (token, post) => post.uploader === token.value,
+
+    pool: (token, post) => post.pools.includes(parseInt(token.value) || 0),
+  },
+
+  /**
+   * Returns the filter type based on the metatag present in the input.
+   * If none can be found, assumes that this is a regular tag instead.
+   * @param {string} input
+   * @returns
+   */
+  getFilterType: (input) => {
+    input = input.toLowerCase();
+    for (const key of Object.keys(FilterUtils.FilterTests))
+      if (input.startsWith(key + ":")) return key;
+    return "tag";
+  },
+
+  /**
+   * Some people are incredibly strange and put comparisons backwards.
+   * This makes sure that they get normalized regardless.
+   */
+  ComparisonTable: {
+    "<=": "<=",
+    "=<": "<=",
+    ">=": ">=",
+    "=>": ">=",
+    "=": "=",
+    "==": "=",
+    "<": "<",
+    ">": ">",
+  },
+
+  /**
+   * Normalize the comparison type
+   * @param {string} input Comparison string
+   * @returns Normalized comparison string
+   */
+  getComparison: (input) => {
+    if (/.+\.\..+/.test(input)) return "..";
+    for (const [key, comparison] of Object.entries(FilterUtils.ComparisonTable))
+      if (input.startsWith(key)) return comparison;
+    return "=";
+  },
+
+  /**
+   * Compare the provided value with the one listed in the token
+   * @param {number} a Value to match against
+   * @param {FilterToken} token Token to compare to
+   * @returns true if the provided values pass the specified comparison type
+   */
+  compare: (a, token) => {
+    switch (token.comparison) {
+      case "=":
+        return a == parseFloat(token.value);
+      case "<":
+        return a < parseFloat(token.value);
+      case "<=":
+        return a <= parseFloat(token.value);
+      case ">":
+        return a > parseFloat(token.value);
+      case ">=":
+        return a >= parseFloat(token.value);
+      case "..": {
+        const parts = token.value.split("..");
+        if (parts.length !== 2) return false;
+
+        const parsedParts = [];
+        for (const el of parts) parsedParts.push(parseFloat(el));
+
+        return a >= Math.min(...parsedParts) && a <= Math.max(...parsedParts);
+      }
+      default:
+        return false;
+    }
+  },
+
+  /**
+   * Check if the post has the specified tag
+   * @param {any} post
+   * @param {string} filter
+   * @returns true the post has the tag
+   */
+  tagsMatchesFilter: (post, filter) => {
+    return post.tags.indexOf(filter) >= 0;
+  },
+
+  /**
+   * Normalize the post rating
+   * @param {string} input Rating text
+   * @returns Rating letter
+   */
+  parseRating: (input) => {
+    switch (input) {
+      case "safe":
+      case "s":
+        return "s";
+      case "questionable":
+      case "q":
+        return "q";
+      case "explicit":
+      case "e":
+        return "e";
+      default:
+        return "x";
+    }
+  },
+
+  /**
+   * Takes in a formatted file size string (ex. 5MB) and converts it to bytes
+   * @param {string} input Formatted string
+   * @returns {number} Filesize, in bytes
+   */
+  parseFilesize: function (input) {
+    if (!isNaN(Number(input))) return parseInt(input);
+
+    for (const [index, size] of [/\db$/, /\dkb$/, /\dmb$/].entries()) {
+      if (size.test(input)) return parseInt(input) * Math.pow(1024, index);
+    }
+    return 0;
+  },
+};

--- a/app/javascript/src/javascripts/models/PostCache.js
+++ b/app/javascript/src/javascripts/models/PostCache.js
@@ -1,0 +1,57 @@
+/**
+ * Simple post cache, used to speed up blacklist processing.  
+ * Fetches data from the data-attributes of a thumbnail.
+ */
+export default class PostCache {
+  static _cache = {};
+
+  static fromThumbnail($element) {
+    const id = $element.data("id");
+    if (this._cache[id]) return this._cache[id];
+
+    // As of right now, the code below will take up three
+    // times as long to execute compared to simply fetching
+    // the data from cache. While understandable, it should
+    // still be optimized wherever possible.
+
+    const data = $element[0].dataset; // Faster than $element.data()
+
+    // For some reason, this takes 10x as long on the first post.
+    // But it's still only ~1ms (rather than 0.1ms), so it's fine
+    const tag_string = data.tags || "",
+      tags = tag_string.split(" ");
+
+    const pools = [];
+    for (let value of (data.pools + "").split(" ")) {
+      value = parseInt(value);
+      if (value) pools.push(value);
+    }
+
+    const value = {
+      tag_string: tag_string,
+      tags: tags,
+      tagcount: tags.length,
+
+      id: data.id,
+      flags: (data.flags || "").split(" "),
+      rating: data.rating || "",
+      file_ext: data.fileExt || "",
+
+      width: data.width || -1,
+      height: data.height || -1,
+      size: data.size || -1,
+
+      score: data.score || 0,
+      fav_count: data.favCount || 0,
+      is_favorited: data.isFavorited,
+
+      uploader: (data.uploader || "").toLowerCase(),
+      uploader_id: data.uploaderId || -1,
+
+      pools: pools,
+    };
+
+    this._cache[id] = value;
+    return value;
+  }
+}

--- a/app/javascript/src/javascripts/storage.js
+++ b/app/javascript/src/javascripts/storage.js
@@ -1,0 +1,104 @@
+/**
+ * Abstraction layer for LocalStorage.
+ *
+ */
+let Storage = {};
+const ls = localStorage;
+
+Storage.Blacklist = {
+
+  get AnonymousBlacklist() {
+    return ls.getItem("anonymous-blacklist") || "[]";
+  },
+  set AnonymousBlacklist(value) {
+    return ls.setItem("anonymous-blacklist", value);
+  },
+
+  /**
+   * Whether the blacklist section should be collapsed or expanded
+   * @returns {boolean}
+   */
+  get Collapsed() {
+    // Defaults to "collapsed", so lack of a value is interpreted as "true"
+    return ls.getItem("e621.blk.collapsed") !== "false";
+  },
+  set Collapsed(value) {
+    let newValue = value == true;
+    Cache.Blacklist.Collapsed = newValue;
+    if (newValue) ls.removeItem("e621.blk.collapsed");
+    else ls.setItem("e621.blk.collapsed", false);
+  },
+
+  /**
+   * List of disabled blacklist filters
+   * @returns {Set<string>}
+   */
+  get FilterState() {
+    if (!Cache.Blacklist.FilterState) {
+      try {
+        Cache.Blacklist.FilterState = new Set(
+          JSON.parse(ls.getItem("e621.blk.filters") || "[]")
+        );
+      } catch (e) {
+        console.error(e);
+        ls.removeItem("e621.blk.filters");
+        Cache.Blacklist.FilterState = new Set();
+      }
+
+      StorageUtils.patchBlacklistFunctions();
+    }
+    return Cache.Blacklist.FilterState;
+  },
+  set FilterState(value) {
+    if (!value.size) {
+      ls.removeItem("e621.blk.filters");
+      Cache.Blacklist.FilterState = new Set();
+      return;
+    }
+
+    Cache.Blacklist.FilterState = value;
+    StorageUtils.patchBlacklistFunctions();
+    ls.setItem("e621.blk.filters", JSON.stringify([...value]));
+  },
+};
+
+const StorageUtils = {
+  /**
+   * Adds override methods for the blacklist filter list.  
+   * Needs to be called whenever the variable value is changed.  
+   * Otherwise, there is no way to track changes inside the set.
+   */
+  patchBlacklistFunctions: function () {
+    Cache.Blacklist.FilterState.add = function () {
+      Set.prototype.add.apply(this, arguments);
+      ls.setItem(
+        "e621.blk.filters",
+        JSON.stringify([...Cache.Blacklist.FilterState])
+      );
+    };
+    Cache.Blacklist.FilterState.delete = function () {
+      Set.prototype.delete.apply(this, arguments);
+      if (Cache.Blacklist.FilterState.size == 0)
+        ls.removeItem("e621.blk.filters");
+      else
+        ls.setItem(
+          "e621.blk.filters",
+          JSON.stringify([...Cache.Blacklist.FilterState])
+        );
+    };
+    Cache.Blacklist.FilterState.clear = function () {
+      Set.prototype.clear.apply(this, arguments);
+      ls.removeItem("e621.blk.filters");
+    };
+  },
+};
+
+/**
+ * Simple cache.
+ * Top-level entries are required, bottom ones are not.
+ */
+const Cache = {
+  Blacklist: {},
+};
+
+export default Storage;

--- a/app/javascript/src/javascripts/thumbnails.js
+++ b/app/javascript/src/javascripts/thumbnails.js
@@ -1,71 +1,78 @@
-import Blacklist from './blacklists';
-import LS from './local_storage';
+import Blacklist from "./blacklists";
+import LS from "./local_storage";
 
 const Thumbnails = {};
 
 Thumbnails.initialize = function () {
-  const clearPlaceholder = function (post) {
-    if (post.hasClass('thumb-placeholder-link')) {
-      post.removeClass('thumb-placeholder-link');
-    } else {
-      post.empty();
-    }
-  };
   const postsData = window.___deferred_posts || {};
-  const posts = $('.post-thumb.placeholder, .thumb-placeholder-link');
-  const DAB = LS.get("dab") === "1";
-  $.each(posts, function (i, post) {
-    const p = $(post);
-    const postID = p.data('id');
+  const posts = $(".post-thumb.placeholder, .thumb-placeholder-link");
+
+  const replacedPosts = [];
+
+  $.each(posts, (i, post) => {
+    const $post = $(post);
+
+    // Placeholder is valid
+    const postID = $post.data("id");
     if (!postID) {
-      clearPlaceholder(p);
+      clearPlaceholder($post);
       return;
     }
+
+    // Data exists for this post
     const postData = postsData[postID];
     if (!postData) {
-      clearPlaceholder(p);
+      clearPlaceholder($post);
       return;
     }
-    let blacklist_hit_count = 0;
-    $.each(Blacklist.entries, function (j, entry) {
-      if (Blacklist.postMatchObject(postData, entry)) {
-        entry.hits += 1;
-        blacklist_hit_count += 1;
-      }
-    });
-    const newTag = $('<div>');
-    const blacklisted = DAB ? false : blacklist_hit_count > 0;
+
+    // Building the element
+    const thumbnail = $("<div>")
+      .addClass("post-thumbnail blacklistable")
+      .toggleClass("dtext", $post.hasClass("thumb-placeholder-link"));
     for (const key in postData) {
-      newTag.attr("data-" + key.replace(/_/g, '-'), postData[key]);
+      thumbnail.attr("data-" + key.replace(/_/g, "-"), postData[key]);
     }
-    newTag.attr('class', blacklisted ? "post-thumbnail blacklisted" : "post-thumbnail");
-    if (p.hasClass('thumb-placeholder-link'))
-      newTag.addClass('dtext');
-    const img = $('<img>');
-    img.attr('src', postData.preview_url || '/images/deleted-preview.png');
-    img.attr({
-      height: postData.preview_url ? postData.preview_height : 150,
-      width: postData.preview_url ? postData.preview_width : 150,
-      title: `Rating: ${postData.rating}\r\nID: ${postData.id}\r\nStatus: ${postData.status}\r\nDate: ${postData.created_at}\r\n\r\n${postData.tags}`,
-      alt: postData.tags,
-      class: 'post-thumbnail-img'
-    });
-    const link = $('<a>');
-    link.attr('href', `/posts/${postData.id}`);
-    link.append(img);
-    newTag.append(link);
-    p.replaceWith(newTag);
+
+    const link = $("<a>")
+      .attr("href", `/posts/${postData.id}`)
+      .appendTo(thumbnail);
+
+    $("<img>")
+      .attr({
+        src: postData["preview-url"] || "/images/deleted-preview.png",
+        height: postData["preview-url"] ? postData["preview-height"] : 150,
+        width: postData["preview-url"] ? postData["preview-width"] : 150,
+        title: `Rating: ${postData.rating}\r\nID: ${postData.id}\r\nStatus: ${postData.status}\r\nDate: ${postData["created_at"]}\r\n\r\n${postData.tags}`,
+        alt: postData.tags,
+        class: "post-thumbnail-img",
+      })
+      .appendTo(link);
+
+    $post.replaceWith(thumbnail);
+    replacedPosts.push(thumbnail);
   });
+
+  if(replacedPosts.length > 0) {
+    Blacklist.add_posts(replacedPosts);
+    Blacklist.update_visibility();
+  }
+
+  function clearPlaceholder(post) {
+    if (post.hasClass("thumb-placeholder-link"))
+      post.removeClass("thumb-placeholder-link");
+    else post.empty();
+  }
 };
 
 $(document).ready(function () {
   Thumbnails.initialize();
-  $(window).on('e621:add_deferred_posts', (_, posts) => {
-    window.___deferred_posts = window.___deferred_posts || {}
+  $(window).on("e621:add_deferred_posts", (_, posts) => {
+    window.___deferred_posts = window.___deferred_posts || {};
     window.___deferred_posts = $.extend(window.___deferred_posts, posts);
     Thumbnails.initialize();
   });
-  $(document).on('thumbnails:apply', Thumbnails.initialize);
+  $(document).on("thumbnails:apply", Thumbnails.initialize);
 });
 
 export default Thumbnails;

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -1,78 +1,186 @@
+/*** QUick Edit Form ***/
+#blacklist-edit-dialog {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: min-content 1fr min-content min-content;
+  gap: 0.5rem;
 
+  textarea {
+    grid-column: -1 / 1;
+  }
+  p {
+    margin-bottom: 0;
+    text-align: center;
+  }
+}
 
-#blacklist-box {
-  display: none;
-  margin-bottom: 1em;
+/*** Sidebar Blacklist ***/
+.blacklist-ui {
+  display: flex;
+  flex-flow: column;
 
-  .blacklist-help {
-    font-size: 0.85em;
-    font-weight: bold;
+  &[filters="0"] {
+    display: none;
   }
 
+  // Header
   .blacklist-header {
     display: flex;
-    justify-content: space-between;
-  }
-  #blacklist-collapse {
+
+    font-size: 1.2em;
+    font-weight: bold;
+    margin-left: 1.3em;
+    position: relative;
     cursor: pointer;
+
+    .blacklisted-count {
+      margin-left: 0.25em;
+    }
+
     &::before {
-      content: '▼ '
+      content: "";
+      position: absolute;
+      left: -1.2em;
+      border: 0.3em solid transparent;
+      border-color: transparent var(--color-text) var(--color-text) transparent;
+      transform: rotate(45deg);
+      bottom: 0.25em;
+      transition: 0.25s ease-in-out;
     }
-    &.hidden::before {
-      content: '► ';
+  }
+  &[collapsed="true"] {
+    .blacklist-header::before {
+      transform: rotate(-45deg);
+    }
+
+    .blacklist-filters {
+      max-height: 0;
     }
   }
 
-  #blacklist-list {
-    a {
-      display: inline-block;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      vertical-align: bottom;
-    }
+  // Filters
+  .blacklist-filters {
+    display: flex;
+    flex-flow: column;
+    font-size: 1.1em;
+    gap: 0.125rem;
+    margin: 0.25em 0;
 
-    a.entry-disabled {
-      text-decoration: line-through;
-    }
-  }
+    max-height: 50vh;
+    overflow: hidden auto;
+    transition: max-height 0.25s ease-in-out;
 
-  &.sidebar-blacklist ul li {
-    list-style-type: disc;
-    list-style-position: inside;
+    li {
+      display: flex;
+      cursor: pointer;
 
-    a {
-      max-width: 75%;
-    }
-  }
+      span {
+        color: var(--color-text-muted);
+        margin-left: 0.5em;
+      }
 
-  &.inline-blacklist {
-    margin-bottom: 1em;
+      &::before {
+        content: "\2610"; // ☐
+        display: block;
+        width: 1em;
+        margin-right: 0.5em;
+      }
 
-    #blacklist-list {
-      display: inline;
+      &[enabled="true"] {
+        &::before {
+          content: "\2611"; // ☑
+        }
+      }
 
-      li {
-        display: inline;
-        margin-right: 1em;
-
+      &[enabled="false"] {
+        color: var(--color-text-muted);
         a {
-          max-width: 25%;
+          color: var(--color-text-muted);
         }
       }
     }
   }
+
+  // Footer
+  .blacklist-footer {
+    display: flex;
+
+    a.blacklist-toggle-all {
+      cursor: pointer;
+    }
+
+    .blacklist-help {
+      margin-left: auto;
+    }
+  }
 }
 
+
+/*** Inline Blacklist ***/
+.blacklist-ui.blacklist-inline {
+  flex-flow: row;
+  flex-wrap: wrap;
+
+  .blacklist-header {
+    font-size: 1em;
+    margin-left: 0;
+
+    &::before {
+      display: none;
+    }
+  }
+
+  .blacklist-filters {
+    flex-flow: row;
+    gap: 0.75rem;
+    margin: 0 0.75rem;
+
+    li {
+      &::before {
+        display: none; 
+      }
+    }
+  }
+  &[collapsed=true]{
+    .blacklist-filters {
+      display: none;
+    }
+    .blacklist-footer {
+      margin-left: 0.75rem;
+    }
+  }
+  
+  .blacklist-footer {
+    .blacklist-help {
+      display: none;
+    }
+  }
+}
+
+
+// Settings
+#c-users #a-edit {
+  #user_blacklisted_tags {
+    min-height: 25em;
+    width: 100%;
+  }
+}
+
+
 // Completely hide the blacklisted posts on these pages only
-#c-posts #a-index, #c-popular, #c-favorites {
+#c-posts #a-index,
+#c-popular,
+#c-favorites {
   .post-preview.blacklisted {
     display: none !important;
   }
 }
 
-#image-container.blacklisted, .post-thumbnail.blacklisted, .post-preview.blacklisted {
-  img, video {
+#image-container.blacklisted,
+.post-thumbnail.blacklisted,
+.post-preview.blacklisted {
+  img,
+  video {
     height: 0px !important;
     width: 0px !important;
     padding: 150px 150px 0px 0px !important;

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1401,6 +1401,41 @@ class Post < ApplicationRecord
       hash
     end
 
+    def thumbnail_attributes
+      attributes = {
+        "id": id,
+        "flags": status_flags,
+        "tags": tag_string,
+        "rating": rating,
+        "file-ext": file_ext,
+
+        "width": image_width,
+        "height": image_height,
+        "size": file_size,
+
+        "created-at": created_at,
+        "uploader": uploader_name,
+        "uploader-id": uploader_id,
+
+        "score": score,
+        "fav-count": fav_count,
+        "is-favorited": favorited_by?(CurrentUser.user.id),
+
+        "pools": pool_ids,
+      }
+
+      if visible?
+        attributes["md5"] = md5
+        attributes["preview-url"] = preview_file_url
+        attributes["large-url"] = large_file_url
+        attributes["file-url"] = file_url
+        attributes["preview-width"] = preview_dimensions[1]
+        attributes["preview-height"] = preview_dimensions[0]
+      end
+
+      attributes
+    end
+
     def status
       if is_pending?
         "pending"

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -98,35 +98,14 @@ class PostPresenter < Presenter
     klass << "post-rating-safe" if post.rating == 's'
     klass << "post-rating-questionable" if post.rating == 'q'
     klass << "post-rating-explicit" if post.rating == 'e'
-    klass << "post-no-blacklist" if options[:no_blacklist]
+    klass << "blacklistable" unless options[:no_blacklist]
     klass
   end
 
   def self.data_attributes(post, include_post: false)
-    attributes = {
-        "data-id" => post.id,
-        "data-has-sound" => post.has_tag?("video_with_sound", "flash_with_sound"),
-        "data-tags" => post.tag_string,
-        "data-rating" => post.rating,
-        "data-width" => post.image_width,
-        "data-height" => post.image_height,
-        "data-flags" => post.status_flags,
-        "data-score" => post.score,
-        "data-file-ext" => post.file_ext,
-        "data-uploader-id" => post.uploader_id,
-        "data-uploader" => post.uploader_name,
-        "data-is-favorited" => post.favorited_by?(CurrentUser.user.id)
-    }
-
-    if post.visible?
-      attributes["data-md5"] = post.md5
-      attributes["data-file-url"] = post.file_url
-      attributes["data-large-file-url"] = post.large_file_url
-      attributes["data-preview-file-url"] = post.preview_file_url
-    end
-
+    attributes = {}
+    post.thumbnail_attributes.each_pair { |key, value| attributes["data-#{key}"] = value }
     attributes["data-post"] = post_attribute_attribute(post).to_json if include_post
-
     attributes
   end
 

--- a/app/views/posts/partials/common/_blacklist_editor.html.erb
+++ b/app/views/posts/partials/common/_blacklist_editor.html.erb
@@ -2,6 +2,6 @@
   <h4>Tag Blacklist</h4>
   <textarea id="blacklist-edit" rows="8" cols="30"></textarea>
   <input type="button" value="Save" id="blacklist-save"/>
-  <input type="button" value="Cancel" id="blacklist-cancel" /><br />
-  <p>Additional help about the blacklist can be found <%= link_to "here", help_page_path(id: "blacklist") %></p>
+  <p>[ <%= link_to "Blacklist Help", help_page_path(id: "blacklist") %> ]</p>
+  <input type="button" value="Cancel" id="blacklist-cancel" />
 </div>

--- a/app/views/posts/partials/common/_inline_blacklist.html.erb
+++ b/app/views/posts/partials/common/_inline_blacklist.html.erb
@@ -1,7 +1,12 @@
-<section id="blacklist-box" class="inline-blacklist">
-  <strong id="blacklist-collapse" class="hidden">Blacklisted<span id="blacklisted-count"></span>: </strong>
-  <ul id="blacklist-list" style="display: none;">
-  </ul>
-  <span id="disable-all-blacklists" style="display: none;"><span class="link">Disable all</span></span>
-  <span id="re-enable-all-blacklists" style="display: none;"><span class="link">Re-enable all</span></span>
+<section
+  class="blacklist-ui blacklist-inline"
+  filters="0"
+  collapsed="true"
+>
+  <div class="blacklist-header">Blacklisted <span class="blacklisted-count"></span></div>
+  <div class="blacklist-filters"></div>
+  <span class="blacklist-footer">
+    <a class="blacklist-toggle-all"></a>
+    <div class="blacklist-help"><%= link_to "(help)", help_page_path(id: "blacklist") %></div>
+  </span>
 </section>

--- a/app/views/posts/partials/index/_blacklist.html.erb
+++ b/app/views/posts/partials/index/_blacklist.html.erb
@@ -1,10 +1,11 @@
-<section id="blacklist-box" class="sidebar-blacklist">
-  <div class="blacklist-header">
-    <h1 id="blacklist-collapse" class="hidden">Blacklisted<span id="blacklisted-count"></span></h1>
+<section class="blacklist-ui"
+  filters="0"
+  collapsed="true"
+>
+  <div class="blacklist-header">Blacklisted <span class="blacklisted-count"></span></div>
+  <div class="blacklist-filters"></div>
+  <span class="blacklist-footer">
+    <a class="blacklist-toggle-all"></a>
     <div class="blacklist-help"><%= link_to "(help)", help_page_path(id: "blacklist") %></div>
-  </div>
-  <ul id="blacklist-list" style="display: none;">
-  </ul>
-  <%= link_to "Disable all", "#", :id => "disable-all-blacklists", :style => "display: none;" %>
-  <%= link_to "Re-enable all", "#", :id => "re-enable-all-blacklists", :style => "display: none;" %>
+  </span>
 </section>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -74,7 +74,7 @@
 
         <%= render "ads/leaderboard", tag_string: @post.ad_tag_string %>
 
-        <%= tag.section(id: "image-container", **PostPresenter.data_attributes(@post, include_post: true)) do -%>
+        <%= tag.section(id: "image-container", class: "blacklistable", **PostPresenter.data_attributes(@post, include_post: true)) do -%>
           <div id="note-container"></div>
           <div id="note-preview"></div>
           <%= render "posts/partials/show/embedded", post: @post %>


### PR DESCRIPTION
This pull request replicates re621's extended blacklist to the vanilla site.
This includes both a redesign of the blacklist UI, and adding more usable metatags.

## Design

### Sidebar 
<img align="left" src="https://github.com/e621ng/e621ng/assets/132787557/73cebd4a-f70d-4477-b34c-44b505a84de5">

The blacklist UI in the sidebar had been made more clear and easy to use.
Before, it was not immediately obvious to some users that the crossed-out filters were disabled.
Muting the colors where appropriate, and adding checkboxes that reflect the filter's state, should help with that.

Additionally, the number of posts next to the blacklist header updates dynamically when individual filters are enabled or disabled, and reflects the total number of posts that had been hidden by the blacklist.

<br clear="left"/>

### Inline

![inline](https://github.com/e621ng/e621ng/assets/132787557/308c3cd4-d581-473a-a4b4-228c45b87f59)

The inline blacklist UI looks more or less the same as before.
Under the hood, it is identical to the sidebar UI, just with some style changes.

### Quick edit form


<img align="left" src="https://github.com/e621ng/e621ng/assets/132787557/4545a608-e003-4934-a17e-089e8b7fc302">

The quick edit form used to be fairly small and ugly. The actual textarea used to be just 263x138 pixels in size.
That is quite unacceptable – quite a few of my blacklist entries wouldn't fit on one line.

In addition to increasing its size, proper padding had been added to the form's elements.

<br clear="left"/>
<br />

## Features

### Persistence

Previous blacklist implementation could only save its state between different pages as all or nothing: either all filters are disabled, or all are enabled.

Now, if an individual filter is disabled on one page, it will remain disabled on another.
"Enable All Filters" clears the saved filter states on all pages. Additionally, the script will check that the filters in the disabled list actually still exist on startup, to prevent entries from getting stuck in the list despite being removed from the blacklist.

<img align="left" src="https://github.com/e621ng/e621ng/assets/132787557/93885b44-ac80-4b24-ab66-d21014e990db">

#### Search page 

User disables some filters on the search page.
<br clear="left"/>

<img align="left" src="https://github.com/e621ng/e621ng/assets/132787557/28b50289-cbb5-46fc-ae90-203e8b198e17">

#### Post page

When the user navigates to a post page, the same filters will remain disabled.
<br clear="left"/>


### Metatags <a id="metatags"></a>
The table below lists the available metatags.
Blue checkmarks indicate previous functionality, green ones – tags that had been added in this PR.

"Equality" indicates an exact match: `score:100`.
"Comparison" is relative: `score:>100`.
"Range" supports a range of values: `score:50..100`.

|                  | Equality | Comparison | Range |
|       ---      |     :---:    |        :---:        |   :---:   |
| id             |     ☑️      |        ✅        |    ✅   |
| status       |     ☑️      |                    |             |
| rating       |     ☑️      |                    |             |
| type          |     ✅      |                    |             |
| width        |     ☑️      |        ✅        |    ✅   |
| height      |     ☑️      |         ✅        |    ✅   |
| filesize <sup>1</sup>    |    ✅      |         ✅        |    ✅   |
| score        |     ☑️      |        ☑️        |    ✅   |
| favcount   |     ✅      |        ✅        |    ✅   |
| fav:me <sup>2</sup>   |     ☑️      |                    |             |
| user          |     ☑️      |                    |             |
| userid       |     ☑️      |         ✅        |    ✅   |
| username |     ✅      |                    |             |
| pool         |     ✅      |                    |             |
| tagcount  |     ✅      |         ✅        |    ✅   |

<sup>1</sup> `filesize` accepts both numerical values, or ones in `kb` or `mb`
<sup>2</sup> `fav:me` can only refer to the user's own favorites, same as before.

### Comments
The blacklist now supports proper comments, both inline and standalone.
Anything after the `#` symbol will be ignored by the blacklist.

All of the following are valid:
```
horse male solo # will remove later
rainbow lizard #scaliespe`
# artists I hate:
##### break #####
```

### Whitelist
Any line that starts with the characters `W! ` will be interpreted as a whitelist filter.
If a post matches the other tags on that line, it will never be hidden by the blacklist, even if it matches other filters.

### Click to Reveal
On the post page, clicking on the blacklist placeholder will reveal the post without disabling any of the filters.