### PR TITLE
[ModActions] Add ticket update details

### DIFF
--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -45,7 +45,21 @@ class ModActionDecorator < ApplicationDecorator
 
       ### Ticket ###
     when "ticket_update"
-      "Modified ticket ##{vals['ticket_id']}"
+      text = "Modified ticket ##{vals['ticket_id']}"
+
+      if vals["status"].present? && vals["status"] != vals["status_was"]
+        text += "\nChanged status from #{vals['status_was']} to #{vals['status']}"
+      end
+
+      if vals["response"].present? && vals["response"] != vals["response_was"]
+        if vals["response_was"].present?
+          text += "\nChanged response: [section=Old]#{vals['response_was']}[/section] [section=New]#{vals['response']}[/section]"
+        else
+          text += "\nWith response: #{vals['response']}"
+        end
+      end
+
+      text
     when "ticket_claim"
       "Claimed ticket ##{vals['ticket_id']}"
     when "ticket_unclaim"

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -64,7 +64,7 @@ class ModAction < ApplicationRecord
     tag_implication_update: { implication_id: :integer, implication_desc: :string, change_desc: :string },
     ticket_claim: { ticket_id: :integer },
     ticket_unclaim: { ticket_id: :integer },
-    ticket_update: { ticket_id: :integer },
+    ticket_update: { ticket_id: :integer, status: :string, response: :string, status_was: :string, response_was: :string },
     upload_whitelist_create: { pattern: :string, note: :string, hidden: :boolean },
     upload_whitelist_update: { pattern: :string, note: :string, old_pattern: :string, hidden: :boolean },
     upload_whitelist_delete: { pattern: :string, note: :string, hidden: :boolean },
@@ -202,6 +202,10 @@ class ModAction < ApplicationRecord
         else
           sanitized_values = sanitized_values.slice("hidden", "note")
         end
+      end
+
+      if !CurrentUser.is_moderator? && %i[ticket_update].include?(action.to_sym)
+        sanitized_values = sanitized_values.slice("ticket_id")
       end
 
       sanitized_values

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -371,7 +371,7 @@ class Ticket < ApplicationRecord
     def log_update
       return unless saved_change_to_response? || saved_change_to_status?
 
-      ModAction.log(:ticket_update, { ticket_id: id })
+      ModAction.log(:ticket_update, { ticket_id: id, status: status, response: response, status_was: status_before_last_save, response_was: response_before_last_save })
     end
   end
 


### PR DESCRIPTION
Adds status and reason changes for Ticket mod actions.
Omits details for anyone below Moderator.

![image](https://github.com/user-attachments/assets/85f0d72c-7f8b-41c7-8657-ae7f97bd4e6e)
