### PR TITLE
[ForumTopics] Fix page number mismatch

### DIFF
--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -42,7 +42,7 @@ class ForumTopicsController < ApplicationController
     if request.format == Mime::Type.lookup("text/html")
       @forum_topic.mark_as_read!(CurrentUser.user)
     end
-    @forum_posts = ForumPost.includes(topic: [:category]).search(:topic_id => @forum_topic.id).reorder("forum_posts.id").paginate(params[:page])
+    @forum_posts = ForumPost.permitted(CurrentUser.user).includes(topic: [:category]).search(topic_id: @forum_topic.id).reorder("forum_posts.id").paginate(params[:page])
     @original_forum_post_id = @forum_topic.original_post.id
     respond_with(@forum_topic)
   end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -47,18 +47,22 @@ class ForumPost < ApplicationRecord
     end
 
     def visible(user)
+      active(user).permitted(user)
+    end
+
+    def permitted(user)
       q = joins(topic: :category).where("forum_categories.can_view <= ?", user.level)
-      unless user.is_moderator?
-        q = q.where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id)
-        q = q.where("forum_posts.is_hidden = FALSE OR forum_posts.creator_id = ?", user.id)
-      end
+      q = q.joins(:topic).where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id) if user.is_moderator?
       q
+    end
+
+    def active(user)
+      return all if user.is_moderator?
+      where("forum_posts.is_hidden = FALSE OR forum_posts.creator_id = ?", user.id)
     end
 
     def search(params)
       q = super
-      q = q.visible(CurrentUser.user)
-
       q = q.where_user(:creator_id, :creator, params)
 
       if params[:topic_id].present?

--- a/test/functional/forum_topics_controller_test.rb
+++ b/test/functional/forum_topics_controller_test.rb
@@ -31,6 +31,24 @@ class ForumTopicsControllerTest < ActionDispatch::IntegrationTest
         @user.reload
         assert_nil(@user.last_forum_read_at)
       end
+
+      should "have the correct page number" do
+        Danbooru.config.stubs(:records_per_page).returns(2)
+        assert_equal(1, @forum_topic.last_page)
+        as(@user) { @forum_posts = create_list(:forum_post, 3, topic: @forum_topic) }
+        assert_equal(2, @forum_topic.last_page)
+
+        get_auth forum_topic_path(@forum_topic), @user, params: { page: 2 }
+        assert_select "#forum_post_#{@forum_posts.second.id}"
+        assert_select "#forum_post_#{@forum_posts.third.id}"
+        as(@mod) { @forum_posts.first.hide! }
+        assert_equal([1, 2, 2], @forum_posts.map(&:forum_topic_page))
+
+        get_auth forum_topic_path(@forum_topic), @user, params: { page: 2 }
+        assert_select "#forum_post_#{@forum_posts.second.id}"
+        assert_select "#forum_post_#{@forum_posts.third.id}"
+        assert_equal([1, 2, 2], @forum_posts.map(&:forum_topic_page))
+      end
     end
 
     context "index action" do

--- a/test/functional/forum_topics_controller_test.rb
+++ b/test/functional/forum_topics_controller_test.rb
@@ -43,11 +43,13 @@ class ForumTopicsControllerTest < ActionDispatch::IntegrationTest
         assert_select "#forum_post_#{@forum_posts.third.id}"
         as(@mod) { @forum_posts.first.hide! }
         assert_equal([1, 2, 2], @forum_posts.map(&:forum_topic_page))
+        assert_equal(2, @forum_topic.last_page)
 
         get_auth forum_topic_path(@forum_topic), @user, params: { page: 2 }
         assert_select "#forum_post_#{@forum_posts.second.id}"
         assert_select "#forum_post_#{@forum_posts.third.id}"
         assert_equal([1, 2, 2], @forum_posts.map(&:forum_topic_page))
+        assert_equal(2, @forum_topic.last_page)
       end
     end
 

--- a/test/functional/forum_topics_controller_test.rb
+++ b/test/functional/forum_topics_controller_test.rb
@@ -41,10 +41,10 @@ class ForumTopicsControllerTest < ActionDispatch::IntegrationTest
         get_auth forum_topic_path(@forum_topic), @user, params: { page: 2 }
         assert_select "#forum_post_#{@forum_posts.second.id}"
         assert_select "#forum_post_#{@forum_posts.third.id}"
-        as(@mod) { @forum_posts.first.hide! }
         assert_equal([1, 2, 2], @forum_posts.map(&:forum_topic_page))
         assert_equal(2, @forum_topic.last_page)
 
+        as(@mod) { @forum_posts.first.hide! }
         get_auth forum_topic_path(@forum_topic), @user, params: { page: 2 }
         assert_select "#forum_post_#{@forum_posts.second.id}"
         assert_select "#forum_post_#{@forum_posts.third.id}"


### PR DESCRIPTION
An issue introduced in #674, this pr fixes a disparity between forum topic pages shown within the topic and on the index list. This restores the previous behavior of filtering the forum posts in the html **for topics only**.