### PR TITLE
[Posts] Fix the misaligned related post issue

### DIFF
--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -2,6 +2,7 @@
 
 
 #has-parent-relationship-preview, #has-children-relationship-preview {
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
 


### PR DESCRIPTION
The line with `display: flex` was missing for some reason, so the thumbnails were wonky.