### PR TITLE
[Blacklist] Add wildcard support

### DIFF
--- a/app/javascript/src/javascripts/models/Filter.js
+++ b/app/javascript/src/javascripts/models/Filter.js
@@ -138,7 +138,12 @@ class FilterToken {
 
     // Get filter type: tag, id, score, rating, etc.
     this.type = FilterUtils.getFilterType(raw);
-    if (this.type != "tag") raw = raw.slice(this.type.length + 1);
+    if (this.type !== "tag") raw = raw.slice(this.type.length + 1);
+    else if (raw.includes("*")) {
+      this.value = new RegExp(raw.replaceAll(/\*/g, ".*"));
+      this.type = "wildcard";
+      return;
+    }
 
     // Get comparison methods: equals, smaller then, etc
     this.comparison = FilterUtils.getComparison(raw);

--- a/app/javascript/src/javascripts/utility/filter_util.js
+++ b/app/javascript/src/javascripts/utility/filter_util.js
@@ -34,6 +34,9 @@ FilterUtils.FilterTests = {
   username: (token, post) => post.uploader === token.value,
 
   pool: (token, post) => post.pools.includes(parseInt(token.value) || 0),
+
+  // Not a supported metatag, type is assigned manually
+  wildcard: (token, post) => FilterUtils.wildcardTagMatchesFilter(post, token.value),
 };
 
 /** Array of supported metatags. */
@@ -88,6 +91,8 @@ FilterUtils.getComparison = (input) => {
  */
 FilterUtils.normalizeData = (value, type) => {
   switch (type) {
+    case "tag":
+      return value;
     case "tagcount":
     case "id":
     case "width":
@@ -136,6 +141,12 @@ FilterUtils.compare = (a, token) => {
  */
 FilterUtils.tagsMatchesFilter = (post, filter) => {
   return post.tags.indexOf(filter) >= 0;
+};
+
+FilterUtils.wildcardTagMatchesFilter = (post, filter) => {
+  for (const one of post.tags)
+    if (filter.test(one)) return true;
+  return false;
 };
 
 /**


### PR DESCRIPTION
Exactly what it says on the tin.
The blacklist tags can now contain asterisk `*` symbols that are used as wildcards.

There is a mild performance impact, of course, since the blacklist now has to check for asterisks in every non-meta tag.
But it should be barely noticeable to the users.