### PR TITLE
[WikiPages] Add tag category dropdown

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -123,7 +123,7 @@ class WikiPagesController < ApplicationController
   end
 
   def wiki_page_params(context)
-    permitted_params = %i[body edit_reason]
+    permitted_params = %i[body category_id edit_reason]
     permitted_params += %i[parent] if CurrentUser.is_privileged?
     permitted_params += %i[is_locked is_deleted skip_secondary_validations] if CurrentUser.is_janitor?
     permitted_params += %i[title] if context == :create || CurrentUser.is_janitor?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -80,8 +80,12 @@ class Tag < ApplicationRecord
 
       def category_for(tag_name)
         Cache.fetch("tc:#{tag_name}") do
-          Tag.where(name: tag_name).pick(:category).to_i
+          category_for!(tag_name).to_i
         end
+      end
+
+      def category_for!(tag_name)
+        Tag.where(name: tag_name).pick(:category)
       end
 
       def categories_for(tag_names, disable_cache: false)

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -12,6 +12,8 @@
 
     <%= f.input :body, as: :dtext, limit: Danbooru.config.wiki_page_max_size, allow_color: true %>
 
+    <%= f.input(:category_id, label: "Tag Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: true, disabled: !@wiki_page.category_editable?) %>
+
     <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page", input_html: { disabled: !CurrentUser.is_privileged? } %>
 
     <% if CurrentUser.is_janitor? && @wiki_page.is_deleted? %>


### PR DESCRIPTION
Adds a tag category dropdown to wiki pages, as requested [here](https://discord.com/channels/431908090883997698/1099361575116222656/1305646376834830429)

With this we could remove the "Edit Tag Category" link from the subnav, if we want to

![image](https://github.com/user-attachments/assets/cbf860fb-18b3-41cb-9983-2b456f1773c0)
