### PR TITLE
[ModActions] Add value field whitelist

### DIFF
--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -91,6 +91,8 @@ class ModAction < ApplicationRecord
     takedown_process: %i[takedown_id],
   }.freeze
 
+  KnownActionKeys = KnownActions.keys.freeze
+
   def self.search(params)
     q = super
 

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -109,7 +109,8 @@ class ModAction < ApplicationRecord
     if CurrentUser.is_admin?
       original_values
     else
-      sanitized_values = original_values.slice(*KnownActions[action.to_sym].map(&:to_s))
+      valid_keys = KnownActions[action.to_sym]&.map(&:to_s) || []
+      sanitized_values = original_values.slice(*valid_keys)
 
       if %i[ip_ban_create ip_ban_delete].include?(action.to_sym)
         sanitized_values = sanitized_values.slice([])

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -1,95 +1,95 @@
 # frozen_string_literal: true
 
 class ModAction < ApplicationRecord
-  belongs_to :creator, :class_name => "User"
-  before_validation :initialize_creator, :on => :create
+  belongs_to :creator, class_name: "User"
+  before_validation :initialize_creator, on: :create
   validates :creator_id, presence: true
 
-  KnownActions = [
-      :artist_page_rename,
-      :artist_page_lock,
-      :artist_page_unlock,
-      :artist_user_linked,
-      :artist_user_unlinked,
-      :avoid_posting_create,
-      :avoid_posting_update,
-      :avoid_posting_delete,
-      :avoid_posting_undelete,
-      :avoid_posting_destroy,
-      :blip_delete,
-      :blip_hide,
-      :blip_unhide,
-      :blip_update,
-      :comment_delete,
-      :comment_hide,
-      :comment_unhide,
-      :comment_update,
-      :forum_category_create,
-      :forum_category_delete,
-      :forum_category_update,
-      :forum_post_delete,
-      :forum_post_hide,
-      :forum_post_unhide,
-      :forum_post_update,
-      :forum_topic_delete,
-      :forum_topic_hide,
-      :forum_topic_unhide,
-      :forum_topic_lock,
-      :forum_topic_unlock,
-      :forum_topic_stick,
-      :forum_topic_unstick,
-      :forum_topic_update,
-      :help_create,
-      :help_delete,
-      :help_update,
-      :ip_ban_create,
-      :ip_ban_delete,
-      :mascot_create,
-      :mascot_update,
-      :mascot_delete,
-      :pool_delete,
-      :report_reason_create,
-      :report_reason_delete,
-      :report_reason_update,
-      :set_update,
-      :set_delete,
-      :set_change_visibility,
-      :tag_alias_create,
-      :tag_alias_update,
-      :tag_implication_create,
-      :tag_implication_update,
-      :ticket_claim,
-      :ticket_unclaim,
-      :ticket_update,
-      :upload_whitelist_create,
-      :upload_whitelist_update,
-      :upload_whitelist_delete,
-      :user_blacklist_changed,
-      :user_text_change,
-      :user_upload_limit_change,
-      :user_flags_change,
-      :user_level_change,
-      :user_name_change,
-      :user_delete,
-      :user_ban,
-      :user_ban_update,
-      :user_unban,
-      :user_feedback_create,
-      :user_feedback_update,
-      :user_feedback_delete,
-      :user_feedback_undelete,
-      :user_feedback_destroy,
-      :wiki_page_rename,
-      :wiki_page_delete,
-      :wiki_page_lock,
-      :wiki_page_unlock,
+  KnownActions = {
+    artist_page_rename: %i[old_name new_name],
+    artist_page_lock: %i[artist_page],
+    artist_page_unlock: %i[artist_page],
+    artist_user_linked: %i[artist_page user_id],
+    artist_user_unlinked: %i[artist_page user_id],
+    avoid_posting_create: %i[id artist_name],
+    avoid_posting_update: %i[id artist_name details old_details staff_notes old_staff_notes],
+    avoid_posting_delete: %i[id artist_name],
+    avoid_posting_undelete: %i[id artist_name],
+    avoid_posting_destroy: %i[id artist_name],
+    blip_delete: %i[blip_id user_id],
+    blip_hide: %i[blip_id user_id],
+    blip_unhide: %i[blip_id user_id],
+    blip_update: %i[blip_id user_id],
+    comment_delete: %i[comment_id user_id],
+    comment_hide: %i[comment_id user_id],
+    comment_unhide: %i[comment_id user_id],
+    comment_update: %i[comment_id user_id],
+    forum_category_create: %i[forum_category_id],
+    forum_category_delete: %i[forum_category_id],
+    forum_category_update: %i[forum_category_id],
+    forum_post_delete: %i[forum_post_id forum_topic_id user_id],
+    forum_post_hide: %i[forum_post_id forum_topic_id user_id],
+    forum_post_unhide: %i[forum_post_id forum_topic_id user_id],
+    forum_post_update: %i[forum_post_id forum_topic_id user_id],
+    forum_topic_delete: %i[forum_topic_id forum_topic_title user_id],
+    forum_topic_hide: %i[forum_topic_id forum_topic_title user_id],
+    forum_topic_unhide: %i[forum_topic_id forum_topic_title user_id],
+    forum_topic_lock: %i[forum_topic_id forum_topic_title user_id],
+    forum_topic_unlock: %i[forum_topic_id forum_topic_title user_id],
+    forum_topic_stick: %i[forum_topic_id forum_topic_title user_id],
+    forum_topic_unstick: %i[forum_topic_id forum_topic_title user_id],
+    forum_topic_update: [], # FIXME: this key is never used anywhere
+    help_create: %i[name wiki_page],
+    help_delete: %i[name wiki_page],
+    help_update: %i[name wiki_page],
+    ip_ban_create: %i[ip_addr reason],
+    ip_ban_delete: %i[ip_addr reason],
+    mascot_create: %i[id],
+    mascot_update: %i[id],
+    mascot_delete: %i[id],
+    pool_delete: %i[pool_id pool_name user_id],
+    report_reason_create: %i[reason],
+    report_reason_delete: %i[reason user_id],
+    report_reason_update: %i[reason reason_was description description_was],
+    set_update: %i[set_id user_id],
+    set_delete: %i[set_id user_id],
+    set_change_visibility: %i[set_id user_id is_public],
+    tag_alias_create: %i[alias_id alias_desc],
+    tag_alias_update: %i[alias_id alias_desc change_desc],
+    tag_implication_create: %i[implication_id implication_desc],
+    tag_implication_update: %i[implication_id implication_desc change_desc],
+    ticket_claim: %i[ticket_id],
+    ticket_unclaim: %i[ticket_id],
+    ticket_update: %i[ticket_id],
+    upload_whitelist_create: %i[pattern note hidden],
+    upload_whitelist_update: %i[pattern note old_pattern hidden],
+    upload_whitelist_delete: %i[pattern note hidden],
+    user_blacklist_changed: %i[user_id],
+    user_text_change: %i[user_id],
+    user_upload_limit_change: %i[user_id old_upload_limit new_upload_limit],
+    user_flags_change: %i[user_id added removed],
+    user_level_change: %i[user_id level level_was],
+    user_name_change: %i[user_id],
+    user_delete: %i[user_id],
+    user_ban: %i[user_id duration reason],
+    user_ban_update: %i[user_id ban_id expires_at expires_at_was reason reason_was],
+    user_unban: %i[user_id],
+    user_feedback_create: %i[user_id reason type record_id],
+    user_feedback_update: %i[user_id reason reason_was type type_was record_id],
+    user_feedback_delete: %i[user_id reason reason_was type type_was record_id],
+    user_feedback_undelete: %i[user_id reason reason_was type type_was record_id],
+    user_feedback_destroy: %i[user_id reason type record_id],
+    wiki_page_rename: %i[new_title old_title],
+    wiki_page_delete: %i[wiki_page wiki_page_id],
+    wiki_page_lock: %i[wiki_page],
+    wiki_page_unlock: %i[wiki_page],
 
-      :mass_update,
-      :nuke_tag,
+    mass_update: %i[antecedent consequent],
+    nuke_tag: %i[tag_name],
 
-      :takedown_delete,
-      :takedown_process,
-  ]
+    takedown_delete: %i[takedown_id],
+    takedown_process: %i[takedown_id],
+  }.freeze
 
   def self.search(params)
     q = super
@@ -97,13 +97,41 @@ class ModAction < ApplicationRecord
     q = q.where_user(:creator_id, :creator, params)
 
     if params[:action].present?
-      q = q.where('action = ?', params[:action])
+      q = q.where("action = ?", params[:action])
     end
 
     q.apply_basic_order(params)
   end
 
+  def values
+    original_values = self[:values]
+
+    if CurrentUser.is_admin?
+      original_values
+    else
+      sanitized_values = original_values.slice(*KnownActions[action.to_sym].map(&:to_s))
+
+      if %i[ip_ban_create ip_ban_delete].include?(action.to_sym)
+        sanitized_values = sanitized_values.slice([])
+      end
+
+      if %i[upload_whitelist_create upload_whitelist_update upload_whitelist_delete].include?(action.to_sym)
+        if sanitized_values["hidden"]
+          sanitized_values = sanitized_values.slice("hidden")
+        else
+          sanitized_values = sanitized_values.slice("hidden", "note")
+        end
+      end
+
+      sanitized_values
+    end
+  end
+
   def hidden_attributes
+    super + [:values]
+  end
+
+  def method_attributes
     super + [:values]
   end
 

--- a/app/views/mod_actions/_search.html.erb
+++ b/app/views/mod_actions/_search.html.erb
@@ -1,4 +1,4 @@
 <%= form_search(path: mod_actions_path) do |f| %>
   <%= f.user :creator %>
-  <%= f.input :action, label: "Action", collection: ModAction::KnownActions.keys.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true %>
+  <%= f.input :action, label: "Action", collection: ModAction::KnownActionKeys.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true %>
 <% end %>

--- a/app/views/mod_actions/_search.html.erb
+++ b/app/views/mod_actions/_search.html.erb
@@ -1,4 +1,4 @@
 <%= form_search(path: mod_actions_path) do |f| %>
   <%= f.user :creator %>
-  <%= f.input :action, label: "Action", collection: ModAction::KnownActions.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true %>
+  <%= f.input :action, label: "Action", collection: ModAction::KnownActions.keys.map {|k| [k.to_s.capitalize.tr("_"," "), k.to_s]}, include_blank: true %>
 <% end %>


### PR DESCRIPTION
Exposes the values in the ModActions through the JSON API.
Implements a strict field whitelist to ensure that no unwanted data is leaked.
The field whitelist is applied directly at Model level. This is similar to how this is handled in the Post model. This impacts the HTML, but the functionality is identical. We could simplify the HTML by removing the checks for Admin and replace them with checks for nil. 
The field whitelist is disabled for Admins.