### PR TITLE
[Autocomplete] Remove mp4 from file type completion

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -364,10 +364,10 @@ Autocomplete.static_metatags = {
     "any", "none"
   ],
   filetype: [
-    "jpg", "png", "gif", "swf", "webm", "mp4"
+    "jpg", "png", "gif", "swf", "webm"
   ],
   type: [
-    "jpg", "png", "gif", "swf", "webm", "mp4"
+    "jpg", "png", "gif", "swf", "webm"
   ],
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3b8aa284-2ec7-45fa-a231-3ad16ee39789)

e621 does not have mp4 posts, nor does it intend to, so having this here is nothing but confusing.