### PR TITLE
[WikiPages] Allow empty pages

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -18,7 +18,6 @@ class WikiPage < ApplicationRecord
   validates :title, uniqueness: { case_sensitive: false }
   validates :title, presence: true
   validates :title, tag_name: true, if: :title_changed?
-  validates :body, presence: { unless: -> { is_deleted? || other_names.present? || parent.present? } }
   validates :title, length: { minimum: 1, maximum: 100 }
   validates :body, length: { maximum: Danbooru.config.wiki_page_max_size }
   validate :user_not_limited

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -41,7 +41,7 @@
         <%= subnav_link_to "Report", new_ticket_path(disp_id: @wiki_page.id, qtype: "wiki") %>
       <% end %>
     <% else %>
-      <%= subnav_link_to "Edit", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>
+      <%= subnav_link_to "Edit", new_wiki_page_path(wiki_page: { title: params[:title] }) %>
     <% end %>
 
 

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -40,6 +40,8 @@
       <% if CurrentUser.is_member? %>
         <%= subnav_link_to "Report", new_ticket_path(disp_id: @wiki_page.id, qtype: "wiki") %>
       <% end %>
+    <% else %>
+      <%= subnav_link_to "Edit", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>
     <% end %>
 
 

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -21,7 +21,11 @@
       <% end %>
 
       <div id="wiki-page-body" class="dtext-container">
-        <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>
+        <% if wiki_content.body.present? %>
+          <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>  
+        <% else %>
+          <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>.</p>
+        <% end %>
 
         <% if wiki_content.artist %>
           <p><%= link_to "View artist", wiki_content.artist %></p>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -24,7 +24,7 @@
         <% if wiki_content.body.present? %>
           <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>  
         <% else %>
-          <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>.</p>
+          <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path({ wiki_page: { title: params[:title] } }) %>.</p>
         <% end %>
 
         <% if wiki_content.artist %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -24,7 +24,7 @@
         <% if wiki_content.body.present? %>
           <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>  
         <% else %>
-          <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path({ wiki_page: { title: params[:title] } }) %>.</p>
+          <p>This wiki page is empty. <%= link_to "Click here to add details", edit_wiki_page_path(@wiki_page) %>.</p>
         <% end %>
 
         <% if wiki_content.artist %>

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -7,7 +7,7 @@
         <%= link_to @wiki_page.pretty_title_with_category, posts_path(:tags => @wiki_page.title), :class => "tag-type-#{@wiki_page.category_id}" %>
       </h1>
       <div id="wiki-page-body" class="dtext-container">
-        <p>This wiki page does not exist. <%= link_to "Create new wiki page", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>.</p>
+        <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>.</p>
       </div>
 
       <% if @wiki_page.tag&.category == Tag.categories.artist %>

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -7,7 +7,7 @@
         <%= link_to @wiki_page.pretty_title_with_category, posts_path(:tags => @wiki_page.title), :class => "tag-type-#{@wiki_page.category_id}" %>
       </h1>
       <div id="wiki-page-body" class="dtext-container">
-        <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path(:wiki_page => {:title => params[:title]}) %>.</p>
+        <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path(wiki_page: { title: params[:title] }) %>.</p>
       </div>
 
       <% if @wiki_page.tag&.category == Tag.categories.artist %>

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -7,7 +7,7 @@
         <%= link_to @wiki_page.pretty_title_with_category, posts_path(:tags => @wiki_page.title), :class => "tag-type-#{@wiki_page.category_id}" %>
       </h1>
       <div id="wiki-page-body" class="dtext-container">
-        <p>This wiki is empty. <%= link_to "Click here to add details", new_wiki_page_path(wiki_page: { title: params[:title] }) %>.</p>
+        <p>This wiki page is empty. <%= link_to "Click here to add details", new_wiki_page_path(wiki_page: { title: params[:title] }) %>.</p>
       </div>
 
       <% if @wiki_page.tag&.category == Tag.categories.artist %>


### PR DESCRIPTION
- Allows empty wikis
- Changes the text for non-existent wikis
- Adds edit link for non-existent wikis
- Adds text for empty wikis

Empty text:
![image](https://github.com/user-attachments/assets/a4fa56e0-3268-4895-a2db-f5b72f330b84)
Non-existent text and edit link:
![image](https://github.com/user-attachments/assets/85364a1a-277e-4db0-943c-3b4b6139a867)
