### PR TITLE
[UserVote] Allow viewing own votes

### DIFF
--- a/app/models/user_vote.rb
+++ b/app/models/user_vote.rb
@@ -40,6 +40,14 @@ class UserVote < ApplicationRecord
   end
 
   module SearchMethods
+    def visible(user)
+      if user.is_moderator?
+        all
+      else
+        where(user_id: user.id)
+      end
+    end
+
     def search(params)
       q = super
 

--- a/app/views/user_votes/_common_index.html.erb
+++ b/app/views/user_votes/_common_index.html.erb
@@ -59,16 +59,18 @@
       </tbody>
     </table>
     <br/>
-    <%= tag.button "Select All", id: "select-all-votes" %><br/>
-    <%= tag.button "Lock Votes",  id: "lock-votes" %> Set the votes to 0, preventing the user
-    from voting on the <%= type.model_type %> again<br/>
-    <% if CurrentUser.is_admin? %>
-      <%= tag.button "Delete Votes", id: "delete-votes" %> Remove the votes
-    <% end %>
+    <% if CurrentUser.is_moderator? %>
+      <%= tag.button "Select All", id: "select-all-votes" %><br/>
+      <%= tag.button "Lock Votes",  id: "lock-votes" %> Set the votes to 0, preventing the user
+      from voting on the <%= type.model_type %> again<br/>
+      <% if CurrentUser.is_admin? %>
+        <%= tag.button "Delete Votes", id: "delete-votes" %> Remove the votes
+      <% end %>
 
-    <%= javascript_tag nonce: true do -%>
-      new Danbooru.VoteManager('<%= type.model_type %>');
-    <% end -%>
+      <%= javascript_tag nonce: true do -%>
+        new Danbooru.VoteManager('<%= type.model_type %>');
+      <% end -%>
+    <% end %>
 
     <%= numbered_paginator(votes) %>
   </div>

--- a/test/factories/post_vote.rb
+++ b/test/factories/post_vote.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:post_vote) do
+    score { 1 }
+  end
+end

--- a/test/functional/comment_votes_controller_test.rb
+++ b/test/functional/comment_votes_controller_test.rb
@@ -6,26 +6,51 @@ class CommentVotesControllerTest < ActionDispatch::IntegrationTest
   context "A comment votes controller" do
     setup do
       @user = create(:user)
-      @post = create(:post, uploader: @user)
+      @admin = create(:admin_user)
       CurrentUser.user = @user
+      @post = create(:post, uploader: @user)
       @comment = create(:comment, post: @post)
 
-      @user = create(:user)
-      CurrentUser.user = @user
+      @user2 = create(:user)
+      CurrentUser.user = @user2
+    end
+
+    context "index action" do
+      should "render" do
+        get_auth url_for(controller: "comment_votes", action: "index", only_path: true), @admin
+        assert_response :success
+      end
+
+      context "members" do
+        should "render" do
+          get_auth url_for(controller: "comment_votes", action: "index", only_path: true), @user2
+          assert_response :success
+        end
+
+        should "only list own votes" do
+          create(:comment_vote, comment: @comment, user: @user2, score: -1)
+          create(:comment_vote, comment: @comment, user: @admin, score: 1)
+
+          get_auth url_for(controller: "comment_votes", action: "index", format: "json", only_path: true), @user2
+          assert_response :success
+          assert_equal(1, response.parsed_body.length)
+          assert_equal(@user2.id, response.parsed_body[0]["user_id"])
+        end
+      end
     end
 
     context "create action" do
       should "create a vote" do
         assert_difference("CommentVote.count", 1) do
-          post_auth comment_votes_path(@comment), @user, params: { score: -1, format: :json }
+          post_auth comment_votes_path(@comment), @user2, params: { score: -1, format: :json }
           assert_response :success
         end
       end
 
       should "unvote when the vote already exists" do
-        create(:comment_vote, comment: @comment, user: @user, score: -1)
+        create(:comment_vote, comment: @comment, user: @user2, score: -1)
         assert_difference(-> { CommentVote.count }, -1) do
-          post_auth comment_votes_path(@comment), @user, params: { score: -1, format: :json }
+          post_auth comment_votes_path(@comment), @user2, params: { score: -1, format: :json }
           assert_response :success
         end
       end
@@ -33,16 +58,16 @@ class CommentVotesControllerTest < ActionDispatch::IntegrationTest
       should "prevent voting on comment locked posts" do
         @post.update(is_comment_locked: true)
         assert_no_difference("CommentVote.count") do
-          post_auth comment_votes_path(@comment), @user, params: { score: -1, format: :json }
+          post_auth comment_votes_path(@comment), @user2, params: { score: -1, format: :json }
           assert_response 422
         end
       end
 
       should "prevent unvoting on comment locked posts" do
         @post.update(is_comment_locked: true)
-        create(:comment_vote, comment: @comment, user: @user, score: -1)
+        create(:comment_vote, comment: @comment, user: @user2, score: -1)
         assert_no_difference("CommentVote.count") do
-          post_auth comment_votes_path(@comment), @user, params: { score: -1, format: :json }
+          post_auth comment_votes_path(@comment), @user2, params: { score: -1, format: :json }
           assert_response 422
         end
       end
@@ -57,9 +82,9 @@ class CommentVotesControllerTest < ActionDispatch::IntegrationTest
 
       should "prevent unvoting on comment disabled posts" do
         @post.update(is_comment_disabled: true)
-        create(:comment_vote, comment: @comment, user: @user, score: -1)
+        create(:comment_vote, comment: @comment, user: @user2, score: -1)
         assert_no_difference("CommentVote.count") do
-          post_auth comment_votes_path(@comment), @user, params: { score: -1, format: :json }
+          post_auth comment_votes_path(@comment), @user2, params: { score: -1, format: :json }
           assert_response 422
         end
       end


### PR DESCRIPTION
Allows users to view their own comment & post votes in `/comment_votes` & `/post_votes`, which is useful since we source these in records.