### PR TITLE
[PostSets] Add view access check to /post_sets/:id/maintainers

### DIFF
--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -68,6 +68,7 @@ class PostSetsController < ApplicationController
 
   def maintainers
     @post_set = PostSet.find(params[:id])
+    check_view_access(@post_set)
   end
 
   def post_list


### PR DESCRIPTION
This fixes a small missing access check issue with `/post_sets/:id/maintainers`. While this isn't a huge issue since private sets can't have maintainers, this does allow viewing the name of any private set.