### PR TITLE
[Bans] Enable API for index & show

### DIFF
--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class BansController < ApplicationController
-  before_action :moderator_only, :except => [:show, :index]
+  before_action :moderator_only, except: %i[index show]
   respond_to :html
+  respond_to :json, only: %i[index show]
   helper_method :search_params
 
   def new
@@ -15,8 +16,8 @@ class BansController < ApplicationController
 
   def index
     @bans = Ban.search(search_params).paginate(params[:page], :limit => params[:limit])
-    respond_with(@bans) do |fmt|
-      fmt.html { @bans = @bans.includes(:user, :banner) }
+    respond_with(@bans) do |format|
+      format.html { @bans = @bans.includes(:user, :banner) }
     end
   end
 


### PR DESCRIPTION
This PR enables the api for bans, but only for the `index` & `show` actions. We can have a discussion on if we want create/update/destroy to be possible, but I personally think it's for the best to not allow managing bans from the api since the html variant requires a csrf token.