### PR TITLE
Change artverified fixer to update all posts

### DIFF
--- a/db/fixes/114_2_add_opensearch_artverified_data.rb
+++ b/db/fixes/114_2_add_opensearch_artverified_data.rb
@@ -8,6 +8,5 @@ artists = Artist.select(:name, :linked_user_id).where.not(linked_user_id: nil).t
 client = Post.document_store.client
 Post.find_each do |post|
   puts post.id
-  next unless post.tag_array.any? { |tag| artists.key?(tag) && artists[tag] == post.uploader_id }
-  client.update(index: Post.document_store.index_name, id: post.id, body: { doc: { artverified: true } })
+  client.update(index: Post.document_store.index_name, id: post.id, body: { doc: { artverified: post.tag_array.any? { |tag| artists.key?(tag) && artists[tag] == post.uploader_id } } })
 end


### PR DESCRIPTION
This pr changes the artverified fixer to apply to all posts, as we discovered is required.