### PR TITLE
[BUR] Move "duplicate of" text location

### DIFF
--- a/app/logical/bulk_update_request_importer.rb
+++ b/app/logical/bulk_update_request_importer.rb
@@ -59,10 +59,10 @@ class BulkUpdateRequestImporter
     tokens.map do |token|
       case token[0]
       when :create_alias
-        comment = "# duplicate of #{token[3]}" if token[3].present?
+        comment = "# #{token[3]}" if token[3].present?
         "alias #{token[1]} -> #{token[2]} #{comment}".strip
       when :create_implication
-        comment = "# duplicate of #{token[3]}" if token[3].present?
+        comment = "# #{token[3]}" if token[3].present?
         "implicate #{token[1]} -> #{token[2]} #{comment}".strip
       when :remove_alias
         comment = "# missing" if token[3] == false
@@ -88,10 +88,10 @@ class BulkUpdateRequestImporter
   def validate_alias(token)
     tag_alias = TagAlias.duplicate_relevant.find_by(antecedent_name: token[1], consequent_name: token[2])
     if tag_alias.present? && tag_alias.has_transitives
-      return [nil, "alias ##{tag_alias.id}, has blocking transitive relationships, cannot be applied through BUR"]
+      return [nil, "duplicate of alias ##{tag_alias.id}; has blocking transitive relationships, cannot be applied through BUR"]
     end
-    return [nil, "alias ##{tag_alias.id}"] unless tag_alias.nil?
-    tag_alias = TagAlias.new(:forum_topic_id => forum_id, :status => "pending", :antecedent_name => token[1], :consequent_name => token[2])
+    return [nil, "duplicate of alias ##{tag_alias.id}"] unless tag_alias.nil?
+    tag_alias = TagAlias.new(forum_topic_id: forum_id, status: "pending", antecedent_name: token[1], consequent_name: token[2])
     unless tag_alias.valid?
       return ["Error: #{tag_alias.errors.full_messages.join("; ")} (create alias #{tag_alias.antecedent_name} -> #{tag_alias.consequent_name})", nil]
     end
@@ -103,8 +103,8 @@ class BulkUpdateRequestImporter
 
   def validate_implication(token)
     tag_implication = TagImplication.duplicate_relevant.find_by(antecedent_name: token[1], consequent_name: token[2])
-    return [nil, "implication ##{tag_implication.id}"] unless tag_implication.nil?
-    tag_implication = TagImplication.new(:forum_topic_id => forum_id, :status => "pending", :antecedent_name => token[1], :consequent_name => token[2])
+    return [nil, "duplicate of implication ##{tag_implication.id}"] unless tag_implication.nil?
+    tag_implication = TagImplication.new(forum_topic_id: forum_id, status: "pending", antecedent_name: token[1], consequent_name: token[2])
     unless tag_implication.valid?
       return ["Error: #{tag_implication.errors.full_messages.join("; ")} (create implication #{tag_implication.antecedent_name} -> #{tag_implication.consequent_name})", nil]
     end


### PR DESCRIPTION
This moves the "duplicate of" text into the verification functions, so we don't end up with "duplicate of has blocking(...)" with no implication/alias, which makes the error difficult to understand. The comma after "duplicate of alias #" is also replaced with a semicolon, to better show that there are two distinct errors.

![image](https://github.com/e621ng/e621ng/assets/17226394/d074832f-d8a6-483d-8e85-98c72e822008)
![image](https://github.com/e621ng/e621ng/assets/17226394/e0b39e5b-c9e5-4653-b9c1-145df0893139)
