### PR TITLE
[StaffNotes] Restrict deletions to own notes or admins

### DIFF
--- a/app/models/staff_note.rb
+++ b/app/models/staff_note.rb
@@ -75,7 +75,6 @@ class StaffNote < ApplicationRecord
 
   def can_delete?(user)
     return false unless user.is_staff?
-    return true if creator_id == user.id || user.is_admin?
-    user_id != user.id
+    user.id == creator_id || user.is_admin?
   end
 end


### PR DESCRIPTION
Prevents users from deleting each other's staff notes, unless they are admins.