### PR TITLE
[Sources] Allow source_diff to wrap dead sources in quotes

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -336,8 +336,8 @@ class Post < ApplicationRecord
 
       diff = source_diff.gsub(/\r\n?/, "\n").gsub(/%0A/i, "\n").split(/(?:\r)?\n/)
       to_remove, to_add = diff.partition {|x| x =~ /\A-/i}
-      to_remove = to_remove.map {|x| x[1..-1].delete_prefix('"').delete_suffix('"')}
-      to_add = to_add.map {|x| x.delete_prefix('"').delete_suffix('"')}
+      to_remove = to_remove.map {|x| x[1..-1].starts_with?('"') && x.ends_with?('"') ? x[1..-1].delete_prefix('"').delete_suffix('"') : x[1..-1]}
+      to_add = to_add.map {|x| x.starts_with?('"') && x.ends_with?('"') ? x.delete_prefix('"').delete_suffix('"') : x}
 
       current_sources = source_array
       current_sources += to_add

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -336,7 +336,8 @@ class Post < ApplicationRecord
 
       diff = source_diff.gsub(/\r\n?/, "\n").gsub(/%0A/i, "\n").split(/(?:\r)?\n/)
       to_remove, to_add = diff.partition {|x| x =~ /\A-/i}
-      to_remove = to_remove.map {|x| x[1..-1]}
+      to_remove = to_remove.map {|x| x[1..-1].delete_prefix('"').delete_suffix('"')}
+      to_add = to_add.map {|x| x.delete_prefix('"').delete_suffix('"')}
 
       current_sources = source_array
       current_sources += to_add


### PR DESCRIPTION
Fixes #554

Allows you to wrap sources in quotes, meaning dead sources can be added like so:
```json
{
  "post": {
    "source_diff": "\"-test source\""
  }
}
```

and removed (oddly) like so:
```json
{
  "post": {
    "source_diff": "-\"-test source\""
  }
}
```

Yeah, it's weird, but it's better than not being able to do it.

This isn't required though, you can add/remove regular sources exactly the same as before. This does however mean no sources can start or end with quotes (when added with `source_diff`), which at the moment affects 40 posts:
https://e621.net/posts?tags=%7Esource%3A%5C%22*+%7Esource%3A*%5C%22

and I'd argue all of them are invalid sources anyways...

Alternatively, the prefix/suffix can be anything, it doesn't need to be quotes.