### PR TITLE
[Blacklist] Mark posts that match any filters

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -7,7 +7,10 @@ let Blacklist = {};
 
 Blacklist.isAnonymous = false;
 Blacklist.filters = {};
+
 Blacklist.hiddenPosts = new Set();
+Blacklist.matchedPosts = new Set();
+
 Blacklist.ui = [];
 
 /** Import the anonymous blacklist from the LocalStorage */
@@ -196,6 +199,24 @@ Blacklist.update_visibility = function () {
     });
 };
 
+/**
+ * Adds a `filter-matches` class to any thumbnails that match any of the filters,
+ * including disabled ones. Only needs to run after new posts get added to the page.
+ */
+Blacklist.update_styles = function () {
+  let allPosts = [];
+  for (const filter of Object.values(Blacklist.filters))
+    allPosts = allPosts.concat(Array.from(filter.matchIDs));
+  Blacklist.matchedPosts = new Set(allPosts);
+  console.log("matched", Blacklist.matchedPosts);
+
+  $(".filter-matches").removeClass("filter-matches");
+  for (const postID of Blacklist.matchedPosts)
+    PostCache.apply(postID, ($element) => {
+      $element.addClass("filter-matches");
+    });
+};
+
 $(() => {
   Blacklist.init_anonymous_blacklist();
   Blacklist.init_blacklist_editor();
@@ -203,6 +224,7 @@ $(() => {
 
   Blacklist.regenerate_filters();
   Blacklist.add_posts($(".blacklistable"));
+  Blacklist.update_styles();
   Blacklist.update_visibility();
   $("#blacklisted-hider").remove();
 

--- a/app/javascript/src/javascripts/thumbnails.js
+++ b/app/javascript/src/javascripts/thumbnails.js
@@ -61,6 +61,7 @@ Thumbnails.initialize = function () {
 
   if (replacedPosts.length > 0) {
     Blacklist.add_posts(replacedPosts);
+    Blacklist.update_styles();
     Blacklist.update_visibility();
   }
 

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -23,6 +23,9 @@ article.post-preview {
     font-size: 80%;
     margin-bottom: 0;
   }
+  &.filter-matches .desc {
+    background-color: var(--palette-background-red);
+  }
 
   .post-score>span {
     font-size: 0.8rem;


### PR DESCRIPTION
Even if the filter is disabled, the post still gets a class that makes the info bar red.

![Screenshot 2024-08-22 105603](https://github.com/user-attachments/assets/80ee7945-30b1-4f4c-817b-a0e581dbe8b3)