### PR TITLE
[Pools] Fix ordering returning 406

### DIFF
--- a/app/controllers/pool_orders_controller.rb
+++ b/app/controllers/pool_orders_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PoolOrdersController < ApplicationController
-  respond_to :html, :json, :js
+  respond_to :html, :json
   before_action :member_only
 
   def edit

--- a/app/javascript/src/javascripts/pools.js
+++ b/app/javascript/src/javascripts/pools.js
@@ -1,3 +1,5 @@
+import Utility from "./utility";
+
 let Pool = {};
 
 Pool.dialog_setup = false;
@@ -35,12 +37,16 @@ Pool.initialize_simple_edit = function() {
   $("#sortable").disableSelection();
 
   $("#ordering-form").submit(function(e) {
-    $.ajax({
-      type: "put",
-      url: e.target.action,
-      data: $("#sortable").sortable("serialize") + "&" + $(e.target).serialize()
-    });
     e.preventDefault();
+    $.ajax({
+      type: "post",
+      url: e.target.action,
+      data: $("#sortable").sortable("serialize") + "&" + $(e.target).serialize() + "&format=json"
+    }).done(() => {
+      window.location.href = e.target.action;
+    }).fail((data) => {
+      Utility.error(`Error: ${data.responseText}`);
+    });
   });
 }
 

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -13,8 +13,8 @@
       <% end %>
     </ul>
 
-    <%= custom_form_for(@pool, :format => :js, :html => {:id => "ordering-form"}) do |f| %>
-      <%= submit_tag "Save" %>
+    <%= custom_form_for(@pool, html: { id: "ordering-form" }) do |f| %>
+      <%= f.submit "Save" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This pr fixes ordering pools resulting in a 406 and a stuck form. The 406 doesn't really matter since the action still worked, but the form would be stuck in an unusable state with no feedback. It now redirects to `/pools/:id`.

Fixes #555