### PR TITLE
[Users] Make the forum notification toggle a user setting

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -127,6 +127,7 @@ class UsersController < ApplicationController
       enable_auto_complete
       disable_cropped_thumbnails
       enable_safe_mode disable_responsive_mode
+      forum_notification_dot
     ]
 
     permitted_params += [dmail_filter_attributes: %i[id words]]

--- a/app/javascript/src/javascripts/themes.js
+++ b/app/javascript/src/javascripts/themes.js
@@ -4,7 +4,7 @@ import LStorage from "./utility/storage";
 const Theme = {};
 
 Theme.Values = {
-  "Theme": ["Main", "Extra", "Palette", "Font", "StickyHeader", "Navbar", "Gestures", "ForumNotif"],
+  "Theme": ["Main", "Extra", "Palette", "Font", "StickyHeader", "Navbar", "Gestures"],
   "Posts": ["WikiExcerpt", "StickySearch"],
 };
 

--- a/app/javascript/src/javascripts/utility/storage.js
+++ b/app/javascript/src/javascripts/utility/storage.js
@@ -68,9 +68,6 @@ LStorage.Theme = {
 
   /** @returns {boolean} True if the sticky header is enabled */
   StickyHeader: ["theme-sheader", false],
-
-  /** @returns {boolean} True if the forum notification dot is enabled */
-  ForumNotif: ["theme-forumnotif", false],
 };
 StorageUtils.bootstrapMany(LStorage.Theme);
 

--- a/app/javascript/src/styles/common/navigation.scss
+++ b/app/javascript/src/styles/common/navigation.scss
@@ -237,7 +237,7 @@ body[data-th-sheader="true"] nav.navigation {
 
 
 // Forum notification
-body[data-th-forumnotif="true"] nav.navigation .nav-primary li.forum-updated {
+nav.navigation .nav-primary li.notification {
   position: relative;
 
   &::after {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,8 @@ class User < ApplicationRecord
     :approver,
   ]
 
+  # unintended consequences
+  # * _has_mail -> forum_notification_dot
   BOOLEAN_ATTRIBUTES = %w[
     _show_avatars
     _blacklist_avatars
@@ -32,7 +34,7 @@ class User < ApplicationRecord
     show_hidden_comments
     show_post_statistics
     is_banned
-    _has_mail
+    forum_notification_dot
     receive_email_notifications
     enable_keyboard_navigation
     enable_privacy_mode
@@ -402,7 +404,7 @@ class User < ApplicationRecord
 
   module ForumMethods
     def has_forum_been_updated?
-      return false unless is_member?
+      return false unless is_member? && forum_notification_dot
       max_updated_at = ForumTopic.visible(self).order(updated_at: :desc).first&.updated_at
       return false if max_updated_at.nil?
       return true if last_forum_read_at.nil?
@@ -664,7 +666,7 @@ class User < ApplicationRecord
           can_approve_posts can_upload_free
           disable_cropped_thumbnails enable_safe_mode
           disable_responsive_mode no_flagging disable_user_dmails
-          enable_compact_uploader replacements_beta
+          enable_compact_uploader replacements_beta forum_notification_dot
         ]
         list += boolean_attributes + [
           :updated_at, :email, :last_logged_in_at, :last_forum_read_at,

--- a/app/views/layouts/_main_links.html.erb
+++ b/app/views/layouts/_main_links.html.erb
@@ -10,4 +10,4 @@
 <%= decorated_nav_link_to("Tags", :tags, tags_path) %>
 <%= decorated_nav_link_to("Blips", :megaphone, blips_path) %>
 <%= decorated_nav_link_to("Comments", :message_square, comments_path(group_by: "post")) %>
-<%= decorated_nav_link_to("Forum", :lectern, forum_topics_path, class: (CurrentUser.has_forum_been_updated? ? "forum-updated" : nil)) %>
+<%= decorated_nav_link_to("Forum", :lectern, forum_topics_path, class: (CurrentUser.has_forum_been_updated? ? "notification" : nil)) %>

--- a/app/views/layouts/_theme_include.html.erb
+++ b/app/views/layouts/_theme_include.html.erb
@@ -6,7 +6,6 @@
       "th-main": localStorage.getItem("theme") || "hexagon",
       "th-extra": localStorage.getItem("theme-extra") || "hexagon",
       "th-sheader": localStorage.getItem("theme-sheader") || false,
-      "th-forumnotif": localStorage.getItem("theme-forumnotif") || false,
       "th-palette": localStorage.getItem("theme-palette") || "default",
       "th-font": localStorage.getItem("theme-font") || "Verdana",
       "th-nav": localStorage.getItem("theme-nav") || "top",

--- a/app/views/static/theme.html.erb
+++ b/app/views/static/theme.html.erb
@@ -58,12 +58,6 @@
 
 
   <h3>Features</h3>
-    <label for="Theme_ForumNotif">Forum Activity Dot</label>
-    <select id="Theme_ForumNotif">
-      <option value="false">Disabled</option>
-      <option value="true">Enabled</option>
-    </select>
-
     <label for="Posts_WikiExcerpt">Wiki Excerpt</label>
     <select id="Posts_WikiExcerpt">
       <option value="0">Collapsed</option>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -45,7 +45,11 @@
   </tab-body>
 </tab-entry>
 
-<tab-entry tab="<%= tab_name %>" group="account" class="inline" search="user account email notify notifications">
+
+<!-- Notifications -->
+<tab-group name="notifications">Notifications</tab-group>
+
+<tab-entry tab="<%= tab_name %>" group="notifications" class="inline" search="user account email notify notifications">
   <tab-head>Email Notifications</tab-head>
   <tab-body>
     <%= form.input_field :receive_email_notifications, as: :boolean, class: "st-toggle" %>
@@ -53,8 +57,13 @@
   </tab-body>
 </tab-entry>
 
-
-<!-- General -->
+<tab-entry tab="<%= tab_name %>" group="notifications" class="inline" search="user account forum activity dot bubble toggle notify notification">
+  <tab-head>Forum Activity Dot</tab-head>
+  <tab-body>
+    <%= form.input_field :forum_notification_dot, as: :boolean, class: "st-toggle" %>
+    <%= form.label :forum_notification_dot, "!", class: "st-toggle" %>
+  </tab-body>
+</tab-entry>
 
 
 <!-- Profile -->


### PR DESCRIPTION
There are multiple reasons to do this.
* Users who are not logged out do not receive forum notifications anyways.
* Every user sends a database query to check for forum notifications on every page load, even if they have the dot disabled.
* Fewer theme-related body attributes.

There may be unintended consequences.
I have reused the `_has_mail` bit flag for this purpose. It's possible that some users had unread mail when this flag had been disabled – they may unintentionally have the notification dot turned on. But that is a fairly minor side effect, and the number of queries will be reduced either way.