### PR TITLE
[CSS] Start cleaning up the color variables

### DIFF
--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -32,7 +32,7 @@ module TagsHelper
   end
 
   def format_transitive_item(transitive)
-    html = "<strong class=\"redtext\">#{transitive[0].to_s.titlecase}</strong> ".html_safe
+    html = "<strong class=\"text-error\">#{transitive[0].to_s.titlecase}</strong> ".html_safe
     if transitive[0] == :alias
       html << "#{transitive[2]} -> #{transitive[3]} will become #{transitive[2]} -> #{transitive[4]}"
     else

--- a/app/helpers/takedowns_helper.rb
+++ b/app/helpers/takedowns_helper.rb
@@ -2,10 +2,10 @@ module TakedownsHelper
   def pretty_takedown_status(takedown)
     status = takedown.status.capitalize
     classes = {
-      "inactive" => "sect_grey",
-      "denied" => "sect_red",
-      "partial" => "sect_green",
-      "approved" => "sect_green",
+      "inactive" => "background-grey",
+      "denied" => "background-red",
+      "partial" => "background-green",
+      "approved" => "background-green",
     }
     tag.td(status, class: classes[takedown.status])
   end

--- a/app/javascript/src/javascripts/replacement_uploader.vue
+++ b/app/javascript/src/javascripts/replacement_uploader.vue
@@ -19,7 +19,7 @@
     <span class="hint">Tell us why this file should replace the original.</span>
   </div>
 
-  <div class="sect_red error_message" v-if="showErrors && errorMessage !== undefined">
+  <div class="background-red error_message" v-if="showErrors && errorMessage !== undefined">
     {{ errorMessage }}
   </div>
     

--- a/app/javascript/src/javascripts/uploader/file_input.vue
+++ b/app/javascript/src/javascripts/uploader/file_input.vue
@@ -1,7 +1,7 @@
 <template>
   <span>
     <div v-if="!disableFileUpload">
-      <div class="box-section sect_red" v-if="fileTooLarge">
+      <div class="box-section background-red" v-if="fileTooLarge">
         The file you are trying to upload is too large. Maximum allowed is {{this.maxFileSize / (1024*1024) }} MiB.<br>
         Check out <a href="/help/supported_filetypes">the Supported Formats</a> for more information.
       </div>
@@ -13,7 +13,7 @@
       <button @click.prevent="clearFileUpload" v-show="disableURLUpload">Clear</button>
     </div>
     <div v-if="!disableURLUpload">
-      <div class="box-section sect_red" v-if="badDirectURL">
+      <div class="box-section background-red" v-if="badDirectURL">
         The direct URL entered has the following problem: {{ directURLProblem }}<br>
         You should review <a href="/wiki_pages/howto:sites_and_sources">the sourcing guide</a>.
       </div>

--- a/app/javascript/src/javascripts/uploader/file_preview.vue
+++ b/app/javascript/src/javascripts/uploader/file_preview.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="upload_preview_container" :class="classes">
-    <div class="box-section sect_red" v-show="overDims">
+    <div class="box-section background-red" v-show="overDims">
       One of the image dimensions is above the maximum allowed of 15,000px and will fail to upload.
     </div>
     <div v-if="!failed">
@@ -12,7 +12,7 @@
         referrerpolicy="no-referrer"
         v-on:load="updateDimensions($event)" v-on:error="previewFailed()"/>
     </div>
-    <div v-else class="preview-fail box-section sect_yellow">
+    <div v-else class="preview-fail box-section background-yellow">
       <p>The preview for this file failed to load. Please, double check that the URL you provided is correct.</p>
       Note that some sites intentionally prevent images they host from being displayed on other sites. The file can still be uploaded despite that.
     </div>

--- a/app/javascript/src/javascripts/uploader/sources.vue
+++ b/app/javascript/src/javascripts/uploader/sources.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="box-section sect_red source_warning" v-show="showErrors && sourceWarning">
+  <div class="box-section background-red source_warning" v-show="showErrors && sourceWarning">
     A source must be provided or you must select that there is no available source.
   </div>
   <div v-if="!noSource">

--- a/app/javascript/src/javascripts/uploader/uploader.vue.erb
+++ b/app/javascript/src/javascripts/uploader/uploader.vue.erb
@@ -113,7 +113,7 @@
                     </div>
                 </div>
                 <div class="col2">
-                    <div class="box-section sect_red" v-if="showErrors && invalidRating">
+                    <div class="box-section background-red" v-if="showErrors && invalidRating">
                         You must select an appropriate rating for this image.
                     </div>
                     <div>
@@ -144,7 +144,7 @@
                 </div>
                 <div class="col2">
                   <file-preview classes="box-section in-editor" :data="previewData"></file-preview>
-                    <div class="box-section sect_red" v-show="showErrors && notEnoughTags">
+                    <div class="box-section background-red" v-show="showErrors && notEnoughTags">
                         You must provide at least <b>{{4 - tagCount}}</b> more tags. Tags in other sections count
                         towards this total.
                     </div>
@@ -218,16 +218,16 @@
             <div class="flex-grid">
                 <div class="col"></div>
                 <div class="col2">
-                    <div class="box-section sect_red" v-show="preventUpload && showErrors">
+                    <div class="box-section background-red" v-show="preventUpload && showErrors">
                         Unmet requirements above prevent the submission of the post.
                     </div>
-                    <div class="box-section sect_green" v-show="submitting">
+                    <div class="box-section background-green" v-show="submitting">
                         Submitting your post, please wait.
                     </div>
-                    <div class="box-section sect_red" v-show="error">
+                    <div class="box-section background-red" v-show="error">
                         {{ error }}
                     </div>
-                    <div class="box-section sect_red" v-show="duplicateId">
+                    <div class="box-section background-red" v-show="duplicateId">
                         Post is a duplicate of <a :href="duplicatePath">post #{{duplicateId}}.</a>
                     </div>
                     <button @click="submit" :disabled="(showErrors && preventUpload) || submitting" accesskey="s">

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -1,4 +1,5 @@
 @import "base/functions";
+@import "base/palette";
 @import "base/themable"; //Drags in themes automatically
 @import "base/colors";
 @import "base/vars";
@@ -8,6 +9,7 @@
 @import "base/fontawesome";
 
 @import "common/helper_classes";
+@import "common/helper_palette";
 @import "common/ads.scss";
 @import "common/autocomplete.scss";
 @import "common/blacklists.scss";

--- a/app/javascript/src/styles/base/_base.scss
+++ b/app/javascript/src/styles/base/_base.scss
@@ -100,8 +100,3 @@ table tfoot {
   font-style: italic;
   font-size: 80%;
 }
-
-.greentext, .greentext a, .approved-ticket { color: $green-text-color !important; font-weight:bold; }
-.greytext, .greytext a { color: $grey-text-color !important; font-weight:bold; }
-.yellowtext, .yellowtext a, .partial-ticket { color: $yellow-text-color !important; font-weight:bold; }
-.redtext, .redtext a { color: $red-text-color !important; font-weight:bold; }

--- a/app/javascript/src/styles/base/_base.scss
+++ b/app/javascript/src/styles/base/_base.scss
@@ -105,10 +105,3 @@ table tfoot {
 .greytext, .greytext a { color: $grey-text-color !important; font-weight:bold; }
 .yellowtext, .yellowtext a, .partial-ticket { color: $yellow-text-color !important; font-weight:bold; }
 .redtext, .redtext a { color: $red-text-color !important; font-weight:bold; }
-
-
-.sect_green { background-color: $section-green-background; /* green */ }
-.sect_red { background-color: $section-red-background; /* red */ }
-.sect_yellow { background-color: $section-yellow-background; /* yellow */ }
-.sect_grey { background-color: $section-grey-background; /* yellow */ }
-.sect_green a:hover, .sect_red a:hover, .sect_yellow a:hover { color: $section-link-hover-color; }

--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -5,13 +5,6 @@ $yellow-text-color: #e4e150;
 $red-text-color: #e45f5f;
 $grey-text-color: #959595;
 
-
-$section-green-background: #288233;
-$section-yellow-background: #828028;
-$section-red-background: #822828;
-$section-grey-background: #5d656e;
-$section-link-hover-color: white;
-
 // Main background colors
 $lighten-background-5: rgba(255,255,255,0.05);
 
@@ -23,7 +16,7 @@ $state-error-color: #e45f5f;
 $dtext-code-background: rgba(255,255,255,0.2);
 
 // Blips
-$blip-hidden-background: $section-red-background;
+$blip-hidden-background: palette("background-red");
 
 // Forms
 $form-focus-color: black;
@@ -88,7 +81,7 @@ $negative-record-color: $red-color;
 $neutral-record-color: $dark-grey-color;
 
 $comment-highlight-background: rgba(255,255,255,0.25);
-$comment-hidden-background: $section-red-background;
+$comment-hidden-background: palette("background-red");
 $comment-vote-background: rgba(255, 255, 255, 0.2);
 
 // Keyboard shortcuts
@@ -111,8 +104,8 @@ $forum-vote-down-color: red;
 $forum-vote-meh-color: goldenrod;
 $forum-topic-new-color: red;
 $forum-topic-except-color: gray;
-$forum-topic-hidden-background: rgba(130,40,40,0.75);
-$forum-post-hidden-background: rgba(130,40,40,0.75);
+$forum-topic-hidden-background: palette("background-red");
+$forum-post-hidden-background: palette("background-red");
 
 // IQDB lookup
 $iqdb-post-border: lightgrey;
@@ -142,12 +135,12 @@ $post-preview-highlight-background: rgba(0,0,0,0.1);
 $post-tag-low-count-color: red;
 
 // Post Mode
-$post-mode-edit: $section-yellow-background;
+$post-mode-edit: palette("background-yellow");
 $post-mode-tag-script: #4f114f;
 $post-mode-add-fav: #104e17;
 $post-mode-remove-fav: darken($post-mode-add-fav, 10%);
-$post-mode-vote-up: $section-green-background;
-$post-mode-vote-down: $section-red-background;
+$post-mode-vote-up: palette("background-green");
+$post-mode-vote-down: palette("background-red");
 $post-mode-add-pool: #104b57;
 $post-mode-lock-rating: #AA3;
 $post-mode-lock-note: #3AA;

--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -1,9 +1,5 @@
 // Font
 $inverted-text-color: invert(#fff);
-$green-text-color: #3e9e49;
-$yellow-text-color: #e4e150;
-$red-text-color: #e45f5f;
-$grey-text-color: #959595;
 
 // Main background colors
 $lighten-background-5: rgba(255,255,255,0.05);

--- a/app/javascript/src/styles/base/_palette.scss
+++ b/app/javascript/src/styles/base/_palette.scss
@@ -8,6 +8,11 @@ $palette: (
   "background-yellow": #828028,
   "background-green": #227d2a,
   "background-grey": #60686f,
+
+  "text-red": #e13d3d,
+  "text-yellow": #e4e150,
+  "text-green": #3e9e49,
+  "text-grey": #959595,
 );
 
 :root {

--- a/app/javascript/src/styles/base/_palette.scss
+++ b/app/javascript/src/styles/base/_palette.scss
@@ -5,10 +5,11 @@
 // Palette definitions
 $palette: (
   "background-red": #76312E,
-  "background-yellow": #828028,
+  "background-yellow": #a98837,
   "background-green": #227d2a,
   "background-grey": #60686f,
 
+  "text-white": #ffffff,
   "text-red": #e13d3d,
   "text-yellow": #e4e150,
   "text-green": #3e9e49,

--- a/app/javascript/src/styles/base/_palette.scss
+++ b/app/javascript/src/styles/base/_palette.scss
@@ -1,0 +1,22 @@
+// Base color palette.
+// These colors should not normally change between
+// themes, but could still be overriden if need be.
+
+// Palette definitions
+$palette: (
+  "background-red": #76312E,
+  "background-yellow": #828028,
+  "background-green": #227d2a,
+  "background-grey": #60686f,
+);
+
+:root {
+  @each $name, $color in $palette {
+    --palette-#{$name}: #{$color};
+  }
+}
+
+// Helper function
+@function palette($key) {
+  @return var(--palette-#{$key});
+}

--- a/app/javascript/src/styles/common/_helper_palette.scss
+++ b/app/javascript/src/styles/common/_helper_palette.scss
@@ -1,0 +1,5 @@
+@each $name in ("red", "yellow", "green", "grey") {
+  .background-#{$name} {
+    background: palette("background-#{$name}") !important;
+  }
+}

--- a/app/javascript/src/styles/common/_helper_palette.scss
+++ b/app/javascript/src/styles/common/_helper_palette.scss
@@ -2,4 +2,16 @@
   .background-#{$name} {
     background: palette("background-#{$name}") !important;
   }
+  .text-#{$name} {
+    color: palette("text-#{$name}") !important;
+  }
+}
+
+.text-error {
+  color: palette("text-red") !important;
+  font-weight: bold;
+}
+
+.text-bold {
+  font-weight: bold;
 }

--- a/app/javascript/src/styles/common/containers.scss
+++ b/app/javascript/src/styles/common/containers.scss
@@ -1,24 +1,13 @@
-
-
 .box-section {
   background-color: themed("color-section");
   padding: $base-padding;
   margin-bottom: 1.5rem;
   border-radius: $border-radius-half;
-}
 
-.box-section.sect_green {
-  background-color: $section-green-background;
-}
-
-.box-section.sect_grey {
-  background-color: $section-grey-background;
-}
-
-.box-section.sect_red {
-  background-color: $section-red-background;
-}
-
-.box-section.sect_yellow {
-  background-color: $section-yellow-background;
+  &.background-green, &.background-grey, &.background-red, &.background-yellow {
+    a:hover {
+      // Legacy, not sure why this is here
+      color: themed("color-text");
+    }
+  }
 }

--- a/app/javascript/src/styles/specific/tickets.scss
+++ b/app/javascript/src/styles/specific/tickets.scss
@@ -20,3 +20,12 @@
     }
   }
 } 
+
+.approved-ticket {
+  color: palette("text-green");
+  font-weight: bold;
+}
+.partial-ticket { 
+  color: palette("text-yellow");
+  font-weight: bold;
+}

--- a/app/views/maintenance/user/email_changes/new.html.erb
+++ b/app/views/maintenance/user/email_changes/new.html.erb
@@ -2,7 +2,7 @@
   <div id="a-new">
     <h1>Change Email</h1>
 
-    <div class="box-section sect_red">
+    <div class="box-section background-red">
     <p>Warning: Changing the email on your account will mark it as unactivated until you confirm the new email address.</p>
 
     <p>You must confirm your password in order to change your email address.</p>

--- a/app/views/static/theme.html.erb
+++ b/app/views/static/theme.html.erb
@@ -1,10 +1,10 @@
 <p>Theme settings are saved using cookies and javascript. This means that they will not persist across private browsing
   sessions, or work inside incognito mode on mobile devices.</p>
 
-<h3 class="redtext" id="no_save_warning" style="display:none;">Your device does not allow the site to save theme
+<h3 class="text-error" id="no_save_warning" style="display:none;">Your device does not allow the site to save theme
   settings.</h3>
 <noscript>
-  <h3 class="redtext" id="no_save_warning">Your device does not allow the site to save theme settings.</h3>
+  <h3 class="text-error" id="no_save_warning">Your device does not allow the site to save theme settings.</h3>
 </noscript>
 
 <div class="simple_form">

--- a/app/views/tag_relationships/_listing.html.erb
+++ b/app/views/tag_relationships/_listing.html.erb
@@ -22,7 +22,7 @@
           <span class="count"><%= tag_relation.consequent_tag.post_count rescue 0 %></span>
           <% if tag_relation.is_a?(TagAlias) %>
             <% if CurrentUser.is_member? && tag_relation.status == "pending" && tag_relation.has_transitives %>
-              <span class="redtext"> HAS TRANSITIVES</span>
+              <span class="text-error"> HAS TRANSITIVES</span>
             <% end %>
           <% end %>
         </td>

--- a/app/views/takedowns/_editor.html.erb
+++ b/app/views/takedowns/_editor.html.erb
@@ -71,8 +71,8 @@
         <td colspan='2'><%= check_box "takedown", "reason_hidden", checked: @takedown.reason_hidden %>
           <label for="takedown_reason_hidden">Hide Reason?
             (Currently
-            <% if !@takedown.reason_hidden %><span class='greentext'>not hidden</span>
-            <% else %><span class='redtext'>hidden</span>
+            <% if !@takedown.reason_hidden %><span class="text-green">not hidden</span>
+            <% else %><span class="text-error">hidden</span>
             <% end %>)
           </label></td>
       </tr>

--- a/app/views/takedowns/index.html.erb
+++ b/app/views/takedowns/index.html.erb
@@ -30,7 +30,7 @@
                 <%= link_to takedown.source, "https://#{takedown.source}", rel: "noopener noreferrer nofollow" %>
               <% end %>
             <% else %>
-              <span class="redtext">(Source hidden)</span>
+              <span class="text-error">(Source hidden)</span>
             <% end %>
           </td>
 

--- a/app/views/takedowns/show.html.erb
+++ b/app/views/takedowns/show.html.erb
@@ -1,7 +1,7 @@
 <div id="c-takedowns">
   <div id="c-show">
     <% if @show_instructions && (!@takedown.completed?) %>
-      <div class='box-section sect_red'>
+      <div class='box-section background-red'>
         <div style="font-size:2rem;margin-top:0;margin-bottom:1rem;">Wait! You're not done yet!</div>
         <p>Your verification code is <span class='takedown-vericode'><%= @takedown.vericode %></span></p>
         <p>Your takedown request has been successfully created. Using the gallery account that you specified below as the "source", <span style="font-weight:bold;">please send your verification code via PM/note to</span>:</p>
@@ -137,7 +137,7 @@
         </div>
 
       <% elsif @takedown.status == "inactive" && !@takedown.takedown_posts.blank? %>
-        <div class='box-section sect_grey'>
+        <div class='box-section background-grey'>
           <p style="margin-bottom:0px;">This takedown request has been marked as inactive as the submitter has not responded in a reasonable time frame. It will be handled once the submitter responds.</p>
             <br>
             <p>The following posts are up for dispute:</p>
@@ -147,7 +147,7 @@
         </div>
 
       <% elsif @takedown.status == "denied" %>
-        <div class='box-section sect_red'>
+        <div class='box-section background-red'>
           <p>The request has been denied. The following posts were not removed:</p>
           <% @takedown.actual_kept_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post)) %><br>
@@ -155,14 +155,14 @@
         </div>
 
       <% elsif @takedown.status == "partial" %>
-        <div class='box-section sect_green'>
+        <div class='box-section background-green'>
           <p>The request has been partially approved. The following posts were removed:</p>
           <% @takedown.actual_deleted_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post), class: "takedown_post_deleted") %><br>
           <% end %>
         </div>
 
-        <div class='box-section sect_red'>
+        <div class='box-section background-red'>
           <p>The following posts were kept:</p>
           <% @takedown.actual_kept_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post), class: "takedown_post_kept") %><br>
@@ -170,7 +170,7 @@
         </div>
 
       <% elsif @takedown.status == "approved" %>
-        <div class='box-section sect_green'>
+        <div class='box-section background-green'>
           <p>The request has been approved. The following posts were removed:</p>
           <% @takedown.actual_deleted_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post)) %><br>

--- a/app/views/takedowns/show.html.erb
+++ b/app/views/takedowns/show.html.erb
@@ -26,7 +26,7 @@
                 <%= link_to @takedown.source, "https://#{@takedown.source}", rel: "noopener noreferrer nofollow" %>
               <% end %>
             <% else %>
-              <span class="redtext">[Source hidden by submitter]</span>
+              <span class="text-error">[Source hidden by submitter]</span>
             <% end %>
           </td>
         </tr>
@@ -35,9 +35,9 @@
           <td><label>Reason</label></td>
           <% if !@takedown.reason_hidden || CurrentUser.is_moderator? || @show_instructions %>
             <td><%= h @takedown.reason %>
-              <% if @takedown.reason_hidden %><span class="redtext">(HIDDEN)</span><% end %></td>
+              <% if @takedown.reason_hidden %><span class="text-error">(HIDDEN)</span><% end %></td>
           <% else %>
-            <td><span class="redtext">[Reason hidden by submitter]</span></td>
+            <td><span class="text-error">[Reason hidden by submitter]</span></td>
           <% end %>
         </tr>
 
@@ -101,9 +101,9 @@
       <div class="box-section dtext-container">
         <% if !@takedown.reason_hidden || CurrentUser.is_moderator? %>
           <%= format_text(@takedown.notes) %>
-          <% if @takedown.reason_hidden %><span class="redtext">(HIDDEN)</span><% end %>
+          <% if @takedown.reason_hidden %><span class="text-error">(HIDDEN)</span><% end %>
         <% else %>
-          <span class="redtext">[Admin notes hidden]</span>
+          <span class="text-error">[Admin notes hidden]</span>
         <% end %>
       </div>
     <% end %>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -33,7 +33,7 @@
               </td>
               <td>
               <% if ticket.claimant.nil? %>
-                <span class="redtext">Unclaimed</span>
+                <span class="text-error">Unclaimed</span>
               <% else %>
                 <%= link_to_user ticket.claimant %>
               <% end %>
@@ -42,7 +42,7 @@
             <td><%= link_to ticket.type_title, ticket_path(ticket) %></td>
 
             <% if !ticket.can_see_details?(CurrentUser.user) %>
-              <td><span style="cursor:help;" class="redtext" title="Due to privacy concerns, this information is confidential">Confidential</span></td>
+              <td><span style="cursor:help;" class="text-error" title="Due to privacy concerns, this information is confidential">Confidential</span></td>
             <% else %>
               <%= tag.td class: "ticket-subject full-width-link", title: truncate(strip_tags(format_text(ticket.reason)), length: 200) do %>
                 <%= link_to truncate(strip_tags(format_text(ticket.subject)), length: 200), ticket_path(ticket.id) %>

--- a/app/views/tickets/types/_blip.html.erb
+++ b/app/views/tickets/types/_blip.html.erb
@@ -1,13 +1,13 @@
 <% if @ticket.content %>
     <tr>
-      <td><span class='title'>Reported Blip</span></td>
+      <td><span class="title">Reported Blip</span></td>
       <td>
         <%= link_to "Blip by #{@ticket.content.creator_name}", blip_path(@ticket.content) %>
       </td>
     </tr>
 <% else %>
     <tr>
-      <td><span class='title'>Reported Blip</span></td>
-      <td><span class='redtext'>Blip has been deleted</span></td>
+      <td><span class="title">Reported Blip</span></td>
+      <td><span class="text-error">Blip has been deleted</span></td>
     </tr>
 <% end %>

--- a/app/views/tickets/types/_comment.html.erb
+++ b/app/views/tickets/types/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if @ticket.content %>
   <tr>
-    <td><span class='title'>Reported Comment</span></td>
+    <td><span class="title">Reported Comment</span></td>
     <td>
       <%= link_to("Comment by #{@ticket.content.creator_name}", comment_path(@ticket.content)) %> on
       <%= link_to("post ##{@ticket.content.post_id}", post_path(@ticket.content.post_id)) %>
@@ -8,7 +8,7 @@
   </tr>
 <% else %>
   <tr>
-    <td><span class='title'>Reported Comment</span></td>
-    <td><span class='redtext'>Comment has been deleted</span></td>
+    <td><span class="title">Reported Comment</span></td>
+    <td><span class="text-error">Comment has been deleted</span></td>
   </tr>
 <% end %>

--- a/app/views/tickets/types/_forum.html.erb
+++ b/app/views/tickets/types/_forum.html.erb
@@ -7,7 +7,7 @@
   </tr>
 <% else %>
   <tr>
-    <td><span class='title'>Reported Forum Post</span></td>
-    <td><span class='redtext'>Forum post has been deleted</span></td>
+    <td><span class="title">Reported Forum Post</span></td>
+    <td><span class="text-error">Forum post has been deleted</span></td>
   </tr>
 <% end %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -13,7 +13,7 @@
   <div id="uploader"></div>
   <% if CurrentUser.upload_limit <= 5 || CurrentUser.post_upload_throttle <= 5 %>
     <% @limit_pieces = CurrentUser.upload_limit_pieces %>
-    <div id="post-uploads-remaining" class="box-section section<% if [CurrentUser.upload_limit, CurrentUser.post_upload_throttle].min <= 0 %> sect_red<% end %>" style="width:640px;">
+    <div id="post-uploads-remaining" class="box-section section<% if [CurrentUser.upload_limit, CurrentUser.post_upload_throttle].min <= 0 %> background-red<% end %>" style="width:640px;">
       <p>
         You currently have <span class="post-uploads-remaining-count"><%= CurrentUser.upload_limit %></span> upload<%= CurrentUser.upload_limit!=1?"s":"" %> remaining.
 
@@ -25,7 +25,7 @@
       See <%= link_to "here", upload_limit_users_path %> for more details.
     </div>
   <% elsif CurrentUser.post_upload_throttle <= 5 %>
-    <div id="post-uploads-remaining" class="section<% if CurrentUser.post_upload_throttle <= 0 %> sect_red<% end %>" style="width:640px;">
+    <div id="post-uploads-remaining" class="section<% if CurrentUser.post_upload_throttle <= 0 %> background-red<% end %>" style="width:640px;">
       You have <span class="post-uploads-remaining-count"><%= CurrentUser.post_upload_throttle %></span> uploads remaining this hour.
       See <%= link_to "here", upload_limit_users_path %> for more details.
     </div>

--- a/app/views/user_votes/_common_index.html.erb
+++ b/app/views/user_votes/_common_index.html.erb
@@ -45,9 +45,9 @@
           <% end %>
           <td><%= time_ago_in_words_tagged(vote.user.created_at) %></td>
           <td>
-            <% if vote.is_positive? %><span class='greentext'>Up</span>
-            <% elsif vote.is_locked? %><span class='yellowtext'>Locked</span>
-            <% else %><span class='redtext'>Down</span>
+            <% if vote.is_positive? %><span class="text-green text-bold">Up</span>
+            <% elsif vote.is_locked? %><span class="text-yellow text-bold">Locked</span>
+            <% else %><span class="text-red text-bold">Down</span>
             <% end %>
           </td>
           <td><%= time_ago_in_words_tagged(vote.created_at) %></td>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,7 +4,7 @@
 
     <p>An account is <strong>free</strong> and lets you keep favorites, upload artwork, and write comments.</p>
 
-    <div class="box-section sect_red">
+    <div class="box-section background-red">
       <p>Make sure to read the <a href="/wiki_pages/e621:rules">site rules</a> before continuing.</p>
       <p>You must confirm your email address, so use something you can receive email with.</p>
       <p>This site is open to web crawlers so whatever name you choose will be public!</p>


### PR DESCRIPTION
This PR is the beginning of a cleanup attempt of the colors used on the site.
There are quite a lot of them, in fact. Some are found as variables in `colors.scss`, others are directly used elsewhere in the stylesheet. Worse yet, there are a number of different shades of the same colors being used all over the place.

I would like to try to reduce those to a somewhat manageable palette.
This does not include colors used in different themes: these are just the colors that are used regardless of which theme is chosen.

I do realize that a full cleanup would be a nightmare to review, and hell to debug.
So, I'll be handling it in small pieces. Or at least as small as I can manage.

Here's a quick reference guide to the current state of the palette.
It will certainly grow as this project progresses.

<table>
<thead align="center"><tr><td></td><td>red</td><td>yellow</td><td>green</td><td>grey</td></tr></thead>
<tbody>
  <tr>
    <td>text color</td>
    <td><img src="https://placehold.co/32x32/152f56/e13d3d.png?text=e" /></td>
    <td><img src="https://placehold.co/32x32/152f56/e4e150.png?text=6" /></td>
    <td><img src="https://placehold.co/32x32/152f56/3e9e49.png?text=2" /></td>
    <td><img src="https://placehold.co/32x32/152f56/959595.png?text=1" /></td>
  </tr>
  <tr>
    <td>background</td>
    <td><img src="https://placehold.co/32x32/76312E/fff.png?text=e" /></td>
    <td><img src="https://placehold.co/32x32/a98837/fff.png?text=6" /></td>
    <td><img src="https://placehold.co/32x32/227d2a/fff.png?text=2" /></td>
    <td><img src="https://placehold.co/32x32/60686f/fff.png?text=1" /></td>
  </tr>
</tbody>
</table>

This PR sets up CSS variables and helper classes to facilitate further cleanup.

### Text Color

The text color variables were defined a few times in the stylesheets, with different values each time.
This PR eliminates a few of them.

![red](https://placehold.co/600x50/152f56/e13d3d.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)
![yellow](https://placehold.co/600x50/152f56/e4e150.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)
![green](https://placehold.co/600x50/152f56/3e9e49.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)
![grey](https://placehold.co/600x50/152f56/959595.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)

Note that the red specifically is different to the other reds used on the site, like the ones in the tag diffs, or in the user feedback summary. I have picked it because it was the most readable of them all – this color would be used reasonably frequently for all sorts of warning and error messages, as well as to denote things like ticket or takedown status.

![feedback red](https://placehold.co/300x50/152f56/822828.png?text=feedback)![diff red](https://placehold.co/300x50/152f56/red.png?text=tags+diff)

These colors had been used throughout the site already through the use of helper classes `.greentext`, `.greytext`, `.yellowtext`, and `.redtext`. In this PR, these classes had been supplanted by new ones.

The following variables had been eliminated:
```
$green-text-color: #3e9e49;
$yellow-text-color: #e4e150;
$red-text-color: #e45f5f;
$grey-text-color: #959595;
```

### Background

Just like with text colors, the backgrounds are not consistent in their colors.
I have decided to go with the following selection of background colors:

![red](https://placehold.co/600x50/76312E/fff.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)
![yellow](https://placehold.co/600x50/828028/fff.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)
![green](https://placehold.co/600x50/227d2a/fff.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)
![grey](https://placehold.co/600x50/60686f/fff.png?text=The+quick+brown+fox+jumps+over+the+lazy+dog.)

They are different to the ones currently used for things like user feedback backgrounds. These are somewhat less bright and harsh on the eyes, increasing readability.

![feedback red](https://placehold.co/200x50/822828/fff.png?text=feedback)![feedback grey](https://placehold.co/200x50/666/fff.png?text=feedback)![feedback green](https://placehold.co/200x50/008000/fff.png?text=feedback)

These colors had been used throughout the site already through the use of helper classes `.sect_green`, `.sect_yellow`, `.sect_red`, and `.sect_grey`. For reasons unclear to me, those classes are defined twice: once in `/base/_base.scss`, and once in `/common/containers.scss`. In this PR, these classes had been supplanted by new ones.

Takedowns make ample use of these to denote their status, but other pages also reference them at times.
Specifically, various error messages use `$section-red-background` as their background.

Additionally, both comments and blips use `$section-red-background` to highlight hidden messages.
For some reason, forum topics and posts do not. That had been fixed now, but the forum topics page has a different bug that prevents hidden topics from being highlighted correctly. This issue will be addressed in a different PR.

The following variables had been eliminated:
```
$section-green-background: #288233;
$section-yellow-background: #828028;
$section-red-background: #822828;
$section-grey-background: #5d656e;
$section-link-hover-color: white;
```