### PR TITLE
[WikiPages] Redirect back to wiki when editing/fixing tag

### DIFF
--- a/app/controllers/tag_corrections_controller.rb
+++ b/app/controllers/tag_corrections_controller.rb
@@ -20,8 +20,8 @@ class TagCorrectionsController < ApplicationController
 
     if params[:commit] == "Fix"
       @correction.fix!
-      if params[:from_wiki].to_s.truthy? && @correction.tag.wiki_page.present?
-        return redirect_to(show_or_new_wiki_pages_path(WikiPage.normalize_name(@correction.tag.name)), notice: "Tag will be fixed in a few seconds")
+      if params[:from_wiki].to_s.truthy?
+        return redirect_to(show_or_new_wiki_pages_path(title: WikiPage.normalize_name(@correction.tag.name)), notice: "Tag will be fixed in a few seconds")
       end
       redirect_to(tags_path(search: { name_matches: @correction.tag.name, hide_empty: "no"}), notice: "Tag will be fixed in a few seconds")
     else

--- a/app/controllers/tag_corrections_controller.rb
+++ b/app/controllers/tag_corrections_controller.rb
@@ -5,6 +5,7 @@ class TagCorrectionsController < ApplicationController
   before_action :janitor_only, only: [:new, :create]
 
   def new
+    @from_wiki = request.referer.try(:include?, "wiki_pages") || false
     @correction = TagCorrection.new(params[:tag_id])
     respond_with(@correction)
   end
@@ -19,9 +20,12 @@ class TagCorrectionsController < ApplicationController
 
     if params[:commit] == "Fix"
       @correction.fix!
-      redirect_to tags_path(:search => {:name_matches => @correction.tag.name, :hide_empty => "no"}), :notice => "Tag will be fixed in a few seconds"
+      if params[:from_wiki].to_s.truthy? && @correction.tag.wiki_page.present?
+        return redirect_to(wiki_page_path(@correction.tag.wiki_page), notice: "Tag will be fixed in a few seconds")
+      end
+      redirect_to(tags_path(search: { name_matches: @correction.tag.name, hide_empty: "no"}), notice: "Tag will be fixed in a few seconds")
     else
-      redirect_to tags_path(:search => {:name_matches => @correction.tag.name})
+      redirect_to(tags_path(search: { name_matches: @correction.tag.name }))
     end
   end
 end

--- a/app/controllers/tag_corrections_controller.rb
+++ b/app/controllers/tag_corrections_controller.rb
@@ -21,7 +21,7 @@ class TagCorrectionsController < ApplicationController
     if params[:commit] == "Fix"
       @correction.fix!
       if params[:from_wiki].to_s.truthy? && @correction.tag.wiki_page.present?
-        return redirect_to(wiki_page_path(@correction.tag.wiki_page), notice: "Tag will be fixed in a few seconds")
+        return redirect_to(show_or_new_wiki_pages_path(WikiPage.normalize_name(@correction.tag.name)), notice: "Tag will be fixed in a few seconds")
       end
       redirect_to(tags_path(search: { name_matches: @correction.tag.name, hide_empty: "no"}), notice: "Tag will be fixed in a few seconds")
     else

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -41,10 +41,11 @@ class TagsController < ApplicationController
     @tag.update(tag_params)
     respond_with(@tag) do |format|
       format.html do
-        if @tag.from_wiki.to_s.truthy? && @tag.wiki_page.present?
-          return redirect_to(wiki_page_path(@tag.wiki_page), notice: "Tag updated")
+        if @tag.from_wiki.to_s.truthy?
+          return redirect_to(show_or_new_wiki_pages_path(title: WikiPage.normalize_name(@tag.name)), notice: "Tag updated")
+        else
+          redirect_to(tags_path(search: { name_matches: @tag.name, hide_empty: "no" }))
         end
-        redirect_to(tag_path(@tag))
       end
     end
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,6 +16,8 @@ class Tag < ApplicationRecord
 
   before_save :update_category, if: :category_changed?
 
+  attr_accessor :from_wiki
+
   class CategoryMapping
     TagCategory::REVERSE_MAPPING.each do |value, category|
       define_method(category) do

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -47,7 +47,7 @@ class WikiPage < ApplicationRecord
 
   module SearchMethods
     def titled(title)
-      find_by(title: title&.downcase&.tr(" ", "_"))
+      find_by(title: WikiPage.normalize_name(title))
     end
 
     def active
@@ -215,6 +215,10 @@ class WikiPage < ApplicationRecord
 
   def self.normalize_other_name(name)
     name.unicode_normalize(:nfkc).gsub(/[[:space:]]+/, " ").strip.tr(" ", "_")
+  end
+
+  def self.normalize_name(name)
+    name&.downcase&.tr(" ", "_")
   end
 
   def skip_secondary_validations=(value)

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -11,7 +11,8 @@
       </ul>
     </div>
 
-    <%= form_tag(tag_correction_path(:tag_id => @correction.tag.id)) do %>
+    <%= form_tag(tag_correction_path(tag_id: @correction.tag.id)) do %>
+      <%= hidden_field_tag "from_wiki", @from_wiki %>
       <%= submit_tag "Fix" %>
       <%= submit_tag "Cancel" %>
     <% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -3,6 +3,7 @@
     <h1>Tag: <%= link_to @tag.name, posts_path(:tags => @tag.name), :class => "tag-type-#{@tag.category}" %></h1>
 
     <%= custom_form_for(@tag) do |f| %>
+      <%= f.hidden_field(:from_wiki, value: @from_wiki) %>
       <% if @tag.is_locked? %>
         <p>This tag is category locked</p>
       <% else %>

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -53,14 +53,14 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
 
       should "update the tag" do
         put_auth tag_path(@tag), @user, params: { tag: { category: Tag.categories.general } }
-        assert_redirected_to tag_path(@tag)
+        assert_redirected_to(tags_path(search: { name_matches: @tag.name, hide_empty: "no" }))
         assert_equal(Tag.categories.general, @tag.reload.category)
       end
 
       should "lock the tag for an admin" do
         put_auth tag_path(@tag), create(:admin_user), params: { tag: { is_locked: true } }
 
-        assert_redirected_to @tag
+        assert_redirected_to(tags_path(search: { name_matches: @tag.name, hide_empty: "no" }))
         assert_equal(true, @tag.reload.is_locked)
       end
 
@@ -87,7 +87,7 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
           @admin = create(:admin_user)
           put_auth tag_path(@tag), @admin, params: { tag: { category: Tag.categories.general } }
 
-          assert_redirected_to @tag
+          assert_redirected_to(tags_path(search: { name_matches: @tag.name, hide_empty: "no" }))
           assert_equal(Tag.categories.general, @tag.reload.category)
         end
       end


### PR DESCRIPTION
This pr adds a simple hidden field, filled in from the `Referer` header which if the header contains `wiki_pages` will redirect to the wiki page rather than the tag.