### PR TITLE
[Uploads] Fix error with direct url & no sources

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -213,6 +213,7 @@ class Upload < ApplicationRecord
   end
 
   def fixup_source
+    self.source = "" if source.nil?
     if direct_url_parsed.present?
       canonical = Sources::Strategies.find(direct_url_parsed).canonical_url
       self.source += "\n#{canonical}" if canonical


### PR DESCRIPTION
This pr fixes an error when uploading via direct url without providing `source`.

Fixes #337