### PR TITLE
Fix UI issue on Pool 

### DIFF
--- a/app/javascript/src/styles/common/z_responsive.scss
+++ b/app/javascript/src/styles/common/z_responsive.scss
@@ -211,7 +211,7 @@
       text-align: center;
       vertical-align: middle;
       display: inline-block;
-      width: 31vw;
+      width: min-content;
 
       a {
         margin: 0 auto;

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -6,7 +6,7 @@
 article.post-preview {
   box-sizing: border-box;
   height: auto;
-  width: fit-content;
+  width: min-content;
   margin: 0 10px 10px 0;
   overflow: hidden;
   text-align: center;


### PR DESCRIPTION
# Issue:
#791 

# Summary:
where text can be too long and cause large area of empty space.
patched by limiting max text width can only be as wide as the image.

# Demo:
small screen:
<img width="351" alt="image" src="https://github.com/user-attachments/assets/cc46a785-38bd-4477-a496-25e01922533e">
large screen (2560px wide):
<img width="970" alt="image" src="https://github.com/user-attachments/assets/cd5b3bf6-1678-47ce-ad54-3f9fbf8a57e1">
