### PR TITLE
[PostVersions] Make the "Undo Selected" tool Priv+

### DIFF
--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -16,7 +16,5 @@ class PostVersionsController < ApplicationController
 
     @post_version = PostVersion.find(params[:id])
     @post_version.undo!
-
-    redirect_back fallback_location: post_versions_path
   end
 end

--- a/app/javascript/src/javascripts/post_versions.js
+++ b/app/javascript/src/javascripts/post_versions.js
@@ -6,35 +6,34 @@ let PostVersion = {};
 
 PostVersion.updated = 0;
 PostVersion.initialize_all = function () {
-  if ($("#c-post-versions #a-index").length) {
-    PostVersion.initialize_undo();
-    $("#subnav-select-all-link").on("click", function (event) {
-      event.preventDefault();
-      $(".post-version-select:not(:disabled)").prop("checked", true).change();
-    });
-    $("#subnav-apply-tag-script-to-selected-link").on("click", PostVersion.tag_script_selected);
-  }
+  if (!$("#c-post-versions #a-index").length) return;
+
+  PostVersion.init_undo_selected();
+  $("#subnav-apply-tag-script-to-selected-link").on("click", PostVersion.tag_script_selected);
 };
 
-PostVersion.initialize_undo = function () {
-  /* Expand the clickable area of the checkbox to the entire table cell. */
-  $(".post-version-row-select").on("click.danbooru", function (event) {
-    $(event.target).find(".post-version-select:not(:disabled)").prop("checked", (_, checked) => !checked).change();
+PostVersion.init_undo_selected = function () {
+  if (!$("body").data("userIsPrivileged")) return;
+
+  // "Select All" and "Undo Selected" buttons
+  $("#subnav-select-all-link").on("click.danbooru", (event) => {
+    event.preventDefault();
+    $(".post-version-select:not(:disabled)").prop("checked", true).trigger("change");
+  });
+  $("#subnav-undo-selected-link").on("click.danbooru", PostVersion.undo_selected);
+
+  // Expand the clickable area of the checkbox to the entire table cell
+  $(".post-version-row-select").on("click.danbooru", (event) => {
+    $(event.target).find(".post-version-select:not(:disabled)").prop("checked", (_, checked) => !checked).trigger("change");
   });
 
-  $("#post-version-select-all").on("change.danbooru", function () {
-    $(".post-version-select:not(:disabled)").prop("checked", $("#post-version-select-all").prop("checked")).change();
-  });
-
-  $(".post-version-select").on("change.danbooru", function () {
+  $(".post-version-select").on("change.danbooru", () => {
     let checked = $(".post-version-select:checked");
     $("#subnav-undo-selected-link").text(`Undo selected (${checked.length})`).toggle(checked.length > 0);
   });
-
-  $("#subnav-undo-selected-link").on("click.danbooru", PostVersion.undo_selected);
 };
 
-PostVersion.undo_selected = function () {
+PostVersion.undo_selected = function (event) {
   event.preventDefault();
 
   PostVersion.updated = 0;
@@ -51,7 +50,7 @@ PostVersion.undo_selected = function () {
   }
 };
 
-PostVersion.tag_script_selected = function () {
+PostVersion.tag_script_selected = function (event) {
   event.preventDefault();
 
   PostVersion.updated = 0;
@@ -71,5 +70,6 @@ PostVersion.tag_script_selected = function () {
   }
 };
 
-$(document).ready(PostVersion.initialize_all);
+$(() => PostVersion.initialize_all());
+
 export default PostVersion;

--- a/app/views/post_versions/_listing.html.erb
+++ b/app/views/post_versions/_listing.html.erb
@@ -2,7 +2,9 @@
   <% @post_versions.each do |post_version| %>
     <div id="post-version-<%= post_version.id %>" data-post-version-id="<%= post_version.id %>" data-post-id="<%= post_version.post_id %>" class="post-version">
       <div class="post-version-row-select pv-check pv-label">
-        <input type="checkbox" class="post-version-select" <%= "disabled" if !CurrentUser.can_undo_post_versions? || !post_version.undoable? %> >
+        <% if CurrentUser.is_privileged? %>
+          <input type="checkbox" class="post-version-select" <%= "disabled" if !CurrentUser.can_undo_post_versions? || !post_version.undoable? %> >
+        <% end %>
       </div>
       <div class="pv-post-label pv-label">
         Post #:Version

--- a/app/views/post_versions/_secondary_links.html.erb
+++ b/app/views/post_versions/_secondary_links.html.erb
@@ -3,7 +3,7 @@
   <%= subnav_link_to "Upload", new_upload_path %>
   <%= subnav_link_to "Changes", post_versions_path %>
   <%= subnav_link_to "Help", help_page_path(id: "posts") %>
-  <% if params[:action] == "index" %>
+  <% if params[:action] == "index" && CurrentUser.is_privileged? %>
     | <%= subnav_link_to "Undo selected", "" %>
     <%= subnav_link_to "Select All", "" %>
     <% if CurrentUser.is_moderator? %>


### PR DESCRIPTION
Exactly what it says on the tin. Only allows users with a Privileged rank or above to use that tool.
While it is situationally useful, it was also frequently used by tag vandals to mass-undo legitimate tag changes.