### PR TITLE
Add support for folding displays

### DIFF
--- a/app/javascript/src/styles/common/z_responsive.scss
+++ b/app/javascript/src/styles/common/z_responsive.scss
@@ -199,8 +199,9 @@
 
     #posts #posts-container {
       width: 100%;
-      display: flex;
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1vw;
       align-items: center;
       justify-content: space-evenly;
     }
@@ -211,7 +212,8 @@
       text-align: center;
       vertical-align: middle;
       display: inline-block;
-      width: 31vw;
+      width: 100%;
+      container-type: inline-size;
 
       a {
         margin: 0 auto;
@@ -219,7 +221,7 @@
 
       img {
         max-height: 150px;
-        max-width: 31vw;
+        max-width: 100cqw;
       }
 
       .desc {
@@ -229,13 +231,11 @@
 
     .user-disable-cropped-false {
       article.post-preview {
-        width: 31vw;
-
         img {
           height: auto;
           max-height: none;
           max-width: none;
-          width: 31vw;
+          width: 100cqw;
 
           &.has-cropped-false {
             object-fit: cover;
@@ -311,6 +311,13 @@
       h1 {
         display: inline; //Needed for menu button
       }
+    }
+  }
+}
+@media screen and (max-width: 800px) and (horizontal-viewport-segments: 2) {
+  body.resp {
+    #posts #posts-container {
+      grid-template-columns: repeat(4, 1fr);
     }
   }
 }


### PR DESCRIPTION
## Summary
This adds support for folding displays in responsive mode by ensuring that there's an even number of columns (4) so that the search results do not get laid out onto the fold.

![image](https://github.com/user-attachments/assets/a6f4b765-f84c-4a29-be64-f512c0f27236)

## Technical Details
This is done by having the results use `display: grid` (instead of `flex`) to be able to control the number of rows.
Since `31vw` can now not be used as a constant for how wide a result should be, this is now `100cqw` (100% of container with), with the post having been declared a container in the inline direction.
The four-column layout gets toggled with a media query for `horizontal-viewport-segments`, which is available by default in Samsung Internet and some versions of Edge, as well as behind an experimental feature flag in Chrome.