### PR TITLE
[PostFlags] Move flag reasons into database

### DIFF
--- a/app/controllers/post_flag_reasons_controller.rb
+++ b/app/controllers/post_flag_reasons_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class PostFlagReasonsController < ApplicationController
+  before_action :admin_only, except: %i[index]
+  respond_to :html, :json
+  respond_to :js, only: %i[reorder]
+
+  def index
+    @reasons = PostFlagReason.ordered
+    respond_with(@reasons)
+  end
+
+  def new
+    @reason = PostFlagReason.new
+  end
+
+  def edit
+    @reason = PostFlagReason.find(params[:id])
+  end
+
+  def create
+    @reason = PostFlagReason.create(reason_params)
+    flash[:notice] = @reason.valid? ? "Post flag reason created" : @reason.errors.full_messages.join("; ")
+    redirect_to(post_flag_reasons_path)
+  end
+
+  def update
+    @reason = PostFlagReason.find(params[:id])
+    @reason.update(reason_params)
+    flash[:notice] = @reason.valid? ? "Post flag reason updated" : @reason.errors.full_messages.join("; ")
+    redirect_to(post_flag_reasons_path)
+  end
+
+  def destroy
+    @reason = PostFlagReason.find(params[:id])
+    @reason.destroy
+    respond_with(@reason)
+  end
+
+  def order
+    @reasons = PostFlagReason.ordered
+  end
+
+  def reorder
+    return render_expected_error(422, "Error: No post flag reasons provided") unless params[:_json].is_a?(Array) && params[:_json].any?
+    changes = 0
+    PostFlagReason.transaction do
+      params[:_json].each do |data|
+        reason = PostFlagReason.find(data[:id])
+        next if reason.order == data[:order].to_i
+        reason.update_column(:order, data[:order])
+        changes += 1
+      end
+
+      reasons = PostFlagReason.all
+      if reasons.any?(&:invalid?)
+        errors = []
+        reasons.each do |reason|
+          errors << { id: reason.id, name: reason.name, message: reason.errors.full_messages.join("; ") } if !reason.valid? && reason.errors.any?
+        end
+        render(json: { success: false, errors: errors }, status: 422)
+        raise(ActiveRecord::Rollback)
+      else
+        PostFlagReason.log_reorder(changes) if changes != 0
+        respond_to do |format|
+          format.json { head(204) }
+          format.js do
+            render(json: { html: render_to_string(partial: "post_flag_reasons/table", locals: { reasons: PostFlagReason.ordered }) })
+          end
+        end
+      end
+    end
+  rescue ActiveRecord::RecordNotFound
+    render_expected_error(422, "Error: Post flag reason not found")
+  end
+
+  private
+
+  def reason_params
+    params.require(:post_flag_reason).permit(%i[name reason text parent])
+  end
+end

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -289,6 +289,16 @@ class ModActionDecorator < ApplicationDecorator
     when "deleted_flag_reason"
       "Deleted flag reason ##{vals['flag_reason_id']} (#{vals['flag_reason']})"
 
+      ### Post Flag Reasons ###
+    when "post_flag_reason_create"
+      "Created post flag reason ##{vals['post_flag_reason_id']} (#{vals['name']})"
+    when "post_flag_reason_update"
+      "Edited post flag reason ##{vals['post_flag_reason_id']} (#{vals['name']})"
+    when "post_flag_reason_delete"
+      "Destroyed post flag reason ##{vals['post_flag_reason_id']} (#{vals['name']})"
+    when "post_flag_reasons_reorder"
+      "Reordered #{vals['count']} post flag #{'reason'.pluralize(vals['count'])}"
+
       ### Post Report Reasons ###
 
     when "report_reason_create"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,8 +30,9 @@ module ApplicationHelper
 
   def li_link_to(text, url, id_prefix: "", **options)
     klass = options.delete(:class)
+    li_options = options.delete(:li_options) || {}
     id = id_prefix + text.downcase.gsub(/[^a-z ]/, "").parameterize
-    tag.li(link_to(text, url, id: "#{id}-link", **options), id: id, class: klass)
+    tag.li(link_to(text, url, id: "#{id}-link", **options), id: id, class: klass, **li_options)
   end
 
   def dtext_ragel(text, **)

--- a/app/javascript/src/javascripts/post_flag_reasons.js
+++ b/app/javascript/src/javascripts/post_flag_reasons.js
@@ -1,0 +1,77 @@
+import Utility from "./utility";
+
+class PostFlagReasons {
+  static initialize_listeners () {
+    const $editOrderLink = $(".edit-order-link");
+    const $saveOrderLink = $(".save-order-link");
+    const $sortableReasons = $("#sortable-reasons");
+
+    $editOrderLink.on("click.e621.sorting", function (event) {
+      event.preventDefault();
+      $saveOrderLink.show();
+      $editOrderLink.hide();
+      $sortableReasons.sortable({
+        items: "tbody tr",
+      });
+      Utility.notice("Drag and drop to reorder.");
+    });
+
+    $saveOrderLink.on("click.e621.sorting", function (event) {
+      event.preventDefault();
+      $saveOrderLink.hide();
+      $.ajax({
+        url: "/post_flag_reasons/reorder.js",
+        type: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        data: PostFlagReasons.reorder_data(),
+        dataType: "json",
+        success (data) {
+          $("#sortable-rules-container").html(data.html);
+          Utility.notice("Order updated.");
+          $editOrderLink.show();
+          PostFlagReasons.reinitialize_listeners();
+        },
+        error (data) {
+          if (data.responseJSON.message) {
+            Utility.error(`Failed to update order: ${data.responseJSON.message}`);
+          } else if (data.responseJSON.errors) {
+            Utility.error(`Failed to update order:<br>${data.responseJSON.errors.map(e => `${e.name}: ${e.message}`).join("<br>")}`);
+          } else {
+            Utility.error("Failed to update order.");
+          }
+          $saveOrderLink.show();
+          $sortableReasons.sortable({
+            items: "tbody tr",
+          });
+        },
+      });
+    });
+  }
+
+  static reinitialize_listeners () {
+    $(".edit-order-link").off("click.e621.sorting");
+    $(".save-order-link").off("click.e621.sorting");
+    this.initialize_listeners();
+  }
+
+  static reorder_data () {
+    const data = [];
+    Array.from($("#sortable-reasons tbody tr")).forEach((category, index) => {
+      data.push({
+        id: Number(category.dataset.reasonId),
+        order: index + 1,
+      });
+    });
+    return JSON.stringify(data);
+  }
+}
+
+$(document).ready(function () {
+  if ($("#c-post-flag-reasons #a-order").length) {
+    PostFlagReasons.initialize_listeners();
+  }
+});
+
+export default PostFlagReasons;

--- a/app/models/post_flag_reason.rb
+++ b/app/models/post_flag_reason.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class PostFlagReason < ApplicationRecord
+  belongs_to_creator
+  belongs_to_updater
+
+  validates :name, uniqueness: true, length: { maximum: 128 }, presence: true
+  validates :reason, length: { maximum: 256 }, presence: true
+  validates :text, length: { maximum: 1024 }, presence: true
+  validates :order, uniqueness: true, numericality: { only_integer: true, greater_than: 0 }
+  scope :ordered, -> { order(:order) }
+
+  before_validation :initialize_order, on: :create
+  after_create :log_create
+  after_update :log_update
+  after_destroy :log_destroy
+  after_commit :invalidate_cache
+
+  def initialize_order
+    self.order = PostFlagReason.maximum(:order).to_i + 1
+  end
+
+  def invalidate_cache
+    Cache.delete("post_flag_reasons")
+  end
+
+  def self.cached
+    Cache.fetch("post_flag_reasons", expires_in: 12.hours) do
+      PostFlagReason.ordered.index_by { |x| x[:name] }
+    end
+  end
+
+  module LogMethods
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def log_reorder(count)
+        ModAction.log(:post_flag_reasons_reorder, { count: count })
+      end
+    end
+
+    def log_create
+      ModAction.log(:post_flag_reason_create, { post_flag_reason_id: id, name: name, reason: reason, text: text, parent: parent })
+    end
+
+    def log_update
+      ModAction.log(:post_flag_reason_update, { post_flag_reason_id: id, name: name, reason: reason, text: text, parent: parent })
+    end
+
+    def log_destroy
+      ModAction.log(:post_flag_reason_delete, { post_flag_reason_id: id, name: name, reason: reason, text: text, parent: parent })
+    end
+  end
+
+  include LogMethods
+end

--- a/app/views/post_flag_reasons/_form.html.erb
+++ b/app/views/post_flag_reasons/_form.html.erb
@@ -1,0 +1,7 @@
+<%= custom_form_for(@reason) do |f| %>
+  <%= f.input(:name, hint: "Used for internal things. Must be unique.") %>
+  <%= f.input(:reason, as: :dtext, hint: "Shown as the flag reason. Only inline dtext is allowed.", allow_color: false) %>
+  <%= f.input(:text, as: :dtext, hint: "Shown as a more detailed description under the reason.", allow_color: false) %>
+  <%= f.input(:parent, hint: "If a \"Parent #\" input should be present alongside the option.") %>
+  <%= f.button(:submit) %>
+<% end %>

--- a/app/views/post_flag_reasons/_secondary_links.html.erb
+++ b/app/views/post_flag_reasons/_secondary_links.html.erb
@@ -1,0 +1,12 @@
+<% content_for(:secondary_links) do %>
+  <%= subnav_link_to("Listing", post_flag_reasons_path) %>
+  <% if CurrentUser.is_admin? %>
+    <%= subnav_link_to("New", new_post_flag_reason_path) %>
+    <% if params[:action] == "order" %>
+      <%= subnav_link_to("Edit Order", "#", class: "edit-order-link") %>
+      <%= subnav_link_to("Save Order", "#", class: "save-order-link", li_options: { style: "display: none;" }) %>
+    <% else %>
+      <%= subnav_link_to("Change order", order_post_flag_reasons_path) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/post_flag_reasons/_table.html.erb
+++ b/app/views/post_flag_reasons/_table.html.erb
@@ -1,0 +1,58 @@
+<%# locals: (reasons:, sort: false) -%>
+
+<table class="striped">
+  <thead>
+  <tr>
+    <% if sort %>
+      <th width="15%">Name</th>
+      <th width="80%">Reason/Text</th>
+    <% else %>
+      <th width="11%">Name</th>
+      <th width="17%">Creator/Updater</th>
+      <th width="65%">Reason/Text</th>
+      <% if CurrentUser.is_admin? %>
+        <th width="7%"></th>
+      <% end %>
+    <% end %>
+  </tr>
+  </thead>
+  <tbody>
+  <% reasons.each do |reason| %>
+    <tr id="reason-<%= reason.id %>" data-reason-id="<%= reason.id %>">
+      <td><%= reason.name %></td>
+      <% unless sort %>
+        <td>
+          <p>
+            Created by <%= link_to_user(reason.creator) %>
+            <% if CurrentUser.is_admin? %>
+              (<%= link_to_ip(reason.creator_ip_addr) %>)
+            <% end %>
+            at <%= compact_time(reason.created_at) %>
+          </p>
+          <p>
+            Updated by <%= link_to_user(reason.updater) %>
+            <% if CurrentUser.is_admin? %>
+              (<%= link_to_ip(reason.updater_ip_addr) %>)
+            <% end %>
+            at <%= compact_time(reason.updated_at) %>
+          </p>
+        </td>
+      <% end %>
+      <td>
+        <p>
+          <b>Reason</b> <%= reason.reason %>
+        </p>
+        <p>
+          <b>Text</b> <%= reason.text %>
+        </p>
+      </td>
+      <% if !sort && CurrentUser.is_admin? %>
+        <td>
+          <%= link_to("Edit", edit_post_flag_reason_path(reason)) %>
+          | <%= link_to("Delete", post_flag_reason_path(reason), method: :delete, data: { confirm: "Are you sure? This action cannot be undone." }) %>
+        </td>
+      <% end %>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/post_flag_reasons/edit.html.erb
+++ b/app/views/post_flag_reasons/edit.html.erb
@@ -1,0 +1,13 @@
+<div id="c-post-flag-reasons">
+  <div id="a-edit">
+    <h1>Edit Post Flag Reason</h1>
+
+    <%= render "form" %>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Edit Post Flag Reason
+<% end %>

--- a/app/views/post_flag_reasons/index.html.erb
+++ b/app/views/post_flag_reasons/index.html.erb
@@ -1,0 +1,14 @@
+<div id="c-post-flag-reasons">
+  <div id="a-index">
+    <h1>Post Flag Reasons</h1>
+
+    <%= render(partial: "table", locals: { reasons: @reasons }) %>
+  </div>
+</div>
+
+
+<%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Post Flag Reasons
+<% end %>

--- a/app/views/post_flag_reasons/new.html.erb
+++ b/app/views/post_flag_reasons/new.html.erb
@@ -1,0 +1,13 @@
+<div id="c-post-flag-reasons">
+  <div id="a-new">
+    <h1>Create Post Flag Reason</h1>
+
+    <%= render "form" %>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Create Post Flag Reason
+<% end %>

--- a/app/views/post_flag_reasons/order.html.erb
+++ b/app/views/post_flag_reasons/order.html.erb
@@ -1,0 +1,15 @@
+<div id="c-post-flag-reasons">
+  <div id="a-order">
+    <h1>Order Post Flag Reasons</h1>
+
+    <div id="sortable-reasons">
+      <%= render(partial: "table", locals: { reasons: @reasons, sort: true }) %>
+    </div>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Order Post Flag Reasons
+<% end %>

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -3,8 +3,8 @@
   <div class="flag_post">
     <%= PostPresenter.preview(@post, show_deleted: true, no_blacklist: true) %>
   </div>
-  
-  
+
+
   <div class="dtext-container">
     <%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page)&.body) %>
   </div>
@@ -18,23 +18,23 @@
   <%= custom_form_for(post_flag) do |f| %>
     <%= f.hidden_field :post_id %>
 
-    <% Danbooru.config.flag_reasons.each do |flag_reason| %>
-      <% if flag_reason[:name] == "uploading_guidelines" && !@post.flaggable_for_guidelines? %>
+    <% PostFlagReason.cached.values.each do |reason| %>
+      <% if reason.name == "uploading_guidelines" && !@post.flaggable_for_guidelines? %>
         <% next %>
       <% end %>
 
       <label>
-        <%= radio_button_tag "post_flag[reason_name]", flag_reason[:name], false %>
-        <span class="flag-reason-title"><%= format_text(flag_reason[:reason], inline: true) %></span>
-        <div class="dtext-container flag-reason-text"><%= format_text(flag_reason[:text]) %></div>
+        <%= radio_button_tag "post_flag[reason_name]", reason.name, false %>
+        <span class="flag-reason-title"><%= format_text(reason.reason, inline: true) %></span>
+        <div class="dtext-container flag-reason-text"><%= format_text(reason.text) %></div>
       </label>
-      
-      <% if flag_reason[:parent] %>
-        <%= f.input :parent_id, as: :string, label: "Inferior of Post #" %>
+
+      <% if reason.parent? %>
+        <%= f.input :parent_id, as: :string, label: "Post #" %>
       <% end %>
-      
+
     <% end %>
-    
+
     <div>
       <%= f.submit "Submit" %>
     </div>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -112,13 +112,14 @@
         <% if CurrentUser.is_admin? %>
           <li><%= link_to("Admin Dashboard", admin_dashboard_path) %></li>
           <li><%= link_to("Email Blacklist", email_blacklists_path) %></li>
-          <li><%= link_to("Post Report Reasons", post_report_reasons_path) %></li>
           <li><%= link_to("Danger Zone", admin_danger_zone_index_path) %></li>
           <li><%= link_to("IP Bans", ip_bans_path) %></li>
           <li><%= link_to("Alt list", alt_list_admin_users_path) %></li>
           <li><%= link_to("Stuck DNP tags", new_admin_stuck_dnp_path) %></li>
           <li><%= link_to("Destroyed Posts", admin_destroyed_posts_path) %></li>
+          <li><%= link_to("Post Report Reasons", post_report_reasons_path) %></li>
         <% end %>
+        <li><%= link_to("Post Flag Reasons", post_flag_reasons_path) %></li>
         <li><%= link_to("Upload Whitelist", upload_whitelists_path) %></li>
         <li><%= link_to("Mod Actions", mod_actions_path) %></li>
         <li><%= link_to("Bulk Update Requests", bulk_update_requests_path) %></li>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -446,57 +446,6 @@ module Danbooru
       true
     end
 
-    def flag_reasons
-      [
-        {
-          name: "uploading_guidelines",
-          reason: "Does not meet the [[uploading_guidelines|uploading guidelines]]",
-          text: "This post fails to meet the site's standards, be it for artistic worth, image quality, relevancy, or something else.\nKeep in mind that your personal preferences have no bearing on this. If you find the content of a post objectionable, simply [[e621:blacklist|blacklist]] it.",
-        },
-        {
-          name: "young_human",
-          reason: "Young [[human]]-[[humanoid|like]] character in an explicit situation",
-          text: "Posts featuring human and human-like characters depicted in a sexual or explicit nude way, are not acceptable on this site.",
-        },
-        {
-          name: "dnp_artist",
-          reason: "The artist of this post is on the \"avoid posting list\":/static/avoid_posting",
-          text: "Certain artists have requested that their work is not to be published on this site, and were granted [[avoid_posting|Do Not Post]] status.\nSometimes, that status comes with conditions; see [[conditional_dnp]] for more information",
-        },
-        {
-          name: "pay_content",
-          reason: "Paysite, commercial, or subscription content",
-          text: "We do not host paysite or commercial content of any kind. This includes Patreon leaks, reposts from piracy websites, and so on.",
-        },
-        {
-          name: "trace",
-          reason: "Trace of another artist's work",
-          text: "Images traced from other artists' artwork are not accepted on this site. Referencing from something is fine, but outright copying someone else's work is not.\nPlease, leave more information in the comments, or simply add the original artwork as the posts's parent if it's hosted on this site.",
-        },
-        {
-          name: "previously_deleted",
-          reason: "Previously deleted",
-          text: "Posts usually get removed for a good reason, and reuploading of deleted content is not acceptable.\nPlease, leave more information in the comments, or simply add the original post as this post's parent.",
-        },
-        {
-          name: "real_porn",
-          reason: "Real-life pornography",
-          text: "Posts featuring real-life pornography are not acceptable on this site. No exceptions.\nNote that images featuring non-erotic photographs are acceptable.",
-        },
-        {
-          name: "corrupt",
-          reason: "File is either corrupted, broken, or otherwise does not work",
-          text: "Something about this post does not work quite right. This may be a broken video, or a corrupted image.\nEither way, in order to avoid confusion, please explain the situation in the comments.",
-        },
-        {
-          name: "inferior",
-          reason: "Duplicate or inferior version of another post",
-          text: "A superior version of this post already exists on the site.\nThis may include images with better visual quality (larger, less compressed), but may also feature \"fixed\" versions, with visual mistakes accounted for by the artist.\nNote that edits and alternate versions do not fall under this category.",
-          parent: true,
-        },
-      ]
-    end
-
     def deletion_reasons
       [
         "Inferior version/duplicate of post #%PARENT_ID%",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -327,6 +327,12 @@ Rails.application.routes.draw do
     end
   end
   resources :post_report_reasons
+  resources :post_flag_reasons, except: %i[show] do
+    collection do
+      get :order
+      post :reorder
+    end
+  end
   resources :post_sets do
     collection do
       get :for_select

--- a/db/fixes/121_create_post_flag_reasons.rb
+++ b/db/fixes/121_create_post_flag_reasons.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+CurrentUser.as_system do
+  PostFlagReason.create!(name: "uploading_guidelines", reason: "Does not meet the [[uploading_guidelines|uploading guidelines]]", text: "This post fails to meet the site's standards, be it for artistic worth, image quality, relevancy, or something else.\nKeep in mind that your personal preferences have no bearing on this. If you find the content of a post objectionable, simply [[e621:blacklist|blacklist]] it.")
+  PostFlagReason.create!(name: "young_human", reason: "Young [[human]]-[[humanoid|like]] character in an explicit situation", text: "Posts featuring human and human-like characters depicted in a sexual or explicit nude way, are not acceptable on this site.")
+  PostFlagReason.create!(name: "dnp_artist", reason: "The artist of this post is on the \"avoid posting list\":/static/avoid_posting", text: "Certain artists have requested that their work is not to be published on this site, and were granted [[avoid_posting|Do Not Post]] status.\nSometimes, that status comes with conditions; see [[conditional_dnp]] for more information.")
+  PostFlagReason.create!(name: "pay_content", reason: "Paysite, commercial, or subscription content", text: "We do not host paysite or commercial content of any kind. This includes Patreon leaks, reposts from piracy websites, and so on.")
+  PostFlagReason.create!(name: "trace", reason: "Trace of another artist's work", text: "Images traced from other artists' artwork are not accepted on this site. Referencing from something is fine, but outright copying someone else's work is not.\nPlease, leave more information in the comments, or simply add the original artwork as the posts's parent if it's hosted on this site.")
+  PostFlagReason.create!(name: "previously_deleted", reason: "Previously deleted", text: "Posts usually get removed for a good reason, and reuploading of deleted content is not acceptable.\nPlease, leave more information in the comments, or simply add the original post as this post's parent.")
+  PostFlagReason.create!(name: "real_porn", reason: "Real-life pornography", text: "Posts featuring real-life pornography are not acceptable on this site. No exceptions.\nNote that images featuring non-erotic photographs are acceptable.")
+  PostFlagReason.create!(name: "corrupt", reason: "File is either corrupted, broken, or otherwise does not work", text: "Something about this post does not work quite right. This may be a broken video, or a corrupted image.\nEither way, in order to avoid confusion, please explain the situation in the comments.")
+  PostFlagReason.create!(name: "inferior", reason: "Duplicate or inferior version of another post", text: "A superior version of this post already exists on the site.\nThis may include images with better visual quality (larger, less compressed), but may also feature \"fixed\" versions, with visual mistakes accounted for by the artist.\nNote that edits and alternate versions do not fall under this category.", parent: true)
+end

--- a/db/migrate/20240823225851_create_post_flag_reasons.rb
+++ b/db/migrate/20240823225851_create_post_flag_reasons.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePostFlagReasons < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:post_flag_reasons) do |t|
+      t.references(:creator, null: false, foreign_key: { to_table: :users })
+      t.inet(:creator_ip_addr, null: false)
+      t.references(:updater, null: false, foreign_key: { to_table: :users })
+      t.inet(:updater_ip_addr, null: false)
+      t.string(:name, null: false, index: { unique: true })
+      t.string(:reason, null: false)
+      t.string(:text, null: false)
+      t.boolean(:parent, null: false, default: false)
+      t.integer(:order, null: false)
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1359,6 +1359,45 @@ ALTER SEQUENCE public.post_events_id_seq OWNED BY public.post_events.id;
 
 
 --
+-- Name: post_flag_reasons; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.post_flag_reasons (
+    id bigint NOT NULL,
+    creator_id bigint NOT NULL,
+    creator_ip_addr inet NOT NULL,
+    updater_id bigint NOT NULL,
+    updater_ip_addr inet NOT NULL,
+    name character varying NOT NULL,
+    reason character varying NOT NULL,
+    text character varying NOT NULL,
+    parent boolean DEFAULT false NOT NULL,
+    "order" integer NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: post_flag_reasons_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.post_flag_reasons_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: post_flag_reasons_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.post_flag_reasons_id_seq OWNED BY public.post_flag_reasons.id;
+
+
+--
 -- Name: post_flags; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2699,6 +2738,13 @@ ALTER TABLE ONLY public.post_events ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
+-- Name: post_flag_reasons id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.post_flag_reasons ALTER COLUMN id SET DEFAULT nextval('public.post_flag_reasons_id_seq'::regclass);
+
+
+--
 -- Name: post_flags id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3181,6 +3227,14 @@ ALTER TABLE ONLY public.post_disapprovals
 
 ALTER TABLE ONLY public.post_events
     ADD CONSTRAINT post_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: post_flag_reasons post_flag_reasons_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.post_flag_reasons
+    ADD CONSTRAINT post_flag_reasons_pkey PRIMARY KEY (id);
 
 
 --
@@ -4053,6 +4107,27 @@ CREATE INDEX index_post_events_on_post_id ON public.post_events USING btree (pos
 
 
 --
+-- Name: index_post_flag_reasons_on_creator_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_flag_reasons_on_creator_id ON public.post_flag_reasons USING btree (creator_id);
+
+
+--
+-- Name: index_post_flag_reasons_on_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_post_flag_reasons_on_name ON public.post_flag_reasons USING btree (name);
+
+
+--
+-- Name: index_post_flag_reasons_on_updater_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_flag_reasons_on_updater_id ON public.post_flag_reasons USING btree (updater_id);
+
+
+--
 -- Name: index_post_flags_on_creator_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4598,6 +4673,14 @@ ALTER TABLE ONLY public.avoid_posting_versions
 
 
 --
+-- Name: post_flag_reasons fk_rails_8dc1e9a414; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.post_flag_reasons
+    ADD CONSTRAINT fk_rails_8dc1e9a414 FOREIGN KEY (creator_id) REFERENCES public.users(id);
+
+
+--
 -- Name: user_feedback fk_rails_9329a36823; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4619,6 +4702,14 @@ ALTER TABLE ONLY public.mascots
 
 ALTER TABLE ONLY public.favorites
     ADD CONSTRAINT fk_rails_a7668ef613 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: post_flag_reasons fk_rails_b13eea4230; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.post_flag_reasons
+    ADD CONSTRAINT fk_rails_b13eea4230 FOREIGN KEY (updater_id) REFERENCES public.users(id);
 
 
 --
@@ -4676,6 +4767,7 @@ ALTER TABLE ONLY public.avoid_postings
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240823225851'),
 ('20240726170041'),
 ('20240709134926'),
 ('20240706061122'),

--- a/test/controllers/post_flag_reasons_controller_test.rb
+++ b/test/controllers/post_flag_reasons_controller_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PostFlagReasonsControllerTest < ActionDispatch::IntegrationTest
+  context "The post flag reasons controller" do
+    setup do
+      @admin = create(:admin_user)
+      @user = create(:user)
+      CurrentUser.user = @admin
+      @reason = create(:post_flag_reason)
+    end
+
+    context "index action" do
+      should "render" do
+        get post_flag_reasons_path
+        assert_response :success
+      end
+    end
+
+    context "new action" do
+      should "render" do
+        get_auth new_post_flag_reason_path, @admin
+        assert_response :success
+      end
+    end
+
+    context "create action" do
+      should "work" do
+        assert_difference(%w[PostFlagReason.count ModAction.count], 1) do
+          post_auth post_flag_reasons_path, @admin, params: { post_flag_reason: { name: "test", reason: "test", text: "test" } }
+        end
+
+        assert_equal("post_flag_reason_create", ModAction.last.action)
+      end
+    end
+
+    context "edit action" do
+      should "render" do
+        get_auth edit_post_flag_reason_path(@reason), @admin
+        assert_response :success
+      end
+    end
+
+    context "update action" do
+      should "work" do
+        assert_difference("ModAction.count", 1) do
+          put_auth post_flag_reason_path(@reason), @admin, params: { post_flag_reason: { name: "xxx" } }
+          assert_redirected_to(post_flag_reasons_path)
+        end
+        assert_equal("post_flag_reason_update", ModAction.last.action)
+        assert_equal("xxx", @reason.reload.name)
+      end
+    end
+
+    context "destroy action" do
+      should "work" do
+        assert_difference({ "PostFlagReason.count" => -1, "ModAction.count" => 1 }) do
+          delete_auth post_flag_reason_path(@reason), @admin
+          assert_redirected_to(post_flag_reasons_path)
+        end
+        assert_raises(ActiveRecord::RecordNotFound) { @reason.reload }
+        assert_equal("post_flag_reason_delete", ModAction.last.action)
+      end
+    end
+
+    context "order action" do
+      should "render" do
+        get_auth order_post_flag_reasons_path, @admin
+        assert_response :success
+      end
+    end
+
+    context "reorder action" do
+      setup do
+        count = PostFlagReason.count
+        if count < 3
+          create_list(:post_flag_reason, 3 - count)
+        end
+      end
+
+      should "work" do
+        data = PostFlagReason.pluck(:id, :order).map { |id, order| { id: id, order: order } }
+        swap = data[0][:order]
+        data[0][:order] = data[1][:order]
+        data[1][:order] = swap
+        assert_difference("ModAction.count", 1) do
+          post_auth reorder_post_flag_reasons_path, @admin, params: { _json: data, format: :json }
+          assert_response :success
+        end
+        assert_equal("post_flag_reasons_reorder", ModAction.last.action)
+        assert_equal(data[0][:order], PostFlagReason.find(data[0][:id]).order)
+        assert_equal(data[1][:order], PostFlagReason.find(data[1][:id]).order)
+      end
+
+      should "not allow duplicate orders" do
+        data = PostFlagReason.pluck(:id, :order).map { |id, order| { id: id, order: order } }
+        data[1][:order] = data[0][:order]
+        post_auth reorder_post_flag_reasons_path, @admin, params: { _json: data, format: :json }
+        assert_response 422
+      end
+    end
+  end
+end

--- a/test/factories/post_flag.rb
+++ b/test/factories/post_flag.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory(:post_flag) do
     post
-    reason_name { "dnp_artist" }
+    reason_name { association(:post_flag_reason).name }
     is_resolved { false }
   end
 end

--- a/test/factories/post_flag_reason.rb
+++ b/test/factories/post_flag_reason.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:post_flag_reason) do
+    sequence(:name) { |n| "reason_#{n}" }
+    reason { "reason" }
+    text { "text" }
+    parent { false }
+  end
+end

--- a/test/functional/post_flags_controller_test.rb
+++ b/test/functional/post_flags_controller_test.rb
@@ -41,12 +41,13 @@ class PostFlagsControllerTest < ActionDispatch::IntegrationTest
       setup do
         as(@user) do
           @post = create(:post)
+          @reason = create(:post_flag_reason)
         end
       end
 
       should "create a new flag" do
         assert_difference("PostFlag.count", 1) do
-          post_auth post_flags_path, @user, params: { format: :json, post_flag: { post_id: @post.id, reason_name: "dnp_artist" } }
+          post_auth post_flags_path, @user, params: { format: :json, post_flag: { post_id: @post.id, reason_name: @reason.name } }
         end
       end
     end

--- a/test/unit/post_flag_test.rb
+++ b/test/unit/post_flag_test.rb
@@ -40,6 +40,7 @@ class PostFlagTest < ActiveSupport::TestCase
     end
 
     should "not be able to flag a non-pending post with the uploading_guidelines reason" do
+      as(create(:admin_user)) { create(:post_flag_reason, name: "uploading_guidelines") }
       error = assert_raises(ActiveRecord::RecordInvalid) do
         as(@bob) do
           @post_flag = create(:post_flag, post: @post, reason_name: "uploading_guidelines")

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -447,7 +447,7 @@ class PostTest < ActiveSupport::TestCase
       end
 
       should "not allow new flags" do
-        flag = build(:post_flag, post: @post)
+        flag = build(:post_flag, post: @post, reason_name: create(:post_flag_reason).name)
         flag.validate
         assert_equal(["Post is locked and cannot be flagged"], flag.errors.full_messages)
       end


### PR DESCRIPTION
This pr moves the flag reasons out of the config, and into a table in the database so they can be customized on the fly by any admin. This is also equipped with [drag and drop reordering](https://discord.com/channels/431908090883997698/1255244495533113354/1276704977611526205).

This feature allows anyone to read the index (`/post_flag_reasons`) contrary to similar routes like post report reasons. I don't see the point in restricting it when they can see the items directly in the new flag page, and look up the creators in the mod actions.