### PR TITLE
Fix atom feed invalid source href in link

### DIFF
--- a/app/views/posts/index.atom.erb
+++ b/app/views/posts/index.atom.erb
@@ -15,7 +15,9 @@
       <title><%= post.presenter.humanized_essential_tag_string %></title>
       <link href="<%= post_url(post) %>" rel="alternate"/>
       <% if post.source =~ %r{\Ahttps?://} %>
-        <link href="<%= post.source %>" rel="related"/>
+        <% post.source.split("\n").each do |source| %>
+          <link href="<%= source %>" rel="related"/>
+        <% end %>
       <% end %>
       <id><%= post_url(post) %></id>
       <updated><%= post.created_at.gmtime.xmlschema %></updated>


### PR DESCRIPTION
Some of the entry in the feed include multiple sources, those entries put all the source concatenated together with a newline and put it all in a single link tag's href, the resulting href is then parsed as an invalid href, which result in some stricter rss/atom feed reader refusing the process the feed.

Resulting in the feed sometimes suddenly seemingly randomly refusing to load until the offending entry get old enough to get excluded/pushed off from the feed.

This pull request just properly split the sources by newline and then put each source in their own link tag

example, original invalid link href:
```xml
    <entry>
      <title>goldie and marble (vixen logic) created by foxboy83 and tootaloo</title>
      <link href="https://e926.net/posts/5100442" rel="alternate"/>
        <link href="https://www.vixenlogic.com/
https://www.vixenlogic.com/vl0090/
https://www.weasyl.com/~foxboy83/submissions/2422762/vixenlogic0090-storytime-with-goldie
https://www.furaffinity.net/view/58377552/
https://www.deviantart.com/foxboy83/art/VixenLogic0090-Storytime-with-Goldie-1107455514
https://foxboy83.com/post/763697078724689920/
https://x.com/Foxboy83Arts/status/1843320380725059982
https://cdn.weasyl.com/~foxboy83/submissions/2422762/a2fcaca315768341fabcb59b96cdaa160356ec524e113ce564c3507594ea6f3e/foxboy83-vixenlogic0090-storytime-with-goldie.png" rel="related"/>
```

```xml
    <entry>
      <title>goldie and marble (vixen logic) created by foxboy83 and tootaloo</title>
      <link href="https://e926.net/posts/5100442" rel="alternate"/>
        <link href="https://www.vixenlogic.com/" rel="related"/>
        <link href="https://www.vixenlogic.com/vl0090/" rel="related"/>
        <link href="https://www.weasyl.com/~foxboy83/submissions/2422762/vixenlogic0090-storytime-with-goldie" rel="related"/>
        <link href="https://www.furaffinity.net/view/58377552/" rel="related"/>
        <link href="https://www.deviantart.com/foxboy83/art/VixenLogic0090-Storytime-with-Goldie-1107455514" rel="related"/>
        <link href="https://foxboy83.com/post/763697078724689920/" rel="related"/>
        <link href="https://x.com/Foxboy83Arts/status/1843320380725059982" rel="related"/>
        <link href="https://cdn.weasyl.com/~foxboy83/submissions/2422762/a2fcaca315768341fabcb59b96cdaa160356ec524e113ce564c3507594ea6f3e/foxboy83-vixenlogic0090-storytime-with-goldie.png" rel="related"/>
```