### PR TITLE
[Dmails] Increase title input length

### DIFF
--- a/app/views/dmails/_form.html.erb
+++ b/app/views/dmails/_form.html.erb
@@ -1,7 +1,7 @@
 <%= error_messages_for :dmail %>
 <%= custom_form_for(dmail) do |f| %>
   <%= f.input :to_name, label: "To", autocomplete: "user", input_html: { value: dmail.to.try(:name) } %>
-  <%= f.input :title, :as => :string %>
+  <%= f.input :title, :as => :string, input_html: { size: 100 } %>
   <%= f.input :body, as: :dtext, limit: Danbooru.config.dmail_max_size %>
   <%= f.button :submit, "Send", :data => { :disable_with => "Sending..." } %>
 <% end %>

--- a/app/views/dmails/_form.html.erb
+++ b/app/views/dmails/_form.html.erb
@@ -1,7 +1,7 @@
 <%= error_messages_for :dmail %>
 <%= custom_form_for(dmail) do |f| %>
   <%= f.input :to_name, label: "To", autocomplete: "user", input_html: { value: dmail.to.try(:name) } %>
-  <%= f.input :title, :as => :string, input_html: { size: 100 } %>
+  <%= f.input :title, as: :string, input_html: { size: 100 } %>
   <%= f.input :body, as: :dtext, limit: Danbooru.config.dmail_max_size %>
-  <%= f.button :submit, "Send", :data => { :disable_with => "Sending..." } %>
+  <%= f.button :submit, "Send", data: { disable_with: "Sending..." } %>
 <% end %>


### PR DESCRIPTION
Tiny PR, fixing a mildly annoying issue.
It's been in [the backlog](https://github.com/orgs/e621ng/projects/2/views/1?pane=issue&itemId=18707514) forever.

The DMail title input is way too short  which gets annoying if you are trying to edit it.
![dmails1](https://github.com/e621ng/e621ng/assets/132787557/908787a7-9e44-4eee-a897-9a5cb3dbdcff)

It's been expanded to the same length as the forum topic title input.
![dmails2](https://github.com/e621ng/e621ng/assets/132787557/d954ee4b-d633-4c55-8ca1-db4bf5b3a434)
