### PR TITLE
[PostVersions] Fix ordering

### DIFF
--- a/app/logical/elastic_post_version_query_builder.rb
+++ b/app/logical/elastic_post_version_query_builder.rb
@@ -61,5 +61,7 @@ class ElasticPostVersionQueryBuilder < ElasticQueryBuilder
         must.push({ term: { version: 1 } })
       end
     end
+
+    apply_basic_order
   end
 end


### PR DESCRIPTION
Re-adds the basic ordering in post versions, the same way as it was originally (id_desc) + allowing id_asc.

Follow up of #772 