### PR TITLE
[Posts] Fix pool metatags with capital letters

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -696,7 +696,7 @@ class Post < ApplicationRecord
         when /^newpool:(.+)$/i
           pool = Pool.find_by_name($1)
           if pool.nil?
-            pool = Pool.create(name: $1, description: "This pool was automatically generated")
+            pool = Pool.create(name: $1, description: "")
           end
         end
       end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -509,7 +509,7 @@ class Post < ApplicationRecord
       return unless tag_string_diff.present?
 
       current_tags = tag_array
-      diff = TagQuery.scan(tag_string_diff.downcase)
+      diff = TagQuery.scan(tag_string_diff)
       to_remove, to_add = diff.partition {|x| x =~ /\A-/i}
       to_remove = to_remove.map {|x| x[1..-1]}
       to_remove = TagAlias.to_aliased(to_remove)
@@ -696,7 +696,7 @@ class Post < ApplicationRecord
         when /^newpool:(.+)$/i
           pool = Pool.find_by_name($1)
           if pool.nil?
-            pool = Pool.create(:name => $1, :description => "This pool was automatically generated")
+            pool = Pool.create(name: $1, description: "This pool was automatically generated")
           end
         end
       end
@@ -741,7 +741,7 @@ class Post < ApplicationRecord
           end
 
         when /^-pool:(.+)$/i
-          pool = Pool.find_by(name: $1)
+          pool = Pool.find_by_name($1)
           if pool
             pool.remove!(self)
             if pool.errors.any?
@@ -759,7 +759,7 @@ class Post < ApplicationRecord
           end
 
         when /^(?:new)?pool:(.+)$/i
-          pool = Pool.find_by(name: $1)
+          pool = Pool.find_by_name($1)
           if pool
             pool.add!(self)
             if pool.errors.any?

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2331,6 +2331,7 @@ class PostTest < ActiveSupport::TestCase
     context "pool:" do
       setup do
         @pool = create(:pool)
+        @pool2 = create(:pool, name: "Test_Pool")
         @post = create(:post)
       end
 
@@ -2357,6 +2358,12 @@ class PostTest < ActiveSupport::TestCase
           assert_equal("pool:#{@pool.id}", @post.pool_string)
         end
 
+        should "work with capital letters" do
+          @post.update(tag_string_diff: "pool:#{@pool2.name}")
+          assert_equal([@post.id], @pool2.reload.post_ids)
+          assert_equal("pool:#{@pool2.id}", @post.pool_string)
+        end
+
         should "gracefully fail if the pool is full" do
           Danbooru.config.stubs(:pool_post_limit).returns(0)
           @post.update(tag_string_diff: "pool:#{@pool.name}")
@@ -2379,6 +2386,18 @@ class PostTest < ActiveSupport::TestCase
         @pool = Pool.last
         assert_equal([@post.id], @pool.reload.post_ids)
         assert_equal("pool:#{@pool.id}", @post.pool_string)
+        assert_equal("test", @pool.name)
+      end
+
+      should "work with capital letters" do
+        assert_difference("Pool.count", 1) do
+          @post.update(tag_string_diff: "newpool:Test2_Pool")
+        end
+        @pool = Pool.last
+        puts Pool.all.map(&:name)
+        assert_equal([@post.id], @pool.reload.post_ids)
+        assert_equal("pool:#{@pool.id}", @post.pool_string)
+        assert_equal("Test2_Pool", @pool.name)
       end
     end
   end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2394,7 +2394,6 @@ class PostTest < ActiveSupport::TestCase
           @post.update(tag_string_diff: "newpool:Test2_Pool")
         end
         @pool = Pool.last
-        puts Pool.all.map(&:name)
         assert_equal([@post.id], @pool.reload.post_ids)
         assert_equal("pool:#{@pool.id}", @post.pool_string)
         assert_equal("Test2_Pool", @pool.name)


### PR DESCRIPTION
A regression that happened in b3b16759c4901cbe3df7803b1afd85f9e7af5463

Fixes the pool metatags (`newpool`, `pool`, `-pool`) with capital letters (such as `A_Pool`)
Previously the pool would be created successfully but the post would not be added to the pool

This also removes the downcasing from `tag_string_diff`, which prevented using capital letters in the pool metatags (the ui uses tag_string & old_tag_string which doesn't do this, so this only affects api usage)

Additionally the default text when using newpool has been replaced with an empty string (if we leave it blank the description will be null due to the column being nullable)