### PR TITLE
[Flags] Deleting a post should resolve all flags.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1207,10 +1207,12 @@ class Post < ApplicationRecord
         reason = pending_flag.reason
       end
 
+      flags.each(&:resolve!)
+
       force_flag = options.fetch(:force, false)
       Post.with_timeout(30_000) do
         transaction do
-          flag = flags.create(reason: reason, reason_name: 'deletion', is_resolved: false, is_deletion: true, force_flag: force_flag)
+          flag = flags.create(reason: reason, reason_name: 'deletion', is_resolved: true, is_deletion: true, force_flag: force_flag)
 
           if flag.errors.any?
             raise PostFlag::Error.new(flag.errors.full_messages.join("; "))


### PR DESCRIPTION
Deleting a post right now neither resolves the flags on the post, nor does it resolve even its own deletion flag. This makes a pileup of useless unresolved flags. This will fix that problem in the future, but all deleted + flagged posts will need to have their flags updated to resolved in order to clear out the old mess.

I am unsure if this was an intentional feature, but it feels like all it does is create issues for resolving flags properly as the list becomes too hard to understand where we're at with flags