### PR TITLE
add "User-Agent" to CORS access control header.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
 
   def enable_cors
     response.headers["Access-Control-Allow-Origin"] = "*"
-    response.headers["Access-Control-Allow-Headers"] = "Authorization"
+    response.headers["Access-Control-Allow-Headers"] = "Authorization, User-Agent"
   end
 
   def check_valid_username


### PR DESCRIPTION
I was getting CORS errors when adding a User-Agent header to my web app. This will fix that issue and bring it more in line with what is recommended the API documentation.