### PR TITLE
Add a fully featured blocking system

### DIFF
--- a/app/controllers/user_blocks_controller.rb
+++ b/app/controllers/user_blocks_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class UserBlocksController < ApplicationController
+  before_action :member_only
+  before_action :load_user
+  before_action :check_privilege, except: %i[index]
+  respond_to :html, :json
+
+  def index
+    raise(User::PrivilegeError) if @user != CurrentUser.user && !CurrentUser.is_admin?
+    @blocks = UserBlock.where(user_id: params[:user_id]).paginate(params[:page], limit: params[:limit])
+    respond_with(@blocks)
+  end
+
+  def new
+    @block = UserBlock.new(block_params(:create))
+  end
+
+  def edit
+    @block = UserBlock.find(params[:id])
+  end
+
+  def create
+    @block = @user.blocks.create(block_params(:create))
+    respond_with(@block, location: user_blocks_path(@user)) do |format|
+      format.html do
+        flash[:notice] = @block.errors.any? ? "Failed to block user: #{@block.errors.full_messages.join('; ')}" : "Blocked #{@block.target_name}"
+        redirect_to(user_blocks_path(@user))
+      end
+    end
+  end
+
+  def update
+    @block = UserBlock.find(params[:id])
+    @block.update(block_params)
+    respond_with(@block, location: user_blocks_path(@user)) do |format|
+      format.html do
+        flash[:notice] = @block.errors.any? ? "Failed to update block: #{@block.errors.full_messages.join('; ')}" : "Updated block for #{@block.target_name}"
+        redirect_to(user_blocks_path(@user))
+      end
+    end
+  end
+
+  def destroy
+    @block = UserBlock.find(params[:id])
+    @block.destroy
+    respond_with(@block) do |format|
+      format.html do
+        flash[:notice] = "Unblocked #{@block.target_name}"
+        redirect_to(user_blocks_path(@user))
+      end
+    end
+  end
+
+  private
+
+  def block_params(context = nil)
+    permitted_params = %i[hide_blips hide_comments hide_forum_topics hide_forum_posts disable_messages]
+    permitted_params += %i[target_id target_name] if context == :create
+    params.fetch(:user_block, {}).permit(permitted_params)
+  end
+
+  def load_user
+    @user = User.find(params[:user_id])
+  end
+
+  def check_privilege
+    raise(User::PrivilegeError) if @user != CurrentUser.user
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -37,8 +37,10 @@ require.context("../../../public/images", true)
 export { default as Autocomplete } from '../src/javascripts/autocomplete.js.erb';
 export { default as Blacklist } from '../src/javascripts/blacklists.js';
 export { default as Blip } from '../src/javascripts/blips.js';
+export { default as Block } from '../src/javascripts/blocks.js';
 export { default as Comment } from '../src/javascripts/comments.js';
 export { default as DText } from '../src/javascripts/dtext.js';
+export { default as LStorage } from '../src/javascripts/utility/storage.js';
 export { default as Note } from '../src/javascripts/notes.js';
 export { default as Post } from '../src/javascripts/posts.js';
 export { default as PostDeletion } from "../src/javascripts/post_delete.js";

--- a/app/javascript/src/javascripts/blocks.js
+++ b/app/javascript/src/javascripts/blocks.js
@@ -1,0 +1,155 @@
+import Utility from "./utility";
+import LStorage from "./utility/storage";
+
+class Block {
+  static entries = JSON.parse(Utility.meta("user-blocks") || "[]");
+
+  static hiddenCount = {
+    Blips: 0,
+    Comments: 0,
+    ForumPosts: 0,
+    ForumTopics: 0,
+  };
+
+  static nameMap = {
+    Blips: "blip",
+    Comments: "comment",
+    ForumPosts: "forum post",
+    ForumTopics: "forum topic",
+  };
+
+  static disabled = [];
+
+  static init () {
+    this.activateAll();
+    for (const type of Object.keys(this.hiddenCount)) {
+      const disabled = LStorage.Blocking[`DisableHide${type}`];
+      if (disabled) {
+        this.deactivateType(type);
+      }
+    }
+  }
+
+  static hide ($selector, name) {
+    this.hiddenCount[name] += $selector.length;
+    $selector.hide();
+  }
+
+  static show ($selector, name) {
+    this.hiddenCount[name] -= $selector.length;
+    $selector.show();
+  }
+
+  static text (name) {
+    const n = this.hiddenCount[name];
+    return `${n} ${this.nameMap[name]}${n === 1 ? "" : "s"} on this page ${n === 1 ? "was" : "were"} hidden due to a user being blocked.`;
+  }
+
+  static updateText () {
+    let html = "";
+    for (const [name, counts] of Object.entries(this.hiddenCount)) {
+      if (counts === 0) {
+        if (this.disabled.includes(name)) {
+          html += `<p>Hiding of ${this.nameMap[name]}s has been disabled. Click <a href="#" class="reactivate-blocks" data-block-type="${name}">here</a> to reenable blocking.</p>`;
+        }
+        continue;
+      }
+
+      html += `<p>${this.text(name)} Click <a href="#" class="deactivate-blocks" data-block-type="${name}">here</a> to temporarily disable blocking these.</p>`;
+    }
+
+    $(".blocked-notice").html(html);
+    this.reinitialize_listeners();
+  }
+
+  static toggle (id, hide = true) {
+    const entry = this.entries.find(e => e.target_id === id);
+    if (!entry) {
+      return;
+    }
+
+    const { hide_blips, hide_comments, hide_forum_topics, hide_forum_posts } = entry;
+
+    if (hide_blips) {
+      if (hide) {
+        this.hide($(`article.blip[data-creator-id=${entry.target_id}]:visible`), "Blips");
+      } else {
+        this.show($(`article.blip[data-creator-id=${entry.target_id}]:hidden`), "Blips");
+      }
+    }
+
+    if (hide_comments) {
+      if (hide) {
+        this.hide($(`article.comment[data-creator-id=${entry.target_id}]:visible`), "Comments");
+      } else {
+        this.show($(`article.comment[data-creator-id=${entry.target_id}]:hidden`), "Comments");
+      }
+    }
+
+    if (hide_forum_topics) {
+      if (hide) {
+        this.hide($(`tr.forum-topic-row[data-creator-id=${entry.target_id}]:visible`), "ForumTopics");
+      } else {
+        this.show($(`tr.forum-topic-row[data-creator-id=${entry.target_id}]:hidden`), "ForumTopics");
+      }
+    }
+
+    if (hide_forum_posts) {
+      if (hide) {
+        this.hide($(`article.forum-post[data-creator-id=${entry.target_id}]:visible`), "ForumPosts");
+      } else {
+        this.show($(`article.forum-post[data-creator-id=${entry.target_id}]:hidden`), "ForumPosts");
+      }
+    }
+  }
+
+  static activate (id) { return this.toggle(id, true); }
+
+  static deactivate (id) { return this.toggle(id, false); }
+
+  static activateAll () { return this.entries.map(e => this.activate(e.target_id)); }
+
+  static deactivateAll () { return this.entries.map(e => this.deactivate(e.target_id)); }
+
+  static activateType (name) {
+    if (!this.disabled.includes(name)) {
+      return;
+    }
+
+    const entries = this.entries.filter(e => e[`hide_${this.nameMap[name].replaceAll(" ", "_")}s`] === true);
+    entries.forEach(e => this.activate(e.target_id));
+    this.disabled.splice(this.disabled.indexOf(name), 1);
+    LStorage.Blocking[`DisableHide${name}`] = false;
+    this.updateText();
+  }
+
+  static deactivateType (name) {
+    if (this.disabled.includes(name)) {
+      return;
+    }
+
+    const entries = this.entries.filter(e => e[`hide_${this.nameMap[name].replaceAll(" ", "_")}s`] === true);
+    entries.forEach(e => this.deactivate(e.target_id));
+    this.disabled.push(name);
+    LStorage.Blocking[`DisableHide${name}`] = true;
+    this.updateText();
+  }
+
+  static reinitialize_listeners () {
+    $(".deactivate-blocks").off("click.e621.block").on("click.e621.block", function (event) {
+      event.preventDefault();
+      Block.deactivateType($(event.currentTarget).data("block-type"));
+    });
+    $(".reactivate-blocks").off("click.e621.block").on("click.e621.block", function (event) {
+      event.preventDefault();
+      Block.activateType($(event.currentTarget).data("block-type"));
+    });
+  }
+}
+
+$(document).ready(function () {
+  Block.init();
+  Block.updateText();
+});
+
+export default Block;

--- a/app/javascript/src/javascripts/utility/storage.js
+++ b/app/javascript/src/javascripts/utility/storage.js
@@ -77,5 +77,17 @@ LStorage.Posts.TagScript = {
   },
 };
 
+LStorage.Blocking = {
+  /** @returns {boolean} True if the user has disabled hiding blips */
+  DisableHideBlips: ["disable_hide_blips", false],
+  /** @returns {boolean} True if the user has disabled hiding comments */
+  DisableHideComments: ["disable_hide_comments", false],
+  /** @returns {boolean} True if the user has disabled hiding forum topics */
+  DisableHideForumTopics: ["disable_hide_forum_topics", false],
+  /** @returns {boolean} True if the user has disabled hiding forum posts */
+  DisableHideForumPosts: ["disable_hide_forum_posts", false],
+};
+StorageUtils.bootstrapMany(LStorage.Blocking);
+
 
 export default LStorage;

--- a/app/logical/apng_inspector.rb
+++ b/app/logical/apng_inspector.rb
@@ -24,7 +24,7 @@ class ApngInspector
 
   #This function calls associated block for each PNG chunk
   #parameters passed are |chunk_name, chunk_length, file_descriptor|
-  #returns true if file is read succesfully from start to IEND,
+  #returns true if file is read successfully from start to IEND,
   #or if 100 000 chunks are read; returns false otherwise.
   def each_chunk
     iend_reached = false

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -169,7 +169,7 @@ class Dmail < ApplicationRecord
       errors.add(:to_name, "is not a valid recipient while blocking DMails from others. You may only message janitors and above")
       return false
     end
-    if to.is_blacklisting_user?(from)
+    if to.is_blacklisting_user?(from) || to.is_blocking_messages_from?(from)
       errors.add(:to_name, "does not wish to receive DMails from you")
       return false
     end

--- a/app/models/user_block.rb
+++ b/app/models/user_block.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class UserBlock < ApplicationRecord
+  belongs_to :user
+  belongs_to :target, class_name: "User"
+  validates :target_id, uniqueness: { scope: :user_id }
+  validate :validate_staff_user_not_blocking_messages
+  validate :validate_target_valid
+
+  def target_name=(value)
+    self.target_id = User.name_to_id(value)
+  end
+
+  def target_name
+    return nil unless target_id
+    User.id_to_name(target_id)
+  end
+
+  def validate_target_valid
+    return if target_id.blank?
+    if target_id == user_id
+      errors.add(:base, "You cannot block yourself")
+      throw :abort
+    end
+
+    if target.is_staff? && disable_messages?
+      errors.add(:base, "You cannot block messages from staff members")
+    end
+  end
+
+  def validate_staff_user_not_blocking_messages
+    if user.is_staff? && disable_messages?
+      errors.add(:base, "You cannot block messages")
+      throw :abort
+    end
+  end
+end

--- a/app/views/dmails/show.html.erb
+++ b/app/views/dmails/show.html.erb
@@ -33,6 +33,7 @@
         <% end %>
         <% if @dmail.to_id == CurrentUser.id %>
           | <%= link_to "Mark as unread", mark_as_unread_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as unread?" } %>
+          | <%= link_to "Block sender", new_user_block_path(@dmail.to, user_block: { target_id: @dmail.from_id }) %>
           | <%= link_to "Report", new_ticket_path(disp_id: @dmail.id, qtype: 'dmail') %>
         <% end %>
       </p>

--- a/app/views/forum_posts/index.html.erb
+++ b/app/views/forum_posts/index.html.erb
@@ -12,7 +12,7 @@
       </thead>
       <tbody>
         <% @forum_posts.each do |forum_post| %>
-          <tr id="forum-post-<%= forum_post.id %>" data-topic-is-hidden="<%= forum_post.topic.is_hidden? %>" data-is-hidden="<%= forum_post.is_hidden? %>">
+          <tr id="forum-post-<%= forum_post.id %>" data-topic-is-hidden="<%= forum_post.topic.is_hidden? %>" data-creator-id="<%= forum_post.creator_id %>" data-is-hidden="<%= forum_post.is_hidden? %>">
             <td class="forum-post-topic-title">
               <%= link_to forum_post.topic.title, forum_topic_path(forum_post.topic) %>
             </td>

--- a/app/views/forum_topics/_listing.html.erb
+++ b/app/views/forum_topics/_listing.html.erb
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     <% forum_topics.each do |topic| %>
-      <tr class="forum-topic-row forum-topic-category-<%= topic.category_id %>" data-topic-is-hidden="<%= topic.is_hidden? %>">
+      <tr class="forum-topic-row forum-topic-category-<%= topic.category_id %>" data-topic-is-hidden="<%= topic.is_hidden? %>" data-creator-id="<%= topic.creator_id %>">
         <td>
           <% if topic.is_sticky? %>
             <span class="sticky">Sticky:</span>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -23,7 +23,7 @@
 <% else %>
   <meta name="blacklisted-tags" content="[]">
   <meta name="blacklist-users" content="false">
-<% end %>
+<% end %><meta name="user-blocks" content="<%= CurrentUser.user.blocks.to_json %>">
 <meta name="enable-js-navigation" content="<%= CurrentUser.user.enable_keyboard_navigation %>">
 <meta name="enable-auto-complete" content="<%= CurrentUser.user.enable_auto_complete %>">
 <meta name="style-usernames" content="<%= CurrentUser.user.style_usernames? %>">

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -47,6 +47,8 @@
       <a href="#" id="close-notice-link">close</a>
     </div>
 
+    <div class="info blocked-notice"></div>
+
     <%= yield :layout %>
   </div>
 

--- a/app/views/pools/new.html.erb
+++ b/app/views/pools/new.html.erb
@@ -1,5 +1,5 @@
 <div id="c-pools">
-  <div id="c-new">
+  <div id="a-new">
     <h2>New Pool</h2>
 
     <p style="font-weight: bold;">Before creating a pool, read the <%= link_to "pool guidelines", wiki_page_path(:id => "e621:pools") %>.</p>

--- a/app/views/takedowns/new.html.erb
+++ b/app/views/takedowns/new.html.erb
@@ -1,5 +1,5 @@
 <div id="c-takedowns">
-  <div id="c-new">
+  <div id="a-new">
     <h4>You may request a takedown by submitting the following form.</h4>
     <p>Please read our <%= link_to "takedown policy page", takedown_static_path %> before submitting a takedown request form. This form is for use ONLY by people who have a legitimate copyright/trademark infringement claim.</p>
     <p>If you feel you need to handle a takedown request with an admin personally, you can email <%= Danbooru.config.takedown_email %></p>

--- a/app/views/user_blocks/_secondary_links.html.erb
+++ b/app/views/user_blocks/_secondary_links.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:secondary_links) do %>
+  <%= subnav_link_to "List", user_blocks_path(@user) %>
+  <% if CurrentUser.user == @user %>
+    <%= subnav_link_to "New", new_user_block_path(@user) %>
+  <% end %>
+<% end %>

--- a/app/views/user_blocks/edit.html.erb
+++ b/app/views/user_blocks/edit.html.erb
@@ -1,0 +1,19 @@
+<div id="c-users-blocks">
+  <div id="a-edit">
+    <h2>Edit User Block</h2>
+
+    <%= custom_form_for(@block, url: user_block_path(@user, @block.id)) do |f| %>
+      <%= f.input(:hide_blips) %>
+      <%= f.input(:hide_comments) %>
+      <%= f.input(:hide_forum_topics) %>
+      <%= f.input(:hide_forum_posts) %>
+      <%= f.input(:disable_messages) %>
+      <%= f.button(:submit, "Update Block") %>
+    <% end %>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+<% content_for(:page_title) do %>
+  Edit User Block
+<% end %>

--- a/app/views/user_blocks/index.html.erb
+++ b/app/views/user_blocks/index.html.erb
@@ -1,0 +1,42 @@
+<div id="c-users-blocks">
+  <div id="a-index">
+    <table class="striped">
+      <thead>
+      <tr>
+        <th>User</th>
+        <th>Hide Blips</th>
+        <th>Hide Comments</th>
+        <th>Hide Forum Topics</th>
+        <th>Hide Forum Posts</th>
+        <th>Disable Messages</th>
+        <th></th>
+      </tr>
+      </thead>
+      <tbody>
+      <% @blocks.each do |block| %>
+        <tr>
+          <td><%= link_to_user(block.target) %></td>
+          <td><%= block.hide_blips ? "Yes" : "No" %></td>
+          <td><%= block.hide_comments ? "Yes" : "No" %></td>
+          <td><%= block.hide_forum_topics ? "Yes" : "No" %></td>
+          <td><%= block.hide_forum_posts ? "Yes" : "No" %></td>
+          <td><%= block.disable_messages ? "Yes" : "No" %></td>
+          <td>
+            <% if CurrentUser.user == @user %>
+              <%= link_to "Edit", edit_user_block_path(@user, block) %> |
+              <%= link_to "Remove", user_block_path(@user, block), method: :delete %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+    <%= numbered_paginator(@blocks) %>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+<% content_for(:page_title) do %>
+  Blocked Users List
+<% end %>

--- a/app/views/user_blocks/new.html.erb
+++ b/app/views/user_blocks/new.html.erb
@@ -1,0 +1,20 @@
+<div id="c-users-blocks">
+  <div id="a-new">
+    <h2>Block User</h2>
+
+    <%= custom_form_for(@block) do |f| %>
+      <%= f.input(:target_name, label: "User") %>
+      <%= f.input(:hide_blips) %>
+      <%= f.input(:hide_comments) %>
+      <%= f.input(:hide_forum_topics) %>
+      <%= f.input(:hide_forum_posts) %>
+      <%= f.input(:disable_messages) %>
+      <%= f.button(:submit, "Block") %>
+    <% end %>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+<% content_for(:page_title) do %>
+  Block User
+<% end %>

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -13,9 +13,18 @@
       <%= subnav_link_to "Settings", edit_user_path(CurrentUser.user) %>
       <%= subnav_link_to "Profile", user_path(CurrentUser.user) %>
       <%= subnav_link_to "Messages #{unread_dmails(CurrentUser.user)}", dmails_current_folder_path %>
+      <%= subnav_link_to "Blocked Users", user_blocks_path(CurrentUser.user) %>
     <% else %>
       <%= subnav_link_to "Send message", new_dmail_path(dmail: { to_id: @user.id }) %>
       <%= subnav_link_to "Report/Commend", new_ticket_path(disp_id: @user.id, qtype: "user") %>
+      <% if CurrentUser.user.is_blocking?(@user) %>
+        <%= subnav_link_to "Edit Block", edit_user_block_path(CurrentUser.user, CurrentUser.user.block_for(@user)) %>
+      <% else %>
+        <%= subnav_link_to "Block", new_user_block_path(CurrentUser.user, user_block: { target_id: @user.id }) %>
+      <% end %>
+      <% if CurrentUser.user.is_admin? %>
+        <%= subnav_link_to "Blocked Users", user_blocks_path(@user) %>
+      <% end %>
     <% end %>
 
     <% if CurrentUser.is_admin? %>

--- a/app/views/users/home.html.erb
+++ b/app/views/users/home.html.erb
@@ -142,6 +142,7 @@
       <li>» <%= link_to "My profile", action: "show", id: CurrentUser.id %></li>
       <li>» <%= link_to "My messages", dmails_path %></li>
       <li>» <%= link_to "My favorites", favorites_path %></li>
+      <li>» <%= link_to "My blocked users", user_blocks_path(CurrentUser.user) %></li>
       <br>
       <li>» <%= link_to "My sets", post_sets_path(search: {creator_id: CurrentUser.id}) %></li>
       <li>» <%= link_to "Sets I maintain", post_sets_path(maintainer_id: CurrentUser.id) %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,6 +286,7 @@ Rails.application.routes.draw do
       post :view
     end
     resources :staff_notes, only: [:index, :new, :create], controller: "admin/staff_notes"
+    resources :blocks, only: %i[index new create edit update destroy], controller: "user_blocks"
 
     collection do
       get :home

--- a/db/migrate/20240814162849_create_user_blocks.rb
+++ b/db/migrate/20240814162849_create_user_blocks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateUserBlocks < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:user_blocks) do |t|
+      t.references(:user, foreign_key: true, null: false)
+      t.references(:target, foreign_key: { to_table: :users }, null: false)
+      t.boolean(:hide_blips, default: false, null: false)
+      t.boolean(:hide_comments, default: false, null: false)
+      t.boolean(:hide_forum_topics, default: false, null: false)
+      t.boolean(:hide_forum_posts, default: false, null: false)
+      t.boolean(:disable_messages, default: false, null: false)
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2160,6 +2160,43 @@ ALTER SEQUENCE public.uploads_id_seq OWNED BY public.uploads.id;
 
 
 --
+-- Name: user_blocks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_blocks (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    target_id bigint NOT NULL,
+    hide_blips boolean DEFAULT false NOT NULL,
+    hide_comments boolean DEFAULT false NOT NULL,
+    hide_forum_topics boolean DEFAULT false NOT NULL,
+    hide_forum_posts boolean DEFAULT false NOT NULL,
+    disable_messages boolean DEFAULT false NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: user_blocks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_blocks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_blocks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_blocks_id_seq OWNED BY public.user_blocks.id;
+
+
+--
 -- Name: user_feedback; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2839,6 +2876,13 @@ ALTER TABLE ONLY public.uploads ALTER COLUMN id SET DEFAULT nextval('public.uplo
 
 
 --
+-- Name: user_blocks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_blocks ALTER COLUMN id SET DEFAULT nextval('public.user_blocks_id_seq'::regclass);
+
+
+--
 -- Name: user_feedback id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3343,6 +3387,14 @@ ALTER TABLE ONLY public.upload_whitelists
 
 ALTER TABLE ONLY public.uploads
     ADD CONSTRAINT uploads_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_blocks user_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_blocks
+    ADD CONSTRAINT user_blocks_pkey PRIMARY KEY (id);
 
 
 --
@@ -4362,6 +4414,20 @@ CREATE INDEX index_uploads_on_uploader_ip_addr ON public.uploads USING btree (up
 
 
 --
+-- Name: index_user_blocks_on_target_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_blocks_on_target_id ON public.user_blocks USING btree (target_id);
+
+
+--
+-- Name: index_user_blocks_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_blocks_on_user_id ON public.user_blocks USING btree (user_id);
+
+
+--
 -- Name: index_user_feedback_on_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4662,11 +4728,27 @@ ALTER TABLE ONLY public.favorites
 
 
 --
+-- Name: user_blocks fk_rails_d2416b669a; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_blocks
+    ADD CONSTRAINT fk_rails_d2416b669a FOREIGN KEY (target_id) REFERENCES public.users(id);
+
+
+--
 -- Name: avoid_postings fk_rails_d45cc0f1a1; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.avoid_postings
     ADD CONSTRAINT fk_rails_d45cc0f1a1 FOREIGN KEY (creator_id) REFERENCES public.users(id);
+
+
+--
+-- Name: user_blocks fk_rails_d98a90b4c8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_blocks
+    ADD CONSTRAINT fk_rails_d98a90b4c8 FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
 --
@@ -4676,6 +4758,7 @@ ALTER TABLE ONLY public.avoid_postings
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240814162849'),
 ('20240726170041'),
 ('20240709134926'),
 ('20240706061122'),

--- a/test/controllers/user_blocks_controller_test.rb
+++ b/test/controllers/user_blocks_controller_test.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UserBlocksControllerTest < ActionDispatch::IntegrationTest
+  context "The user blocks controller" do
+    setup do
+      @user = create(:user)
+      @user2 = create(:user)
+      @admin = create(:admin_user)
+      CurrentUser.user = @user
+    end
+
+    context "index action" do
+      should "allow user to view their own blocks" do
+        get_auth user_blocks_path(@user), @user
+        assert_response :success
+      end
+
+      should "not allow users to view other users blocks" do
+        get_auth user_blocks_path(@user2), @user
+        assert_response :forbidden
+      end
+
+      should "allow admins to view other users blocks" do
+        get_auth user_blocks_path(@user), @admin
+        assert_response :success
+      end
+    end
+
+    context "create action" do
+      context "as a member" do
+        should "allow blocking other members" do
+          post_auth user_blocks_path(@user), @user, params: { user_block: { target_id: @user2.id, disable_messages: true }, format: :json }
+          assert_response :success
+
+          assert @user.is_blocking_messages_from?(@user2)
+        end
+
+        should "not allow blocking messages from staff" do
+          post_auth user_blocks_path(@user), @user, params: { user_block: { target_id: @admin.id, disable_messages: true }, format: :json }
+          assert_response :unprocessable_entity
+          assert_includes(@response.parsed_body.dig("errors", "base"), "You cannot block messages from staff members")
+
+          assert_not @user.is_blocking_messages_from?(@user2)
+        end
+
+        should "not allow blocking self" do
+          post_auth user_blocks_path(@user), @user, params: { user_block: { target_id: @user.id, hide_comments: true }, format: :json }
+          assert_response :unprocessable_entity
+          assert_includes(@response.parsed_body.dig("errors", "base"), "You cannot block yourself")
+
+          assert_not @admin.is_blocking_comments_from?(@admin)
+        end
+
+        should "not allow creating duplicate blocks" do
+          create(:user_block, user: @user, target: @user2)
+          post_auth user_blocks_path(@user), @user, params: { user_block: { target_id: @user2.id, hide_comments: true }, format: :json }
+          assert_response :unprocessable_entity
+          assert_includes(@response.parsed_body.dig("errors", "target_id"), "has already been taken")
+        end
+
+        should "not allow creating invalid blocks" do
+          post_auth user_blocks_path(@user), @user, params: { user_block: { hide_comments: true }, format: :json }
+          assert_response :unprocessable_entity
+          assert_includes(@response.parsed_body.dig("errors", "target"), "must exist")
+        end
+
+        should "not allow creating blocks for others" do
+          post_auth user_blocks_path(@user), @user2, params: { user_block: { target_id: @user2.id, hide_comments: true }, format: :json }
+          assert_response :forbidden
+
+          assert_not @user.is_blocking_comments_from?(@user2)
+        end
+      end
+
+      context "as an admin" do
+        should "allow blocking other members" do
+          post_auth user_blocks_path(@admin), @admin, params: { user_block: { target_id: @user.id, hide_comments: true }, format: :json }
+          assert_response :success
+
+          assert @admin.is_blocking_comments_from?(@user)
+          assert_not @admin.is_blocking_messages_from?(@user)
+        end
+
+        should "not allow blocking messages" do
+          post_auth user_blocks_path(@admin), @admin, params: { user_block: { target_id: @user.id, disable_messages: true }, format: :json }
+          assert_response :unprocessable_entity
+          assert_includes(@response.parsed_body.dig("errors", "base"), "You cannot block messages")
+
+          assert_not @admin.is_blocking_messages_from?(@user)
+        end
+
+        should "not allow creating blocks for others" do
+          post_auth user_blocks_path(@user), @admin, params: { user_block: { target_id: @admin.id, hide_comments: true }, format: :json }
+          assert_response :forbidden
+
+          assert_not @user.is_blocking_comments_from?(@admin)
+        end
+      end
+    end
+
+    context "update action" do
+      context "as a member" do
+        setup do
+          @block = create(:user_block, user: @user, target: @user2)
+        end
+
+        should "allow updating" do
+          assert_not @user.is_blocking_messages_from?(@user2)
+
+          put_auth user_block_path(@user, @block), @user, params: { user_block: { disable_messages: true }, format: :json }
+          assert_response :success
+
+          assert @user.is_blocking_messages_from?(@user2)
+        end
+
+        should "not allow blocking messages from staff" do
+          block = create(:user_block, user: @user, target: @admin)
+          put_auth user_block_path(@user, block), @user, params: { user_block: { disable_messages: true }, format: :json }
+          assert_response :unprocessable_entity
+          assert_includes(@response.parsed_body.dig("errors", "base"), "You cannot block messages from staff members")
+
+          assert_not @user.is_blocking_messages_from?(@admin)
+        end
+
+        should "not allow editing target" do
+          put_auth user_block_path(@user, @block), @user, params: { user_block: { target_id: @admin.id, hide_comments: true }, format: :json }
+          assert_response :forbidden
+
+          assert_equal(@user2, @block.reload.target)
+        end
+
+        should "not allow editing others blocks" do
+          put_auth user_block_path(@user, @block), @user2, params: { user_block: { hide_comments: true }, format: :json }
+          assert_response :forbidden
+
+          assert_not @user.is_blocking_comments_from?(@user2)
+        end
+      end
+
+      context "as an admin" do
+        setup do
+          @block = create(:user_block, user: @admin, target: @user)
+        end
+
+        should "allow updating" do
+          assert_not @admin.is_blocking_comments_from?(@user)
+
+          put_auth user_block_path(@admin, @block), @admin, params: { user_block: { hide_comments: true }, format: :json }
+          assert_response :success
+
+          assert @admin.is_blocking_comments_from?(@user)
+        end
+
+        should "not allow blocking messages" do
+          put_auth user_block_path(@admin, @block), @admin, params: { user_block: { disable_messages: true }, format: :json }
+          assert_response :unprocessable_entity
+          assert_includes(@response.parsed_body.dig("errors", "base"), "You cannot block messages")
+
+          assert_not @admin.is_blocking_messages_from?(@user)
+        end
+
+        should "not allow editing target" do
+          put_auth user_block_path(@admin, @block), @admin, params: { user_block: { target_id: @user2.id, hide_comments: true }, format: :json }
+          assert_response :forbidden
+
+          assert_equal(@user, @block.reload.target)
+        end
+
+        should "not allow editing others blocks" do
+          block = create(:user_block, user: @user, target: @user2)
+          put_auth user_block_path(@user, block), @admin, params: { user_block: { hide_comments: true }, format: :json }
+          assert_response :forbidden
+
+          assert_not @user.is_blocking_comments_from?(@user2)
+        end
+      end
+    end
+
+    context "delete action" do
+      context "as a member" do
+        setup do
+          @block = create(:user_block, user: @user, target: @user2)
+        end
+
+        should "work" do
+          delete_auth user_block_path(@user, @block), @user, params: { format: :json }
+          assert_response :success
+
+          assert_raises(ActiveRecord::RecordNotFound) do
+            @block.reload
+          end
+        end
+
+        should "not allow deleting others blocks" do
+          delete_auth user_block_path(@user, @block), @user2, params: { format: :json }
+          assert_response :forbidden
+
+          assert_nothing_raised do
+            @block.reload
+          end
+        end
+      end
+
+      context "as an admin" do
+        setup do
+          @block = create(:user_block, user: @admin, target: @user)
+        end
+
+        should "work" do
+          delete_auth user_block_path(@admin, @block), @admin, params: { format: :json }
+          assert_response :success
+
+          assert_raises(ActiveRecord::RecordNotFound) do
+            @block.reload
+          end
+        end
+
+        should "not allow deleting others blocks" do
+          block = create(:user_block, user: @user, target: @user2)
+          delete_auth user_block_path(@user, block), @admin, params: { format: :json }
+          assert_response :forbidden
+
+          assert_nothing_raised do
+            @block.reload
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/factories/user_block.rb
+++ b/test/factories/user_block.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:user_block) do
+    target { create(:user) }
+  end
+end


### PR DESCRIPTION
This pr adds a fully featured blocking system.

Hiding blips, comments, forum topics/posts, and blocking dmails can each be selected separately.
![image](https://github.com/user-attachments/assets/32f27c3a-c1f8-4746-a26b-d81d3f8b1356)
![image](https://github.com/user-attachments/assets/0a0d4d9c-56bf-4fec-8876-0962ab140a97)

Each of these has a link to toggle blocking. This toggle is persistent in the current browser.
![image](https://github.com/user-attachments/assets/f78f4ab1-317b-4a2b-a71a-df49a9da7613)

Admins can view the blocks of anyone, but they cannot edit them or block people on their behalf.
Staff members cannot disable messages, but they can use any other option.
![image](https://github.com/user-attachments/assets/34c9b627-c2cd-4090-a1a9-f3d5499017f4)
