### PR TITLE
Adding Apple Silicon Mac support in Docker Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.3.1-alpine3.19 as ruby-builder
 
-RUN apk --no-cache add build-base cmake git glib-dev postgresql15-dev
+RUN apk --no-cache add build-base cmake git glib-dev postgresql15-dev gcompat
 
 COPY Gemfile Gemfile.lock ./
 RUN gem i foreman && BUNDLE_IGNORE_CONFIG=true bundle install -j$(nproc) \
@@ -19,7 +19,7 @@ FROM ruby:3.3.1-alpine3.19
 RUN apk --no-cache add ffmpeg vips \
   postgresql15-client \
   git jemalloc tzdata \
-  sudo
+  sudo gcompat
 
 WORKDIR /app
 


### PR DESCRIPTION
## Issue

![image](https://github.com/user-attachments/assets/01a6e3b1-30e6-4d7c-9cbc-2cd607e198ea)

launching docker on Apple silicon mac would fail due to nokogiri library not found.

## Solution

by adding gcompat, a glibc compatibility layer to the docker image, the docker can be launched and webpage is up for apple silicon macs

### source
https://stackoverflow.com/questions/70963924/unable-to-load-nokogiri-in-docker-container-on-m1-mac/71014474#71014474

## testing

rebuild the docker and relaunch the server
`docker compose down -v`
`docker compose build --no-cache`
`docker compose run --rm e621 /app/bin/setup`
`docker compose up`
`docker exec -it e621ng-e621-1 /app/bin/populate`
- then access localhost:3000 and verify basic functionality 

machine tested on: 
Chip: M2 Pro
MacOS: 14.6.1 (23G93)

## Other
Special thanks to @DonovanDMC for finding the StackOverflow solution