### PR TITLE
[CSS] Apply palette colors to records and ratings

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -121,7 +121,7 @@ module PostsHelper
 
   def pretty_html_rating(post)
     rating_text = post.pretty_rating
-    rating_class = "post-rating-text-#{rating_text.downcase}"
+    rating_class = "text-#{rating_text.downcase}"
     tag.span(rating_text, id: "post-rating-text", class: rating_class)
   end
 

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -32,7 +32,7 @@ module TagsHelper
   end
 
   def format_transitive_item(transitive)
-    html = "<strong class=\"redtext\">#{transitive[0].to_s.titlecase}</strong> ".html_safe
+    html = "<strong class=\"text-error\">#{transitive[0].to_s.titlecase}</strong> ".html_safe
     if transitive[0] == :alias
       html << "#{transitive[2]} -> #{transitive[3]} will become #{transitive[2]} -> #{transitive[4]}"
     else

--- a/app/helpers/takedowns_helper.rb
+++ b/app/helpers/takedowns_helper.rb
@@ -2,10 +2,10 @@ module TakedownsHelper
   def pretty_takedown_status(takedown)
     status = takedown.status.capitalize
     classes = {
-      "inactive" => "sect_grey",
-      "denied" => "sect_red",
-      "partial" => "sect_green",
-      "approved" => "sect_green",
+      "inactive" => "background-grey",
+      "denied" => "background-red",
+      "partial" => "background-green",
+      "approved" => "background-green",
     }
     tag.td(status, class: classes[takedown.status])
   end

--- a/app/javascript/src/javascripts/replacement_uploader.vue
+++ b/app/javascript/src/javascripts/replacement_uploader.vue
@@ -19,7 +19,7 @@
     <span class="hint">Tell us why this file should replace the original.</span>
   </div>
 
-  <div class="sect_red error_message" v-if="showErrors && errorMessage !== undefined">
+  <div class="background-red error_message" v-if="showErrors && errorMessage !== undefined">
     {{ errorMessage }}
   </div>
     

--- a/app/javascript/src/javascripts/uploader/file_input.vue
+++ b/app/javascript/src/javascripts/uploader/file_input.vue
@@ -1,7 +1,7 @@
 <template>
   <span>
     <div v-if="!disableFileUpload">
-      <div class="box-section sect_red" v-if="fileTooLarge">
+      <div class="box-section background-red" v-if="fileTooLarge">
         The file you are trying to upload is too large. Maximum allowed is {{this.maxFileSize / (1024*1024) }} MiB.<br>
         Check out <a href="/help/supported_filetypes">the Supported Formats</a> for more information.
       </div>
@@ -13,7 +13,7 @@
       <button @click.prevent="clearFileUpload" v-show="disableURLUpload">Clear</button>
     </div>
     <div v-if="!disableURLUpload">
-      <div class="box-section sect_red" v-if="badDirectURL">
+      <div class="box-section background-red" v-if="badDirectURL">
         The direct URL entered has the following problem: {{ directURLProblem }}<br>
         You should review <a href="/wiki_pages/howto:sites_and_sources">the sourcing guide</a>.
       </div>

--- a/app/javascript/src/javascripts/uploader/file_preview.vue
+++ b/app/javascript/src/javascripts/uploader/file_preview.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="upload_preview_container" :class="classes">
-    <div class="box-section sect_red" v-show="overDims">
+    <div class="box-section background-red" v-show="overDims">
       One of the image dimensions is above the maximum allowed of 15,000px and will fail to upload.
     </div>
     <div v-if="!failed">
@@ -12,7 +12,7 @@
         referrerpolicy="no-referrer"
         v-on:load="updateDimensions($event)" v-on:error="previewFailed()"/>
     </div>
-    <div v-else class="preview-fail box-section sect_yellow">
+    <div v-else class="preview-fail box-section background-yellow">
       <p>The preview for this file failed to load. Please, double check that the URL you provided is correct.</p>
       Note that some sites intentionally prevent images they host from being displayed on other sites. The file can still be uploaded despite that.
     </div>

--- a/app/javascript/src/javascripts/uploader/sources.vue
+++ b/app/javascript/src/javascripts/uploader/sources.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="box-section sect_red source_warning" v-show="showErrors && sourceWarning">
+  <div class="box-section background-red source_warning" v-show="showErrors && sourceWarning">
     A source must be provided or you must select that there is no available source.
   </div>
   <div v-if="!noSource">

--- a/app/javascript/src/javascripts/uploader/uploader.vue.erb
+++ b/app/javascript/src/javascripts/uploader/uploader.vue.erb
@@ -113,7 +113,7 @@
                     </div>
                 </div>
                 <div class="col2">
-                    <div class="box-section sect_red" v-if="showErrors && invalidRating">
+                    <div class="box-section background-red" v-if="showErrors && invalidRating">
                         You must select an appropriate rating for this image.
                     </div>
                     <div>
@@ -144,7 +144,7 @@
                 </div>
                 <div class="col2">
                   <file-preview classes="box-section in-editor" :data="previewData"></file-preview>
-                    <div class="box-section sect_red" v-show="showErrors && notEnoughTags">
+                    <div class="box-section background-red" v-show="showErrors && notEnoughTags">
                         You must provide at least <b>{{4 - tagCount}}</b> more tags. Tags in other sections count
                         towards this total.
                     </div>
@@ -218,16 +218,16 @@
             <div class="flex-grid">
                 <div class="col"></div>
                 <div class="col2">
-                    <div class="box-section sect_red" v-show="preventUpload && showErrors">
+                    <div class="box-section background-red" v-show="preventUpload && showErrors">
                         Unmet requirements above prevent the submission of the post.
                     </div>
-                    <div class="box-section sect_green" v-show="submitting">
+                    <div class="box-section background-green" v-show="submitting">
                         Submitting your post, please wait.
                     </div>
-                    <div class="box-section sect_red" v-show="error">
+                    <div class="box-section background-red" v-show="error">
                         {{ error }}
                     </div>
-                    <div class="box-section sect_red" v-show="duplicateId">
+                    <div class="box-section background-red" v-show="duplicateId">
                         Post is a duplicate of <a :href="duplicatePath">post #{{duplicateId}}.</a>
                     </div>
                     <button @click="submit" :disabled="(showErrors && preventUpload) || submitting" accesskey="s">

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -1,4 +1,5 @@
 @import "base/functions";
+@import "base/palette";
 @import "base/themable"; //Drags in themes automatically
 @import "base/colors";
 @import "base/vars";
@@ -8,6 +9,7 @@
 @import "base/fontawesome";
 
 @import "common/helper_classes";
+@import "common/helper_palette";
 @import "common/ads.scss";
 @import "common/autocomplete.scss";
 @import "common/blacklists.scss";

--- a/app/javascript/src/styles/base/_base.scss
+++ b/app/javascript/src/styles/base/_base.scss
@@ -100,8 +100,3 @@ table tfoot {
   font-style: italic;
   font-size: 80%;
 }
-
-.greentext, .greentext a, .approved-ticket { color: $green-text-color !important; font-weight:bold; }
-.greytext, .greytext a { color: $grey-text-color !important; font-weight:bold; }
-.yellowtext, .yellowtext a, .partial-ticket { color: $yellow-text-color !important; font-weight:bold; }
-.redtext, .redtext a { color: $red-text-color !important; font-weight:bold; }

--- a/app/javascript/src/styles/base/_base.scss
+++ b/app/javascript/src/styles/base/_base.scss
@@ -105,10 +105,3 @@ table tfoot {
 .greytext, .greytext a { color: $grey-text-color !important; font-weight:bold; }
 .yellowtext, .yellowtext a, .partial-ticket { color: $yellow-text-color !important; font-weight:bold; }
 .redtext, .redtext a { color: $red-text-color !important; font-weight:bold; }
-
-
-.sect_green { background-color: $section-green-background; /* green */ }
-.sect_red { background-color: $section-red-background; /* red */ }
-.sect_yellow { background-color: $section-yellow-background; /* yellow */ }
-.sect_grey { background-color: $section-grey-background; /* yellow */ }
-.sect_green a:hover, .sect_red a:hover, .sect_yellow a:hover { color: $section-link-hover-color; }

--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -5,13 +5,6 @@ $yellow-text-color: #e4e150;
 $red-text-color: #e45f5f;
 $grey-text-color: #959595;
 
-
-$section-green-background: #288233;
-$section-yellow-background: #828028;
-$section-red-background: #822828;
-$section-grey-background: #5d656e;
-$section-link-hover-color: white;
-
 // Main background colors
 $lighten-background-5: rgba(255,255,255,0.05);
 
@@ -23,7 +16,7 @@ $state-error-color: #e45f5f;
 $dtext-code-background: rgba(255,255,255,0.2);
 
 // Blips
-$blip-hidden-background: $section-red-background;
+$blip-hidden-background: palette("background-red");
 
 // Forms
 $form-focus-color: black;
@@ -88,7 +81,7 @@ $negative-record-color: $red-color;
 $neutral-record-color: $dark-grey-color;
 
 $comment-highlight-background: rgba(255,255,255,0.25);
-$comment-hidden-background: $section-red-background;
+$comment-hidden-background: palette("background-red");
 $comment-vote-background: rgba(255, 255, 255, 0.2);
 
 // Keyboard shortcuts
@@ -111,8 +104,8 @@ $forum-vote-down-color: red;
 $forum-vote-meh-color: goldenrod;
 $forum-topic-new-color: red;
 $forum-topic-except-color: gray;
-$forum-topic-hidden-background: rgba(130,40,40,0.75);
-$forum-post-hidden-background: rgba(130,40,40,0.75);
+$forum-topic-hidden-background: palette("background-red");
+$forum-post-hidden-background: palette("background-red");
 
 // IQDB lookup
 $iqdb-post-border: lightgrey;
@@ -142,12 +135,12 @@ $post-preview-highlight-background: rgba(0,0,0,0.1);
 $post-tag-low-count-color: red;
 
 // Post Mode
-$post-mode-edit: $section-yellow-background;
+$post-mode-edit: palette("background-yellow");
 $post-mode-tag-script: #4f114f;
 $post-mode-add-fav: #104e17;
 $post-mode-remove-fav: darken($post-mode-add-fav, 10%);
-$post-mode-vote-up: $section-green-background;
-$post-mode-vote-down: $section-red-background;
+$post-mode-vote-up: palette("background-green");
+$post-mode-vote-down: palette("background-red");
 $post-mode-add-pool: #104b57;
 $post-mode-lock-rating: #AA3;
 $post-mode-lock-note: #3AA;

--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -1,9 +1,5 @@
 // Font
 $inverted-text-color: invert(#fff);
-$green-text-color: #3e9e49;
-$yellow-text-color: #e4e150;
-$red-text-color: #e45f5f;
-$grey-text-color: #959595;
 
 // Main background colors
 $lighten-background-5: rgba(255,255,255,0.05);

--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -62,20 +62,7 @@ $diff-text-removed-strong-color: rgba(248 ,81, 73, 0.4);
 // Notices
 $error-notice-color: #a00;
 
-$grey-color: hsl(0, 0%, 90%); // Light grey
-
-$red-color: #e45f5f;
-$green-color: #3e9e49;
-$dark-grey-color: hsl(0, 0%, 50%);
-
-// User Feedback page
-$neutral-record-background: #666;
-$positive-record-background: green;
-$negative-record-background: #822828;
-$positive-record-color: $green-color;
-$negative-record-color: $red-color;
-$neutral-record-color: $dark-grey-color;
-
+// Comments
 $comment-highlight-background: rgba(255,255,255,0.25);
 $comment-hidden-background: palette("background-red");
 $comment-vote-background: rgba(255, 255, 255, 0.2);
@@ -124,19 +111,16 @@ $post-version-grid-border: black;
 $post-version-content-background: inherit;
 
 // Posts
-$post-rating-explicit-color: $red-color;
-$post-rating-questionable-color: hsl(50, 100%, 70%);
-$post-rating-safe-color: $green-color;
 $post-preview-highlight-background: rgba(0,0,0,0.1);
 $post-tag-low-count-color: red;
 
 // Post Mode
-$post-mode-edit: palette("background-yellow");
+$post-mode-edit: #76551b;
 $post-mode-tag-script: #4f114f;
 $post-mode-add-fav: #104e17;
 $post-mode-remove-fav: darken($post-mode-add-fav, 10%);
-$post-mode-vote-up: palette("background-green");
-$post-mode-vote-down: palette("background-red");
+$post-mode-vote-up: #227d2a;
+$post-mode-vote-down: #76312E;
 $post-mode-add-pool: #104b57;
 $post-mode-lock-rating: #AA3;
 $post-mode-lock-note: #3AA;
@@ -144,9 +128,9 @@ $post-mode-approve: #48C;
 $post-mode-delete: #4e1010;
 $post-mode-add-to-set: #A51;
 $post-mode-remove-from-set: darken($post-mode-add-to-set, 10%);
-$post-mode-rating-s: darken($post-rating-safe-color, 25%);
-$post-mode-rating-q: darken($post-rating-questionable-color, 50%);
-$post-mode-rating-e: darken($post-rating-explicit-color, 25%);
+$post-mode-rating-e: #7b1414;
+$post-mode-rating-q: #79660a;
+$post-mode-rating-s: #1a421f;
 $post-mode-remove-parent: #38F;
 $post-mode-undelete: #818;
 $post-mode-unflag: #304;

--- a/app/javascript/src/styles/base/_palette.scss
+++ b/app/javascript/src/styles/base/_palette.scss
@@ -8,6 +8,11 @@ $palette: (
   "background-yellow": #828028,
   "background-green": #227d2a,
   "background-grey": #60686f,
+
+  "text-red": #e13d3d,
+  "text-yellow": #e4e150,
+  "text-green": #3e9e49,
+  "text-grey": #959595,
 );
 
 :root {

--- a/app/javascript/src/styles/base/_palette.scss
+++ b/app/javascript/src/styles/base/_palette.scss
@@ -5,10 +5,11 @@
 // Palette definitions
 $palette: (
   "background-red": #76312E,
-  "background-yellow": #828028,
+  "background-yellow": #a98837,
   "background-green": #227d2a,
   "background-grey": #60686f,
 
+  "text-white": #ffffff,
   "text-red": #e13d3d,
   "text-yellow": #e4e150,
   "text-green": #3e9e49,

--- a/app/javascript/src/styles/base/_palette.scss
+++ b/app/javascript/src/styles/base/_palette.scss
@@ -1,0 +1,22 @@
+// Base color palette.
+// These colors should not normally change between
+// themes, but could still be overriden if need be.
+
+// Palette definitions
+$palette: (
+  "background-red": #76312E,
+  "background-yellow": #828028,
+  "background-green": #227d2a,
+  "background-grey": #60686f,
+);
+
+:root {
+  @each $name, $color in $palette {
+    --palette-#{$name}: #{$color};
+  }
+}
+
+// Helper function
+@function palette($key) {
+  @return var(--palette-#{$key});
+}

--- a/app/javascript/src/styles/base/_palette.scss
+++ b/app/javascript/src/styles/base/_palette.scss
@@ -9,6 +9,9 @@ $palette: (
   "background-green": #227d2a,
   "background-grey": #60686f,
 
+  "background-red-d5": darken(#76312E, 5%),
+  "background-green-d5": darken(#227d2a, 5%),
+
   "text-white": #ffffff,
   "text-red": #e13d3d,
   "text-yellow": #e4e150,

--- a/app/javascript/src/styles/common/_helper_palette.scss
+++ b/app/javascript/src/styles/common/_helper_palette.scss
@@ -7,9 +7,15 @@
   }
 }
 
-.text-error {
-  color: palette("text-red") !important;
-  font-weight: bold;
+.text {
+  &-explicit { color: palette("text-red"); }
+  &-questionable { color: palette("text-yellow"); }
+  &-safe { color: palette("text-green"); }
+
+  &-error {
+    color: palette("text-red") !important;
+    font-weight: bold;
+  }
 }
 
 .text-bold {

--- a/app/javascript/src/styles/common/_helper_palette.scss
+++ b/app/javascript/src/styles/common/_helper_palette.scss
@@ -1,0 +1,5 @@
+@each $name in ("red", "yellow", "green", "grey") {
+  .background-#{$name} {
+    background: palette("background-#{$name}") !important;
+  }
+}

--- a/app/javascript/src/styles/common/_helper_palette.scss
+++ b/app/javascript/src/styles/common/_helper_palette.scss
@@ -2,4 +2,16 @@
   .background-#{$name} {
     background: palette("background-#{$name}") !important;
   }
+  .text-#{$name} {
+    color: palette("text-#{$name}") !important;
+  }
+}
+
+.text-error {
+  color: palette("text-red") !important;
+  font-weight: bold;
+}
+
+.text-bold {
+  font-weight: bold;
 }

--- a/app/javascript/src/styles/common/_scores.scss
+++ b/app/javascript/src/styles/common/_scores.scss
@@ -26,13 +26,3 @@
     color: themed("color-text-muted");
   }
 }
-
-.post-rating-text-safe {
-  color: themed("color-rating-safe");
-}
-.post-rating-text-questionable {
-  color: themed("color-rating-questionable");
-}
-.post-rating-text-explicit {
-  color: themed("color-rating-explicit");
-}

--- a/app/javascript/src/styles/common/containers.scss
+++ b/app/javascript/src/styles/common/containers.scss
@@ -1,24 +1,13 @@
-
-
 .box-section {
   background-color: themed("color-section");
   padding: $base-padding;
   margin-bottom: 1.5rem;
   border-radius: $border-radius-half;
-}
 
-.box-section.sect_green {
-  background-color: $section-green-background;
-}
-
-.box-section.sect_grey {
-  background-color: $section-grey-background;
-}
-
-.box-section.sect_red {
-  background-color: $section-red-background;
-}
-
-.box-section.sect_yellow {
-  background-color: $section-yellow-background;
+  &.background-green, &.background-grey, &.background-red, &.background-yellow {
+    a:hover {
+      // Legacy, not sure why this is here
+      color: themed("color-text");
+    }
+  }
 }

--- a/app/javascript/src/styles/specific/bans.scss
+++ b/app/javascript/src/styles/specific/bans.scss
@@ -1,17 +1,17 @@
 #c-bans #a-index {
   tr[data-expired="true"] {
-    background-color: $positive-record-background;
+    background-color: palette("background-green");
 
     &:hover {
-      background-color: darken($positive-record-background, 5%);
+      background-color: palette("background-green-d5");
     }
   }
 
   tr[data-expired="false"] {
-    background-color: $negative-record-background;
+    background-color: palette("background-red");
 
     &:hover {
-      background-color: darken($negative-record-background, 5%);
+      background-color: palette("background-red-d5");
     }
   }
 }

--- a/app/javascript/src/styles/specific/post_flags.scss
+++ b/app/javascript/src/styles/specific/post_flags.scss
@@ -1,6 +1,6 @@
 div#c-post-flags {
   tr.flag-resolved-true {
-    background: $negative-record-background !important;
+    background: palette("background-red") !important;
   }
 
   .flag-reason-title, .flag-reason-text {

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -30,15 +30,15 @@ article.post-preview {
   }
 
   &.post-rating-explicit .post-score-rating {
-    color: $post-rating-explicit-color;
+    color: palette("text-red");
   }
 
   &.post-rating-safe .post-score-rating {
-    color: $post-rating-safe-color;
+    color: palette("text-green");
   }
 
   &.post-rating-questionable .post-score-rating {
-    color: $post-rating-questionable-color;
+    color: palette("text-yellow");
   }
 
   img {
@@ -361,15 +361,21 @@ div#c-posts {
       }
 
       #post_rating_e:checked + label {
-        background-color: themed("color-rating-explicit");
+        background-color: palette("background-red");
+        color: palette("text-white") !important;
+        text-shadow: 0 0 2px BLACK;
       }
 
       #post_rating_q:checked + label {
-        background-color: themed("color-rating-questionable");
+        background-color: palette("background-yellow");
+        color: palette("text-white") !important;
+        text-shadow: 0 0 2px BLACK;
       }
 
       #post_rating_s:checked + label {
-        background-color: themed("color-rating-safe");
+        background-color: palette("background-green");
+        color: palette("text-white") !important;
+        text-shadow: 0 0 2px BLACK;
       }
     }
 

--- a/app/javascript/src/styles/specific/tickets.scss
+++ b/app/javascript/src/styles/specific/tickets.scss
@@ -20,3 +20,12 @@
     }
   }
 } 
+
+.approved-ticket {
+  color: palette("text-green");
+  font-weight: bold;
+}
+.partial-ticket { 
+  color: palette("text-yellow");
+  font-weight: bold;
+}

--- a/app/javascript/src/styles/specific/uploads.scss
+++ b/app/javascript/src/styles/specific/uploads.scss
@@ -21,13 +21,19 @@ div#c-uploads {
     }
 
     .rating-e.active {
-      background-color: themed("color-rating-explicit");
+      background-color: palette("background-red");
+      color: palette("text-white");
+      text-shadow: 0 0 2px #000;
     }
     .rating-q.active {
-      background-color: themed("color-rating-questionable");
+      background-color: palette("background-yellow");
+      color: palette("text-white");
+      text-shadow: 0 0 2px #000;
     }
     .rating-s.active {
-      background-color: themed("color-rating-safe");
+      background-color: palette("background-green");
+      color: palette("text-white");
+      text-shadow: 0 0 2px #000;
     }
 
     .flex-grid-outer {

--- a/app/javascript/src/styles/specific/user_feedback.scss
+++ b/app/javascript/src/styles/specific/user_feedback.scss
@@ -1,30 +1,16 @@
-
-
-.user-feedback-positive {
-  color: $positive-record-color;
-}
-
-.user-feedback-neutral {
-  color: $neutral-record-color;
-}
-
-.user-feedback-negative {
-  color: $negative-record-background;
+.user-feedback {
+  &-negative { color: palette("text-red"); }
+  &-neutral { color: palette("text-grey"); }
+  &-positive { color: palette("text-green"); }
 }
 
 div#c-user-feedbacks, div#c-moderator-dashboards .activity-container {
-  .feedback-category-positive {
-    background: $positive-record-background;
+  .feedback-category {
+    &-negative { background: palette("background-red"); }
+    &-neutral { background: palette("background-grey"); }
+    &-positive { background: palette("background-green"); }
   }
-
-  .feedback-category-negative {
-    background: $negative-record-background;
-  }
-
-  .feedback-category-neutral {
-    background: $neutral-record-background;
-  }
-
+  
   blockquote {
     padding: 0.5em;
   }

--- a/app/javascript/src/styles/specific/user_warned.scss
+++ b/app/javascript/src/styles/specific/user_warned.scss
@@ -1,3 +1,3 @@
 .user-warning em {
-  color: themed("color-rating-explicit");
+  color: palette("text-red");
 }

--- a/app/javascript/src/styles/themes/_theme_hexagon.scss
+++ b/app/javascript/src/styles/themes/_theme_hexagon.scss
@@ -44,10 +44,6 @@ body {
   --color-warning:                sienna;
   --color-warning-darken-5:       #{darken(sienna, 5%)};
 
-  --color-rating-explicit:        #e45f5f;
-  --color-rating-questionable:    hsl(50, 100%, 70%);
-  --color-rating-safe:            #3e9e49;
-
   --color-score-positive:         #3e9e49;
   --color-score-negative:         #e45f5f;
 

--- a/app/views/maintenance/user/email_changes/new.html.erb
+++ b/app/views/maintenance/user/email_changes/new.html.erb
@@ -2,7 +2,7 @@
   <div id="a-new">
     <h1>Change Email</h1>
 
-    <div class="box-section sect_red">
+    <div class="box-section background-red">
     <p>Warning: Changing the email on your account will mark it as unactivated until you confirm the new email address.</p>
 
     <p>You must confirm your password in order to change your email address.</p>

--- a/app/views/static/theme.html.erb
+++ b/app/views/static/theme.html.erb
@@ -1,10 +1,10 @@
 <p>Theme settings are saved using cookies and javascript. This means that they will not persist across private browsing
   sessions, or work inside incognito mode on mobile devices.</p>
 
-<h3 class="redtext" id="no_save_warning" style="display:none;">Your device does not allow the site to save theme
+<h3 class="text-error" id="no_save_warning" style="display:none;">Your device does not allow the site to save theme
   settings.</h3>
 <noscript>
-  <h3 class="redtext" id="no_save_warning">Your device does not allow the site to save theme settings.</h3>
+  <h3 class="text-error" id="no_save_warning">Your device does not allow the site to save theme settings.</h3>
 </noscript>
 
 <div class="simple_form">

--- a/app/views/tag_relationships/_listing.html.erb
+++ b/app/views/tag_relationships/_listing.html.erb
@@ -22,7 +22,7 @@
           <span class="count"><%= tag_relation.consequent_tag.post_count rescue 0 %></span>
           <% if tag_relation.is_a?(TagAlias) %>
             <% if CurrentUser.is_member? && tag_relation.status == "pending" && tag_relation.has_transitives %>
-              <span class="redtext"> HAS TRANSITIVES</span>
+              <span class="text-error"> HAS TRANSITIVES</span>
             <% end %>
           <% end %>
         </td>

--- a/app/views/takedowns/_editor.html.erb
+++ b/app/views/takedowns/_editor.html.erb
@@ -71,8 +71,8 @@
         <td colspan='2'><%= check_box "takedown", "reason_hidden", checked: @takedown.reason_hidden %>
           <label for="takedown_reason_hidden">Hide Reason?
             (Currently
-            <% if !@takedown.reason_hidden %><span class='greentext'>not hidden</span>
-            <% else %><span class='redtext'>hidden</span>
+            <% if !@takedown.reason_hidden %><span class="text-green">not hidden</span>
+            <% else %><span class="text-error">hidden</span>
             <% end %>)
           </label></td>
       </tr>

--- a/app/views/takedowns/index.html.erb
+++ b/app/views/takedowns/index.html.erb
@@ -30,7 +30,7 @@
                 <%= link_to takedown.source, "https://#{takedown.source}", rel: "noopener noreferrer nofollow" %>
               <% end %>
             <% else %>
-              <span class="redtext">(Source hidden)</span>
+              <span class="text-error">(Source hidden)</span>
             <% end %>
           </td>
 

--- a/app/views/takedowns/show.html.erb
+++ b/app/views/takedowns/show.html.erb
@@ -1,7 +1,7 @@
 <div id="c-takedowns">
   <div id="c-show">
     <% if @show_instructions && (!@takedown.completed?) %>
-      <div class='box-section sect_red'>
+      <div class='box-section background-red'>
         <div style="font-size:2rem;margin-top:0;margin-bottom:1rem;">Wait! You're not done yet!</div>
         <p>Your verification code is <span class='takedown-vericode'><%= @takedown.vericode %></span></p>
         <p>Your takedown request has been successfully created. Using the gallery account that you specified below as the "source", <span style="font-weight:bold;">please send your verification code via PM/note to</span>:</p>
@@ -137,7 +137,7 @@
         </div>
 
       <% elsif @takedown.status == "inactive" && !@takedown.takedown_posts.blank? %>
-        <div class='box-section sect_grey'>
+        <div class='box-section background-grey'>
           <p style="margin-bottom:0px;">This takedown request has been marked as inactive as the submitter has not responded in a reasonable time frame. It will be handled once the submitter responds.</p>
             <br>
             <p>The following posts are up for dispute:</p>
@@ -147,7 +147,7 @@
         </div>
 
       <% elsif @takedown.status == "denied" %>
-        <div class='box-section sect_red'>
+        <div class='box-section background-red'>
           <p>The request has been denied. The following posts were not removed:</p>
           <% @takedown.actual_kept_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post)) %><br>
@@ -155,14 +155,14 @@
         </div>
 
       <% elsif @takedown.status == "partial" %>
-        <div class='box-section sect_green'>
+        <div class='box-section background-green'>
           <p>The request has been partially approved. The following posts were removed:</p>
           <% @takedown.actual_deleted_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post), class: "takedown_post_deleted") %><br>
           <% end %>
         </div>
 
-        <div class='box-section sect_red'>
+        <div class='box-section background-red'>
           <p>The following posts were kept:</p>
           <% @takedown.actual_kept_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post), class: "takedown_post_kept") %><br>
@@ -170,7 +170,7 @@
         </div>
 
       <% elsif @takedown.status == "approved" %>
-        <div class='box-section sect_green'>
+        <div class='box-section background-green'>
           <p>The request has been approved. The following posts were removed:</p>
           <% @takedown.actual_deleted_posts.each do |post| %>
             <%= link_to("post ##{post.id}", post_path(post)) %><br>

--- a/app/views/takedowns/show.html.erb
+++ b/app/views/takedowns/show.html.erb
@@ -26,7 +26,7 @@
                 <%= link_to @takedown.source, "https://#{@takedown.source}", rel: "noopener noreferrer nofollow" %>
               <% end %>
             <% else %>
-              <span class="redtext">[Source hidden by submitter]</span>
+              <span class="text-error">[Source hidden by submitter]</span>
             <% end %>
           </td>
         </tr>
@@ -35,9 +35,9 @@
           <td><label>Reason</label></td>
           <% if !@takedown.reason_hidden || CurrentUser.is_moderator? || @show_instructions %>
             <td><%= h @takedown.reason %>
-              <% if @takedown.reason_hidden %><span class="redtext">(HIDDEN)</span><% end %></td>
+              <% if @takedown.reason_hidden %><span class="text-error">(HIDDEN)</span><% end %></td>
           <% else %>
-            <td><span class="redtext">[Reason hidden by submitter]</span></td>
+            <td><span class="text-error">[Reason hidden by submitter]</span></td>
           <% end %>
         </tr>
 
@@ -101,9 +101,9 @@
       <div class="box-section dtext-container">
         <% if !@takedown.reason_hidden || CurrentUser.is_moderator? %>
           <%= format_text(@takedown.notes) %>
-          <% if @takedown.reason_hidden %><span class="redtext">(HIDDEN)</span><% end %>
+          <% if @takedown.reason_hidden %><span class="text-error">(HIDDEN)</span><% end %>
         <% else %>
-          <span class="redtext">[Admin notes hidden]</span>
+          <span class="text-error">[Admin notes hidden]</span>
         <% end %>
       </div>
     <% end %>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -33,7 +33,7 @@
               </td>
               <td>
               <% if ticket.claimant.nil? %>
-                <span class="redtext">Unclaimed</span>
+                <span class="text-error">Unclaimed</span>
               <% else %>
                 <%= link_to_user ticket.claimant %>
               <% end %>
@@ -42,7 +42,7 @@
             <td><%= link_to ticket.type_title, ticket_path(ticket) %></td>
 
             <% if !ticket.can_see_details?(CurrentUser.user) %>
-              <td><span style="cursor:help;" class="redtext" title="Due to privacy concerns, this information is confidential">Confidential</span></td>
+              <td><span style="cursor:help;" class="text-error" title="Due to privacy concerns, this information is confidential">Confidential</span></td>
             <% else %>
               <%= tag.td class: "ticket-subject full-width-link", title: truncate(strip_tags(format_text(ticket.reason)), length: 200) do %>
                 <%= link_to truncate(strip_tags(format_text(ticket.subject)), length: 200), ticket_path(ticket.id) %>

--- a/app/views/tickets/types/_blip.html.erb
+++ b/app/views/tickets/types/_blip.html.erb
@@ -1,13 +1,13 @@
 <% if @ticket.content %>
     <tr>
-      <td><span class='title'>Reported Blip</span></td>
+      <td><span class="title">Reported Blip</span></td>
       <td>
         <%= link_to "Blip by #{@ticket.content.creator_name}", blip_path(@ticket.content) %>
       </td>
     </tr>
 <% else %>
     <tr>
-      <td><span class='title'>Reported Blip</span></td>
-      <td><span class='redtext'>Blip has been deleted</span></td>
+      <td><span class="title">Reported Blip</span></td>
+      <td><span class="text-error">Blip has been deleted</span></td>
     </tr>
 <% end %>

--- a/app/views/tickets/types/_comment.html.erb
+++ b/app/views/tickets/types/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if @ticket.content %>
   <tr>
-    <td><span class='title'>Reported Comment</span></td>
+    <td><span class="title">Reported Comment</span></td>
     <td>
       <%= link_to("Comment by #{@ticket.content.creator_name}", comment_path(@ticket.content)) %> on
       <%= link_to("post ##{@ticket.content.post_id}", post_path(@ticket.content.post_id)) %>
@@ -8,7 +8,7 @@
   </tr>
 <% else %>
   <tr>
-    <td><span class='title'>Reported Comment</span></td>
-    <td><span class='redtext'>Comment has been deleted</span></td>
+    <td><span class="title">Reported Comment</span></td>
+    <td><span class="text-error">Comment has been deleted</span></td>
   </tr>
 <% end %>

--- a/app/views/tickets/types/_forum.html.erb
+++ b/app/views/tickets/types/_forum.html.erb
@@ -7,7 +7,7 @@
   </tr>
 <% else %>
   <tr>
-    <td><span class='title'>Reported Forum Post</span></td>
-    <td><span class='redtext'>Forum post has been deleted</span></td>
+    <td><span class="title">Reported Forum Post</span></td>
+    <td><span class="text-error">Forum post has been deleted</span></td>
   </tr>
 <% end %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -13,7 +13,7 @@
   <div id="uploader"></div>
   <% if CurrentUser.upload_limit <= 5 || CurrentUser.post_upload_throttle <= 5 %>
     <% @limit_pieces = CurrentUser.upload_limit_pieces %>
-    <div id="post-uploads-remaining" class="box-section section<% if [CurrentUser.upload_limit, CurrentUser.post_upload_throttle].min <= 0 %> sect_red<% end %>" style="width:640px;">
+    <div id="post-uploads-remaining" class="box-section section<% if [CurrentUser.upload_limit, CurrentUser.post_upload_throttle].min <= 0 %> background-red<% end %>" style="width:640px;">
       <p>
         You currently have <span class="post-uploads-remaining-count"><%= CurrentUser.upload_limit %></span> upload<%= CurrentUser.upload_limit!=1?"s":"" %> remaining.
 
@@ -25,7 +25,7 @@
       See <%= link_to "here", upload_limit_users_path %> for more details.
     </div>
   <% elsif CurrentUser.post_upload_throttle <= 5 %>
-    <div id="post-uploads-remaining" class="section<% if CurrentUser.post_upload_throttle <= 0 %> sect_red<% end %>" style="width:640px;">
+    <div id="post-uploads-remaining" class="section<% if CurrentUser.post_upload_throttle <= 0 %> background-red<% end %>" style="width:640px;">
       You have <span class="post-uploads-remaining-count"><%= CurrentUser.post_upload_throttle %></span> uploads remaining this hour.
       See <%= link_to "here", upload_limit_users_path %> for more details.
     </div>

--- a/app/views/user_votes/_common_index.html.erb
+++ b/app/views/user_votes/_common_index.html.erb
@@ -45,9 +45,9 @@
           <% end %>
           <td><%= time_ago_in_words_tagged(vote.user.created_at) %></td>
           <td>
-            <% if vote.is_positive? %><span class='greentext'>Up</span>
-            <% elsif vote.is_locked? %><span class='yellowtext'>Locked</span>
-            <% else %><span class='redtext'>Down</span>
+            <% if vote.is_positive? %><span class="text-green text-bold">Up</span>
+            <% elsif vote.is_locked? %><span class="text-yellow text-bold">Locked</span>
+            <% else %><span class="text-red text-bold">Down</span>
             <% end %>
           </td>
           <td><%= time_ago_in_words_tagged(vote.created_at) %></td>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,7 +4,7 @@
 
     <p>An account is <strong>free</strong> and lets you keep favorites, upload artwork, and write comments.</p>
 
-    <div class="box-section sect_red">
+    <div class="box-section background-red">
       <p>Make sure to read the <a href="/wiki_pages/e621:rules">site rules</a> before continuing.</p>
       <p>You must confirm your email address, so use something you can receive email with.</p>
       <p>This site is open to web crawlers so whatever name you choose will be public!</p>


### PR DESCRIPTION
This PR builds upon #614, continuing the cleanup process of the color variables.
Some of the more prominent elements were handled this time, namely user feedbacks and post ratings.

Two new colors were added to the palette to deal with the need for slightly darker backgrounds to show when hovering over a colored-in row. That was only necessary for red and green colors so far, so I decided not to include yellow and grey to avoid bloating the stylesheet.

Here's the palette as it is right now:
<table>
<thead align="center"><tr><td></td><td>red</td><td>yellow</td><td>green</td><td>grey</td></tr></thead>
<tbody>
  <tr>
    <td>text color</td>
    <td><img src="https://placehold.co/32x32/152f56/e13d3d.png?text=e" /></td>
    <td><img src="https://placehold.co/32x32/152f56/e4e150.png?text=6" /></td>
    <td><img src="https://placehold.co/32x32/152f56/3e9e49.png?text=2" /></td>
    <td><img src="https://placehold.co/32x32/152f56/959595.png?text=1" /></td>
  </tr>
  <tr>
    <td>background</td>
    <td><img src="https://placehold.co/32x32/76312E/fff.png?text=e" /></td>
    <td><img src="https://placehold.co/32x32/a98837/fff.png?text=6" /></td>
    <td><img src="https://placehold.co/32x32/227d2a/fff.png?text=2" /></td>
    <td><img src="https://placehold.co/32x32/60686f/fff.png?text=1" /></td>
  </tr>
  <tr>
    <td>bg-darker</td>
    <td><img src="https://placehold.co/32x32/642927/fff.png?text=e" /></td>
    <td></td>
    <td><img src="https://placehold.co/32x32/1d6923/fff.png?text=2" /></td>
    <td></td>
  </tr>
</tbody>
</table>

### Backgrounds: Feedbacks, Bans, and Rejected Flags

The backgrounds of user feedbacks were affected by the switch to the palette colors.
The colors overall are less bright and harsh on the eyes.

old
![negative](https://placehold.co/200x50/822828/fff.png?text=negative)![neutral](https://placehold.co/200x50/666/fff.png?text=neutral)![positive](https://placehold.co/200x50/008000/fff.png?text=positive)
new
![negative](https://placehold.co/200x50/76312E/fff.png?text=negative)![neutral](https://placehold.co/200x50/60686f/fff.png?text=neutral)![positive](https://placehold.co/200x50/227d2a/fff.png?text=positive)

### Text color: Post Ratings and Feedback Counts

Initially, I planned to only replace the colors of the user feedback counts – visible on their profile page, or next to their name in the post sidebar. However, it turns out that the post ratings used the exact same color variables, and thus were affected too.

... and that is when I discovered that apparently rating colors are theme-specific. Sometimes.
The ones in the post sidebar can be customized, but not the ones in the post thumbnails.

I found this to be extremely strange, especially since none of the themes making use of this kind of customization.
For now, I have removed the rating CSS variables from the themes, and replaced them with the palette variables where appropriate.

old
![explicit](https://placehold.co/200x50/152f56/822828.png?text=explicit)![questionable](https://placehold.co/200x50/152f56/ffe566.png?text=questionable)![safe](https://placehold.co/200x50/152f56/3e9e49.png?text=safe)
new
![explicit](https://placehold.co/200x50/152f56/e13d3d.png?text=explicit)![questionable](https://placehold.co/200x50/152f56/e4e150.png?text=questionable)![safe](https://placehold.co/200x50/152f56/3e9e49.png?text=safe)

### Other themes

Here's how the changed text colors look with the `bloodlust` and `pony` themes respectively.

![explicit](https://placehold.co/200x50/222222/e13d3d.png?text=explicit)![questionable](https://placehold.co/200x50/222222/e4e150.png?text=questionable)![safe](https://placehold.co/200x50/222222/3e9e49.png?text=safe)
![explicit](https://placehold.co/200x50/2f175c/e13d3d.png?text=explicit)![questionable](https://placehold.co/200x50/2f175c/e4e150.png?text=questionable)![safe](https://placehold.co/200x50/2f175c/3e9e49.png?text=safe)
