### PR TITLE
[JS] Fix an error in older browsers caused by replaceAll

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -279,7 +279,7 @@ Autocomplete.render_item = function(list, item) {
   if (item.type === "tag") {
     $link.addClass("tag-type-" + item.category);
   } else if (item.type === "user") {
-    var level_class = "user-" + item.level.replaceAll(" ", "-").toLowerCase();
+    var level_class = "user-" + item.level.replace(/ /g, "-").toLowerCase();
     $link.addClass(level_class);
     if (Utility.meta("style-usernames") === "true") {
       $link.addClass("with-style");

--- a/app/javascript/src/javascripts/forum_topics.js
+++ b/app/javascript/src/javascripts/forum_topics.js
@@ -2,7 +2,7 @@ let ForumTopic = {};
 
 ForumTopic.init_mark_all_as_read = function () {
   $("#subnav-mark-all-as-read-link").on("click.danbooru", () => {
-    return confirm(`Are you sure that you want to mark all ${$("body").data("controller").replaceAll("-", " ")} as read?`);
+    return confirm(`Are you sure that you want to mark all ${$("body").data("controller").replace(/-/g, " ")} as read?`);
   });
 };
 

--- a/app/javascript/src/javascripts/models/Filter.js
+++ b/app/javascript/src/javascripts/models/Filter.js
@@ -140,7 +140,7 @@ class FilterToken {
     this.type = FilterUtils.getFilterType(raw);
     if (this.type !== "tag") raw = raw.slice(this.type.length + 1);
     else if (raw.includes("*")) {
-      this.value = new RegExp(raw.replaceAll(/\*/g, ".*"));
+      this.value = new RegExp(raw.replace(/\*/g, ".*"));
       this.type = "wildcard";
       return;
     }


### PR DESCRIPTION
Evidently, there are a number of people who use browsers old enough or obscure enough not to support that function.