### PR TITLE
Add deleted record count to profiles

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -106,12 +106,13 @@ module PostsHelper
     neutral = user.neutral_feedback_count
     negative = user.negative_feedback_count
 
-    return "" unless positive > 0 || neutral > 0 || negative > 0
-    positive_html = %{<span class="user-feedback-positive">#{positive} Pos</span>}.html_safe if positive > 0
-    neutral_html = %{<span class="user-feedback-neutral">#{neutral} Neutral</span>}.html_safe if neutral > 0
-    negative_html = %{<span class="user-feedback-negative">#{negative} Neg</span>}.html_safe if negative > 0
+    return "" if (positive + neutral + negative) == 0
+    positive_html = %{<span class="user-feedback-positive">#{positive}</span>}.html_safe if positive > 0
+    neutral_html = %{<span class="user-feedback-neutral">#{neutral}</span>}.html_safe if neutral > 0
+    negative_html = %{<span class="user-feedback-negative">#{negative}</span>}.html_safe if negative > 0
+    list_html = "#{positive_html} #{neutral_html} #{negative_html}".strip
 
-    link_to(%{(#{positive_html} #{neutral_html} #{negative_html})}.html_safe,  user_feedbacks_path(:search => {:user_id => user.id}))
+    link_to(%{(#{list_html})}.html_safe,  user_feedbacks_path(search: { user_id: user.id}))
   end
 
   private

--- a/app/javascript/src/styles/specific/user_feedback.scss
+++ b/app/javascript/src/styles/specific/user_feedback.scss
@@ -10,6 +10,10 @@
   color: palette("text-red");
 }
 
+.user-feedback-deleted {
+  color: palette("text-yellow");
+}
+
 div#c-user-feedbacks, div#c-moderator-dashboards .activity-container {
   .feedback-category-positive {
     background: palette("background-green");

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ApplicationRecord
   has_many :bans, -> { order("bans.id desc") }
   has_many :dmails, -> { order("dmails.id desc") }, foreign_key: "owner_id"
   has_many :favorites, -> { order(id: :desc) }
-  has_many :feedback, -> { active }, class_name: "UserFeedback", dependent: :destroy
+  has_many :feedback, class_name: "UserFeedback", dependent: :destroy
   has_many :forum_posts, -> { order("forum_posts.created_at, forum_posts.id") }, foreign_key: "creator_id"
   has_many :forum_topic_visits
   has_many :note_versions, foreign_key: "updater_id"
@@ -726,15 +726,19 @@ class User < ApplicationRecord
     end
 
     def positive_feedback_count
-      feedback.positive.count
+      feedback.active.positive.count
     end
 
     def neutral_feedback_count
-      feedback.neutral.count
+      feedback.active.neutral.count
     end
 
     def negative_feedback_count
-      feedback.negative.count
+      feedback.active.negative.count
+    end
+
+    def deleted_feedback_count
+      feedback.deleted.count
     end
 
     def post_replacement_rejected_count

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -154,10 +154,10 @@ class UserPresenter
 
     total_class = (positive - negative) > 0 ? "user-feedback-positive" : "user-feedback-negative"
     total_class = "" if (positive - negative) == 0
-    positive_html = %{<span class="user-feedback-positive">#{positive} Pos</span>}.html_safe if positive > 0
-    neutral_html = %{<span class="user-feedback-neutral">#{neutral} Neutral</span>}.html_safe if neutral > 0
-    negative_html = %{<span class="user-feedback-negative">#{negative} Neg</span>}.html_safe if negative > 0
-    deleted_html = %{<span class="user-feedback-deleted">#{deleted} Del</span>}.html_safe if deleted > 0
+    positive_html = %{<span class="user-feedback-positive">#{positive}</span>}.html_safe if positive > 0
+    neutral_html = %{<span class="user-feedback-neutral">#{neutral}</span>}.html_safe if neutral > 0
+    negative_html = %{<span class="user-feedback-negative">#{negative}</span>}.html_safe if negative > 0
+    deleted_html = %{<span class="user-feedback-deleted">#{deleted}</span>}.html_safe if deleted > 0
     list_html = "#{positive_html} #{neutral_html} #{negative_html} #{deleted_html}".strip
 
     %{<span class="#{total_class}">#{positive - negative}</span> (#{list_html})}.html_safe

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -148,16 +148,19 @@ class UserPresenter
     positive = user.positive_feedback_count
     neutral = user.neutral_feedback_count
     negative = user.negative_feedback_count
+    deleted = CurrentUser.user.is_staff? ? user.deleted_feedback_count : 0
 
-    return "0" unless positive > 0 || neutral > 0 || negative > 0
+    return "0" if (positive + neutral + negative + deleted) == 0
 
     total_class = (positive - negative) > 0 ? "user-feedback-positive" : "user-feedback-negative"
     total_class = "" if (positive - negative) == 0
     positive_html = %{<span class="user-feedback-positive">#{positive} Pos</span>}.html_safe if positive > 0
     neutral_html = %{<span class="user-feedback-neutral">#{neutral} Neutral</span>}.html_safe if neutral > 0
     negative_html = %{<span class="user-feedback-negative">#{negative} Neg</span>}.html_safe if negative > 0
+    deleted_html = %{<span class="user-feedback-deleted">#{deleted} Del</span>}.html_safe if deleted > 0
+    list_html = "#{positive_html} #{neutral_html} #{negative_html} #{deleted_html}".strip
 
-    %{<span class="#{total_class}">#{positive - negative}</span> ( #{positive_html} #{neutral_html} #{negative_html} ) }.html_safe
+    %{<span class="#{total_class}">#{positive - negative}</span> (#{list_html})}.html_safe
   end
 
   def previous_names(template)

--- a/test/functional/user_feedbacks_controller_test.rb
+++ b/test/functional/user_feedbacks_controller_test.rb
@@ -164,7 +164,7 @@ class UserFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
       context "by a moderator" do
         should "allow deleting feedbacks given to other users" do
-          assert_difference({ "UserFeedback.count" => 0, "ModAction.count" => 1, "@user.feedback.count" => -1 }) do
+          assert_difference({ "UserFeedback.count" => 0, "ModAction.count" => 1, "@user.feedback.active.count" => -1 }) do
             put_auth delete_user_feedback_path(@user_feedback), @mod
           end
         end
@@ -174,7 +174,7 @@ class UserFeedbacksControllerTest < ActionDispatch::IntegrationTest
             @user_feedback = create(:user_feedback, user: @mod)
           end
 
-          assert_no_difference(%w[UserFeedback.count ModAction.count @mod.feedback.count]) do
+          assert_no_difference(%w[UserFeedback.count ModAction.count @mod.feedback.active.count]) do
             put_auth delete_user_feedback_path(@user_feedback), @mod
           end
         end
@@ -196,17 +196,17 @@ class UserFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
       context "by a moderator" do
         should "allow deleting feedbacks given to other users" do
-          assert_difference({ "UserFeedback.count" => 0, "ModAction.count" => 1, "@user.feedback.count" => 1 }) do
+          assert_difference({ "UserFeedback.count" => 0, "ModAction.count" => 1, "@user.feedback.active.count" => 1 }) do
             put_auth undelete_user_feedback_path(@user_feedback), @mod
           end
         end
 
-        should "not allow deleting feedbacks given to themselves" do
+        should "not allow undeleting feedbacks given to themselves" do
           as(@critic) do
             @user_feedback = create(:user_feedback, user: @mod)
           end
 
-          assert_no_difference(%w[UserFeedback.count ModAction.count @mod.feedback.count]) do
+          assert_no_difference(%w[UserFeedback.count ModAction.count @mod.feedback.active.count]) do
             put_auth undelete_user_feedback_path(@user_feedback), @mod
           end
         end

--- a/test/functional/user_feedbacks_controller_test.rb
+++ b/test/functional/user_feedbacks_controller_test.rb
@@ -195,7 +195,7 @@ class UserFeedbacksControllerTest < ActionDispatch::IntegrationTest
       end
 
       context "by a moderator" do
-        should "allow deleting feedbacks given to other users" do
+        should "allow undeleting feedbacks given to other users" do
           assert_difference({ "UserFeedback.count" => 0, "ModAction.count" => 1, "@user.feedback.active.count" => 1 }) do
             put_auth undelete_user_feedback_path(@user_feedback), @mod
           end


### PR DESCRIPTION
This pr both adds a deleted count to the record numbers on profiles, and removes the words, leaving just the numbers. The record meta on posts does not include deleted records.
![image](https://github.com/user-attachments/assets/fe6d04dd-8cad-434e-b96c-9499a7e8d04e)
![image](https://github.com/user-attachments/assets/20a69240-95f5-4219-b454-3cd173093bef)
