### PR TITLE
Allow janitors to bypass dmail limits

### DIFF
--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -136,6 +136,7 @@ class Dmail < ApplicationRecord
     return true if bypass_limits == true
     return true if from_id == User.system.id
     return true if from.is_moderator?
+    return true if from.is_janitor?
 
     allowed = CurrentUser.can_dmail_with_reason
     if allowed != true

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -135,7 +135,6 @@ class Dmail < ApplicationRecord
     # System user must be able to send dmails at a very high rate, do not rate limit the system user.
     return true if bypass_limits == true
     return true if from_id == User.system.id
-    return true if from.is_moderator?
     return true if from.is_janitor?
 
     allowed = CurrentUser.can_dmail_with_reason


### PR DESCRIPTION
Janitors are basically detectives that find artist user accounts. Some choose to dmail these users to ask them to verify. This limit makes that hard.