### PR TITLE
[Uploads] Allow for AV1 Webms to be uploaded by making mimetype "audio/webm" part of webm.

### DIFF
--- a/app/javascript/src/styles/common/z_responsive.scss
+++ b/app/javascript/src/styles/common/z_responsive.scss
@@ -30,7 +30,7 @@
       }
     }
 
-    #search-box { display: none; }
+    /*#search-box { display: none; }*/
 
     .mobile-search {
       display: block;

--- a/app/javascript/src/styles/common/z_responsive.scss
+++ b/app/javascript/src/styles/common/z_responsive.scss
@@ -30,7 +30,7 @@
       }
     }
 
-    /*#search-box { display: none; }*/
+    #search-box { display: none; }
 
     .mobile-search {
       display: block;

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -81,7 +81,7 @@ module FileMethods
         "gif"
       when "image/png"
         "png"
-      when "video/webm"
+      when "video/webm", "audio/webm"
         "webm"
       else
         mime_type


### PR DESCRIPTION
Seems to work. If someone tries to upload an audio only WebM it gets caught.