### PR TITLE
[DangerZone] Allow admins to hide pending posts for a specified amount of hours

### DIFF
--- a/app/controllers/admin/danger_zone_controller.rb
+++ b/app/controllers/admin/danger_zone_controller.rb
@@ -16,5 +16,14 @@ module Admin
       end
       redirect_to admin_danger_zone_index_path
     end
+
+    def hide_pending_posts
+      duration = params[:hide_pending_posts][:duration].to_f
+      if duration >= 0 && duration != DangerZone.hide_pending_posts_for
+        DangerZone.hide_pending_posts_for = duration
+        StaffAuditLog.log(:hide_pending_posts_for, CurrentUser.user, { duration: duration })
+      end
+      redirect_to admin_danger_zone_index_path
+    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -26,6 +26,8 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
 
+    raise User::PrivilegeError.new("Post unavailable") unless DangerZone.post_visible?(@post, CurrentUser.user)
+
     include_deleted = @post.is_deleted? || (@post.parent_id.present? && @post.parent.is_deleted?) || CurrentUser.is_approver?
     @parent_post_set = PostSets::PostRelationship.new(@post.parent_id, :include_deleted => include_deleted, want_parent: true)
     @children_post_set = PostSets::PostRelationship.new(@post.id, :include_deleted => include_deleted, want_parent: false)

--- a/app/logical/danger_zone.rb
+++ b/app/logical/danger_zone.rb
@@ -26,7 +26,7 @@ module DangerZone
   def self.hide_pending_posts_for
     Cache.redis.get("hide_pending_posts_for").to_f || 0
   rescue Redis::CannotConnectError
-    0
+    PostPruner::DELETION_WINDOW * 24
   end
 
   def self.hide_pending_posts_for=(duration)

--- a/app/logical/danger_zone.rb
+++ b/app/logical/danger_zone.rb
@@ -10,7 +10,7 @@ module DangerZone
       return true
     end
 
-    user.is_staff? || !post.is_pending? || post.created_at.before?(hide_pending_posts_for.hours.ago)
+    post.uploader_id == user.id || user.is_staff? || !post.is_pending? || post.created_at.before?(hide_pending_posts_for.hours.ago)
   end
 
   def self.min_upload_level

--- a/app/logical/danger_zone.rb
+++ b/app/logical/danger_zone.rb
@@ -10,7 +10,7 @@ module DangerZone
       return true
     end
 
-    (!user.nil? && user.is_approver?) || !post.is_pending? || post.created_at.before?(hide_pending_posts_for.hours.ago)
+    user.is_staff? || !post.is_pending? || post.created_at.before?(hide_pending_posts_for.hours.ago)
   end
 
   def self.min_upload_level

--- a/app/logical/danger_zone.rb
+++ b/app/logical/danger_zone.rb
@@ -5,6 +5,14 @@ module DangerZone
     user.level < min_upload_level
   end
 
+  def self.post_visible?(post, user)
+    if hide_pending_posts_for <= 0
+      return true
+    end
+
+    (user != nil && user.is_approver?) || !post.is_pending? || post.created_at.before?(hide_pending_posts_for.hours.ago)
+  end
+
   def self.min_upload_level
     (Cache.redis.get("min_upload_level") || User::Levels::MEMBER).to_i
   rescue Redis::CannotConnectError
@@ -13,5 +21,15 @@ module DangerZone
 
   def self.min_upload_level=(min_upload_level)
     Cache.redis.set("min_upload_level", min_upload_level)
+  end
+
+  def self.hide_pending_posts_for
+    Cache.redis.get("hide_pending_posts_for").to_f || 0
+  rescue Redis::CannotConnectError
+    0
+  end
+
+  def self.hide_pending_posts_for=(duration)
+    Cache.redis.set("hide_pending_posts_for", duration)
   end
 end

--- a/app/logical/danger_zone.rb
+++ b/app/logical/danger_zone.rb
@@ -10,7 +10,7 @@ module DangerZone
       return true
     end
 
-    (user != nil && user.is_approver?) || !post.is_pending? || post.created_at.before?(hide_pending_posts_for.hours.ago)
+    (!user.nil? && user.is_approver?) || !post.is_pending? || post.created_at.before?(hide_pending_posts_for.hours.ago)
   end
 
   def self.min_upload_level

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -315,7 +315,7 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
       order.push({id: :desc})
     end
 
-    if !CurrentUser.is_approver? && DangerZone.hide_pending_posts_for > 0
+    if !CurrentUser.user.is_staff? && DangerZone.hide_pending_posts_for > 0
       must.push({
         bool: {
           should: [

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -331,11 +331,11 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
         }
       ]
 
-      if !CurrentUser.user.id.nil?
+      unless CurrentUser.user.id.nil?
         should.push({
           term: {
-            uploader: CurrentUser.user.id
-          }
+            uploader: CurrentUser.user.id,
+          },
         })
       end
 

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -316,22 +316,32 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
     end
 
     if !CurrentUser.user.is_staff? && DangerZone.hide_pending_posts_for > 0
+      should = [
+        {
+          range: {
+            created_at: {
+              lte: DangerZone.hide_pending_posts_for.hours.ago,
+            },
+          },
+        },
+        {
+          term: {
+            pending: false,
+          },
+        }
+      ]
+
+      if !CurrentUser.user.id.nil?
+        should.push({
+          term: {
+            uploader: CurrentUser.user.id
+          }
+        })
+      end
+
       must.push({
         bool: {
-          should: [
-            {
-              range: {
-                created_at: {
-                  lte: DangerZone.hide_pending_posts_for.hours.ago,
-                },
-              },
-            },
-            {
-              term: {
-                pending: false,
-              },
-            }
-          ],
+          should: should,
           minimum_should_match: 1,
         },
       })

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -7,8 +7,7 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
     status: :status_locked,
   }.freeze
 
-  def initialize(query_string, user, resolve_aliases:, free_tags_count:, enable_safe_mode:, always_show_deleted:)
-    @user = user
+  def initialize(query_string, resolve_aliases:, free_tags_count:, enable_safe_mode:, always_show_deleted:)
     super(TagQuery.new(query_string, resolve_aliases: resolve_aliases, free_tags_count: free_tags_count))
     @enable_safe_mode = enable_safe_mode
     @always_show_deleted = always_show_deleted
@@ -316,25 +315,25 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
       order.push({id: :desc})
     end
 
-    if (@user == nil || !@user.is_approver?) && DangerZone.hide_pending_posts_for > 0
+    if !CurrentUser.is_approver? && DangerZone.hide_pending_posts_for > 0
       must.push({
         bool: {
           should: [
             {
               range: {
                 created_at: {
-                  lte: DangerZone.hide_pending_posts_for.hours.ago
-                }
-              }
+                  lte: DangerZone.hide_pending_posts_for.hours.ago,
+                },
+              },
             },
             {
               term: {
-                pending: false
-              }
+                pending: false,
+              },
             }
           ],
-          minimum_should_match: 1
-        }
+          minimum_should_match: 1,
+        },
       })
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1521,6 +1521,7 @@ class Post < ApplicationRecord
     def tag_match(query, resolve_aliases: true, free_tags_count: 0, enable_safe_mode: CurrentUser.safe_mode?, always_show_deleted: false)
       ElasticPostQueryBuilder.new(
         query,
+        CurrentUser.user,
         resolve_aliases: resolve_aliases,
         free_tags_count: free_tags_count,
         enable_safe_mode: enable_safe_mode,

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1521,7 +1521,6 @@ class Post < ApplicationRecord
     def tag_match(query, resolve_aliases: true, free_tags_count: 0, enable_safe_mode: CurrentUser.safe_mode?, always_show_deleted: false)
       ElasticPostQueryBuilder.new(
         query,
-        CurrentUser.user,
         resolve_aliases: resolve_aliases,
         free_tags_count: free_tags_count,
         enable_safe_mode: enable_safe_mode,

--- a/app/views/admin/danger_zone/index.html.erb
+++ b/app/views/admin/danger_zone/index.html.erb
@@ -7,6 +7,15 @@
       <%= f.input :min_level, collection: User.level_hash.select {|k,v| v >= User::Levels::MEMBER }.to_a, selected: DangerZone.min_upload_level %>
       <%= f.button :submit, value: "Submit" %>
     <% end %>
+    <% if DangerZone.hide_pending_posts_for > 0 %>
+    Unapproved posts are currently only visible to staff for <b><%= DangerZone.hide_pending_posts_for %></b> hours.
+    <% else %>
+      Unapproved posts are currently not hidden.
+    <% end %>
+    <%= custom_form_for(:hide_pending_posts_for, url: hide_pending_posts_admin_danger_zone_index_path, method: :put) do |f| %>
+      <%= f.input :duration, :as => :float, :hint => "in hours", input_html: { value: DangerZone.hide_pending_posts_for } %>
+      <%= f.button :submit, value: "Submit" %>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/admin/danger_zone/index.html.erb
+++ b/app/views/admin/danger_zone/index.html.erb
@@ -7,6 +7,7 @@
       <%= f.input :min_level, collection: User.level_hash.select {|k,v| v >= User::Levels::MEMBER }.to_a, selected: DangerZone.min_upload_level %>
       <%= f.button :submit, value: "Submit" %>
     <% end %>
+    <h2>Pending Posts</h2>
     <% if DangerZone.hide_pending_posts_for > 0 %>
       Unapproved posts are currently only visible to staff for <b><%= DangerZone.hide_pending_posts_for %></b> hours.
     <% else %>

--- a/app/views/admin/danger_zone/index.html.erb
+++ b/app/views/admin/danger_zone/index.html.erb
@@ -10,9 +10,9 @@
     <% if DangerZone.hide_pending_posts_for > 0 %>
     Unapproved posts are currently only visible to staff for <b><%= DangerZone.hide_pending_posts_for %></b> hours.
     <% else %>
-      Unapproved posts are currently not hidden.
+    Unapproved posts are currently not hidden.
     <% end %>
-    <%= custom_form_for(:hide_pending_posts_for, url: hide_pending_posts_admin_danger_zone_index_path, method: :put) do |f| %>
+    <%= custom_form_for(:hide_pending_posts, url: hide_pending_posts_admin_danger_zone_index_path, method: :put) do |f| %>
       <%= f.input :duration, :as => :float, :hint => "in hours", input_html: { value: DangerZone.hide_pending_posts_for } %>
       <%= f.button :submit, value: "Submit" %>
     <% end %>

--- a/app/views/admin/danger_zone/index.html.erb
+++ b/app/views/admin/danger_zone/index.html.erb
@@ -8,12 +8,12 @@
       <%= f.button :submit, value: "Submit" %>
     <% end %>
     <% if DangerZone.hide_pending_posts_for > 0 %>
-    Unapproved posts are currently only visible to staff for <b><%= DangerZone.hide_pending_posts_for %></b> hours.
+      Unapproved posts are currently only visible to staff for <b><%= DangerZone.hide_pending_posts_for %></b> hours.
     <% else %>
-    Unapproved posts are currently not hidden.
+      Unapproved posts are currently not hidden.
     <% end %>
     <%= custom_form_for(:hide_pending_posts, url: hide_pending_posts_admin_danger_zone_index_path, method: :put) do |f| %>
-      <%= f.input :duration, :as => :float, :hint => "in hours", input_html: { value: DangerZone.hide_pending_posts_for } %>
+      <%= f.input :duration, as: :float, hint: "in hours", input_html: { value: DangerZone.hide_pending_posts_for } %>
       <%= f.button :submit, value: "Submit" %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
     resources :danger_zone, only: [:index] do
       collection do
         put :uploading_limits
+        put :hide_pending_posts
       end
     end
   end

--- a/test/functional/admin/danger_zone_controller_test.rb
+++ b/test/functional/admin/danger_zone_controller_test.rb
@@ -10,6 +10,7 @@ class Admin::DangerZoneControllerTest < ActionDispatch::IntegrationTest
 
     teardown do
       DangerZone.min_upload_level = User::Levels::MEMBER
+      DangerZone.hide_pending_posts_for = 0
     end
 
     context "index action" do

--- a/test/functional/admin/danger_zone_controller_test.rb
+++ b/test/functional/admin/danger_zone_controller_test.rb
@@ -25,5 +25,12 @@ class Admin::DangerZoneControllerTest < ActionDispatch::IntegrationTest
         assert_equal DangerZone.min_upload_level, User::Levels::PRIVILEGED
       end
     end
+
+    context "hide pending posts action" do
+      should "work" do
+        put_auth hide_pending_posts_admin_danger_zone_index_path, @admin, params: { hide_pending_posts: { duration: 24 } }
+        assert_equal DangerZone.hide_pending_posts_for, 24
+      end
+    end
   end
 end


### PR DESCRIPTION
Implements https://github.com/orgs/e621ng/projects/2/views/1?pane=issue&itemId=18707651, but as hours instead of days, since that seemed more useful.

A security tool for mass post raids. It will hide pending posts for the amount of hours specified, afterwards they will be visible again.

Uses an opensearch query when active, so this does not reduce pages to a few entries per page, since they aren't returned in the query in the first place.

Made a small video to show what it does. There are cuts to reduce the video duration because local load speeds are awful for me and because github has a 10mb limit:

https://github.com/user-attachments/assets/ffa2d11e-1d43-444c-968d-f391d182e55b

