### PR TITLE
[Tests] Fix post expunge note/post update count test

### DIFF
--- a/test/functional/artist_urls_controller_test.rb
+++ b/test/functional/artist_urls_controller_test.rb
@@ -17,7 +17,7 @@ class ArtistUrlsControllerTest < ActionDispatch::IntegrationTest
         end
 
         get artist_urls_path(search: {
-          artist: { name: "bkub", },
+          artist_name: "bkub",
           url_matches: "*bkub*",
           is_active: "false",
           order: "created_at",

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -17,7 +17,7 @@ class PostTest < ActiveSupport::TestCase
     context "Expunging a post" do
       # That belonged in a museum!
       setup do
-        @upload = UploadService.new(attributes_for(:jpg_upload)).start!
+        @upload = UploadService.new(attributes_for(:jpg_upload).merge({ uploader: @user })).start!
         @post = @upload.post
         FavoriteManager.add!(user: @post.uploader, post: @post)
       end
@@ -44,14 +44,14 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
-      should_eventually "decrement the user's note update count" do
+      should "decrement the user's note update count" do
         create(:note, post: @post)
         assert_difference(["@post.uploader.reload.note_update_count"], -1) do
           @post.expunge!
         end
       end
 
-      should_eventually "decrement the user's post update count" do
+      should "decrement the user's post update count" do
         assert_difference(["@post.uploader.reload.post_update_count"], -1) do
           @post.expunge!
         end


### PR DESCRIPTION
This pr fixes and reenables these tests:
* "Deletion: Expunging a post should decrement the user's note update count"
* "Deletion: Expunging a post should decrement the user's post update count"

These were both failing to to the uploader differing from our current user.

This pr also changes `search[artist][name]` in the artist urls controller test to the correct `search[artist_name]`. While this wasn't causing the test to fail due to search params on that route not being strictly validated, it's still incorrect.
https://github.com/e621ng/e621ng/blob/75fdab1c852fb30345f0447ad47d01f07cd4957f/test/functional/artist_urls_controller_test.rb#L20