### PR TITLE
Avoid posting cleanup

### DIFF
--- a/app/controllers/avoid_posting_versions_controller.rb
+++ b/app/controllers/avoid_posting_versions_controller.rb
@@ -10,7 +10,7 @@ class AvoidPostingVersionsController < ApplicationController
 
   def search_params
     permitted_params = %i[updater_name updater_id any_name_matches artist_name artist_id any_other_name_matches group_name is_active]
-    permitted_params += %i[updater_ip_addr] if CurrentUser.is_admin?
+    permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params
   end
 end

--- a/app/controllers/avoid_postings_controller.rb
+++ b/app/controllers/avoid_postings_controller.rb
@@ -27,7 +27,7 @@ class AvoidPostingsController < ApplicationController
   def create
     @avoid_posting = AvoidPosting.new(avoid_posting_params)
     artparams = avoid_posting_params.try(:[], :artist_attributes)
-    if artparams.present? && (artist = Artist.find_by(name: Artist.normalize_name(artparams[:name])))
+    if artparams.present? && (artist = Artist.named(artparams[:name]))
       @avoid_posting.artist = artist
       notices = []
       if artist.other_names.present? && (artparams.key?(:other_names_string) || artparams.key?(:other_names))

--- a/app/controllers/avoid_postings_controller.rb
+++ b/app/controllers/avoid_postings_controller.rb
@@ -89,7 +89,7 @@ class AvoidPostingsController < ApplicationController
     if id =~ /\A\d+\z/
       @avoid_posting = AvoidPosting.find(id)
     else
-      @avoid_posting = AvoidPosting.find_by!(artist_name: id)
+      @avoid_posting = AvoidPosting.joins(:artist).find_by!("artists.name": id)
     end
   end
 

--- a/app/controllers/avoid_postings_controller.rb
+++ b/app/controllers/avoid_postings_controller.rb
@@ -96,7 +96,7 @@ class AvoidPostingsController < ApplicationController
   def search_params
     permitted_params = %i[creator_name creator_id any_name_matches artist_id artist_name any_other_name_matches group_name details is_active]
     permitted_params += %i[staff_notes] if CurrentUser.is_staff?
-    permitted_params += %i[creator_ip_addr] if CurrentUser.is_admin?
+    permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params
   end
 

--- a/app/controllers/avoid_postings_controller.rb
+++ b/app/controllers/avoid_postings_controller.rb
@@ -69,17 +69,17 @@ class AvoidPostingsController < ApplicationController
 
   def destroy
     @avoid_posting.destroy
-    redirect_to artist_path(@avoid_posting.artist), notice: "Avoid posting entry destroyed"
+    redirect_to(artist_path(@avoid_posting.artist), notice: "Avoid posting entry destroyed")
   end
 
   def delete
     @avoid_posting.update(is_active: false)
-    redirect_to avoid_posting_path(@avoid_posting), notice: "Avoid posting entry deleted"
+    redirect_back(fallback_location: avoid_posting_path(@avoid_posting), notice: "Avoid posting entry deleted")
   end
 
   def undelete
     @avoid_posting.update(is_active: true)
-    redirect_to avoid_posting_path(@avoid_posting), notice: "Avoid posting entry undeleted"
+    redirect_back(fallback_location: avoid_posting_path(@avoid_posting), notice: "Avoid posting entry undeleted")
   end
 
   private

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -72,7 +72,7 @@ class StaticController < ApplicationController
   private
 
   def format_wiki_page(name)
-    wiki = WikiPage.find_by(title: name)
+    wiki = WikiPage.titled(name)
     return WikiPage.new(body: "Wiki page \"#{name}\" not found.") if wiki.blank?
     wiki
   end

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -336,10 +336,6 @@ div#c-posts {
       background-color: themed("color-section");
       border: 1px solid themed("color-foreground");
 
-      /*.artist-separator {
-        color: var(--color-text-muted);
-      }*/
-
       ul {
         list-style: disc;
       }

--- a/app/models/avoid_posting.rb
+++ b/app/models/avoid_posting.rb
@@ -99,7 +99,7 @@ class AvoidPosting < ApplicationRecord
       q = q.attribute_matches(:details, params[:details])
       q = q.attribute_matches(:staff_notes, params[:staff_notes])
       q = q.where_user(:creator_id, :creator, params)
-      q = q.where("creator_ip_addr <<= ?", params[:creator_ip_addr]) if params[:creator_ip_addr].present?
+      q = q.where("creator_ip_addr <<= ?", params[:ip_addr]) if params[:ip_addr].present?
       q.apply_basic_order(params)
     end
   end

--- a/app/models/avoid_posting.rb
+++ b/app/models/avoid_posting.rb
@@ -76,10 +76,6 @@ class AvoidPosting < ApplicationRecord
   end
 
   module SearchMethods
-    def for_artist(name)
-      active.find_by(artist_name: name)
-    end
-
     def artist_search(params)
       Artist.search(params.slice(:any_name_matches, :any_other_name_matches).merge({ id: params[:artist_id], name: params[:artist_name] }))
     end

--- a/app/models/avoid_posting_version.rb
+++ b/app/models/avoid_posting_version.rb
@@ -15,7 +15,7 @@ class AvoidPostingVersion < ApplicationRecord
   end
 
   def previous
-    AvoidPostingVersion.joins(:avoid_posting).where(id: ...id).order(id: :desc).first
+    AvoidPostingVersion.joins(:avoid_posting).where("id < ?", id).order(id: :desc).first
   end
 
   module ApiMethods

--- a/app/models/avoid_posting_version.rb
+++ b/app/models/avoid_posting_version.rb
@@ -15,7 +15,7 @@ class AvoidPostingVersion < ApplicationRecord
   end
 
   def previous
-    AvoidPostingVersion.joins(:avoid_posting).where("id < ?", id).order(id: :desc).first
+    AvoidPostingVersion.joins(:avoid_posting).where("avoid_posting_versions.id < ?", id).order(id: :desc).first
   end
 
   module ApiMethods

--- a/app/models/avoid_posting_version.rb
+++ b/app/models/avoid_posting_version.rb
@@ -38,7 +38,7 @@ class AvoidPostingVersion < ApplicationRecord
 
       q = q.attribute_matches(:is_active, params[:is_active])
       q = q.where_user(:updater_id, :updater, params)
-      q = q.where("updater_ip_addr <<= ?", params[:updater_ip_addr]) if params[:updater_ip_addr].present?
+      q = q.where("updater_ip_addr <<= ?", params[:ip_addr]) if params[:ip_addr].present?
       q.apply_basic_order(params)
     end
   end

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -7,7 +7,7 @@
   <% else %>
     <p><%= @artist.name %></p>
     <% if @artist.dnp_restricted? %>
-      <p>Name, other names, and group name cannot be edited for artists on the <%= link_to "Avoid Posting", avoid_postings_path %> list.</p>
+      <p>Name, other names, and group name cannot be edited for artists on the <%= link_to "Avoid Posting", avoid_posting_static_path %> list.</p>
     <% end %>
   <% end %>
   <% if CurrentUser.is_janitor? %>

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:secondary_links) do %>
   <li><%= render "artists/quick_search" %></li>
   <%= subnav_link_to "Listing", artists_path %>
-  <%= subnav_link_to "Avoid Posting", avoid_postings_path %>
+  <%= subnav_link_to "Avoid Posting", avoid_posting_static_path %>
   <% if CurrentUser.is_member? %>
     <%= subnav_link_to "New", new_artist_path %>
   <% end %>

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -9,7 +9,7 @@
 
     <% if @artist.is_dnp? %>
       <div id="avoid-posting">
-        <h2>This artist is on the <%= link_to "Avoid Posting", avoid_postings_path %> list.</h2>
+        <h2>This artist is on the <%= link_to "Avoid Posting", avoid_posting_static_path %> list.</h2>
         <% if @artist.avoid_posting.pretty_details.present? %>
           <div class="dtext-container">
             <%= format_text(@artist.avoid_posting.pretty_details, inline: true) %>

--- a/app/views/avoid_posting_versions/_search.html.erb
+++ b/app/views/avoid_posting_versions/_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_search(path: avoid_posting_versions_path) do |f| %>
   <%= f.user :updater %>
   <% if CurrentUser.is_admin? %>
-    <%= f.input :updater_ip_addr, label: "Updater IP Address" %>
+    <%= f.input :ip_addr, label: "Updater IP Address" %>
   <% end %>
   <%= f.input :any_name_matches, label: "Name", hint: "Use * for wildcard", autocomplete: "artist" %>
   <%= f.input :artist_name, label: "Artist Name", hide_unless_value: true %>

--- a/app/views/avoid_postings/_search.html.erb
+++ b/app/views/avoid_postings/_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_search(path: avoid_postings_path, always_display: true) do |f| %>
   <%= f.user :creator %>
   <% if CurrentUser.is_admin? %>
-    <%= f.input :creator_ip_addr, label: "Creator IP Address" %>
+    <%= f.input :ip_addr, label: "Creator IP Address" %>
   <% end %>
   <%= f.input :any_name_matches, label: "Name", hint: "Use * for wildcard", autocomplete: "artist" %>
   <%= f.input :artist_name, label: "Artist Name", hide_unless_value: true %>

--- a/app/views/avoid_postings/edit.html.erb
+++ b/app/views/avoid_postings/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="c-avoid-postings">
   <div class="a-edit">
-    <h1>Edit Avoid Posting for <%= link_to @avoid_posting.artist_name, avoid_posting_path(@avoid_posting), class: "tag-type-1" %></h1>
+    <h1>Edit Avoid Posting for <%= link_to @avoid_posting.artist_name, avoid_posting_path(@avoid_posting), class: "tag-type-#{Tag.categories.artist}" %></h1>
 
     <%= error_messages_for :avoid_posting %>
     <%= render "form" %>

--- a/app/views/avoid_postings/index.html.erb
+++ b/app/views/avoid_postings/index.html.erb
@@ -52,7 +52,11 @@
             <%= link_to "Show", avoid_posting_path(avoid_posting) %>
             <% if CurrentUser.can_edit_avoid_posting_entries? %>
               | <%= link_to "Edit", edit_avoid_posting_path(avoid_posting) %>
-              | <%= link_to "Delete", delete_avoid_posting_path(avoid_posting), method: :put, data: { confirm: "Are you sure you want to delete this avoid posting?" } %>
+              <% if avoid_posting.is_active? %>
+                | <%= link_to "Delete", delete_avoid_posting_path(avoid_posting), method: :put, data: { confirm: "Are you sure you want to delete this avoid posting entry?" } %>
+              <% else %>
+                | <%= link_to "Undelete", undelete_avoid_posting_path(avoid_posting), method: :put, data: { confirm: "Are you sure you want to undelete this avoid posting entry?" } %>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/app/views/avoid_postings/show.html.erb
+++ b/app/views/avoid_postings/show.html.erb
@@ -1,6 +1,6 @@
 <div id="c-avoid-postings">
   <div id="a-index">
-    <h1>Avoid Posting: <%= link_to @avoid_posting.artist_name, show_or_new_artists_path(name: @avoid_posting.artist_name), class: "tag-type-1" %><%= " (inactive)" unless @avoid_posting.is_active? %></h1>
+    <h1>Avoid Posting: <%= link_to @avoid_posting.artist_name, show_or_new_artists_path(name: @avoid_posting.artist_name), class: "tag-type-#{Tag.categories.artist}" %><%= " (inactive)" unless @avoid_posting.is_active? %></h1>
     <ul>
       <li><strong>Status</strong> <%= @avoid_posting.status %></li>
 

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -37,7 +37,8 @@
       <ul>
         <li><h1>Artists</h1></li>
         <li><%= link_to("Listing", artists_path) %></li>
-        <li><%= link_to("Avoid Posting", avoid_postings_path) %></li>
+        <li><%= link_to("Avoid Posting Entries", avoid_postings_path) %></li>
+        <li><%= link_to("Avoid Posting List", avoid_posting_static_path) %></li>
         <li><%= link_to("Changes", artist_versions_path) %></li>
         <li><%= link_to("Help", help_page_path(id: "artists")) %></li>
       </ul>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -460,7 +460,7 @@ module Danbooru
         },
         {
           name: "dnp_artist",
-          reason: "The artist of this post is on the \"avoid posting list\":/avoid_postings",
+          reason: "The artist of this post is on the \"avoid posting list\":/static/avoid_posting",
           text: "Certain artists have requested that their work is not to be published on this site, and were granted [[avoid_posting|Do Not Post]] status.\nSometimes, that status comes with conditions; see [[conditional_dnp]] for more information",
         },
         {
@@ -527,7 +527,7 @@ module Danbooru
         "Traced artwork",
         "Traced artwork (post #%PARENT_ID%)",
         "Takedown #%OTHER_ID%",
-        "The artist of this post is on the \"avoid posting list\":/avoid_postings",
+        "The artist of this post is on the \"avoid posting list\":/static/avoid_posting",
         "[[conditional_dnp|Conditional DNP]] (Only the artist is allowed to post)",
         "[[conditional_dnp|Conditional DNP]] (%OTHER_ID%)",
       ]

--- a/test/controllers/avoid_postings_controller_test.rb
+++ b/test/controllers/avoid_postings_controller_test.rb
@@ -27,6 +27,11 @@ class AvoidPostingsControllerTest < ActionDispatch::IntegrationTest
         get_auth avoid_posting_path(@avoid_posting), @user
         assert_response :success
       end
+
+      should "render (by name)" do
+        get_auth avoid_posting_path(id: @avoid_posting.artist_name), @user
+        assert_response :success
+      end
     end
 
     context "edit action" do

--- a/test/factories/avoid_posting.rb
+++ b/test/factories/avoid_posting.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory(:avoid_posting) do
     association :artist
-    is_active { true }
     association :creator, factory: :bd_staff_user
     creator_ip_addr { "127.0.0.1" }
   end


### PR DESCRIPTION
This pr:
* Fixes a bug in the avoid postings controller when using an artist name in place of an id
* Changes the `creator_ip_addr` & `updater_ip_addr` search params to `ip_addr`
  * (For some reason this is the standard)
* Changes most of the `/avoid_postings` links into `/static/avoid_posting`
  * This is the page MOST people will be intending to go to, since it has the full text list as well as the top blurb
  * This changed:
    * The text shown when editing a dnp restricted artist
    * The link in artist's secondary links
    * The header on the artist show action
    * The site map (separated into "Avoid Posting Entries" & "Avoid Posting List" links)
    * The flag reason
    * The deletion reason
* Adds an Undelete link on the avoid posting index
  * Along with this the delete/undelete actions now redirect back rather than only to the entry
* Various amounts of minor code cleanup