### PR TITLE
[Docker] Upgrade Alpine image for ruby & node to 3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.1-alpine3.19 as ruby-builder
+FROM ruby:3.3.1-alpine3.20 as ruby-builder
 
 RUN apk --no-cache add build-base cmake git glib-dev postgresql15-dev gcompat
 
@@ -8,13 +8,13 @@ RUN gem i foreman && BUNDLE_IGNORE_CONFIG=true bundle install -j$(nproc) \
  && find /usr/local/bundle/gems/ -name "*.c" -delete \
  && find /usr/local/bundle/gems/ -name "*.o" -delete
 
-FROM node:20-alpine3.19 as node-builder
+FROM node:20-alpine3.20 as node-builder
 RUN apk --no-cache add git
 WORKDIR /app
 COPY package.json yarn.lock ./
 RUN corepack enable && corepack prepare --activate && yarn install
 
-FROM ruby:3.3.1-alpine3.19
+FROM ruby:3.3.1-alpine3.20
 
 RUN apk --no-cache add ffmpeg vips \
   postgresql15-client \


### PR DESCRIPTION
Creating PR based on https://github.com/e621ng/e621ng/issues/880

Allows upgrade to vips 8.15.2-r1. Ran test suite against latest build with changes resulting in 0 failures, errors and skips.

Resolves an issue where the alpine3.19 vips 8.15.0-r0 package causes thumbnails and previews to be rendered incorrectly when spun up as developer environment per https://github.com/libvips/libvips/issues/3945

Before / after:

<img width="818" alt="Screenshot 2025-02-20 at 11 44 04 AM" src="https://github.com/user-attachments/assets/b61bfe7e-f899-48e2-827d-8c5a178e1821" />
