### PR TITLE
[Flags] Flip inferior flag

### DIFF
--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -59,7 +59,7 @@ Post.initialize_moderation = function () {
   });
   $(".move-flag-to-parent-link").on("click", e => {
     e.preventDefault();
-    const $e = $(e.target)
+    const $e = $(e.target);
     const post_id = $e.data("pid");
     const parent_id = $e.data("parent-id");
 

--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -57,6 +57,15 @@ Post.initialize_moderation = function () {
     Post.unflag($e.data("pid"), $e.data("type"));
     e.preventDefault();
   });
+  $(".move-flag-to-parent-link").on("click", e => {
+    e.preventDefault();
+    const $e = $(e.target)
+    const post_id = $e.data("pid");
+    const parent_id = $e.data("parent-id");
+
+    if (confirm("Move flag to parent?"))
+      Post.move_flag_to_parent(post_id, parent_id);
+  });
 };
 
 Post.initialize_collapse = function () {
@@ -806,7 +815,7 @@ Post.undelete = function (post_id, callback) {
   });
 };
 
-Post.unflag = function (post_id, approval, reload = true) {
+Post.unflag = function (post_id, approval, reload = true, callback = null) {
   Post.notice_update("inc");
   let modApproval = approval || "none";
   SendQueue.add(function () {
@@ -819,14 +828,48 @@ Post.unflag = function (post_id, approval, reload = true) {
       $(window).trigger("danbooru:error", "Error: " + message);
     }).done(function () {
       $(window).trigger("danbooru:notice", "Unflagged post");
-      if (reload) {
-        location.reload();
-      }
+      if (callback) callback();
+      if (reload) location.reload();
     }).always(function () {
       Post.notice_update("dec");
     });
   });
 };
+
+Post.flag = function (post_id, reason_name, parent_id = null, reload = true, callback = null) {
+  Post.notice_update("inc");
+  SendQueue.add(function () {
+    $.ajax({
+      type: "POST",
+      url: "/post_flags.json",
+      data: {
+        post_flag: {
+          post_id: parseInt(post_id),
+          reason_name,
+          parent_id,
+        },
+      },
+    }).fail(function (data) {
+      const message = data.responseJSON.message;
+      $(window).trigger("danbooru:error", "Error: " + message);
+    }).done(function () {
+      $(window).trigger("danbooru:notice", "Flagged post");
+      if (callback) callback();
+      if (reload) location.reload();
+    }).always(function () {
+      Post.notice_update("dec");
+    });
+  });
+};
+
+Post.move_flag_to_parent = function (post_id, parent_id) {
+  Post.unflag(post_id, false, false, function () {
+    Post.flag(parent_id, "inferior", post_id, false, function () {
+      location.href = `/moderator/post/posts/${parent_id}/confirm_delete`;
+    });
+  });
+};
+
 
 Post.unapprove = function (post_id) {
   Post.notice_update("inc");

--- a/app/views/posts/partials/show/_notices.html.erb
+++ b/app/views/posts/partials/show/_notices.html.erb
@@ -14,7 +14,7 @@
         <% unless post.pending_flag&.reason =~ /uploading_guidelines/ %>
            | <%= tag.a "Delete with given reason", href: '#', 'data-post-id': post.id, class: 'delete-with-reason-link button btn-neutral', 'data-reason': '', 'data-prompt': 'given reason' %>
         <% end %>
-        <% if !post.parent_id.nil? && post.pending_flag&.reason =~ /Inferior version\/duplicate of post #\d+/ %>
+        <% if !post.parent_id.nil? && post.pending_flag&.reason =~ %r{Inferior version/duplicate of post #\d+} %>
            | <%= tag.a "Move flag to parent", href: '#', 'data-pid': post.id, 'data-parent-id': post.parent_id, class: 'move-flag-to-parent-link button btn-neutral' %>
         <% end %>
       </div>

--- a/app/views/posts/partials/show/_notices.html.erb
+++ b/app/views/posts/partials/show/_notices.html.erb
@@ -14,6 +14,9 @@
         <% unless post.pending_flag&.reason =~ /uploading_guidelines/ %>
            | <%= tag.a "Delete with given reason", href: '#', 'data-post-id': post.id, class: 'delete-with-reason-link button btn-neutral', 'data-reason': '', 'data-prompt': 'given reason' %>
         <% end %>
+        <% if !post.parent_id.nil? && post.pending_flag&.reason =~ /Inferior version\/duplicate of post #\d+/ %>
+           | <%= tag.a "Move flag to parent", href: '#', 'data-pid': post.id, 'data-parent-id': post.parent_id, class: 'move-flag-to-parent-link button btn-neutral' %>
+        <% end %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Lets staff move an "inferior" type flag to the parent.

See https://github.com/orgs/e621ng/projects/1/views/1?pane=issue&itemId=71429263