### PR TITLE
[HelpPages] Fix showing related only to Janitor+

### DIFF
--- a/app/views/help/_secondary_links.html.erb
+++ b/app/views/help/_secondary_links.html.erb
@@ -1,23 +1,23 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "List", help_pages_path %>
-  <% if CurrentUser.is_janitor? %>
     <% if CurrentUser.is_admin? %>
       <%= subnav_link_to "New", new_help_page_path %>
     <% end %>
 
-    <% if @help&.id %>
-      <% if CurrentUser.is_admin? %>
-        <%= subnav_link_to "Edit", edit_help_page_path(@help) %>
-        <%= subnav_link_to "Delete", help_page_path(@help), method: :delete, data: { confirm: "Are you sure you want to delete this entry?" } %>
-      <% end %>
+  <% if @help&.id %>
+    <% if CurrentUser.is_admin? %>
+      <%= subnav_link_to "Edit", edit_help_page_path(@help) %>
+      <%= subnav_link_to "Delete", help_page_path(@help), method: :delete, data: { confirm: "Are you sure you want to delete this entry?" } %>
+    <% end %>
+    <% if CurrentUser.is_janitor? %>
       <%= subnav_link_to "Edit Wiki Page", edit_wiki_page_path(id: @help.wiki_page) %>
+    <% end %>
 
-      <% if (related_array = @help.related_array).any? %>
-        <% help_pages = HelpPage.help_index %>
-        <li>|</li>
-        <% related_array.each do |related| %>
-          <li><%= subnav_link_to HelpPage.pretty_related_title(related, help_pages), help_page_path(related) %></li>
-        <% end %>
+    <% if (related_array = @help.related_array).any? %>
+      <% help_pages = HelpPage.help_index %>
+      <li>|</li>
+      <% related_array.each do |related| %>
+        <li><%= subnav_link_to HelpPage.pretty_related_title(related, help_pages), help_page_path(related) %></li>
       <% end %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Fixes the related help pages only being show to Janitor+ due to condition nesting. This happened in 069a009dde5a0f95aae280b68de663d5c46318c7