### PR TITLE
[PostReplacements] Prevent approving if post has notes and is note locked

### DIFF
--- a/app/javascript/src/javascripts/post_replacement.js
+++ b/app/javascript/src/javascripts/post_replacement.js
@@ -35,7 +35,7 @@ PostReplacement.approve = function (id, penalize_current_uploader) {
   }).done(function () {
     set_status($row, "approved");
   }).fail(function (data) {
-    Utility.error(data.responseText);
+    Utility.error(`Failed to approve replacement: ${data.responseJSON.message}`);
     set_status($row, "replacement failed");
   });
 };

--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -107,6 +107,7 @@ class UploadService
     end
 
     def rescale_notes(post)
+      return if post.is_note_locked?
       x_scale = post.image_width.to_f / post.image_width_before_last_save.to_f
       y_scale = post.image_height.to_f / post.image_height_before_last_save.to_f
 

--- a/test/functional/post_replacements_controller_test.rb
+++ b/test/functional/post_replacements_controller_test.rb
@@ -126,6 +126,19 @@ class PostReplacementsControllerTest < ActionDispatch::IntegrationTest
         assert_equal @replacement.md5, @post.md5
         assert_equal @replacement.status, "approved"
       end
+
+      should "work even if the post is note locked" do
+        as(@user) do
+          create(:note, post: @post)
+          @post.update!(is_note_locked: true)
+        end
+        put_auth approve_post_replacement_path(@replacement), @user
+        assert_redirected_to post_path(@post)
+        @replacement.reload
+        @post.reload
+        assert_equal @replacement.md5, @post.md5
+        assert_equal @replacement.status, "approved"
+      end
     end
 
     context "promote action" do


### PR DESCRIPTION
This pr makes approving a replacement skip attempting to resize notes if the post is note locked. As was reported [in Discord](https://discord.com/channels/431908090883997698/432280999293091872/1270320547825455105), this throws an error otherwise.