### PR TITLE
[Blacklist] Fix minor issues

### DIFF
--- a/app/javascript/src/javascripts/models/Filter.js
+++ b/app/javascript/src/javascripts/models/Filter.js
@@ -74,11 +74,12 @@ export default class Filter {
    */
   update ($post) {
     if ($post.length == 0) return false;
-    else if (Array.isArray($post))
-      $post = $post[0]; // Deferred posts return an array
-    else if ($post.length > 1) {
-      // Batch update
+    else if (Array.isArray($post)) { // Deferred posts return an array
       for (const $one of $post)
+        this.update($one);
+      return;
+    } else if ($post.length > 1) { // More than one matched
+      for (const $one of $post.get())
         this.update($($one));
       return;
     }

--- a/app/javascript/src/javascripts/models/PostCache.js
+++ b/app/javascript/src/javascripts/models/PostCache.js
@@ -43,7 +43,7 @@ export default class PostCache {
 
       score: parseInt(data.score) || 0,
       fav_count: parseInt(data.favCount) || 0,
-      is_favorited: !!data.isFavorited,
+      is_favorited: data.isFavorited === "true",
 
       uploader: (data.uploader || "").toLowerCase(),
       uploader_id: parseInt(data.uploaderId) || -1,

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -74,8 +74,7 @@
   .blacklist-filters {
     display: flex;
     flex-flow: column;
-    font-size: 1.1em;
-    gap: 0.125rem;
+    gap: 0.1rem;
     margin: 0.25em 0;
 
     max-height: 50vh;

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -45,7 +45,7 @@
       border-color: transparent var(--color-text) var(--color-text) transparent;
       transform: rotate(45deg);
       bottom: 0.25em;
-      transition: 0.25s ease-in-out;
+      transition: 0.1s ease-in-out;
     }
   }
   &[collapsed="true"] {
@@ -64,7 +64,7 @@
       @keyframes hide-scroll {
         from, to { overflow: hidden; } 
       }
-      animation: hide-scroll 0.25s backwards;
+      animation: hide-scroll 0.1s backwards;
       overflow-x: hidden;
       overflow-y: auto;
     }
@@ -78,7 +78,7 @@
     margin: 0.25em 0;
 
     max-height: 50vh;
-    transition: max-height 0.25s ease-in-out;
+    transition: max-height 0.1s ease-in-out;
 
     li {
       display: flex;

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -65,7 +65,8 @@
         from, to { overflow: hidden; } 
       }
       animation: hide-scroll 0.25s backwards;
-      overflow: hidden auto;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
   }
 


### PR DESCRIPTION
Just fixing a couple of bugs reported in the #693.

1. `fav:me` was not working due to a quirk of string to boolean conversion
2. Deferred posts (dtext thumbnails, avatars, etc) were not getting blacklisted properly
3. Strange overflow issue in older browsers
4. Minor tweak to the font size and space of the blacklist entries