### PR TITLE
[CORS] Allow all http methods

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,7 @@ class ApplicationController < ActionController::Base
   def enable_cors
     response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Access-Control-Allow-Headers"] = "Authorization, User-Agent"
+    response.headers["Access-Control-Allow-Methods"] = "POST, PUT, PATCH, DELETE, GET, HEAD, OPTIONS"
   end
 
   def check_valid_username


### PR DESCRIPTION
Adds all HTTP methods to the CORS header. This finally relieves API users from having to employ strange hacks to do various requests such as unfavoriting posts or editing comments.