### PR TITLE
[ForumTopics] Fix deleted topic row colors

### DIFF
--- a/app/javascript/src/javascripts/forum_posts.js
+++ b/app/javascript/src/javascripts/forum_posts.js
@@ -137,7 +137,7 @@ ForumPost.hide = function (e) {
     dataType: 'json'
   }).done(function (data) {
     $(`.forum-post[data-forum-post-id="${fpid}"] div.author h4`).append(" (hidden)");
-    $(`.forum-post[data-forum-post-id="${fpid}"]`).attr('data-is-deleted', 'true');
+    $(`.forum-post[data-forum-post-id="${fpid}"]`).attr('data-is-hidden', 'true');
   }).fail(function (data) {
     Utility.error("Failed to hide post.");
   });
@@ -156,7 +156,7 @@ ForumPost.unhide = function (e) {
   }).done(function (data) {
     const $author = $(`.forum-post[data-forum-post-id="${fpid}"] div.author h4`);
     $author.text($author.text().replace(" (hidden)", ""));
-    $(`.forum-post[data-forum-post-id="${fpid}"]`).attr('data-is-deleted', 'false');
+    $(`.forum-post[data-forum-post-id="${fpid}"]`).attr('data-is-hidden', 'false');
   }).fail(function (data) {
     Utility.error("Failed to unhide post.");
   });

--- a/app/javascript/src/styles/specific/forum.scss
+++ b/app/javascript/src/styles/specific/forum.scss
@@ -62,7 +62,7 @@ div#c-forum-topics {
   }
 
   tr.forum-topic-row {
-    &[data-is-deleted="true"] {
+    &[data-topic-is-deleted="true"] {
       background-color: $forum-topic-hidden-background;
     }
 

--- a/app/javascript/src/styles/specific/forum.scss
+++ b/app/javascript/src/styles/specific/forum.scss
@@ -14,7 +14,7 @@ div.list-of-forum-posts {
       background-color: $forum-post-highlight-background;
     }
 
-    &[data-is-deleted="true"] {
+    &[data-is-hidden="true"] {
       background-color: $forum-post-hidden-background;
     }
 
@@ -62,7 +62,7 @@ div#c-forum-topics {
   }
 
   tr.forum-topic-row {
-    &[data-topic-is-deleted="true"] {
+    &[data-topic-is-hidden="true"] {
       background-color: $forum-topic-hidden-background;
     }
 
@@ -77,12 +77,12 @@ div#c-forum-topics {
 }
 
 #c-forum-posts #a-index {
-  tr[data-topic-is-deleted="true"] .forum-post-topic-title::after,
-  tr[data-is-deleted="true"] .forum-post-excerpt::after {
-    content: " (deleted)";
+  tr[data-topic-is-hidden="true"] .forum-post-topic-title::after,
+  tr[data-is-hidden="true"] .forum-post-excerpt::after {
+    content: " (hidden)";
     color: $forum-topic-except-color;
   }
-  tr[data-is-deleted="true"], tr[data-topic-is-deleted="true"] {
+  tr[data-is-hidden="true"], tr[data-topic-is-hidden="true"] {
     background-color: $forum-topic-hidden-background;
   }
 }

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -2,7 +2,7 @@
   <article class="forum-post comment-post-grid" id="forum_post_<%= forum_post.id %>"
            data-forum-post-id="<%= forum_post.id %>" data-creator="<%= forum_post.creator&.name.downcase %>"
            data-creator-id="<%= forum_post.creator_id %>"
-           data-is-deleted="<%= forum_post.id == original_forum_post_id ? @forum_topic.is_hidden? : forum_post.is_hidden? %>">
+           data-is-hidden="<%= forum_post.id == original_forum_post_id ? @forum_topic.is_hidden? : forum_post.is_hidden? %>">
     <div class="author-info">
       <div class="name-rank">
         <h4 class="author-name"><%= link_to_user forum_post.creator %></h4>

--- a/app/views/forum_posts/index.html.erb
+++ b/app/views/forum_posts/index.html.erb
@@ -13,14 +13,12 @@
       <tbody>
         <% @forum_posts.each do |forum_post| %>
           <% if forum_post.visible?(CurrentUser.user) %>
-            <tr id="forum-post-<%= forum_post.id %>" data-topic-is-hidden="<%= forum_post.topic.is_hidden? %>" data-is-hidden="<%= forum_post.is_hidden? %>">
+            <tr id="forum-post-<%= forum_post.id %>" data-topic-is-deleted="<%= forum_post.topic.is_hidden? %>" data-is-deleted="<%= forum_post.is_hidden? %>">
               <td class="forum-post-topic-title">
                 <%= link_to forum_post.topic.title, forum_topic_path(forum_post.topic) %>
-                <%= "(hidden)" if forum_post.topic.is_hidden? %>
               </td>
               <td class="forum-post-excerpt">
                 <%= link_to truncate(forum_post.body, :length => 50), forum_post_path(forum_post) %>
-                <%= "(hidden)" if forum_post.is_hidden? %>
               </td>
               <td><%= link_to_user forum_post.creator %></td>
               <td><%= time_ago_in_words_tagged forum_post.created_at %></td>

--- a/app/views/forum_posts/index.html.erb
+++ b/app/views/forum_posts/index.html.erb
@@ -13,7 +13,7 @@
       <tbody>
         <% @forum_posts.each do |forum_post| %>
           <% if forum_post.visible?(CurrentUser.user) %>
-            <tr id="forum-post-<%= forum_post.id %>" data-topic-is-deleted="<%= forum_post.topic.is_hidden? %>" data-is-deleted="<%= forum_post.is_hidden? %>">
+            <tr id="forum-post-<%= forum_post.id %>" data-topic-is-hidden="<%= forum_post.topic.is_hidden? %>" data-is-hidden="<%= forum_post.is_hidden? %>">
               <td class="forum-post-topic-title">
                 <%= link_to forum_post.topic.title, forum_topic_path(forum_post.topic) %>
               </td>

--- a/app/views/forum_topics/_listing.html.erb
+++ b/app/views/forum_topics/_listing.html.erb
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     <% forum_topics.each do |topic| %>
-      <tr class="forum-topic-row forum-topic-category-<%= topic.category_id %>" data-topic-is-deleted="<%= topic.is_hidden? %>">
+      <tr class="forum-topic-row forum-topic-category-<%= topic.category_id %>" data-topic-is-hidden="<%= topic.is_hidden? %>">
         <td>
           <% if topic.is_sticky? %>
             <span class="sticky">Sticky:</span>


### PR DESCRIPTION
This is something I discovered while investigating #614.
Apparently, forum topic rows were supposed to be colored red when the topic had been deleted.

![topics1](https://github.com/e621ng/e621ng/assets/132787557/fdc2fd76-f548-41b3-a578-8f0a2ede6fcb)

That is also the case in the forum posts index.

![topics2](https://github.com/e621ng/e621ng/assets/132787557/4781012c-db4e-4b82-97dd-7fcfce573d18)

Now, I am not entirely sure if this just never worked, or if it broke at some point.
However, it does seem like a nice effect, so might as well restore it.