### PR TITLE
Mobile Fixes

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -29,10 +29,12 @@ Blacklist.init_anonymous_blacklist = function () {
 
 /** Set up the modal dialogue with the blacklist editor */
 Blacklist.init_blacklist_editor = function () {
+  let windowWidth = $(window).width(),
+    windowHeight = $(window).height();
   $("#blacklist-edit-dialog").dialog({
     autoOpen: false,
-    width: $(window).width() > 400 ? 400 : "auto",
-    height: 400,
+    width: windowWidth > 400 ? 400 : windowWidth,
+    height: windowHeight > 400 ? 400 : windowHeight,
   });
 
   $("#blacklist-cancel").on("click", function () {

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -1,7 +1,7 @@
 /*** Quick Edit Form ***/
 #blacklist-edit-dialog {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: 1fr 1fr;
   grid-template-rows: min-content 1fr min-content;
   gap: 0.5rem;
 
@@ -10,8 +10,15 @@
   }
   p {
     margin-bottom: 0;
-    text-align: center;
+    text-align: right;
+    text-wrap: nowrap;
   }
+  #blacklist-save,
+  #blacklist-cancel {
+    width: min-content;
+    height: 2em;
+  }
+  #blacklist-cancel { justify-self: end; }
 }
 
 /*** Sidebar Blacklist ***/

--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -5,6 +5,8 @@
 }
 
 .styled-dtext {
+  font-size: 1rem;
+
   div.spoiler, details, pre, blockquote, ul {
     margin-bottom: 0.75em;
   }

--- a/app/javascript/src/styles/common/z_responsive.scss
+++ b/app/javascript/src/styles/common/z_responsive.scss
@@ -86,8 +86,8 @@
     }
 
     div#page {
-      padding-left: 0;
-      padding-right: 0;
+      margin: 0 0.25rem;
+      padding: 0.5rem 0.25rem;
 
       > div /* div#c-$controller */
       {
@@ -313,10 +313,6 @@
       h1 {
         display: inline; //Needed for menu button
       }
-    }
-
-    div#page {
-      margin: 0;
     }
   }
 }

--- a/app/javascript/src/styles/specific/uploads.scss
+++ b/app/javascript/src/styles/specific/uploads.scss
@@ -104,6 +104,7 @@ div#c-uploads {
 
       input {
         margin-bottom: 2px;
+        width: 100%;
       }
     }
 

--- a/app/javascript/src/styles/specific/uploads_file.scss
+++ b/app/javascript/src/styles/specific/uploads_file.scss
@@ -85,6 +85,7 @@
     input[type="text"] {
       font-family: monospace;
       font-size: 1rem; // Match the upload page inputs
+      width: 100%; // Prevent overflow
       text-align: center;
       box-sizing: border-box;
       flex: 1;

--- a/app/views/posts/partials/common/_blacklist_editor.html.erb
+++ b/app/views/posts/partials/common/_blacklist_editor.html.erb
@@ -1,7 +1,7 @@
 <div id="blacklist-edit-dialog" title="<% if CurrentUser.is_anonymous? %> Anonymous <% end %>Blacklist" style="display: none;">
   <h4>Tag Blacklist</h4>
+  <p><%= link_to "Blacklist Help", help_page_path(id: "blacklist") %></p>
   <textarea id="blacklist-edit" rows="8" cols="30"></textarea>
   <input type="button" value="Save" id="blacklist-save"/>
-  <p>[ <%= link_to "Blacklist Help", help_page_path(id: "blacklist") %> ]</p>
   <input type="button" value="Cancel" id="blacklist-cancel" />
 </div>


### PR DESCRIPTION
This is a bunch of miscellaneous UI fixes based on the recent mobile site audit.

1. Enhancing Readability
    Increased the font size in DText to 16px. This is less ideal than changing the global font size, but a quick fix will do for now.
    A larger project for updating the font size to a more reasonable one will be coming later.
2. Creating Space and Reducing Clutter
    Added margins and padding to the mobile site, as per the recommendation.
3. Blacklist Modal
    Tweaked the width and height to match the corresponding page dimensions if it's less than the default.
    Shuffled the UI a little to avoid the layout shifting around when at low resolutions.
4. Uploads Page
    Fixed an issue with the text inputs that caused them to overflow the page.