### PR TITLE
[Users] Redesign the profile page post sections

### DIFF
--- a/app/javascript/src/javascripts/users.js
+++ b/app/javascript/src/javascripts/users.js
@@ -1,0 +1,30 @@
+let User = {};
+
+User.initialize_tabs = function() {
+    const container = $(".user-content");
+
+    let selectedTab = "0";
+    container.find("h2.tab").on("click", (event) => {
+        event.preventDefault();
+        
+        let element = $(event.target);
+        if(element.is("a")) element = element.parents("h2.tab");
+        const newTab = element.attr("tab");
+        if(newTab == selectedTab) return;
+
+        container.find(`h2[tab="${selectedTab}"]`).removeClass("active");
+        container.find(`div.tab-posts[tab="${selectedTab}"]`).addClass("hidden");
+
+        container.find(`h2[tab="${newTab}"]`).addClass("active");
+        container.find(`div.tab-posts[tab="${newTab}"]`).removeClass("hidden");
+        container.attr("tab-active", newTab);
+
+        selectedTab = newTab;
+    });
+}
+
+$(() => {
+    User.initialize_tabs();
+});
+
+export default User;

--- a/app/javascript/src/styles/specific/users.scss
+++ b/app/javascript/src/styles/specific/users.scss
@@ -1,4 +1,3 @@
-
 .user-greeting-outer {
   padding: $padding-025 0 $padding-025;
   span.user-greeting {
@@ -15,6 +14,7 @@ div#c-users {
 
     .bottom-section {
       display: flex;
+      flex-flow: column;
     }
 
     .stats-section {
@@ -22,8 +22,109 @@ div#c-users {
     }
 
     .posts-section {
+      margin-bottom: 1em;
+
+      .blacklist {
+        margin-bottom: 0.5em;
+      }
+
       .posts {
         display: flex;
+        flex-flow: column;
+        gap: 0.5rem;
+      }
+
+      .box {
+        display: grid;
+        grid-template-areas: "box-label box-extra"
+            "box-posts box-posts";
+        grid-template-columns: auto 1fr;
+        gap: 0 0.25rem;
+      }
+
+      .box h2.box-label {
+        display: block;
+        grid-area: box-label;
+        font-size: 1.5em; // Mobile shenanigans
+        margin: unset;
+
+        a {
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+
+          width: min-content;
+          height: 100%;
+          box-sizing: border-box;
+          padding: 0.125em;
+
+          background: var(--color-section);
+          border-radius: 6px 6px 0 0;
+          min-width: 150px;
+
+          &:focus, &:active {
+            outline: 0;
+            color: var(--color-link-active);
+          }
+        }
+      }
+
+      .box span.box-extra {
+        grid-area: box-extra;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+        margin-bottom: 0.25em;
+
+        a {
+          display: flex;
+          background: var(--color-section);
+          align-items: center;
+          padding: 0.125rem 0.5rem;
+          border-radius: 6px;
+          white-space: nowrap;
+
+          &:focus, &:active {
+            outline: 0;
+            color: var(--color-link-active);
+          }
+        }
+
+        span.text {
+          display: flex;
+          align-items: center;
+          justify-items: center;
+          padding: 0.125rem 0.5rem;
+          white-space: nowrap;
+        }
+      }
+
+      .box div.box-posts {
+        grid-area: box-posts;
+
+        display: grid;
+        grid-template-columns: repeat(auto-fit, 150px);
+        grid-auto-flow: column;
+
+        min-height: 201px; // Yes, 201. 150 + 3 * 1em
+        border-radius: 0 6px 6px 6px;
+        background: var(--color-section);
+        align-items: self-end;
+        justify-content: space-between;
+        overflow: hidden;
+        padding: 1em;
+        gap: 1em;
+        box-sizing: border-box;
+
+        article.post-preview {
+          margin: 0;
+          width: 150px;
+          overflow: visible;
+
+          img {
+            width: 100%;
+          }
+        }
       }
     }
 
@@ -32,20 +133,16 @@ div#c-users {
     }
 
     .about-section {
-      flex-grow: 2;
       display: flex;
+      flex-grow: 2;
+      gap: 1em;
+
       .about-piece {
         flex-grow: 1;
-        margin: 0 1em;
       }
       div {
         flex-basis: 50%;
       }
-    }
-
-    .vertical-section {
-      display: flex;
-      flex-direction: column;
     }
 
     .profile-stats {
@@ -126,12 +223,7 @@ div#c-users {
         }
         .posts-section {
           order: 2;
-          .posts {
-            display: block;
-          }
-        }
-        .user-uploads {
-          order: 1;
+          padding: 0 5px;
         }
         .about-section {
           flex-direction: column;
@@ -143,4 +235,29 @@ div#c-users {
       }
     }
   }
+}
+
+@media screen and (max-width: 600px) {
+body.resp #c-users #a-show {
+  .posts-section {
+    .box {
+      grid-template-areas: "box-label"
+      "box-extra"
+      "box-posts";
+      grid-template-columns: auto;
+    }
+    .box h2.box-label a {
+      border-radius: 6px;
+    }
+    .box span.box-extra {
+      margin-top: 0.25em;
+    }
+    .box div.box-posts {
+      grid-auto-flow: dense;
+      border-radius: 6px;
+      padding: 1em 0.25em;
+      gap: 1em 0.25em;
+    }
+  }
+}
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,6 +115,7 @@ class User < ApplicationRecord
   has_many :post_votes
   has_many :staff_notes, -> { order("staff_notes.id desc") }
   has_many :user_name_change_requests, -> { order(id: :asc) }
+  has_many :artists, foreign_key: "linked_user_id"
 
   belongs_to :avatar, class_name: 'Post', optional: true
   accepts_nested_attributes_for :dmail_filter

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -51,8 +51,12 @@ class UserPresenter
     = <abbr title="User Upload Limit Remaining">#{user.upload_limit}</abbr>}.html_safe
   end
 
+  def artwork(name)
+    Post.tag_match(name).limit(10)
+  end
+
   def uploads
-    Post.tag_match("user:#{user.name}").limit(6)
+    Post.tag_match("user:#{user.name}").limit(10)
   end
 
   def has_uploads?
@@ -60,7 +64,7 @@ class UserPresenter
   end
 
   def favorites
-    ids = Favorite.where(user_id: user.id).order(created_at: :desc).limit(50).pluck(:post_id)[0..5]
+    ids = Favorite.where(user_id: user.id).order(created_at: :desc).limit(50).pluck(:post_id)[0..9]
     Post.where(id: ids)
   end
 

--- a/app/views/users/_post_summary.html.erb
+++ b/app/views/users/_post_summary.html.erb
@@ -1,16 +1,14 @@
-<% if presenter.has_favorites? && !@user.hide_favorites? %>
-  <div class="box user-favorites">
-    <h2>
-      <%= link_to "Favorites", favorites_path(:user_id => user.id) %>
+<% user.artists.each do |artist| %>
+  <div class="box user-artwork">
+    <h2 class="box-label">
+      <%= link_to "Artwork", posts_path(:tags => artist.name) %>
     </h2>
-    <% if user.enable_privacy_mode? || user.is_blocked? %>
-      <h4>
-        (hidden)
-      </h4>
-    <% end %>
-    <div class="vertical-section">
-      <% presenter.favorites.each do |post| %>
-        <%= PostPresenter.preview(post, :tags => "fav:#{user.name}") %>
+    <span class="box-extra">
+      <%= link_to("Comments", comments_path(group_by: "comment", search: { post_tags_match: artist.name })) %>
+    </span>
+    <div class="box-posts">
+      <% presenter.artwork(artist.name).each do |post| %>
+        <%= PostPresenter.preview(post, :tags => artist.name) %>
       <% end %>
     </div>
   </div>
@@ -18,12 +16,41 @@
 
 <% if presenter.has_uploads? %>
   <div class="box user-uploads">
-    <h2>
+    <h2 class="box-label">
       <%= link_to "Uploads", posts_path(:tags => "user:#{user.name}") %>
     </h2>
-    <div class="vertical-section">
+    <span class="box-extra">
+      <%= link_to("#{user.post_upload_count - user.post_deleted_count} total", posts_path(tags: "user:#{user.name}")) %>
+      <%= link_to("#{user.post_deleted_count} deleted", deleted_posts_path(user_id: user.id)) %>
+      <%= link_to("#{user.own_post_replaced_count} replaced", post_replacements_path(search: { uploader_id_on_approve: user.id })) %>
+      <%= link_to("#{user.post_replacement_rejected_count} rejected", post_replacements_path(search: { creator_id: user.id, status: "rejected" })) %>
+      <span class="spacer"></span>
+      <%= link_to("Comments", comments_path(group_by: "comment", search: { poster_id: user.id })) %>
+    </span>
+    <div class="box-posts">
       <% presenter.uploads.each do |post| %>
         <%= PostPresenter.preview(post, :tags => "user:#{user.name}") %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if presenter.has_favorites? && !@user.hide_favorites? %>
+  <div class="box user-favorites">
+    <h2 class="box-label">
+      <%= link_to "Favorites", favorites_path(:user_id => user.id) %>
+    </h2>
+    <span class="box-extra">
+      <%= link_to("#{user.favorite_count} total", favorites_path(:user_id => user.id)) %>
+      <% if user.enable_privacy_mode? || user.is_blocked? %>
+        <span class="text">
+          [hidden]
+        </span>
+      <% end %>
+    </span>
+    <div class="box-posts">
+      <% presenter.favorites.each do |post| %>
+        <%= PostPresenter.preview(post, :tags => "fav:#{user.name}") %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Tweaked the posts page to display uploads and favorites horizontally, rather than vertically.
The original version was unbalanced, with a lot of content densely crammed on the left.

This will also allow us to start offloading some of the information crammed into the stats table.
For example, it makes sense that the post counts are displayed next to a preview of the user's latest uploads.

![profile1](https://github.com/e621ng/e621ng/assets/132787557/7a7e2557-ecc5-4be1-962d-bd2a0b4d48ee)

Additionally, if the account has artist tags linked to it, the profile page will also display a preview of the latest posts.

![profile2](https://github.com/e621ng/e621ng/assets/132787557/8e495885-b363-4ea5-b83a-5d7430c5f8e0)
