### PR TITLE
[Comments] Fix the show_hidden_comments setting

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -208,7 +208,7 @@ class Comment < ApplicationRecord
   end
 
   def should_see?(user)
-    return true if creator_id == user.id && is_hidden? && user.show_hidden_comments?
+    return user.show_hidden_comments? if creator_id == user.id && is_hidden?
     visible_to?(user)
   end
 

--- a/app/views/comments/_index_by_comment.html.erb
+++ b/app/views/comments/_index_by_comment.html.erb
@@ -1,6 +1,6 @@
 <div id="p-index-by-comment" class="comments-for-post">
     <% @comments.each do |comment| %>
-      <% if comment.post.present? && comment.visible_to?(CurrentUser.user) %>
+      <% if comment.post.present? && comment.should_see?(CurrentUser.user) %>
       <div class="comment-post">
         <div class="post-container">
           <%= PostPresenter.preview(comment.post, inline: true, show_deleted: true) %>


### PR DESCRIPTION
Addresses the bug reported [here](https://e621.net/forum_posts/387904).
The `show_hidden_comments` setting was effectively being ignored.

Additionally, I fixed a small bug causing the comment's corresponding post to be displayed in the comments index, even if the comment itself was hidden.