### PR TITLE
Generate samples with supplied background color

### DIFF
--- a/app/logical/danbooru_image_resizer.rb
+++ b/app/logical/danbooru_image_resizer.rb
@@ -6,23 +6,29 @@ module DanbooruImageResizer
   # https://www.libvips.org/API/current/libvips-resample.html#vips-thumbnail
   THUMBNAIL_OPTIONS = { size: :down, linear: false, no_rotate: true, export_profile: "srgb", import_profile: "srgb" }.freeze
   # https://www.libvips.org/API/current/VipsForeignSave.html#vips-jpegsave
-  JPEG_OPTIONS = { background: 0, strip: true, interlace: true, optimize_coding: true }.freeze
+  JPEG_OPTIONS = { strip: true, interlace: true, optimize_coding: true }.freeze
   CROP_OPTIONS = { linear: false, no_rotate: true, export_profile: "srgb", import_profile: "srgb", crop: :attention }.freeze
 
-  def resize(file, width, height, resize_quality = 90)
+  def resize(file, width, height, resize_quality = 90, background_color: "000000")
+    r = background_color[0..1].to_i(16)
+    g = background_color[2..3].to_i(16)
+    b = background_color[4..5].to_i(16)
     output_file = Tempfile.new
     resized_image = thumbnail(file, width, height, THUMBNAIL_OPTIONS)
-    resized_image.jpegsave(output_file.path, Q: resize_quality, **JPEG_OPTIONS)
+    resized_image.jpegsave(output_file.path, Q: resize_quality, background: [r, g, b], **JPEG_OPTIONS)
 
     output_file
   end
 
-  def crop(file, width, height, resize_quality = 90)
+  def crop(file, width, height, resize_quality = 90, background_color: "000000")
     return nil unless Danbooru.config.enable_image_cropping?
 
+    r = background_color[0..1].to_i(16)
+    g = background_color[2..3].to_i(16)
+    b = background_color[4..5].to_i(16)
     output_file = Tempfile.new
     resized_image = thumbnail(file, width, height, CROP_OPTIONS)
-    resized_image.jpegsave(output_file.path, Q: resize_quality, **JPEG_OPTIONS)
+    resized_image.jpegsave(output_file.path, Q: resize_quality, background: [r, g, b], **JPEG_OPTIONS)
 
     output_file
   end

--- a/app/logical/post_thumbnailer.rb
+++ b/app/logical/post_thumbnailer.rb
@@ -2,17 +2,17 @@
 
 module PostThumbnailer
   extend self
-  def generate_resizes(file, height, width, type)
+  def generate_resizes(file, height, width, type, background_color: "000000")
     if type == :video
       video = FFMPEG::Movie.new(file.path)
       crop_file = generate_video_crop_for(video, Danbooru.config.small_image_width)
       preview_file = generate_video_preview_for(file.path, Danbooru.config.small_image_width)
       sample_file = generate_video_sample_for(file.path)
     elsif type == :image
-      preview_file = DanbooruImageResizer.resize(file, Danbooru.config.small_image_width, Danbooru.config.small_image_width, 87)
-      crop_file = DanbooruImageResizer.crop(file, Danbooru.config.small_image_width, Danbooru.config.small_image_width, 87)
+      preview_file = DanbooruImageResizer.resize(file, Danbooru.config.small_image_width, Danbooru.config.small_image_width, 87, background_color: background_color)
+      crop_file = DanbooruImageResizer.crop(file, Danbooru.config.small_image_width, Danbooru.config.small_image_width, 87, background_color: background_color)
       if width > Danbooru.config.large_image_width
-        sample_file = DanbooruImageResizer.resize(file, Danbooru.config.large_image_width, height, 87)
+        sample_file = DanbooruImageResizer.resize(file, Danbooru.config.large_image_width, height, 87, background_color: background_color)
       end
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -234,7 +234,7 @@ class Post < ApplicationRecord
 
     def regenerate_image_samples!
       file = self.file()
-      preview_file, crop_file, sample_file = ::PostThumbnailer.generate_resizes(file, image_height, image_width, is_video? ? :video : :image)
+      preview_file, crop_file, sample_file = ::PostThumbnailer.generate_resizes(file, image_height, image_width, is_video? ? :video : :image, background_color: bg_color)
       storage_manager.store_file(sample_file, self, :large) if sample_file.present?
       storage_manager.store_file(preview_file, self, :preview) if preview_file.present?
       storage_manager.store_file(crop_file, self, :crop) if crop_file.present?


### PR DESCRIPTION
Allows the custom background color of the image to be added to the samples/preview

Fixes this issue:
![71sle_18659 1](https://github.com/e621ng/e621ng/assets/61888458/b3a8c8b0-f148-402b-b8b4-b7375cb624ad)

By allowing the custom background color to be shown in the sample (after regenerating thumbnails):
![gvf8gf_18660 1](https://github.com/e621ng/e621ng/assets/61888458/e224048a-0992-49f1-958b-fef4c12f393c)
