### PR TITLE
[UploadPresenter] Normalize tags & strip metatags

### DIFF
--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -105,4 +105,5 @@ class TagCategory
   CATEGORIZED_LIST = %w[invalid artist copyright character species meta general lore].freeze
 
   SHORT_NAME_REGEX = SHORT_NAME_LIST.join("|").freeze
+  ALL_NAMES_REGEX = MAPPING.keys.join("|").freeze
 end

--- a/app/presenters/upload_presenter.rb
+++ b/app/presenters/upload_presenter.rb
@@ -7,6 +7,16 @@ class UploadPresenter < Presenter
   end
 
   def tag_set_presenter
-    @tag_set_presenter ||= TagSetPresenter.new(upload.tag_string.split)
+    @tag_set_presenter ||= TagSetPresenter.new(normalize_tags(upload.tag_string.split))
+  end
+
+  def strip_metatags(tags)
+    tags.grep_v(/\A(?:rating|-?parent|-?locked|-?pool|newpool|-?set|-?fav|-?child|upvote|downvote):/i)
+  end
+
+  def normalize_tags(tags)
+    tags = tags.map(&:downcase)
+    tags = strip_metatags(tags)
+    tags.map { |tag| tag.gsub(/(?:#{TagCategory::ALL_NAMES_REGEX}):/, "") }
   end
 end


### PR DESCRIPTION
This pr normalizes tags given to the TagSetPresenter, so capitalization and prefixes won't result in tags not getting their category color. It also strips metatags (like `set:`), since those shouldn't really be shown for viewing.

I also added `co`, `ch` & `oc` to `TagCategory::SHORT_NAME_MAPPING` so they would be included in the regex.

And lastly, my editor was complaining at me that the rbdoc on line 10 didn't have the correct parameter name, so I added it.
![image](https://github.com/e621ng/e621ng/assets/17226394/862b4c33-2a27-4940-9a1d-7d0c069d7cc1)

### Before
![image](https://github.com/e621ng/e621ng/assets/17226394/f6bcddd8-9c6f-40d6-a252-7a0be4821232)
### After
![image](https://github.com/e621ng/e621ng/assets/17226394/d0e12e5d-0216-4daa-a14b-670bb9160f68)
