### PR TITLE
Fixed non-critical typo in blacklist filter parsing

### DIFF
--- a/app/javascript/src/javascripts/utility/filter_util.js
+++ b/app/javascript/src/javascripts/utility/filter_util.js
@@ -98,7 +98,7 @@ FilterUtils.normalizeData = (value, type) => {
     case "width":
     case "height":
     case "score":
-    case "favcout":
+    case "favcount":
     case "userid":
       return parseInt(value);
     case "rating":


### PR DESCRIPTION
Fixed filter_util.js 'favcout' typo.

normalizeData (line 101) had a typo that failed to parse 'favcount' values to integers. The lack of a strict equality operator in the compare function (line 118) stops this from failing (the value is coerced to a number), it makes sense to either correctly match the case or remove it.