### PR TITLE
[Posts] Always show uploader if they are a verified artist

### DIFF
--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -13,7 +13,7 @@
     Posted: <%= link_to time_ago_in_words_tagged(post.created_at), posts_path(:tags => "date:#{post.created_at.to_date}"), :rel => "nofollow" %>
     <meta itemprop="uploadDate" content="<%= post.created_at.iso8601 %>">
   </li>
-  <% if CurrentUser.is_janitor? %>
+  <% if CurrentUser.is_janitor? || post.uploader_linked_artists.any? %>
     <li>
       Uploader: <%= link_to_user(post.uploader) %> <%= user_record_meta(post.uploader) %>
       <% if post.uploader_linked_artists.any? %>


### PR DESCRIPTION
This pr shows the uploader of the post to everyone if the uploader is linked to an artist on the post.
https://github.com/orgs/e621ng/projects/1/views/1?pane=issue&itemId=73408921