### PR TITLE
[Blacklist] Fix blacklisted thumbnails in related posts

### DIFF
--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -219,7 +219,8 @@
 article.thumbnail.blacklisted {
   width: 100%;
   & > a {
-    height: 100%;
+    width: 150px;
+    height: 150px;
     background-image: url("blacklisted-preview.png");
     background-size: cover;
     background-position: center;


### PR DESCRIPTION
Fix a bug that caused parent/child thumbnails to have 0 height.

![Screenshot 2025-01-20 132539](https://github.com/user-attachments/assets/ed7031ee-ddf2-40b9-b167-d911a35066c1)
