### PR TITLE
[DMails] Update "blacklisting user" tags

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -375,8 +375,9 @@ class User < ApplicationRecord
 
     def is_blacklisting_user?(user)
       return false if blacklisted_tags.blank?
-      blta = blacklisted_tags.split("\n").map{|x| x.downcase}
-      blta.include?("user:#{user.name.downcase}") || blta.include?("uploaderid:#{user.id}")
+      bltags = blacklisted_tags.split("\n").map(&:downcase)
+      strings = %W[user:#{user.name.downcase} user:!#{user.id} userid:#{user.id}]
+      strings.any? { |str| bltags.include?(str) }
     end
   end
 


### PR DESCRIPTION
This pr brings the blacklist tags for blocking dmails up to date with what is actually used in the blacklist.
* Adding `user:!12345` for ids
* Adding `userid:12345` for ids
* Removing `uploaderid:12345`, doesn't seem to actually be used in blacklist anymore, and doesn't make sense for blocking dmails