### PR TITLE
[WikiPages] Normalize title in show_or_new

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -103,7 +103,7 @@ class WikiPagesController < ApplicationController
     if @wiki_page
       redirect_to wiki_page_path(@wiki_page)
     else
-      @wiki_page = WikiPage.new(:title => params[:title])
+      @wiki_page = WikiPage.new(title: WikiPage.normalize_name(params[:title] || ""))
       respond_with(@wiki_page)
     end
   end


### PR DESCRIPTION
This pr normalizes the show_or_new title for wiki pages when no wiki page exists. Without this normalization the search will consider spaces as separate tags, and will not correctly display aliases/implications

https://e621.net/wiki_pages/show_or_new?title=black_shirt
https://e621.net/wiki_pages/show_or_new?title=black%20shirt