### PR TITLE
[Artists] Fix "new" link in link_to_artist

### DIFF
--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -7,7 +7,7 @@ module ArtistsHelper
     if artist
       link_to(artist.name, artist_path(artist))
     else
-      link = link_to(name, new_artist_path(name: name))
+      link = link_to(name, new_artist_path(artist: { name: name }))
       notice = tag.span("*", class: "new-artist", title: "No artist with this name currently exists.")
       "#{link} #{notice}".html_safe
     end


### PR DESCRIPTION
This pr fixes the link that is returned through `link_to_artist` when the artist doesn't exist. Currently it uses the parameter `name`, when it should be `artist[name]`.

We could also get rid of this entirely and just link to `show_or_new` regardless.