### PR TITLE
[Posts] Readd the warning for removing an implicated tag

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -410,7 +410,11 @@ class Post < ApplicationRecord
 
   module TagMethods
     def should_process_tags?
-      tag_string_changed? || locked_tags_changed? || tag_string_diff.present?
+      if @removed_tags.nil?
+        @removed_tags = []
+      end
+
+      tag_string_changed? || locked_tags_changed? || tag_string_diff.present? || @removed_tags.length() > 0 || added_tags.length() > 0
     end
 
     def tag_array
@@ -469,8 +473,6 @@ class Post < ApplicationRecord
     end
 
     def merge_old_changes
-      @removed_tags = []
-
       if old_tag_string
         # If someone else committed changes to this post before we did,
         # then try to merge the tag changes together.
@@ -503,7 +505,6 @@ class Post < ApplicationRecord
     end
 
     def apply_tag_diff
-      @removed_tags = []
       return unless tag_string_diff.present?
 
       current_tags = tag_array
@@ -1644,6 +1645,8 @@ class Post < ApplicationRecord
         unremoved_tags_list = unremoved_tags.map {|t| "[[#{t}]]"}.to_sentence
         self.warnings.add(:base, "#{unremoved_tags_list} could not be removed. Check for implications and locked tags and try again")
       end
+
+      @removed_tags = []
     end
 
     def has_artist_tag

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -414,7 +414,7 @@ class Post < ApplicationRecord
         @removed_tags = []
       end
 
-      tag_string_changed? || locked_tags_changed? || tag_string_diff.present? || @removed_tags.length() > 0 || added_tags.length() > 0
+      tag_string_changed? || locked_tags_changed? || tag_string_diff.present? || @removed_tags.length > 0 || added_tags.length > 0
     end
 
     def tag_array


### PR DESCRIPTION
This already exists, however it just doesn't work right now. So here's fixing it

I didn't change how it looks, so it's just a flash notice like the other warnings
![40sput_19394 1](https://github.com/user-attachments/assets/e7835ddc-fe05-406a-a2c0-c0bb565999c0)

And for locked tags (maybe this should be reworked now that this warning actually works again) it shows two if you attempt to remove a locked tag since it removes it then adds it? Not sure
![swq2d_19396 1](https://github.com/user-attachments/assets/646737ec-1466-46d4-bc98-ecaa0af95c26)

As per the request [in the discord](https://discord.com/channels/431908090883997698/1099361575116222656/1270511382001094738), however it doesn't show which tag prevents it from being removed. Though if that's something we want it could probably be added.
