### PR TITLE
Add period to comment for consistency

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,6 +57,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Raise error when a before_action's only/except options reference missing actions
+  # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 end


### PR DESCRIPTION
Other comment sentences all ended with a period in the file.