### PR TITLE
[Uploads] Show the unload warning if any tags are filled in

### DIFF
--- a/app/javascript/src/javascripts/uploader/uploader.vue.erb
+++ b/app/javascript/src/javascripts/uploader/uploader.vue.erb
@@ -287,7 +287,7 @@
   }
 
   function unloadWarning() {
-    if (this.allowNavigate || this.uploadValue === "") {
+    if (this.allowNavigate || (this.uploadValue === "" && this.tags === "")) {
       return;
     }
     return true;


### PR DESCRIPTION
Done on request from Mairo.

Allegedly, the upload page used to show a confirmation dialogue when navigating away from it if any tags are filled in.
I see no evidence of that, but this PR should make it work like that.