### PR TITLE
[Posts] Standardize thumbnail attributes

### DIFF
--- a/app/controllers/concerns/deferred_posts.rb
+++ b/app/controllers/concerns/deferred_posts.rb
@@ -7,7 +7,7 @@ module DeferredPosts
 
   def deferred_posts
     Post.includes(:uploader).where(id: deferred_post_ids.to_a).find_each.reduce({}) do |post_hash, p|
-      post_hash[p.id] = p.minimal_attributes
+      post_hash[p.id] = p.thumbnail_attributes
       post_hash
     end
   end

--- a/app/decorators/posts_decorator.rb
+++ b/app/decorators/posts_decorator.rb
@@ -21,28 +21,7 @@ class PostsDecorator < ApplicationDecorator
   end
 
   def data_attributes
-    post = object
-    attributes = {
-        "data-id" => post.id,
-        "data-has-sound" => post.has_tag?("video_with_sound", "flash_with_sound"),
-        "data-tags" => post.tag_string,
-        "data-rating" => post.rating,
-        "data-flags" => post.status_flags,
-        "data-uploader-id" => post.uploader_id,
-        "data-uploader" => post.uploader_name,
-        "data-file-ext" => post.file_ext,
-        "data-score" => post.score,
-        "data-fav-count" => post.fav_count,
-        "data-is-favorited" => post.favorited_by?(CurrentUser.user.id)
-    }
-
-    if post.visible?
-      attributes["data-file-url"] = post.file_url
-      attributes["data-large-file-url"] = post.large_file_url
-      attributes["data-preview-file-url"] = post.preview_file_url
-    end
-
-    attributes
+    { data: object.thumbnail_attributes }
   end
 
   def cropped_url(options)

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -238,7 +238,7 @@ Blacklist.postMatch = function (post, entry) {
     uploader_id: $post.data('uploader-id'),
     user: $post.data('uploader').toString().toLowerCase(),
     flags: $post.data('flags'),
-    is_fav: $post.data('is-favorited')
+    is_favorited: $post.data('is-favorited')
   };
   return Blacklist.postMatchObject(post_data, entry);
 };
@@ -272,7 +272,7 @@ Blacklist.postMatchObject = function (post, entry) {
   tags.push(`user:${post.user}`);
   tags.push(`height:${post.height}`);
   tags.push(`width:${post.width}`);
-  if(post.is_fav)
+  if(post.is_favorited)
     tags.push('fav:me');
   $.each(post.flags.match(/\S+/g) || [], function (i, v) {
     tags.push(`status:${v}`);
@@ -284,11 +284,13 @@ Blacklist.postMatchObject = function (post, entry) {
 }
 
 Blacklist.initialize_all = function () {
+  console.time("blacklist");
   Blacklist.entriesParse();
 
   Blacklist.initialize_disable_all_blacklists();
   Blacklist.apply();
   $("#blacklisted-hider").remove();
+  console.timeEnd("blacklist");
 }
 
 Blacklist.initialize_anonymous_blacklist = function () {

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1401,6 +1401,41 @@ class Post < ApplicationRecord
       hash
     end
 
+    def thumbnail_attributes
+      attributes = {
+        id: id,
+        flags: status_flags,
+        tags: tag_string,
+        rating: rating,
+        file_ext: file_ext,
+
+        width: image_width,
+        height: image_height,
+        size: file_size,
+
+        created_at: created_at,
+        uploader: uploader_name,
+        uploader_id: uploader_id,
+
+        score: score,
+        fav_count: fav_count,
+        is_favorited: favorited_by?(CurrentUser.user.id),
+
+        pools: pool_ids,
+      }
+
+      if visible?
+        attributes[:md5] = md5
+        attributes[:preview_url] = preview_file_url
+        attributes[:large_url] = large_file_url
+        attributes[:file_url] = file_url
+        attributes[:preview_width] = preview_dimensions[1]
+        attributes[:preview_height] = preview_dimensions[0]
+      end
+
+      attributes
+    end
+
     def status
       if is_pending?
         "pending"

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -103,31 +103,9 @@ class PostPresenter < Presenter
   end
 
   def self.data_attributes(post, include_post: false)
-    attributes = {
-        "data-id" => post.id,
-        "data-has-sound" => post.has_tag?("video_with_sound", "flash_with_sound"),
-        "data-tags" => post.tag_string,
-        "data-rating" => post.rating,
-        "data-width" => post.image_width,
-        "data-height" => post.image_height,
-        "data-flags" => post.status_flags,
-        "data-score" => post.score,
-        "data-file-ext" => post.file_ext,
-        "data-uploader-id" => post.uploader_id,
-        "data-uploader" => post.uploader_name,
-        "data-is-favorited" => post.favorited_by?(CurrentUser.user.id)
-    }
-
-    if post.visible?
-      attributes["data-md5"] = post.md5
-      attributes["data-file-url"] = post.file_url
-      attributes["data-large-file-url"] = post.large_file_url
-      attributes["data-preview-file-url"] = post.preview_file_url
-    end
-
-    attributes["data-post"] = post_attribute_attribute(post).to_json if include_post
-
-    attributes
+    attributes = post.thumbnail_attributes
+    attributes[:post] = post_attribute_attribute(post).to_json if include_post
+    { data: attributes }
   end
 
   def self.post_attribute_attribute(post)


### PR DESCRIPTION
This is a spinoff from PR #586.

For some unknown reason, some thumbnails have similar, yet subtly different sets of data-attributes.
Specifically, the thumbnails generated via deferred posts (ex. avatars and DText images) differ from the thumbnails on the post search page.

This PR fixes that issue, which results in more consistency, and makes processing the blacklist easier.