### PR TITLE
[Posts] Fix mode menu add/remove from set alerts

### DIFF
--- a/app/javascript/src/javascripts/post_mode_menu.js
+++ b/app/javascript/src/javascripts/post_mode_menu.js
@@ -181,9 +181,9 @@ PostModeMenu.click = function (e) {
   } else if (s === "vote-up") {
     Post.vote(post_id, 1, true);
   } else if (s === "add-to-set") {
-    PostSet.add_post($("#set-id").val(), post_id);
+    PostSet.add_post($("#set-id").val(), post_id, true);
   } else if (s === "remove-from-set") {
-    PostSet.remove_post($("#set-id").val(), post_id);
+    PostSet.remove_post($("#set-id").val(), post_id, true);
   } else if (s === "rating-q") {
     Post.update(post_id, {"post[rating]": "q"});
   } else if (s === "rating-s") {

--- a/app/javascript/src/javascripts/post_sets.js
+++ b/app/javascript/src/javascripts/post_sets.js
@@ -6,7 +6,7 @@ let PostSet = {};
 
 PostSet.dialog_setup = false;
 
-PostSet.add_post = function (set_id, post_id) {
+PostSet.add_post = function (set_id, post_id, silent = false) {
   if (!set_id) {
     $(window).trigger("danbooru:error", "Error: No set specified");
     return;
@@ -25,12 +25,13 @@ PostSet.add_post = function (set_id, post_id) {
       $(window).trigger("danbooru:error", "Error: " + message);
     }).done(function () {
       Post.notice_update("dec");
+      if (silent) return;
       $(window).trigger("danbooru:notice", "Added post to set");
     });
   });
 };
 
-PostSet.remove_post = function (set_id, post_id) {
+PostSet.remove_post = function (set_id, post_id, silent = false) {
   if (!set_id) {
     $(window).trigger("danbooru:error", "Error: No set specified");
     return;
@@ -48,6 +49,7 @@ PostSet.remove_post = function (set_id, post_id) {
       $(window).trigger("danbooru:error", "Error: " + message);
     }).done(function () {
       Post.notice_update("dec");
+      if (silent) return;
       $(window).trigger("danbooru:notice", "Removed post from set");
     });
   });


### PR DESCRIPTION
The "Updating post (# pending)" alert was being replaced with the "Added/Removed post from set", which is unhelpful.