### PR TITLE
[Misc] Ensure that the footer is at the very bottom of the page

### DIFF
--- a/app/javascript/src/styles/common/main_layout.scss
+++ b/app/javascript/src/styles/common/main_layout.scss
@@ -2,7 +2,14 @@ div#search {
   margin-bottom: 1em;
 }
 
+body {
+  display: flex;
+  flex-flow: column;
+  min-height: 100vh;
+}
+
 div#page {
+  flex: 1;
   overflow: visible;
   padding: $padding-050 $padding-025 themed("content-padding-bottom");
 


### PR DESCRIPTION
Minor feature from re621.
Forces the `#page` element to span as much of the page as possible, placing the footer at the bottom of the screen.
Only affects pages that don't stretch that far, like empty profile pages for example.