### PR TITLE
[StaffNotes] Fix DB migration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -156,6 +156,3 @@ Style/TrailingCommaInArrayLiteral:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
-
-Rails/NotNullColumn:
-  Enabled: false

--- a/db/migrate/20240205174652_soft_deletable_staff_notes.rb
+++ b/db/migrate/20240205174652_soft_deletable_staff_notes.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class SoftDeletableStaffNotes < ActiveRecord::Migration[7.1]
-  def change
+  def up
     add_column :staff_notes, :is_deleted, :boolean, null: false, default: false
-    add_reference :staff_notes, :updater, foreign_key: { to_table: :users }, null: false
+
+    add_reference :staff_notes, :updater, foreign_key: { to_table: :users }, null: true
+    execute("UPDATE staff_notes SET updater_id = creator_id")
+    change_column_null :staff_notes, :updater_id, false
+
     remove_column :staff_notes, :resolved, :boolean, null: false, default: false
   end
 end


### PR DESCRIPTION
Fixes the staff notes db migration by adding the updater_id field in two steps.