### PR TITLE
Make upload whitelist case insensitive

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1307,6 +1307,7 @@ Rails/OutputSafety:
     - 'app/views/users/custom_style.css.erb'
     - 'app/views/users/edit.html.erb'
     - 'app/views/users/home.html.erb'
+    - 'app/views/upload_whitelists/_form.html.erb'
 
 # Offense count: 9
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/app/models/upload_whitelist.rb
+++ b/app/models/upload_whitelist.rb
@@ -66,7 +66,7 @@ class UploadWhitelist < ApplicationRecord
     end
 
     entries.each do |x|
-      if File.fnmatch?(x.pattern, url)
+      if File.fnmatch?(x.pattern, url, File::FNM_CASEFOLD)
         return [x.allowed, x.reason]
       end
     end

--- a/app/views/upload_whitelists/_form.html.erb
+++ b/app/views/upload_whitelists/_form.html.erb
@@ -1,7 +1,7 @@
 <%= custom_form_for(@whitelist) do |f| %>
   <%= error_messages_for "whitelist" %>
 
-  <%= f.input :pattern, label: "Pattern", as: :string %>
+  <%= f.input :pattern, label: "Pattern", as: :string, hint: "* matches zero or more, ? matches exactly one character. See more #{link_to('here', 'https://apidock.com/ruby/v2_5_5/File/fnmatch/class')}.".html_safe %>
   <%= f.input :note, label: "Note", as: :string %>
   <%= f.input :allowed, label: "Upload Allowed", as: :boolean %>
   <%= f.input :reason, label: "Ban Reason", as: :string %>


### PR DESCRIPTION
This pr makes matching against upload whitelist entries case insensitive. Currently it is both case sensitive and normalized to lowercase, so it is impossible to properly allow a url with any uppercase character. A prime example that came up today is bluesky, whose urls are like this:
```
https://morel.us-east.host.bsky.network/xrpc/com.atproto.sync.getBlob?did=did:plc:3h367xd76nbukfe6m6xwc6zb&cid=bafkreifhrm2r3pajdum7kcyzfbxgyk5g5g7lsxosx7lepjakwicju5kaou
```

The upload whitelist entry is normalized to `https://*.host.bsky.network/xrpc/com.atproto.sync.getblob*`, which provides no match. We've currently gotten around this via using `https://*.host.bsky.network/xrpc/com.atproto.sync.get?lob*`, but this is a dumb thing to need to work around.

I also added a note to the pattern field using the two most commonly used match characters, `*` for zero or more and `?` for exactly one, as well as a link to https://apidock.com/ruby/v2_5_5/File/fnmatch/class for examples and further information.