### PR TITLE
[UserFeedbacks] Allow janitors to see deleted feedback

### DIFF
--- a/app/controllers/user_feedbacks_controller.rb
+++ b/app/controllers/user_feedbacks_controller.rb
@@ -17,7 +17,7 @@ class UserFeedbacksController < ApplicationController
 
   def show
     @user_feedback = UserFeedback.find(params[:id])
-    raise(User::PrivilegeError) if !CurrentUser.user.is_moderator? && @user_feedback.is_deleted?
+    raise(User::PrivilegeError) if !CurrentUser.user.is_staff? && @user_feedback.is_deleted?
     respond_with(@user_feedback)
   end
 
@@ -88,12 +88,14 @@ class UserFeedbacksController < ApplicationController
   def user_feedback_params(context)
     permitted_params = %i[body category]
     permitted_params += %i[user_id user_name] if context == :create
-    permitted_params += [:send_update_dmail] if context == :update
+    permitted_params += %i[send_update_dmail] if context == :update
 
     params.fetch(:user_feedback, {}).permit(permitted_params)
   end
 
   def search_params
-    permit_search_params(%i[deleted body_matches user_id user_name creator_id creator_name category])
+    permitted_params = %i[body_matches user_id user_name creator_id creator_name category]
+    permitted_params += %i[deleted] if CurrentUser.is_staff?
+    permit_search_params(permitted_params)
   end
 end

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -66,7 +66,7 @@ class UserFeedback < ApplicationRecord
     end
 
     def visible(user)
-      if user.is_moderator?
+      if user.is_staff?
         all
       else
         active

--- a/app/views/user_feedbacks/_search.html.erb
+++ b/app/views/user_feedbacks/_search.html.erb
@@ -2,7 +2,7 @@
   <%= f.user :user %>
   <%= f.user :creator %>
   <%= f.input :body_matches, label: "Message" %>
-  <% if CurrentUser.is_moderator? %>
+  <% if CurrentUser.is_staff? %>
     <%= f.input :deleted, label: "Deleted?", collection: [%w[Excluded excluded], %w[Included included], %w[Only only]], include_blank: true %>
   <% end %>
   <%= f.input :category, collection: %w[positive negative neutral], include_blank: true %>

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -50,7 +50,7 @@
       </tbody>
     </table>
 
-    <% if CurrentUser.is_moderator? && params.dig(:search, :user_id).present? && params.dig(:search, :deleted).blank? %>
+    <% if CurrentUser.is_staff? && params.dig(:search, :user_id).present? && params.dig(:search, :deleted).blank? %>
       <% count = UserFeedback.for_user(params.dig(:search, :user_id)).deleted.count %>
       <% if count > 0 %>
         <%= link_to("Show All (#{count})", { search: params[:search].permit!.merge(deleted: "included") }, class: "show-all-user-feedbacks-link button btn-neutral") %>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -89,7 +89,7 @@
         <span>
           <%= presenter.feedbacks %>
           <%= link_to("List", user_feedbacks_path(search: { user_id: @user.id })) %>
-          <% if CurrentUser.is_moderator? && @user.feedback.count.zero? %>
+          <% if CurrentUser.is_moderator? && @user.feedback.active.count == 0 %>
             | <%= link_to("Create", new_user_feedback_path(user_feedback: { user_id: @user.id, category: "neutral" })) %>
           <% end %>
         </span>


### PR DESCRIPTION
As previously discussed

This pr also changes hiding the "Create" button on user profiles to only consider active records