### PR TITLE
[WikiPages] Implement basic redirects

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -55,7 +55,7 @@ class WikiPagesController < ApplicationController
     end
 
     if @wiki_page.present?
-      unless @wiki_page.parent.nil?
+      if @wiki_page.parent.present?
         @wiki_redirect = WikiPage.titled(@wiki_page.parent)
       end
       respond_with(@wiki_page)

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -55,6 +55,9 @@ class WikiPagesController < ApplicationController
     end
 
     if @wiki_page.present?
+      unless @wiki_page.parent.nil?
+        @wiki_redirect = WikiPage.titled(@wiki_page.parent)
+      end
       respond_with(@wiki_page)
     elsif request.format.html?
       redirect_to show_or_new_wiki_pages_path(title: params[:id])
@@ -121,6 +124,7 @@ class WikiPagesController < ApplicationController
 
   def wiki_page_params(context)
     permitted_params = %i[body skip_secondary_validations edit_reason]
+    permitted_params += %i[parent] if CurrentUser.is_privileged?
     permitted_params += %i[is_locked is_deleted] if CurrentUser.is_janitor?
     permitted_params += %i[title] if context == :create || CurrentUser.is_janitor?
 

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -77,6 +77,7 @@
 @import "specific/user_feedback.scss";
 @import "specific/user_warned.scss";
 @import "specific/users.scss";
+@import "specific/wiki_pages.scss";
 @import "specific/wiki_page_versions.scss";
 
 @import "common/z_responsive.scss";

--- a/app/javascript/src/styles/specific/wiki_pages.scss
+++ b/app/javascript/src/styles/specific/wiki_pages.scss
@@ -1,0 +1,20 @@
+#c-wiki-pages #a-show,
+#c-wiki-page-versions {
+  .wiki-page-redirect {
+    margin-left: 1em;
+    color: var(--color-text-muted);
+    & > i {
+      display: inline-flex;
+      margin-right: 0.25em;
+    }
+  }
+
+  .wiki-redirect-history {
+    color: var(--color-text-muted);
+    margin-bottom: 1em;
+  }
+
+  #wiki-page-body {
+    margin-top: 0.25em;
+  }
+}

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -10,7 +10,7 @@ class WikiPage < ApplicationRecord
   validates :title, uniqueness: { :case_sensitive => false }
   validates :title, presence: true
   validates :title, tag_name: true, if: :title_changed?
-  validates :body, presence: { unless: -> { is_deleted? || other_names.present? } }
+  validates :body, presence: { unless: -> { is_deleted? || other_names.present? || parent.present? } }
   validates :title, length: { minimum: 1, maximum: 100 }
   validates :body, length: { maximum: Danbooru.config.wiki_page_max_size }
   validate :user_not_limited

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -95,9 +95,7 @@ class WikiPage < ApplicationRecord
         q = q.where("is_deleted = false")
       end
 
-      if params[:parent].present?
-        q = q.where("parent LIKE ? ESCAPE E'\\\\'", params[:parent].downcase.strip.tr(" ", "_").to_escaped_for_sql_like)
-      end
+      q = q.attribute_matches(:parent, params[:parent].try(:tr, " ", "_"))
 
       if params[:other_names_present].to_s.truthy?
         q = q.where("other_names is not null and other_names != '{}'")

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -10,7 +10,7 @@ class WikiPage < ApplicationRecord
   validates :title, uniqueness: { :case_sensitive => false }
   validates :title, presence: true
   validates :title, tag_name: true, if: :title_changed?
-  validates :body, presence: { :unless => -> { is_deleted? || other_names.present? } }
+  validates :body, presence: { unless: -> { is_deleted? || other_names.present? } }
   validates :title, length: { minimum: 1, maximum: 100 }
   validates :body, length: { maximum: Danbooru.config.wiki_page_max_size }
   validate :user_not_limited
@@ -93,6 +93,10 @@ class WikiPage < ApplicationRecord
 
       if params[:hide_deleted].to_s.truthy?
         q = q.where("is_deleted = false")
+      end
+
+      if params[:parent].present?
+        q = q.where("parent LIKE ? ESCAPE E'\\\\'", params[:parent].downcase.strip.tr(" ", "_").to_escaped_for_sql_like)
       end
 
       if params[:other_names_present].to_s.truthy?

--- a/app/views/wiki_page_versions/diff.html.erb
+++ b/app/views/wiki_page_versions/diff.html.erb
@@ -8,8 +8,8 @@
       <% if @thispage.parent != @otherpage.parent %>
         <div class="wiki-redirect-history">
           Page redirect changed
-          from <%= @thispage.parent.nil? ? "none" : link_to(@thispage.parent, show_or_new_wiki_pages_path(title: @thispage.parent)) %>
-          to <%= @otherpage.parent.nil? ? "none" : link_to(@otherpage.parent, show_or_new_wiki_pages_path(title: @otherpage.parent)) %>.
+          from <%= @thispage.parent.blank? ? "none" : link_to(@thispage.parent, show_or_new_wiki_pages_path(title: @thispage.parent)) %>
+          to <%= @otherpage.parent.blank? ? "none" : link_to(@otherpage.parent, show_or_new_wiki_pages_path(title: @otherpage.parent)) %>.
         </div>
       <% end %>
 

--- a/app/views/wiki_page_versions/diff.html.erb
+++ b/app/views/wiki_page_versions/diff.html.erb
@@ -5,6 +5,14 @@
     <% if @thispage.visible? %>
       <p>Showing differences between <%= compact_time @thispage.updated_at %> (<%= link_to_user @thispage.updater %>) and <%= compact_time @otherpage.updated_at %> (<%= link_to_user @otherpage.updater %>)</p>
 
+      <% if @thispage.parent != @otherpage.parent %>
+        <div class="wiki-redirect-history">
+          Page redirect changed
+          from <%= @thispage.parent.nil? ? "none" : link_to(@thispage.parent, show_or_new_wiki_pages_path(title: @thispage.parent)) %>
+          to <%= @otherpage.parent.nil? ? "none" : link_to(@otherpage.parent, show_or_new_wiki_pages_path(title: @otherpage.parent)) %>.
+        </div>
+      <% end %>
+
       <div>
         <%= text_diff(@thispage.body, @otherpage.body) %>
       </div>

--- a/app/views/wiki_page_versions/show.html.erb
+++ b/app/views/wiki_page_versions/show.html.erb
@@ -5,6 +5,10 @@
     <section id="content">
       <h1 id="wiki-page-title"><%= @wiki_page_version.pretty_title %> <span class="version">(<%= time_ago_in_words_tagged(@wiki_page_version.updated_at) %>)</span></h1>
 
+      <% unless @wiki_page_version.parent.nil? %>
+        <div class="wiki-page-redirect"><i class="fa-solid fa-turn-up fa-rotate-90"></i> Redirects to <%= link_to @wiki_page_version.parent, show_or_new_wiki_pages_path(title: @wiki_page_version.parent) %></div>
+      <% end %>
+
       <div id="wiki-page-body" class="dtext dtext-container">
         <% if @wiki_page_version.visible? %>
           <%= format_text(@wiki_page_version.body) %>

--- a/app/views/wiki_page_versions/show.html.erb
+++ b/app/views/wiki_page_versions/show.html.erb
@@ -5,7 +5,7 @@
     <section id="content">
       <h1 id="wiki-page-title"><%= @wiki_page_version.pretty_title %> <span class="version">(<%= time_ago_in_words_tagged(@wiki_page_version.updated_at) %>)</span></h1>
 
-      <% unless @wiki_page_version.parent.nil? %>
+      <% if @wiki_page_version.parent.present? %>
         <div class="wiki-page-redirect"><i class="fa-solid fa-turn-up fa-rotate-90"></i> Redirects to <%= link_to @wiki_page_version.parent, show_or_new_wiki_pages_path(title: @wiki_page_version.parent) %></div>
       <% end %>
 

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -12,9 +12,7 @@
 
     <%= f.input :body, as: :dtext, limit: Danbooru.config.wiki_page_max_size, allow_color: true %>
 
-    <% if CurrentUser.is_privileged? %>
-      <%= f.input :parent, :label => "Redirect to", autocomplete: "wiki-page" %>
-    <% end %>
+    <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page", input_html: { disabled: !CurrentUser.is_privileged? } %>
 
     <% if CurrentUser.is_janitor? && @wiki_page.is_deleted? %>
       <%= f.input :is_deleted, :label => "Deleted", :hint => "Uncheck to restore this wiki page" %>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -12,6 +12,10 @@
 
     <%= f.input :body, as: :dtext, limit: Danbooru.config.wiki_page_max_size, allow_color: true %>
 
+    <% if CurrentUser.is_privileged? %>
+      <%= f.input :parent, :label => "Redirect to", autocomplete: "wiki-page" %>
+    <% end %>
+
     <% if CurrentUser.is_janitor? && @wiki_page.is_deleted? %>
       <%= f.input :is_deleted, :label => "Deleted", :hint => "Uncheck to restore this wiki page" %>
     <% end %>

--- a/app/views/wiki_pages/_search.html.erb
+++ b/app/views/wiki_pages/_search.html.erb
@@ -2,6 +2,7 @@
   <%= f.input :title, label: "Title", hint: "Use * for wildcard searches", autocomplete: "wiki-page" %>
   <%= f.input :body_matches, label: "Body" %>
   <%= f.user :creator %>
+  <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page" %>
   <%= f.input :other_names_match, label: "Other names", hint: "Use * for wildcard searches" %>
   <%= f.input :other_names_present, collection: %w[Yes No], include_blank: true %>
   <%= f.input :hide_deleted, collection: %w[Yes No] %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -1,3 +1,4 @@
+<% wiki_content = @wiki_redirect.nil? ? @wiki_page : @wiki_redirect %>
 <div id="c-wiki-pages">
   <div id="a-show">
     <%= render "sidebar" %>
@@ -5,38 +6,41 @@
     <section id="content">
       <h1 id="wiki-page-title">
 
-        <%= link_to @wiki_page.pretty_title_with_category, posts_path(:tags => @wiki_page.title), :class => "tag-type-#{@wiki_page.category_id}" %>
+        <%= link_to wiki_content.pretty_title_with_category, posts_path(:tags => wiki_content.title), :class => "tag-type-#{wiki_content.category_id}" %>
 
-        <% if @wiki_page.is_locked? %>
+        <% if wiki_content.is_locked? %>
           (locked)
         <% end %>
 
-        <% if @wiki_page.is_deleted? %>
+        <% if wiki_content.is_deleted? %>
           (deleted)
         <% end %>
       </h1>
+      <% if !@wiki_redirect.nil? %>
+      <div class="wiki-page-redirect"><i class="fa-solid fa-turn-up fa-rotate-90"></i> <%= @wiki_page.title %></div>
+      <% end %>
 
       <div id="wiki-page-body" class="dtext-container">
-        <% if @wiki_page.visible? %>
-          <%= format_text(@wiki_page.body, allow_color: true, max_thumbs: 75) %>
+        <% if wiki_content.visible? %>
+          <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>
 
-          <% if @wiki_page.artist %>
-            <p><%= link_to "View artist", @wiki_page.artist %></p>
+          <% if wiki_content.artist %>
+            <p><%= link_to "View artist", wiki_content.artist %></p>
           <% end %>
 
-          <%= wiki_page_alias_and_implication_list(@wiki_page) %>
+          <%= wiki_page_alias_and_implication_list(wiki_content) %>
         <% else %>
           <p>This artist has requested removal of their information.</p>
         <% end %>
       </div>
 
-        <%= wiki_page_post_previews(@wiki_page) %>
+        <%= wiki_page_post_previews(wiki_content) %>
     </section>
   </div>
 </div>
 
 <% content_for(:page_title) do %>
-  Wiki - <%= @wiki_page.pretty_title %>
+  Wiki - <%= wiki_content.pretty_title %>
 <% end %>
 
 <%= render "secondary_links" %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -1,4 +1,4 @@
-<% wiki_content = @wiki_redirect.blank? ? @wiki_page : @wiki_redirect %>
+<% wiki_content = @wiki_redirect.presence || @wiki_page %>
 <div id="c-wiki-pages">
   <div id="a-show">
     <%= render "sidebar" %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -1,4 +1,4 @@
-<% wiki_content = @wiki_redirect.nil? ? @wiki_page : @wiki_redirect %>
+<% wiki_content = @wiki_redirect.blank? ? @wiki_page : @wiki_redirect %>
 <div id="c-wiki-pages">
   <div id="a-show">
     <%= render "sidebar" %>
@@ -16,7 +16,7 @@
           (deleted)
         <% end %>
       </h1>
-      <% if !@wiki_redirect.nil? %>
+      <% if @wiki_redirect.present? %>
       <div class="wiki-page-redirect"><i class="fa-solid fa-turn-up fa-rotate-90"></i> <%= @wiki_page.title %></div>
       <% end %>
 

--- a/db/migrate/20240726170041_add_wiki_page_parent_name.rb
+++ b/db/migrate/20240726170041_add_wiki_page_parent_name.rb
@@ -1,0 +1,6 @@
+class AddWikiPageParentName < ActiveRecord::Migration[7.0]
+  def change
+    add_column :wiki_pages, :parent, :string
+    add_column :wiki_page_versions, :parent, :string
+  end
+end

--- a/db/migrate/20240726170041_add_wiki_page_parent_name.rb
+++ b/db/migrate/20240726170041_add_wiki_page_parent_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddWikiPageParentName < ActiveRecord::Migration[7.0]
   def change
     add_column :wiki_pages, :parent, :string

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2316,7 +2316,8 @@ CREATE TABLE public.wiki_page_versions (
     updated_at timestamp without time zone NOT NULL,
     other_names text[] DEFAULT '{}'::text[] NOT NULL,
     is_deleted boolean DEFAULT false NOT NULL,
-    reason character varying
+    reason character varying,
+    parent character varying
 );
 
 
@@ -2354,7 +2355,8 @@ CREATE TABLE public.wiki_pages (
     updated_at timestamp without time zone NOT NULL,
     updater_id integer,
     other_names text[] DEFAULT '{}'::text[] NOT NULL,
-    is_deleted boolean DEFAULT false NOT NULL
+    is_deleted boolean DEFAULT false NOT NULL,
+    parent character varying
 );
 
 
@@ -4496,6 +4498,7 @@ ALTER TABLE ONLY public.favorites
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240726170041'),
 ('20240709134926'),
 ('20240706061122'),
 ('20240101042716'),


### PR DESCRIPTION
This PR allows one wiki page to seamlessly redirect users to another wiki page.
That is necessary to avoid awkward pages like [this](https://e621.net/wiki_pages/6) – users can just be shown what they were looking for instead.

![redirect](https://github.com/e621ng/e621ng/assets/132787557/cebd6e35-26df-4d68-8465-98a1d17c817f)

Users are not technically redirected between pages, as the URL remains the same.
Instead, the contents of the parent wiki page get displayed instead of the original one.

![redirect2](https://github.com/e621ng/e621ng/assets/132787557/470e7693-f3a0-4aef-943a-7ebd31d10a80)

As far as permissions are concerned, I think it's okay to let Privileged+ to handle this.
Opening it up to the public is fraught with peril, and only letting staff members handle this seems unnecessary. Privileged users, on the other hand, are both trustworthy enough to be allowed to set up redirects, and also more likely to be creating wiki pages in the first place.