### PR TITLE
[PostEvents] Add event for changing background color

### DIFF
--- a/app/decorators/post_event_decorator.rb
+++ b/app/decorators/post_event_decorator.rb
@@ -19,6 +19,8 @@ class PostEventDecorator < ApplicationDecorator
       "From: post ##{vals['child_id']}"
     when "replacement_promoted"
       "From: post ##{vals['source_post_id']}"
+    when "changed_bg_color"
+      "To: #{vals['bg_color'] || 'None'}"
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -30,7 +30,7 @@ class Post < ApplicationRecord
   validate :updater_can_change_rating
   before_save :update_tag_post_counts, if: :should_process_tags?
   before_save :set_tag_counts, if: :should_process_tags?
-  after_save :create_lock_post_events
+  after_save :create_post_events
   after_save :create_version
   after_save :update_parent_on_save
   after_save :apply_post_metatags
@@ -1510,7 +1510,7 @@ class Post < ApplicationRecord
   end
 
   module PostEventMethods
-    def create_lock_post_events
+    def create_post_events
       if saved_change_to_is_rating_locked?
         action = is_rating_locked? ? :rating_locked : :rating_unlocked
         PostEvent.add(id, CurrentUser.user, action)
@@ -1526,6 +1526,9 @@ class Post < ApplicationRecord
       if saved_change_to_is_comment_locked?
         action = is_comment_locked? ? :comment_locked : :comment_unlocked
         PostEvent.add(id, CurrentUser.user, action)
+      end
+      if saved_change_to_bg_color?
+        PostEvent.add(id, CurrentUser.user, :changed_bg_color, { bg_color: bg_color })
       end
     end
   end

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -24,6 +24,7 @@ class PostEvent < ApplicationRecord
     replacement_promoted: 20,
     replacement_deleted: 16,
     expunged: 17,
+    changed_bg_color: 21,
   }
   MOD_ONLY_ACTIONS = [
     actions[:comment_locked],

--- a/test/unit/post_event_test.rb
+++ b/test/unit/post_event_test.rb
@@ -92,6 +92,11 @@ class PostEventTest < ActiveSupport::TestCase
         @post.save
       end
 
+      assert_post_events_created(@janitor, :changed_bg_color) do
+        @post.bg_color = "FFFFFF"
+        @post.save
+      end
+
       assert_post_events_created(@admin, :expunged) do
         @post.expunge!
       end


### PR DESCRIPTION
This pr adds a `changed_bg_color` event when the background color of a post is changed.