### PR TITLE
[Pagination] Restore sequential pagination labels

### DIFF
--- a/app/javascript/src/styles/common/paginator.scss
+++ b/app/javascript/src/styles/common/paginator.scss
@@ -102,7 +102,7 @@ nav.pagination {
 
 
 // Sequential paginator
-.paginator.sequential {
+nav.pagination.sequential {
   gap: 5rem;
   a span { display: block; }
 }


### PR DESCRIPTION
![Screenshot 2025-02-11 081513](https://github.com/user-attachments/assets/63a1f559-d7fd-4594-9548-64dc39ddc8e6)

The sequential pagination should always display the prev / next labels.