### PR TITLE
Convert Tag links in PostVersions & Uploads to wiki links

### DIFF
--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -29,14 +29,14 @@ module PostVersionsHelper
 
     diff[:added_tags].each do |tag_name|
       classes = diff[:obsolete_added_tags].include?(tag_name) ? "obsolete" : ""
-      changes << tag.ins(link_to("+#{tag_name}", posts_path(tags: tag_name)), class: classes)
+      changes << tag.ins(link_to_wiki_or_new("+#{tag_name}", tag_name), class: classes)
     end
     diff[:removed_tags].each do |tag_name|
       classes = diff[:obsolete_removed_tags].include?(tag_name) ? "obsolete" : ""
-      changes << tag.del(link_to("-#{tag_name}", posts_path(tags: tag_name)), class: classes)
+      changes << tag.del(link_to_wiki_or_new("-#{tag_name}", tag_name), class: classes)
     end
     diff[:unchanged_tags].each do |tag_name|
-      changes << tag.span(link_to(tag_name, posts_path(tags: tag_name)))
+      changes << tag.span(link_to_wiki_or_new(tag_name))
     end
 
     tag.span(safe_join(changes, " "), class: "diff-list")
@@ -47,13 +47,13 @@ module PostVersionsHelper
     changes = []
 
     diff[:added_locked_tags].each do |tag_name|
-      changes << tag.ins(link_to("+#{tag_name}", posts_path(tags: tag_name)))
+      changes << tag.ins(link_to_wiki_or_new("+#{tag_name}", tag_name))
     end
     diff[:removed_locked_tags].each do |tag_name|
-      changes << tag.del(link_to("-#{tag_name}", posts_path(tags: tag_name)))
+      changes << tag.del(link_to_wiki_or_new("-#{tag_name}", tag_name))
     end
     diff[:unchanged_locked_tags].each do |tag_name|
-      changes << tag.span(link_to(tag_name, posts_path(tags: tag_name)))
+      changes << tag.span(link_to_wiki_or_new(tag_name))
     end
 
     tag.span(safe_join(changes, " "), class: "diff-list")

--- a/app/presenters/tag_set_presenter.rb
+++ b/app/presenters/tag_set_presenter.rb
@@ -7,6 +7,8 @@
 =end
 
 class TagSetPresenter < Presenter
+  include Rails.application.routes.url_helpers
+
   attr_reader :tag_names
 
   # @param [Array<String>] a list of tags to present. Tags will be presented in
@@ -50,10 +52,10 @@ class TagSetPresenter < Presenter
   end
 
   # compact (horizontal) list, as seen in the /comments index.
-  def inline_tag_list_html
+  def inline_tag_list_html(link_type = :tag)
     html = TagCategory::CATEGORIZED_LIST.map do |category|
       tags_for_category(category).map do |tag|
-        %(<li class="category-#{tag.category}">#{tag_link(tag)}</li>)
+        %(<li class="category-#{tag.category}">#{tag_link(tag, tag.name, link_type)}</li>)
       end.join
     end.join
     %(<ul class="inline-tag-list">#{html}</ul>).html_safe
@@ -166,8 +168,9 @@ class TagSetPresenter < Presenter
     html
   end
 
-  def tag_link(tag, link_text = tag.name)
+  def tag_link(tag, link_text = tag.name, link_type = :tag)
+    link = link_type == :wiki_page ? show_or_new_wiki_pages_path(title: tag.name) : posts_path(tags: tag.name)
     itemprop = 'itemprop="author"' if tag.category == Tag.categories.artist
-    %(<a rel="nofollow" class="search-tag" #{itemprop} href="/posts?tags=#{u(tag.name)}">#{h(link_text)}</a> )
+    %(<a rel="nofollow" class="search-tag" #{itemprop} href="#{link}">#{h(link_text)}</a>)
   end
 end

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -49,7 +49,7 @@
 
               <span class="post-info">
                 <strong>Tags</strong>
-                <%= upload.presenter.inline_tag_list_html %>
+                <%= upload.presenter.inline_tag_list_html(:wiki_page) %>
               </span>
             </td>
             <td>


### PR DESCRIPTION
Does just what it says on the tin, converts links for tags on /post_versions & /uploads to wiki page links.
![image](https://github.com/e621ng/e621ng/assets/17226394/ed7cfe60-37cf-41c4-83aa-3e38a8d3dd3d)
![OnPaste 20240301-043007](https://github.com/e621ng/e621ng/assets/17226394/c83d704b-27c9-4eb5-aef2-6d710c3f180c)

Wiki page links are typically much more helpful here, since you're more likely looking at wiki pages to see if those tags are applicable, and not trying to find new tags to search for.