### PR TITLE
[Comments] Add "Post Uploader" to search options

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -124,7 +124,7 @@ private
   end
 
   def search_params
-    permitted_params = %i[body_matches post_id post_tags_match creator_name creator_id post_note_updater_name post_note_updater_id poster_id is_sticky do_not_bump_post order]
+    permitted_params = %i[body_matches post_id post_tags_match creator_name creator_id post_note_updater_name post_note_updater_id poster_id poster_name is_sticky do_not_bump_post order]
     permitted_params += %i[is_hidden] if CurrentUser.is_moderator?
     permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -66,10 +66,6 @@ class Comment < ApplicationRecord
       where(post_id: Post.tag_match_sql(query).order(id: :desc).limit(300))
     end
 
-    def poster_id(user_id)
-      joins(:post).where("posts.uploader_id = ?", user_id)
-    end
-
     def for_creator(user_id)
       user_id.present? ? where("creator_id = ?", user_id) : none
     end
@@ -117,8 +113,8 @@ class Comment < ApplicationRecord
         end
       end
 
-      if params[:poster_id].present?
-        q = q.poster_id(params[:poster_id].to_i)
+      if %i[poster_id poster_name].any? { |key| params[key].present? }
+        q = q.joins(:post).where_user(:"posts.uploader_id", :poster, params)
         # Force a better query plan by ordering by created_at
         q = q.reorder("comments.created_at desc")
       end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -113,13 +113,11 @@ class Comment < ApplicationRecord
         end
       end
 
-      if %i[poster_id poster_name].any? { |key| params[key].present? }
-        q = q.joins(:post).where_user(:"posts.uploader_id", :poster, params)
+      q.where_user(:"posts.uploader_id", :poster, params) do |condition, _ids|
+        condition = condition.joins(:post)
         # Force a better query plan by ordering by created_at
-        q = q.reorder("comments.created_at desc")
+        condition.reorder("comments.created_at desc")
       end
-
-      q
     end
   end
 

--- a/app/views/comments/_search.html.erb
+++ b/app/views/comments/_search.html.erb
@@ -4,6 +4,7 @@
   <%= f.input :body_matches, label: "Body" %>
   <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
   <%= f.user :post_note_updater, label: "Post Note Updater", hide_unless_value: true %>
+  <%= f.user :poster, label: "Post Uploader", hide_unless_value: true %>
   <% if CurrentUser.is_admin? %>
     <%= f.input :ip_addr, label: "IP Address" %>
   <% end %>


### PR DESCRIPTION
Adds A "Post Uploader" input to the comments search (only shows when parameter is present), retaining the search when coming from the "comments on" links
![image](https://github.com/e621ng/e621ng/assets/17226394/b05fb6dc-acf6-44e3-89a1-f488d5a998dd)

Also added explicit `comments` table reference where the score column is used, due to the index page failing to load when grouping by comments, and joined to the post when no comments exist (ambiguous column `posts.score`/`comments.score`)
In theory this is an issue that will show up next to never, but there's also no real harm in explicitly referencing the table