### PR TITLE
Automatically like posts when they are favorited, backend

### DIFF
--- a/app/javascript/src/javascripts/favorites.js
+++ b/app/javascript/src/javascripts/favorites.js
@@ -41,7 +41,7 @@ Favorite.create = function (post_id) {
     }).done(function () {
       Post.notice_update("dec");
       Favorite.after_action(post_id, 1);
-      Utility.notice("Favorite added");
+      Utility.notice("Favorite added and upvoted");
     }).fail(function (data) {
       Utility.error("Error: " + data.responseJSON.message);
     });

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -12,13 +12,13 @@ class FavoriteManager
             raise Favorite::Error, "You can only keep up to #{user.favorite_limit} favorites."
           end
         end
-
         Favorite.create(:user_id => user.id, :post_id => post.id)
         post.append_user_to_fav_string(user.id)
         post.do_not_version_changes = true
         post.save
       end
-      VoteManager.vote!(user: CurrentUser.user, post: upvoted, score: 1)
+      VoteManager.vote!(user: user, post: post, score: 1)
+      
     rescue ActiveRecord::SerializationFailure => e
       retries -= 1
       retry if retries > 0

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -18,6 +18,7 @@ class FavoriteManager
         post.do_not_version_changes = true
         post.save
       end
+      VoteManager.vote!(user: CurrentUser.user, post: upvoted, score: 1)
     rescue ActiveRecord::SerializationFailure => e
       retries -= 1
       retry if retries > 0

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -18,7 +18,6 @@ class FavoriteManager
         post.save
       end
       VoteManager.vote!(user: user, post: post, score: 1)
-      
     rescue ActiveRecord::SerializationFailure => e
       retries -= 1
       retry if retries > 0

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1356,7 +1356,7 @@ class PostTest < ActiveSupport::TestCase
       should "not decrement the post's score" do
         @member = create(:user)
 
-        assert_no_difference("@post.score") { FavoriteManager.add!(user: @member, post: @post) }
+        assert_difference("@post.score", 1) { FavoriteManager.add!(user: @member, post: @post) }
         assert_no_difference("@post.score") { FavoriteManager.remove!(user: @member, post: @post) }
       end
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1389,10 +1389,10 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
-      should "not increment the post's score" do
+      should "increment the post's score" do
         @member = create(:user)
         FavoriteManager.add!(user: @user, post: @post)
-        assert_equal(0, @post.score)
+        assert_equal(1, @post.score)
       end
 
       should "update the fav strings on the post" do


### PR DESCRIPTION
# Issue

https://github.com/orgs/e621ng/projects/1/views/7?pane=issue&itemId=69975628


# What's done

adding upvote action to the backend in favorite action.

upvote doesn't shown right after
view is correct after a refresh

# Demo


## works when haven't upvote yet
<img width="484" alt="image" src="https://github.com/user-attachments/assets/b4c4b712-e8d4-469b-977b-a573068ef0fe">

note: the upvote button didn't go green (view is correct after a refresh)

<img width="334" alt="image" src="https://github.com/user-attachments/assets/337b958b-d525-4e06-a215-80ee4e9bb452">


## favoriting works if post were upvoted before (no error)
<img width="425" alt="image" src="https://github.com/user-attachments/assets/07cb62a1-eb3f-42d1-8fd5-b3ada8c95b84">


