### PR TITLE
[ApngInspector] Change length to bytesize

### DIFF
--- a/app/logical/apng_inspector.rb
+++ b/app/logical/apng_inspector.rb
@@ -40,7 +40,7 @@ class ApngInspector
       chunkheader = +""
       while file.read(8, chunkheader)
         #ensure that first 8 bytes from chunk were read properly
-        if chunkheader == nil || chunkheader.length < 8
+        if chunkheader == nil || chunkheader.bytesize < 8
           return false
         end
 


### PR DESCRIPTION
This pr fixes the apng inspector checking string length rather than byte size, which fixes an issue with multibyte characters (which would be seen as 1 character rather than 2+ bytes, reading an 8 byte sequence as 7 or less)

This issue has presumably resulted in the apng inspector missing a _lot_ of apngs, resulting in possibly missing tags in addition to allowing large file sizes over the intended limit
You can see the entire discord conversation [here](https://discord.com/channels/431908090883997698/1255244495533113354/1269749166243053669)