### PR TITLE
[HelpPages] Fix json & move modaction logging

### DIFF
--- a/app/models/help_page.rb
+++ b/app/models/help_page.rb
@@ -5,7 +5,10 @@ class HelpPage < ApplicationRecord
   validates :wiki_page, :name, presence: true
   normalizes :name, with: ->(name) { name.downcase.strip.tr(" ", "_") }
   validate :wiki_page_exists
+  after_create :log_create
+  after_update :log_update
   after_destroy :invalidate_cache
+  after_destroy :log_destroy
   after_save :invalidate_cache
   belongs_to :wiki, class_name: "WikiPage", foreign_key: "wiki_page", primary_key: "title"
 
@@ -37,4 +40,20 @@ class HelpPage < ApplicationRecord
   def self.help_index
     Cache.fetch("help_index", expires_in: 12.hours) { HelpPage.all.sort_by(&:pretty_title) }
   end
+
+  module LogMethods
+    def log_create
+      ModAction.log(:help_create, { name: name, wiki_page: wiki_page })
+    end
+
+    def log_update
+      ModAction.log(:help_update, { name: name, wiki_page: wiki_page })
+    end
+
+    def log_destroy
+      ModAction.log(:help_delete, { name: name, wiki_page: wiki_page })
+    end
+  end
+
+  include LogMethods
 end


### PR DESCRIPTION
* Fix #492 (json error when no help pages exist)
* Move modactions into class

This is more of a bandaid fix for #492, the root of the issue comes from the `active_model_serializers` gem, but attempting to remove that is a whole different ball game