### PR TITLE
[PostReplacements] Allow setting `additional_source` & `reason` in url

### DIFF
--- a/app/javascript/src/javascripts/replacement_uploader.vue
+++ b/app/javascript/src/javascripts/replacement_uploader.vue
@@ -61,13 +61,11 @@ export default {
   },
   mounted() {
     const params = new URLSearchParams(window.location.search);
-    if (params.has("additional_source")) {
-      this.sources = [params.get("additional_source")]
-    }
+    if (params.has("additional_source"))
+      this.sources = [params.get("additional_source")];
 
-    if (params.has("reason")) {
+    if (params.has("reason"))
       this.reason = params.get("reason");
-    }
   },
   computed: {
     preventUpload() {

--- a/app/javascript/src/javascripts/replacement_uploader.vue
+++ b/app/javascript/src/javascripts/replacement_uploader.vue
@@ -22,7 +22,7 @@
   <div class="sect_red error_message" v-if="showErrors && errorMessage !== undefined">
     {{ errorMessage }}
   </div>
-    
+
   <button @click="submit" :disabled="(showErrors && preventUpload) || submitting">
       {{ submitting ? "Uploading..." : "Upload" }}
   </button>
@@ -58,6 +58,16 @@ export default {
       submitting: false,
       submittedReason: undefined,
     };
+  },
+  mounted() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("additional_source")) {
+      this.sources = [params.get("additional_source")]
+    }
+
+    if (params.has("reason")) {
+      this.reason = params.get("reason");
+    }
   },
   computed: {
     preventUpload() {


### PR DESCRIPTION
This pr enables specifying `additional_source` & `reason` in the query parameters to autofill these values when creating post replacements.

Resolves #585