### PR TITLE
[Bug] Fix regression of title (hover text) not showing up on post

### DIFF
--- a/app/javascript/src/styles/common/thumbnails.scss
+++ b/app/javascript/src/styles/common/thumbnails.scss
@@ -52,7 +52,6 @@ article.thumbnail {
     max-height: $thumb-image-size;
 
     border-radius: $border-radius-half $border-radius-half 0 0;
-    pointer-events: none;   // Should probably just fix the click events, huh
 
     // Mobile view
     width: 100%;


### PR DESCRIPTION
# Issue

https://github.com/e621ng/e621ng/issues/800

# Description

due to pointer action being disabled, simple remove CSS for disabling pointer action

# Test

- Tested clicking on post works normally
- hover over text now shows title (hover text)

<img width="438" alt="image" src="https://github.com/user-attachments/assets/425b1a28-c2f5-4b01-860b-8943421853f8">
