### PR TITLE
[WikiPages] Add editing tag category

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -126,6 +126,7 @@ class WikiPagesController < ApplicationController
     permitted_params = %i[body category_id edit_reason]
     permitted_params += %i[parent] if CurrentUser.is_privileged?
     permitted_params += %i[is_locked is_deleted skip_secondary_validations] if CurrentUser.is_janitor?
+    permitted_params += %i[category_is_locked] if CurrentUser.is_admin?
     permitted_params += %i[title] if context == :create || CurrentUser.is_janitor?
 
     params.fetch(:wiki_page, {}).permit(permitted_params)

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -123,7 +123,7 @@ class WikiPagesController < ApplicationController
   end
 
   def wiki_page_params(context)
-    permitted_params = %i[body edit_reason]
+    permitted_params = %i[body category_id edit_reason]
     permitted_params += %i[parent] if CurrentUser.is_privileged?
     permitted_params += %i[is_locked is_deleted skip_secondary_validations] if CurrentUser.is_janitor?
     permitted_params += %i[title] if context == :create || CurrentUser.is_janitor?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -80,8 +80,12 @@ class Tag < ApplicationRecord
 
       def category_for(tag_name)
         Cache.fetch("tc:#{tag_name}") do
-          Tag.where(name: tag_name).pick(:category).to_i
+          category_for!(tag_name).to_i
         end
+      end
+
+      def category_for!(tag_name)
+        Tag.where(name: tag_name).pick(:category)
       end
 
       def categories_for(tag_names, disable_cache: false)

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -199,10 +199,9 @@ class WikiPage < ApplicationRecord
 
     def update_tag
       updates = tag_update_map
-      return if updates.empty?
-
       @tag = Tag.find_or_create_by_name(title)
 
+      return if updates.empty?
       unless @tag.category_editable_by?(CurrentUser.user)
         reload_tag_attributes
         errors.add(:category_id, "Cannot be changed")

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -336,8 +336,4 @@ class WikiPage < ApplicationRecord
       end
     end.map {|x| x.downcase.tr(" ", "_").to_s}.uniq
   end
-
-  def visible?
-    true
-  end
 end

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -6,7 +6,6 @@ class WikiPageVersion < ApplicationRecord
   belongs_to_updater
   user_status_counter :wiki_edit_count, foreign_key: :updater_id
   belongs_to :artist, optional: true
-  delegate :visible?, to: :wiki_page
 
   module SearchMethods
     def for_user(user_id)

--- a/app/views/wiki_page_versions/diff.html.erb
+++ b/app/views/wiki_page_versions/diff.html.erb
@@ -2,23 +2,19 @@
   <div id="a-diff">
     <h1>Wiki Page: <%= @thispage.title %></h1>
 
-    <% if @thispage.visible? %>
-      <p>Showing differences between <%= compact_time @thispage.updated_at %> (<%= link_to_user @thispage.updater %>) and <%= compact_time @otherpage.updated_at %> (<%= link_to_user @otherpage.updater %>)</p>
+    <p>Showing differences between <%= compact_time @thispage.updated_at %> (<%= link_to_user @thispage.updater %>) and <%= compact_time @otherpage.updated_at %> (<%= link_to_user @otherpage.updater %>)</p>
 
-      <% if @thispage.parent != @otherpage.parent %>
-        <div class="wiki-redirect-history">
-          Page redirect changed
-          from <%= @thispage.parent.blank? ? "none" : link_to(@thispage.parent, show_or_new_wiki_pages_path(title: @thispage.parent)) %>
-          to <%= @otherpage.parent.blank? ? "none" : link_to(@otherpage.parent, show_or_new_wiki_pages_path(title: @otherpage.parent)) %>.
-        </div>
-      <% end %>
-
-      <div>
-        <%= text_diff(@thispage.body, @otherpage.body) %>
+    <% if @thispage.parent != @otherpage.parent %>
+      <div class="wiki-redirect-history">
+        Page redirect changed
+        from <%= @thispage.parent.blank? ? "none" : link_to(@thispage.parent, show_or_new_wiki_pages_path(title: @thispage.parent)) %>
+        to <%= @otherpage.parent.blank? ? "none" : link_to(@otherpage.parent, show_or_new_wiki_pages_path(title: @otherpage.parent)) %>.
       </div>
-    <% else %>
-      <p>The artist requested removal of this page.</p>
     <% end %>
+
+    <div>
+      <%= text_diff(@thispage.body, @otherpage.body) %>
+    </div>
   </div>
 </div>
 

--- a/app/views/wiki_page_versions/show.html.erb
+++ b/app/views/wiki_page_versions/show.html.erb
@@ -10,11 +10,7 @@
       <% end %>
 
       <div id="wiki-page-body" class="dtext dtext-container">
-        <% if @wiki_page_version.visible? %>
-          <%= format_text(@wiki_page_version.body) %>
-        <% else %>
-          <p>The artist has requested removal of this page.</p>
-        <% end %>
+        <%= format_text(@wiki_page_version.body) %>
       </div>
     </section>
   </div>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -12,6 +12,8 @@
 
     <%= f.input :body, as: :dtext, limit: Danbooru.config.wiki_page_max_size, allow_color: true %>
 
+    <%= f.input(:category_id, label: "Tag Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: true, disabled: !@wiki_page.category_editable?) %>
+
     <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page", input_html: { disabled: !CurrentUser.is_privileged? } %>
 
     <% if CurrentUser.is_janitor? && @wiki_page.is_deleted? %>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -12,23 +12,27 @@
 
     <%= f.input :body, as: :dtext, limit: Danbooru.config.wiki_page_max_size, allow_color: true %>
 
-    <%= f.input(:category_id, label: "Tag Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: true, disabled: !@wiki_page.category_editable?) %>
+    <%= f.input :category_id, 
+      label: "Tag Category", 
+      collection: TagCategory::CANONICAL_MAPPING.to_a, 
+      include_blank: true, 
+      disabled: @wiki_page.category_is_locked && !CurrentUser.is_admin? %>
+
+    <% if CurrentUser.is_admin? %>
+      <%= f.input :category_is_locked, label: "Lock Category", as: :boolean %>
+    <% end %>
 
     <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page", input_html: { disabled: !CurrentUser.is_privileged? } %>
 
-    <% if CurrentUser.is_janitor? && @wiki_page.is_deleted? %>
-      <%= f.input :is_deleted, :label => "Deleted", :hint => "Uncheck to restore this wiki page" %>
-    <% end %>
-
     <% if CurrentUser.is_janitor? %>
-      <%= f.input :is_locked, :label => "Locked" %>
+      <%= f.input :is_locked, :label => "Lock Page" %>
     <% end %>
-
-    <%= f.input :edit_reason, label: "Edit Reason" %>
 
     <% if CurrentUser.is_janitor? && @wiki_page.errors[:title]&.any? { |error| error.include?("Move the posts and update any wikis linking to this page first.") }  %>
       <%= f.input :skip_secondary_validations, as: :boolean, label: "Force rename", hint: "Ignore the renaming requirements" %>
     <% end %>
+
+    <%= f.input :edit_reason, label: "Edit Reason" %>
 
     <%= f.button :submit, "Submit" %>
   <% end %>

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -16,6 +16,10 @@
 
     <% if @wiki_page.tag.present? %>
       <%= subnav_link_to "Posts (#{@wiki_page.tag.post_count})", posts_path(tags: @wiki_page.title) %>
+
+      <% if CurrentUser.is_janitor?%>
+        <%= subnav_link_to "Fix Tag Count", new_tag_correction_path(tag_id: @wiki_page.tag.id) %>
+      <% end %>
     <% end %>
 
     <% if @wiki_page.persisted? %>
@@ -32,11 +36,9 @@
       <% if CurrentUser.is_member? %>
         <%= subnav_link_to "Report", new_ticket_path(disp_id: @wiki_page.id, qtype: "wiki") %>
       <% end %>
-
-      <% if CurrentUser.is_janitor? && @wiki_page.tag.present? %>
-        <%= subnav_link_to "Fix Tag Count", new_tag_correction_path(tag_id: @wiki_page.tag.id) %>
-      <% end %>
     <% end %>
+
+
   <% elsif @wiki_page_version %>
     <li class="divider"></li>
 

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -16,13 +16,6 @@
 
     <% if @wiki_page.tag.present? %>
       <%= subnav_link_to "Posts (#{@wiki_page.tag.post_count})", posts_path(tags: @wiki_page.title) %>
-
-      <% if CurrentUser.is_member? %>
-        <%= subnav_link_to "Edit Tag Type", edit_tag_path(@wiki_page.tag) %>
-        <% if CurrentUser.is_janitor? %>
-          <%= subnav_link_to "Fix Tag Count", new_tag_correction_path(tag_id: @wiki_page.tag.id) %>
-        <% end %>
-      <% end %>
     <% end %>
 
     <% if @wiki_page.persisted? %>
@@ -38,6 +31,10 @@
 
       <% if CurrentUser.is_member? %>
         <%= subnav_link_to "Report", new_ticket_path(disp_id: @wiki_page.id, qtype: "wiki") %>
+      <% end %>
+
+      <% if CurrentUser.is_janitor? %>
+        <%= subnav_link_to "Fix Tag Count", new_tag_correction_path(tag_id: @wiki_page.tag.id) %>
       <% end %>
     <% end %>
   <% elsif @wiki_page_version %>

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -33,7 +33,7 @@
         <%= subnav_link_to "Report", new_ticket_path(disp_id: @wiki_page.id, qtype: "wiki") %>
       <% end %>
 
-      <% if CurrentUser.is_janitor? %>
+      <% if CurrentUser.is_janitor? && @wiki_page.tag.present? %>
         <%= subnav_link_to "Fix Tag Count", new_tag_correction_path(tag_id: @wiki_page.tag.id) %>
       <% end %>
     <% end %>

--- a/app/views/wiki_pages/edit.html.erb
+++ b/app/views/wiki_pages/edit.html.erb
@@ -5,11 +5,7 @@
     <section id="content">
       <h1>Edit Wiki</h1>
 
-      <% if @wiki_page.visible? %>
-        <%= render "form" %>
-      <% else %>
-        <p>The artist requested removal of this page.</p>
-      <% end %>
+      <%= render "form" %>
 
       <%= wiki_page_alias_and_implication_list(@wiki_page)%>
       <%= wiki_page_post_previews(@wiki_page) %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -21,17 +21,13 @@
       <% end %>
 
       <div id="wiki-page-body" class="dtext-container">
-        <% if wiki_content.visible? %>
-          <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>
+        <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>
 
-          <% if wiki_content.artist %>
-            <p><%= link_to "View artist", wiki_content.artist %></p>
-          <% end %>
-
-          <%= wiki_page_alias_and_implication_list(wiki_content) %>
-        <% else %>
-          <p>This artist has requested removal of their information.</p>
+        <% if wiki_content.artist %>
+          <p><%= link_to "View artist", wiki_content.artist %></p>
         <% end %>
+
+        <%= wiki_page_alias_and_implication_list(wiki_content) %>
       </div>
 
         <%= wiki_page_post_previews(wiki_content) %>

--- a/test/functional/wiki_pages_controller_test.rb
+++ b/test/functional/wiki_pages_controller_test.rb
@@ -12,8 +12,8 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
     context "index action" do
       setup do
         as(@user) do
-          @wiki_page_abc = create(:wiki_page, :title => "abc")
-          @wiki_page_def = create(:wiki_page, :title => "def")
+          @wiki_page_abc = create(:wiki_page, title: "abc")
+          @wiki_page_def = create(:wiki_page, title: "def")
         end
       end
 
@@ -23,12 +23,12 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "list all wiki_pages (with search)" do
-        get wiki_pages_path, params: {:search => {:title => "abc"}}
+        get wiki_pages_path, params: { search: { title: "abc" } }
         assert_redirected_to(wiki_page_path(@wiki_page_abc))
       end
 
       should "list wiki_pages without tags with order=post_count" do
-        get wiki_pages_path, params: {:search => {:title => "abc", :order => "post_count"}}
+        get wiki_pages_path, params: { search: { title: "abc", order: "post_count" } }
         assert_redirected_to(wiki_page_path(@wiki_page_abc))
       end
     end
@@ -46,7 +46,7 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "render for a title" do
-        get wiki_page_path(:id => @wiki_page.title)
+        get wiki_page_path(id: @wiki_page.title)
         assert_response :success
       end
 
@@ -64,7 +64,7 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
         as(@user) do
           @wiki_page.update(title: "-aaa")
         end
-        get wiki_page_path(:id => @wiki_page.id)
+        get wiki_page_path(id: @wiki_page.id)
         assert_response :success
       end
     end
@@ -89,7 +89,7 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
 
     context "new action" do
       should "render" do
-        get_auth new_wiki_page_path, @mod, params: { wiki_page: { title: "test" }}
+        get_auth new_wiki_page_path, @mod, params: { wiki_page: { title: "test" } }
         assert_response :success
       end
     end
@@ -108,7 +108,7 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
     context "create action" do
       should "create a wiki_page" do
         assert_difference("WikiPage.count", 1) do
-          post_auth wiki_pages_path, @user, params: {:wiki_page => {:title => "abc", :body => "abc"}}
+          post_auth wiki_pages_path, @user, params: { wiki_page: { title: "abc", body: "abc" } }
         end
       end
 
@@ -170,18 +170,18 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "update a wiki_page" do
-        put_auth wiki_page_path(@wiki_page), @user, params: {:wiki_page => {:body => "xyz"}}
+        put_auth wiki_page_path(@wiki_page), @user, params: { wiki_page: { body: "xyz" } }
         @wiki_page.reload
         assert_equal("xyz", @wiki_page.body)
       end
 
       should "not rename a wiki page with a non-empty tag" do
-        put_auth wiki_page_path(@wiki_page), @user, params: {:wiki_page => {:title => "bar"}}
+        put_auth wiki_page_path(@wiki_page), @user, params: { wiki_page: { title: "bar"}}
         assert_equal("foo", @wiki_page.reload.title)
       end
 
       should "rename a wiki page with a non-empty tag if secondary validations are skipped" do
-        put_auth wiki_page_path(@wiki_page), @mod, params: {:wiki_page => {:title => "bar", :skip_secondary_validations => "1"}}
+        put_auth wiki_page_path(@wiki_page), @mod, params: { wiki_page: { title: "bar", skip_secondary_validations: "1" } }
         assert_equal("bar", @wiki_page.reload.title)
       end
 
@@ -241,7 +241,7 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
       should "revert to a previous version" do
         version = @wiki_page.versions.first
         assert_equal("1", version.body)
-        put_auth revert_wiki_page_path(@wiki_page), @user, params: {:version_id => version.id}
+        put_auth revert_wiki_page_path(@wiki_page), @user, params: { version_id: version.id }
         @wiki_page.reload
         assert_equal("1", @wiki_page.body)
       end
@@ -251,7 +251,7 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
           @wiki_page_2 = create(:wiki_page)
         end
 
-        put_auth revert_wiki_page_path(@wiki_page), @user, params: { :version_id => @wiki_page_2.versions.first.id }
+        put_auth revert_wiki_page_path(@wiki_page), @user, params: { version_id: @wiki_page_2.versions.first.id }
         @wiki_page.reload
 
         assert_not_equal(@wiki_page.body, @wiki_page_2.body)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9bbbc8a6-5b1b-4d72-978d-999ab9d89aa8)

Adds the ability to edit the tag category directly on the wiki page.
Based on #790