### PR TITLE
[ForumPosts] Fix voting buttons

### DIFF
--- a/app/javascript/src/javascripts/forum_posts.js
+++ b/app/javascript/src/javascripts/forum_posts.js
@@ -10,7 +10,7 @@ ForumPost.initialize_all = function() {
       $("#edit_forum_post_" + forum_post_id).fadeToggle("fast");
       e.preventDefault();
     });
-  
+
     $(".edit_forum_topic_link").on("click.danbooru", function(e) {
       var link_id = $(this).attr("id");
       var forum_topic_id = link_id.match(/^edit_forum_topic_link_(\d+)$/)[1];
@@ -57,16 +57,16 @@ ForumPost.vote = function(evt, score) {
     container.append(icon).append(' ').append(username);
     $(`#forum-post-votes-for-${new_vote.forum_post_id}`).prepend(container);
   };
-  const id = $(evt.target.parentNode).data('forum-id');
+  const id = $(evt.currentTarget).data("forum-id");
   $.ajax({
     url: `/forum_posts/${id}/votes.json`,
-    type: 'POST',
-    dataType: 'json',
-    accept: 'text/javascript',
-    data: {'forum_post_vote[score]': score}
+    type: "POST",
+    dataType: "json",
+    accept: "text/javascript",
+    data: { "forum_post_vote[score]": score }
   }).done(function(data) {
     create_post(data);
-    $('.forum-post-vote-block').remove();
+    $(`#forum-post-votes-for-${id} .forum-post-vote-block`).hide();
   }).fail(function(data) {
     if(data?.responseJSON?.reason) {
       Utility.error(data.responseJSON.reason);
@@ -78,14 +78,15 @@ ForumPost.vote = function(evt, score) {
 
 ForumPost.vote_remove = function(evt) {
   evt.preventDefault();
-  const id = $(evt.target.parentNode).data('forum-id');
+  const id = $(evt.currentTarget).data("forum-id");
   $.ajax({
     url: `/forum_posts/${id}/votes.json`,
-    type: 'DELETE',
-    dataType: 'json',
-    accept: 'text/javascript',
+    type: "DELETE",
+    dataType: "json",
+    accept: "text/javascript",
   }).done(function(data) {
     $(evt.target).parents(".own-forum-vote").remove();
+    $(`#forum-post-votes-for-${id} .forum-post-vote-block`).show();
     Utility.notice("Vote removed.");
   }).fail(function(data) {
     Utility.error("Failed to unvote on forum post.");


### PR DESCRIPTION
This pr fixes two issues with voting on forum posts.
* All voting buttons currently on the page disappear when voting on anything
* [Clicking outside of the `i` element makes voting fail](https://discord.com/channels/431908090883997698/1099361575116222656/1190249521771450398)

This pr also doesn't fully remove the vote buttons, they're kept around, so they can be restored when unvoting.