### PR TITLE
[Thumbnails] Fix an issue caused by an avatar having an invalid value

### DIFF
--- a/app/javascript/src/javascripts/thumbnails.js
+++ b/app/javascript/src/javascripts/thumbnails.js
@@ -15,14 +15,14 @@ Thumbnails.initialize = function () {
     const postID = $post.data("id");
     if (!postID) {
       clearPlaceholder($post);
-      return;
+      continue;
     }
 
     // Data exists for this post
     const postData = postsData[postID];
     if (!postData) {
       clearPlaceholder($post);
-      return;
+      continue;
     }
 
     // Add data to cache right away, instead of


### PR DESCRIPTION
Evidently, some older user accounts have the avatar value set to 0 when it's empty, rather than nil.
This produced placeholder thumbnails without a `data-id` attribute, which coincided with a bug in the thumbnail script that caused it to stop processing posts if it encountered faulty data.

It would be best to make a more systematic fix for the avatar issue in the database.
But this PR will fix the immediate problem.