### PR TITLE
[UserVote] Add foreign keys to comment & post votes

### DIFF
--- a/db/fixes/120_remove_dangling_votes.rb
+++ b/db/fixes/120_remove_dangling_votes.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+ApplicationRecord.without_timeout do
+  CommentVote.left_joins(:comment).where("comments.id": nil).delete_all
+  PostVote.left_joins(:post).where("posts.id": nil).delete_all
+end

--- a/db/migrate/20240803233733_add_foreign_keys_to_votes.rb
+++ b/db/migrate/20240803233733_add_foreign_keys_to_votes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddForeignKeysToVotes < ActiveRecord::Migration[7.1]
+  def change
+    add_foreign_key(:comment_votes, :comments, column: :comment_id)
+    add_foreign_key(:comment_votes, :users, column: :user_id)
+    add_foreign_key(:post_votes, :posts, column: :post_id)
+    add_foreign_key(:post_votes, :users, column: :user_id)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4566,6 +4566,14 @@ ALTER TABLE ONLY public.staff_audit_logs
 
 
 --
+-- Name: comment_votes fk_rails_0873e64a40; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_votes
+    ADD CONSTRAINT fk_rails_0873e64a40 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: avoid_posting_versions fk_rails_1d1f54e17a; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4614,6 +4622,14 @@ ALTER TABLE ONLY public.mascots
 
 
 --
+-- Name: comment_votes fk_rails_a0196e2ef9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.comment_votes
+    ADD CONSTRAINT fk_rails_a0196e2ef9 FOREIGN KEY (comment_id) REFERENCES public.comments(id);
+
+
+--
 -- Name: favorites fk_rails_a7668ef613; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4627,6 +4643,14 @@ ALTER TABLE ONLY public.favorites
 
 ALTER TABLE ONLY public.avoid_postings
     ADD CONSTRAINT fk_rails_b2ebf2bc30 FOREIGN KEY (artist_id) REFERENCES public.artists(id);
+
+
+--
+-- Name: post_votes fk_rails_b550730fb8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.post_votes
+    ADD CONSTRAINT fk_rails_b550730fb8 FOREIGN KEY (post_id) REFERENCES public.posts(id);
 
 
 --
@@ -4670,12 +4694,21 @@ ALTER TABLE ONLY public.avoid_postings
 
 
 --
+-- Name: post_votes fk_rails_f3edc07390; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.post_votes
+    ADD CONSTRAINT fk_rails_f3edc07390 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240803233733'),
 ('20240726170041'),
 ('20240709134926'),
 ('20240706061122'),


### PR DESCRIPTION
This pr adds a foreign key for both the user & targeted model to the comment/post vote tables. Includes a fixer to remove the dangling votes whose comment/post is missing.