### PR TITLE
[Posts] Show file type in the post sidebar

### DIFF
--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -28,6 +28,9 @@
     Size: <span itemprop="width"><%= post.image_width %></span>x<span itemprop="height"><%= post.image_height %></span> (<%= number_to_human_size(post.file_size) %>)
   </li>
   <li>
+    Type: <%= post.file_ext.upcase %>
+  </li>
+  <li>
     Status:
     <% if post.is_pending? %>
       Pending


### PR DESCRIPTION
By popular demand, add the file type to the post's sidebar.

![filetype](https://github.com/e621ng/e621ng/assets/132787557/7a8508e6-7ad6-47f4-8ff6-acec5496cc9a)
