### PR TITLE
[StaffNote] Fix body searching

### DIFF
--- a/app/controllers/admin/staff_notes_controller.rb
+++ b/app/controllers/admin/staff_notes_controller.rb
@@ -6,8 +6,8 @@ module Admin
     respond_to :html
 
     def index
-      @user = User.where('id = ?', params[:user_id]).first
-      @notes = StaffNote.search(search_params.merge({user_id: params[:user_id]})).includes(:user, :creator).paginate(params[:page])
+      @user = User.find_by(id: params[:user_id])
+      @notes = StaffNote.search(search_params.merge({ user_id: params[:user_id] })).includes(:user, :creator).paginate(params[:page], limit: params[:limit])
       respond_with(@notes)
     end
 
@@ -30,8 +30,12 @@ module Admin
 
     private
 
+    def search_params
+      permit_search_params(%i[creator_id creator_name user_id user_name resolved body_matches without_system_user])
+    end
+
     def note_params
-      params.fetch(:staff_note, {}).permit([:body])
+      params.fetch(:staff_note, {}).permit(%i[body])
     end
   end
 end

--- a/app/models/staff_note.rb
+++ b/app/models/staff_note.rb
@@ -8,10 +8,8 @@ class StaffNote < ApplicationRecord
     def search(params)
       q = super
 
-      if params[:resolved]
-        q = q.attribute_matches(:resolved, params[:resolved])
-      end
-
+      q = q.attribute_matches(:resolved, params[:resolved])
+      q = q.attribute_matches(:body, params[:body_matches])
       q = q.where_user(:user_id, :user, params)
       q = q.where_user(:creator_id, :creator, params)
 


### PR DESCRIPTION
A search param for body exists on https://e621.net/admin/staff_notes yet does nothing because it hasn't been implemented.

This pr makes the body search work, strictly types the search parameters, and allows setting the `limit` parameter
I debated removing `resolved` from the search due to resolved not having been used a single time (see: https://e621.net/admin/staff_notes?search[resolved]=true vs https://e621.net/admin/staff_notes?search[resolved]=false) and has no way to set, but I've just decided to leave it there for the time being
