### PR TITLE
[WikiPages] normalize title in show_or_new & edit

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -15,7 +15,7 @@ class WikiPagesController < ApplicationController
     if params[:id] =~ /\A\d+\z/
       @wiki_page = WikiPage.find(params[:id])
     else
-      @wiki_page = WikiPage.find_by_title(params[:id])
+      @wiki_page = WikiPage.titled(params[:id]).first
       if @wiki_page.nil? && request.format.symbol == :html
         redirect_to show_or_new_wiki_pages_path(:title => params[:id])
         return
@@ -96,7 +96,7 @@ class WikiPagesController < ApplicationController
   end
 
   def show_or_new
-    @wiki_page = WikiPage.find_by_title(params[:title])
+    @wiki_page = WikiPage.titled(params[:title]).first
     if @wiki_page
       redirect_to wiki_page_path(@wiki_page)
     else

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -15,7 +15,7 @@ class WikiPagesController < ApplicationController
     if params[:id] =~ /\A\d+\z/
       @wiki_page = WikiPage.find(params[:id])
     else
-      @wiki_page = WikiPage.titled(params[:id]).first
+      @wiki_page = WikiPage.titled(params[:id])
       if @wiki_page.nil? && request.format.symbol == :html
         redirect_to show_or_new_wiki_pages_path(:title => params[:id])
         return
@@ -51,7 +51,7 @@ class WikiPagesController < ApplicationController
     if params[:id] =~ /\A\d+\z/
       @wiki_page = WikiPage.find(params[:id])
     else
-      @wiki_page = WikiPage.titled(params[:id]).first
+      @wiki_page = WikiPage.titled(params[:id])
     end
 
     if @wiki_page.present?
@@ -96,7 +96,7 @@ class WikiPagesController < ApplicationController
   end
 
   def show_or_new
-    @wiki_page = WikiPage.titled(params[:title]).first
+    @wiki_page = WikiPage.titled(params[:title])
     if @wiki_page
       redirect_to wiki_page_path(@wiki_page)
     else

--- a/app/logical/related_tag_query.rb
+++ b/app/logical/related_tag_query.rb
@@ -55,6 +55,6 @@ class RelatedTagQuery
   end
 
   def wiki_page
-    WikiPage.titled(query).first
+    WikiPage.titled(query)
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -351,9 +351,9 @@ class Artist < ApplicationRecord
     end
 
     def update_wiki
-      if persisted? && saved_change_to_name? && attribute_before_last_save("name").present? && WikiPage.titled(attribute_before_last_save("name")).exists?
+      if persisted? && saved_change_to_name? && attribute_before_last_save("name").present? && WikiPage.titled(attribute_before_last_save("name"))
         # we're renaming the artist, so rename the corresponding wiki page
-        old_page = WikiPage.titled(name_before_last_save).first
+        old_page = WikiPage.titled(name_before_last_save)
         if wiki_page.nil?
           # a wiki page doesn't already exist for the new name, so rename the old one
           old_page.update(title: name, body: @notes || old_page.body)

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -50,7 +50,7 @@ class WikiPage < ApplicationRecord
 
   module SearchMethods
     def titled(title)
-      where("title = ?", title.downcase.tr(" ", "_"))
+      find_by(title: title.downcase.tr(" ", "_"))
     end
 
     def active

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -6,7 +6,7 @@
   
   
   <div class="dtext-container">
-    <%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page).first.try(&:body)) %>
+    <%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page)&.body) %>
   </div>
 </div>
 

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -1,6 +1,6 @@
 <div class="replace-image-dialog-body">
   <div class="dtext-container">
-    <%= format_text(WikiPage.titled(Danbooru.config.replacement_notice_wiki_page).first.try(&:body)) %>
+    <%= format_text(WikiPage.titled(Danbooru.config.replacement_notice_wiki_page)&.body) %>
   </div>
 
   <div>

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -60,9 +60,7 @@ class WikiPageTest < ActiveSupport::TestCase
       end
 
       should "search by title" do
-        matches = WikiPage.titled("hot potato")
-        assert_equal(1, matches.count)
-        assert_equal("hot_potato", matches.first.title)
+        assert_equal("hot_potato", WikiPage.titled("hot potato").title)
       end
 
       should "search other names with wildcards" do


### PR DESCRIPTION
This pr normalizes the title when looking up the wiki page in `show_or_new` (and `edit`)

As it works currently, https://e621.net/wiki_pages/show_or_new?title=male%20anthro is not normalized into `male_anthro`, resulting in no redirect, as well as an empty page displaying the search results for `male anthro`