### PR TITLE
Allow post approvers to search by verified uploaders

### DIFF
--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -171,7 +171,7 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
 
     if q.include?(:uploader_verified)
       verified_uploaders = {}
-      Artist.search({is_linked: true}).each do |artist|
+      Artist.search({is_linked: true}).find_each do |artist|
         verified_uploaders[artist.linked_user_id] = artist.name
       end
       script = {

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -171,14 +171,14 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
 
     if q.include?(:uploader_verified)
       verified_uploaders = {}
-      Artist.search({:is_linked => true}).each do |artist|
+      Artist.search({is_linked: true}).each do |artist|
         verified_uploaders[artist.linked_user_id] = artist.name
       end
       script = {
         script: {
           script: {
             lang: "painless",
-            source: 
+            source:
             "
             String id = doc.uploader.value.toString();
             if (params.verified_uploaders.containsKey(id)) {
@@ -186,10 +186,10 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
             }
             ",
             params: {
-              verified_uploaders: verified_uploaders
-            }
-          }
-        }
+              verified_uploaders: verified_uploaders,
+            },
+          },
+        },
       }
       if q[:uploader_verified]
         must.push(script)

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -337,6 +337,11 @@ class TagQuery
           id_or_invalid(user_id)
         end
 
+      when "uploader_verified"
+        if CurrentUser.can_approve_posts?
+          q[:uploader_verified] = parse_boolean(g2)
+        end
+
       when *COUNT_METATAGS
         q[metatag_name.downcase.to_sym] = ParseValue.range(g2)
 


### PR DESCRIPTION
I'm willing to put in more time to optimize this, but due to the fact that (currently) there are fewer than 20 active approvers and 90k artist entries to search (which is nothing), I don't believe this is really intensive enough for the guaranteed value approvers will obtain from it.