### PR TITLE
[PostView] Show verified uploaders to everyone

### DIFF
--- a/app/decorators/posts_decorator.rb
+++ b/app/decorators/posts_decorator.rb
@@ -92,13 +92,13 @@ class PostsDecorator < ApplicationDecorator
     end
 
     tooltip = "Rating: #{post.rating}\nID: #{post.id}\nDate: #{post.created_at}\nStatus: #{post.status}\nScore: #{post.score}"
-    if CurrentUser.is_janitor?
+    if CurrentUser.is_janitor? || post.uploader_linked_artists.any?
       tooltip += "\nUploader: #{post.uploader_name}"
-      if post.is_flagged? || post.is_deleted?
-        flag = post.flags.order(id: :desc).first
-        tooltip += "\nFlag Reason: #{flag&.reason}" if post.is_flagged?
-        tooltip += "\nDel Reason: #{flag&.reason}" if post.is_deleted?
-      end
+    end
+    if CurrentUser.is_janitor? && (post.is_flagged? || post.is_deleted?)
+      flag = post.flags.order(id: :desc).first
+      tooltip += "\nFlag Reason: #{flag&.reason}" if post.is_flagged?
+      tooltip += "\nDel Reason: #{flag&.reason}" if post.is_deleted?
     end
     tooltip += "\n\n#{post.tag_string}"
 

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -13,7 +13,7 @@
     Posted: <%= link_to time_ago_in_words_tagged(post.created_at), posts_path(:tags => "date:#{post.created_at.to_date}"), :rel => "nofollow" %>
     <meta itemprop="uploadDate" content="<%= post.created_at.iso8601 %>">
   </li>
-  <% if CurrentUser.is_janitor? %>
+  <% if CurrentUser.is_janitor? || post.uploader_linked_artists.any? %>
     <li>
       Uploader: <%= link_to_user(post.uploader) %> <%= user_record_meta(post.uploader) %>
       <% if post.uploader_linked_artists.any? %>


### PR DESCRIPTION
Implements https://github.com/orgs/e621ng/projects/1/views/1?filterQuery=-status%3ADone&pane=issue&itemId=73408921

Not sure if this is actually something that's wanted, but the code existing should make it easier to decide.

Examples (taken while logged out):
Of a post with an uploader linked to one of the artist tags:
![r6exue_19464 1](https://github.com/user-attachments/assets/a43f4348-953e-447e-9f23-7652e1b10240)

Same uploader uploading content to a tag they are not verified for:
![11z5vv_19465 1](https://github.com/user-attachments/assets/3c43dfa7-00f3-4e46-b110-6060677aa3ad)

And for completion, here's the above post while logged into a janitor+ account:
![0rsy1i_19466 1](https://github.com/user-attachments/assets/6a53e361-1b36-42e3-86b6-b1f4fe731b2a)
