### PR TITLE
[Posts] Allow some of the Related links when a post isn't visible

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -32,24 +32,22 @@
 
       <% end %>
 
-      <% if @post.visible? %>
-        <section id="post-related-images">
-          <h1>Related</h1>
-          <ul>
-            <li><%= link_to "Sets with this post", post_sets_path(post_id: @post.id), rel: "nofollow" %></li>
-            <% if IqdbProxy.enabled? && @post.has_preview? %>
-              <li><%= link_to "Visually similar on E6", iqdb_queries_path(search: { post_id: @post.id }), rel: "nofollow" %></li>
-            <% end %>
-            <% if @post.is_image? %>
-              <li><a rel="nofollow" href="https://www.google.com/searchbyimage?image_url=<%= @post.reverse_image_url %>&client=e621">Reverse Google Search</a></li>
-              <li><a rel="nofollow" href="https://saucenao.com/search.php?url=<%= @post.reverse_image_url %>">Reverse SauceNAO Search</a></li>
-              <li><a rel="nofollow" href="https://derpibooru.org/search/reverse?url=<%= @post.reverse_image_url %>">Reverse Derpibooru Search</a></li>
-              <li><a rel="nofollow" href="https://kheina.com/?url=<%= @post.reverse_image_url %>">Reverse Kheina Search</a></li>
-            <% end %>
-            <li><a rel="nofollow" href="https://inkbunny.net/search_process.php?text=<%= @post.md5 %>&md5=yes">Inkbunny MD5 Search</a></li>
-          </ul>
-        </section>
-      <% end %>
+      <section id="post-related-images">
+        <h1>Related</h1>
+        <ul>
+          <li><%= link_to "Sets with this post", post_sets_path(post_id: @post.id), rel: "nofollow" %></li>
+          <% if IqdbProxy.enabled? && @post.has_preview? %>
+            <li><%= link_to "Visually similar on E6", iqdb_queries_path(search: { post_id: @post.id }), rel: "nofollow" %></li>
+          <% end %>
+          <% if @post.visible? && @post.is_image? %>
+            <li><a rel="nofollow" href="https://www.google.com/searchbyimage?image_url=<%= @post.reverse_image_url %>&client=e621">Reverse Google Search</a></li>
+            <li><a rel="nofollow" href="https://saucenao.com/search.php?url=<%= @post.reverse_image_url %>">Reverse SauceNAO Search</a></li>
+            <li><a rel="nofollow" href="https://derpibooru.org/search/reverse?url=<%= @post.reverse_image_url %>">Reverse Derpibooru Search</a></li>
+            <li><a rel="nofollow" href="https://kheina.com/?url=<%= @post.reverse_image_url %>">Reverse Kheina Search</a></li>
+          <% end %>
+          <li><a rel="nofollow" href="https://inkbunny.net/search_process.php?text=<%= @post.md5 %>&md5=yes">Inkbunny MD5 Search</a></li>
+        </ul>
+      </section>
 
     </aside>
 


### PR DESCRIPTION
Currently the whole "Related" section of the sidebar is hidden even though "Sets with this post", "Visually similar on E6", and "Inkbunny MD5 Search" all actually still work and can manually be accessed through the endpoint - they may as well be exposed through the UI.

The only links that won't work when the post isn't visible are the reverse image search URLs, so I've added `@post.visible?` to their if block.

Originally mentioned at https://discord.com/channels/431908090883997698/460517895420772353/1239251162172227707