### PR TITLE
[Blacklist] Add fuzzy direct equality to filesize blacklist tag

### DIFF
--- a/app/javascript/src/javascripts/models/Filter.js
+++ b/app/javascript/src/javascripts/models/Filter.js
@@ -170,7 +170,19 @@ class FilterToken {
           ];
         }
       }
-    } else this.value = FilterUtils.normalizeData(raw, this.type);
+    } else {
+      this.value = FilterUtils.normalizeData(raw, this.type);
+      if (this.comparison === "=" && this.type === "filesize") {
+        // If the comparison uses direct equality, mirror the fudging behavior of 
+        // the filesize search metatag by changing the comparison to a range of 
+        // the initial value -5% and +5%.
+        this.comparison = "..";
+        this.value = [
+          Math.trunc(this.value * 0.95),
+          Math.trunc(this.value * 1.05),
+        ];
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
The [parsing function](https://github.com/e621ng/e621ng/blob/7318b2ddcb5d1ab16b5fa987de8f35f6f4d7bab2/app/logical/parse_value.rb#L25) for search metatag [`filesize`](https://github.com/e621ng/e621ng/blob/3f17beb3b8110e653ea94f485430295f5eb36d75/app/logical/tag_query.rb#L245), when using a direct equality comparison (e.g. `filesize:10kb`), instead uses a range comparison (`..`) with the bounds being the value + & - 5% (e.g. [`filesize:10kb`](https://e621.net/posts?tags=filesize%3A10kB+order%3Afilesize_asc+) is equal to [`filesize:9.5kb..10.5kb`](https://e621.net/posts?tags=filesize%3A9.5kB..10.5kb+order%3Afilesize_asc+)). The equivalent blacklist tag mirrored the search metatag in all aspects but this; this PR adds this fuzzy matching capability.

If the original behavior is desired by users, it can be achieved by using a range bounded on both sides by the desired file size (e.g.`filesize:3071..3071`).

### Testing
Tested by using Chrome's local overrides to inject the modified script, adding `filesize:3071` (-5% = 2917.45 ≈ 2917, +5% = 3224.55 ≈ 3224) and `filesize:3072`/`filesize:3kb` (-5% = 2918.3999... ≈ 2918, +5% = 3225.6 ≈ 3225) to my blacklist and searching `filesize:3072`/`filesize:3kb`; all results matched by `filesize:3072`/`filesize:3kb`, with all but 1 result w/ a file size of 3225 matched by `filesize:3071`. Replacing `filesize:3071` with `filesize:3071..3071` in the blacklist matched the original behavior.

If desired, testing can be replicated by replacing the source map lines 1885 - 1886:
```
                    else
                        this.value = o.default.normalizeData(e, this.type)
```
with: 
```

                    else {
      this.value = o.default.normalizeData(e, this.type);
      if (this.comparison === "=" && this.type === "filesize") {
        // If the comparison uses direct equality, mirror the fudging behavior of 
        // the filesize search metatag by changing the comparison to a range of 
        // the initial value -5% and +5%.
        this.comparison = "..";
          console.log(this.value);
          console.log(this.value * 0.95);
          console.log(this.value * 1.05);
        this.value = [
          Math.trunc(this.value * 0.95),
          Math.trunc(this.value * 1.05),
        ];
          console.log(this.value);
      }
    }
```
and both searching and altering the blacklist as normal. In case the source map is inconsistent, here is my source-mapped local override folder:
[e621-filesize-blacklist-edit-test.zip](https://github.com/user-attachments/files/17653461/e621-filesize-blacklist-edit-test.zip)

### Impact
This would result in any users currently using the direct equality for the `filesize` metatag having their blacklist suddenly match ***a lot*** more posts than before. It might prove beneficial to point the [wiki page](https://e621.net/help/blacklist#metatags) to the [post search equivalent](https://e621.net/wiki_pages/9169#imagesize) to dispel confusion. On that note, I'd wager most users using this tag in this way structured their blacklist expecting this effect, considering the extremely specific nature of blacklisting a precise file size and the current difference between the post search and blacklist variants, which runs counter to the strict parity between variants shared by the other tags, with the exceptions of the naming conventions of `userid`/`user_id`, the `fav` metatag only matching the current user, and the lack of support for the list syntax of [`id:39,41,42`](https://e621.net/posts?tags=id%3A39%2C41%2C42), something users probably wouldn't know about as it isn't mentioned anywhere in the [user-facing documentation](https://e621.net/wiki_pages/9169#rangesyntax). That being said, perhaps betting on that might be unwise. In any case this would only unexpectedly shrink blacklists that use this naked equality with negation.