### PR TITLE
[A/I] Prevent approval for dnp antecedents/consequents

### DIFF
--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -34,18 +34,16 @@ class TagAliasesController < ApplicationController
 
   def destroy
     @tag_alias = TagAlias.find(params[:id])
-    if @tag_alias.deletable_by?(CurrentUser.user)
-      @tag_alias.reject!
-      respond_with(@tag_alias, :location => tag_aliases_path)
-    else
-      access_denied
-    end
+    return access_denied unless @tag_alias.deletable_by?(CurrentUser.user)
+    @tag_alias.reject!
+    respond_with(@tag_alias, location: tag_aliases_path)
   end
 
   def approve
     @tag_alias = TagAlias.find(params[:id])
+    return access_denied unless @tag_alias.approvable_by?(CurrentUser.user)
     @tag_alias.approve!(approver: CurrentUser.user)
-    respond_with(@tag_alias, :location => tag_alias_path(@tag_alias))
+    respond_with(@tag_alias, location: tag_alias_path(@tag_alias))
   end
 
   private

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -194,7 +194,7 @@ class BulkUpdateRequest < ApplicationRecord
 
   def initialize_attributes
     self.user_id = CurrentUser.user.id unless self.user_id
-    self.user_ip_addr = Currentuser.ip_addr unless self.user_ip_addr
+    self.user_ip_addr = CurrentUser.ip_addr unless self.user_ip_addr
     self.status = "pending"
   end
 

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -75,7 +75,7 @@ class TagRelationship < ApplicationRecord
   end
 
   def approvable_by?(user)
-    is_pending? && user.is_admin?
+    is_pending? && user.is_admin? && (user.is_bd_staff? || !(consequent_tag&.artist&.is_dnp? || antecedent_tag&.artist&.is_dnp?))
   end
 
   def deletable_by?(user)

--- a/test/unit/tag_alias_test.rb
+++ b/test/unit/tag_alias_test.rb
@@ -101,7 +101,8 @@ class TagAliasTest < ActiveSupport::TestCase
       end
 
       should "allow creator" do
-        assert_equal(true, @ta.deletable_by?(@user)) end
+        assert_equal(true, @ta.deletable_by?(@user))
+      end
 
       should "allow admins" do
         assert_equal(true, @ta.deletable_by?(@admin))

--- a/test/unit/tag_alias_test.rb
+++ b/test/unit/tag_alias_test.rb
@@ -7,8 +7,8 @@ class TagAliasTest < ActiveSupport::TestCase
     setup do
       @admin = create(:admin_user)
 
-      user = create(:user, created_at: 1.month.ago)
-      CurrentUser.user = user
+      @user = create(:user, created_at: 1.month.ago)
+      CurrentUser.user = @user
     end
 
     context "on validation" do
@@ -57,6 +57,58 @@ class TagAliasTest < ActiveSupport::TestCase
 
       should "get the right count" do
         assert_equal(1, @alias.estimate_update_count)
+      end
+    end
+
+    context "#approvable_by?" do
+      setup do
+        @mod = create(:moderator_user)
+        @bd = create(:bd_staff_user)
+        @ta = as(@user) { create(:tag_alias, status: "pending") }
+        @dnp = as(@bd) { create(:avoid_posting) }
+        @ta2 = as(@user) { create(:tag_alias, antecedent_name: @dnp.artist_name, consequent_name: "ccc", status: "pending") }
+        @ta3 = as(@user) { create(:tag_alias, antecedent_name: "ddd", consequent_name: @dnp.artist_name, status: "pending") }
+      end
+
+      should "not allow creator" do
+        assert_equal(false, @ta.approvable_by?(@user))
+      end
+
+      should "allow admins" do
+        assert_equal(true, @ta.approvable_by?(@admin))
+      end
+
+      should "now allow mods" do
+        assert_equal(false, @ta.approvable_by?(@mod))
+      end
+
+      should "not allow admins if antecedent/consequent is dnp" do
+        assert_equal(false, @ta2.approvable_by?(@admin))
+        assert_equal(false, @ta3.approvable_by?(@admin))
+      end
+
+      should "allow bd staff" do
+        assert_equal(true, @ta2.approvable_by?(@bd))
+        assert_equal(true, @ta3.approvable_by?(@bd))
+      end
+    end
+
+    context "#deletable_by?" do
+      setup do
+        @user = create(:user)
+        @mod = create(:moderator_user)
+        @ta = as(@user) { create(:tag_alias, status: "pending") }
+      end
+
+      should "allow creator" do
+        assert_equal(true, @ta.deletable_by?(@user)) end
+
+      should "allow admins" do
+        assert_equal(true, @ta.deletable_by?(@admin))
+      end
+
+      should "now allow mods" do
+        assert_equal(false, @ta.deletable_by?(@mod))
       end
     end
 


### PR DESCRIPTION
This pr prevents non-bd staff users from approving Aliases/Implications whose antecedent/consequent are on the avoid posting list, since the approval [will fail](https://e621.net/forum_topics/46783)