### PR TITLE
[Blacklist] Separate the post and comment blacklist UI

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -210,7 +210,6 @@ Blacklist.update_styles = function () {
   for (const filter of Object.values(Blacklist.filters))
     allPosts = allPosts.concat(Array.from(filter.matchIDs));
   Blacklist.matchedPosts = new Set(allPosts);
-  console.log("matched", Blacklist.matchedPosts);
 
   $(".filter-matches").removeClass("filter-matches");
   for (const postID of Blacklist.matchedPosts)
@@ -257,6 +256,9 @@ class BlacklistUI {
   constructor ($element) {
     this.$element = $element;
     this.$counter = $element.find(".blacklisted-count");
+
+    this.post = parseInt($element.attr("post"));
+    this.hasPost = !Number.isNaN(this.post);
 
     // Collapsable header
     $element
@@ -305,8 +307,12 @@ class BlacklistUI {
 
     let activeFilters = 0,
       inactiveFilters = 0;
+
     for (const [name, filter] of Object.entries(Blacklist.filters)) {
       if (filter.matchIDs.size == 0) continue;
+
+      if (this.hasPost && !filter.matchIDs.has(this.post))
+        continue;
 
       activeFilters++;
       if (!filter.enabled) inactiveFilters++;

--- a/app/views/posts/partials/index/_blacklist.html.erb
+++ b/app/views/posts/partials/index/_blacklist.html.erb
@@ -1,6 +1,11 @@
+<%# locals: (post_id: nil) %>
+
 <section class="blacklist-ui"
   filters="0"
   collapsed="true"
+  <% unless post_id.blank? %>
+    post="<%= post_id %>"
+  <% end %>
 >
   <div class="blacklist-header">Blacklisted <span class="blacklisted-count"></span></div>
   <div class="blacklist-filters"></div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -204,7 +204,7 @@
       </menu>
 
       <% unless CurrentUser.hide_comments? %>
-        <% if @post.comments.visible(CurrentUser.user).size > 0 %>
+        <% unless @post.comments.visible(CurrentUser.user).empty? %>
           <%= render "posts/partials/common/inline_blacklist" %>
         <% end %>
         <section id="comments">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -3,7 +3,7 @@
     <aside id="sidebar">
       <%= render "posts/partials/common/search", :path => posts_path, :tags => params[:q], :tags_dom_id => "tags" %>
 
-      <%= render "posts/partials/index/blacklist" %>
+      <%= render "posts/partials/index/blacklist", post_id: @post.id %>
 
       <section id="tag-list">
         <%= @post.presenter.post_show_sidebar_tag_list_html(current_query: params[:q], highlighted_tags: @post.uploader_linked_artists.map(&:name)) %>
@@ -204,6 +204,9 @@
       </menu>
 
       <% unless CurrentUser.hide_comments? %>
+        <% if @post.comments.visible(CurrentUser.user).size > 0 %>
+          <%= render "posts/partials/common/inline_blacklist" %>
+        <% end %>
         <section id="comments">
           <%= render "comments/partials/index/list", :comments => @post.comments.visible(CurrentUser.user), :post => @post, :show_header => false %>
         </section>


### PR DESCRIPTION
Evidently, having avatar posts show up in the blacklist next to the post confused people.

![Screenshot 2024-08-26 153845](https://github.com/user-attachments/assets/a5b8b777-6220-4bd6-8521-3891f39e19f8)
