### PR TITLE
[FileInput] Check file size per type

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1297,7 +1297,6 @@ Rails/OutputSafety:
     - 'app/views/static/home.html.erb'
     - 'app/views/tickets/new_types/_post.html.erb'
     - 'app/views/uploads/new.html.erb'
-    - 'app/views/post_replacements/_new.html.erb'
     - 'app/views/users/custom_style.css.erb'
     - 'app/views/users/edit.html.erb'
     - 'app/views/users/home.html.erb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1297,6 +1297,7 @@ Rails/OutputSafety:
     - 'app/views/static/home.html.erb'
     - 'app/views/tickets/new_types/_post.html.erb'
     - 'app/views/uploads/new.html.erb'
+    - 'app/views/post_replacements/_new.html.erb'
     - 'app/views/users/custom_style.css.erb'
     - 'app/views/users/edit.html.erb'
     - 'app/views/users/home.html.erb'

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -16,7 +16,7 @@
 <%= javascript_tag nonce: true do -%>
   var uploaderSettings = {
     maxFileSize: <%= Danbooru.config.max_file_size %>,
-    maxFileSizeMap: <%= Danbooru.config.max_file_sizes.to_json.html_safe %>,
+    maxFileSizeMap: <%= sanitize(Danbooru.config.max_file_sizes.to_json) %>,
   };
   Danbooru.Replacer.init();
 <% end -%>

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -16,6 +16,7 @@
 <%= javascript_tag nonce: true do -%>
   var uploaderSettings = {
     maxFileSize: <%= Danbooru.config.max_file_size %>,
+    maxFileSizeMap: <%= Danbooru.config.max_file_sizes.to_json.html_safe %>,
   };
   Danbooru.Replacer.init();
 <% end -%>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -42,6 +42,7 @@
     allowRatingLock: <%= CurrentUser.is_privileged?.to_json %>,
     allowUploadAsPending: <%= CurrentUser.can_upload_free?.to_json %>,
     maxFileSize: <%= Danbooru.config.max_file_size %>,
+    maxFileSizeMap: <%= Danbooru.config.max_file_sizes.to_json.html_safe %>,
   };
   Danbooru.Uploader.init();
 <% end -%>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -42,7 +42,7 @@
     allowRatingLock: <%= CurrentUser.is_privileged?.to_json %>,
     allowUploadAsPending: <%= CurrentUser.can_upload_free?.to_json %>,
     maxFileSize: <%= Danbooru.config.max_file_size %>,
-    maxFileSizeMap: <%= Danbooru.config.max_file_sizes.to_json.html_safe %>,
+    maxFileSizeMap: <%= sanitize(Danbooru.config.max_file_sizes.to_json) %>,
   };
   Danbooru.Uploader.init();
 <% end -%>


### PR DESCRIPTION
This pr intends to fix [the issue](https://github.com/orgs/e621ng/projects/1/views/1?pane=issue&itemId=70072332) of gifs >100MB reporting that their maximum size is 100MB on the uploader, rather than 20MB. This _should_ be future proofed if we add anything else, presuming their mime type ends with whatever we put in the config.

The same issue exists with APNGs, but due to them sharing the same mime type as normal PNG files, there isn't much we can do about them.