### PR TITLE
[DMails] Add marking as unread

### DIFF
--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -1,13 +1,13 @@
 class DmailsController < ApplicationController
   respond_to :html
-  respond_to :json, only: %i[index show destroy mark_as_read mark_all_as_read]
+  respond_to :json, except: %i[new create]
   before_action :member_only
 
   def new
     if params[:respond_to_id]
       parent = Dmail.find(params[:respond_to_id])
       check_privilege(parent)
-      @dmail = parent.build_response(:forward => params[:forward])
+      @dmail = parent.build_response(forward: params[:forward])
     else
       @dmail = Dmail.new(create_params)
     end
@@ -20,15 +20,15 @@ class DmailsController < ApplicationController
       cookies.permanent[:dmail_folder] = params[:folder]
     end
     @query = Dmail.active.visible.search(search_params)
-    @dmails = @query.paginate(params[:page], :limit => params[:limit])
+    @dmails = @query.paginate(params[:page], limit: params[:limit])
     respond_with(@dmails)
   end
 
   def show
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
-    respond_with(@dmail) do |fmt|
-      fmt.html { @dmail.mark_as_read! unless Danbooru.config.readonly_mode? }
+    respond_with(@dmail) do |format|
+      format.html { @dmail.mark_as_read! }
     end
   end
 
@@ -43,7 +43,7 @@ class DmailsController < ApplicationController
     @dmail.mark_as_read!
     @dmail.update_column(:is_deleted, true)
     respond_to do |format|
-      format.html { redirect_to dmails_path, notice: "Message destroyed" }
+      format.html { redirect_to(dmails_path, notice: "Message deleted") }
       format.json
     end
   end
@@ -52,6 +52,16 @@ class DmailsController < ApplicationController
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
     @dmail.mark_as_read!
+  end
+
+  def mark_as_unread
+    @dmail = Dmail.find(params[:id])
+    check_privilege(@dmail)
+    @dmail.mark_as_unread!
+    respond_to do |format|
+      format.html { redirect_to(dmails_path, notice: "Message marked as unread") }
+      format.json
+    end
   end
 
   def mark_all_as_read

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -192,6 +192,15 @@ class Dmail < ApplicationRecord
     end
   end
 
+  def mark_as_unread!
+    return if Danbooru.config.readonly_mode?
+
+    update_column(:is_read, false)
+    owner.dmails.unread.count.tap do |unread_count|
+      owner.update(has_mail: (unread_count > 0), unread_dmail_count: unread_count)
+    end
+  end
+
   def is_automated?
     from == User.system
   end

--- a/app/views/dmails/show.html.erb
+++ b/app/views/dmails/show.html.erb
@@ -28,7 +28,11 @@
         <%= link_to "Respond", new_dmail_path(:respond_to_id => @dmail) %>
         | <%= link_to "Forward", new_dmail_path(:respond_to_id => @dmail, :forward => true) %>
         | <%= link_to "Filter messages like these", edit_maintenance_user_dmail_filter_path(:dmail_id => @dmail.id) %>
-        <% if CurrentUser.is_member? && @dmail.to_id == CurrentUser.id %>
+        <% if @dmail.owner_id == CurrentUser.id %>
+          | <%= link_to "Delete", dmail_path(@dmail), method: :delete, data: { confirm: "Are you sure you want to delete this Dmail?" } %>
+        <% end %>
+        <% if @dmail.to_id == CurrentUser.id %>
+          | <%= link_to "Mark Unread", mark_as_unread_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this Dmail as unread?" } %>
           | <%= link_to "Report", new_ticket_path(disp_id: @dmail.id, qtype: 'dmail') %>
         <% end %>
       </p>

--- a/app/views/dmails/show.html.erb
+++ b/app/views/dmails/show.html.erb
@@ -29,10 +29,10 @@
         | <%= link_to "Forward", new_dmail_path(:respond_to_id => @dmail, :forward => true) %>
         | <%= link_to "Filter messages like these", edit_maintenance_user_dmail_filter_path(:dmail_id => @dmail.id) %>
         <% if @dmail.owner_id == CurrentUser.id %>
-          | <%= link_to "Delete", dmail_path(@dmail), method: :delete, data: { confirm: "Are you sure you want to delete this Dmail?" } %>
+          | <%= link_to "Delete", dmail_path(@dmail), method: :delete, data: { confirm: "Are you sure you want to delete this DMail?" } %>
         <% end %>
         <% if @dmail.to_id == CurrentUser.id %>
-          | <%= link_to "Mark Unread", mark_as_unread_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this Dmail as unread?" } %>
+          | <%= link_to "Mark as unread", mark_as_unread_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as unread?" } %>
           | <%= link_to "Report", new_ticket_path(disp_id: @dmail.id, qtype: 'dmail') %>
         <% end %>
       </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
   resources :dmails, :only => [:new, :create, :index, :show, :destroy] do
     member do
       put :mark_as_read
+      put :mark_as_unread
     end
     collection do
       put :mark_all_as_read

--- a/test/functional/dmails_controller_test.rb
+++ b/test/functional/dmails_controller_test.rb
@@ -86,6 +86,21 @@ class DmailsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    context "mark as unread action" do
+      should "mark the dmail as unread" do
+        @dmail.mark_as_read!
+        assert_equal 0, @dmail.owner.reload.unread_dmail_count
+        assert_not_predicate @dmail.owner, :has_mail
+
+        put_auth mark_as_unread_dmail_path(@dmail), @dmail.owner, params: { format: :json }
+        assert_response :success
+        assert_not_predicate @dmail.reload, :is_read?
+
+        assert_equal 1, @dmail.owner.reload.unread_dmail_count
+        assert_predicate @dmail.owner, :has_mail
+      end
+    end
+
     context "create action" do
       setup do
         @user_2 = create(:user)


### PR DESCRIPTION
Adds a button to individual dmails to mark them as unread. This can be useful when you read a dmail now, but can't/don't want to reply to it until later.

Includes relevant controller test.
Also adds "Delete" button to individual dmails.