### PR TITLE
[Blacklist] Reveal the blacklisted post on click

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -289,6 +289,8 @@ Blacklist.initialize_all = function () {
   Blacklist.initialize_disable_all_blacklists();
   Blacklist.apply();
   $("#blacklisted-hider").remove();
+
+  Blacklist.init_reveal_on_click();
 }
 
 Blacklist.initialize_anonymous_blacklist = function () {
@@ -370,6 +372,14 @@ Blacklist.initialize_collapse = function () {
   });
   Blacklist.collapseUpdate();
 };
+
+/** Reveals the blacklisted post without disabling any filters */
+Blacklist.init_reveal_on_click = function() {
+  if(!$("#c-posts #a-show").length) return;
+  $("#image-container").on("click", (event) => {
+    $(event.currentTarget).removeClass("blacklisted");
+  });
+}
 
 $(document).ready(function () {
   Blacklist.initialize_collapse();


### PR DESCRIPTION
This is a spinoff from PR #586.
Technically, it's a port from RE621 too.

![chrome_9ZCQb8VQwo](https://github.com/e621ng/e621ng/assets/132787557/8d1f0447-dec5-4ff5-bfff-2bf290755045)

Very simply, is the post had been blacklisted, clicking on the placeholder image reveals it without disabling any filters.