### PR TITLE
[PostSets] Fix excluding all root level parameters

### DIFF
--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -150,7 +150,7 @@ class PostSetsController < ApplicationController
   end
 
   def add_remove_posts_params
-    params.except(:id, :format).permit(post_ids: []).require(:post_ids)
+    params.extract!(:post_ids).permit(post_ids: []).require(:post_ids)
   end
 
   def search_params


### PR DESCRIPTION
Fixes post set params for the 27th (third) time.

The current implementation disallows any other root level parameters to be provided. Via using `extract!`, we get only what we want, then do operations on that, allowing other parameters to be specified once more.

As per [Rails' Documentation](https://api.rubyonrails.org/v7.1.0/classes/ActionController/Parameters.html#method-i-extract-21) this does modify the original parameters instance, but that shouldn't be a problem.

Mentioned [in Discord](https://discord.com/channels/431908090883997698/1099361575116222656/1200592616522272858)