### PR TITLE
[Comments] Show direct link comments to the creator regardless of settings

### DIFF
--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -1,4 +1,4 @@
-<% if comment.should_see?(CurrentUser.user) %>
+<% if comment.should_see?(CurrentUser.user) || (current_page?(:controller => "comments", :action => "show") && CurrentUser.id == comment.creator_id) %>
   <article class="comment comment-post-grid <%= "below-threshold" if comment.below_threshold? %>" data-post-id="<%= comment.post_id %>"
            data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>"
            data-creator="<%= comment.creator&.name.downcase %>" data-is-sticky="<%= comment.is_sticky %>" data-creator-id="<%= comment.creator_id %>"


### PR DESCRIPTION
See https://discord.com/channels/431908090883997698/1099361575116222656/1305898089848242186

Just makes the comment show page always show the comment to the creator of the comment. Even if they have hidden comments disabled or the score is below their threshold.