### PR TITLE
[Posts] Rework the sidebar tag loading

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -119,7 +119,7 @@ class Tag < ApplicationRecord
     end
 
     def category_name
-      TagCategory::REVERSE_MAPPING[category].capitalize
+      @category_name ||= TagCategory::REVERSE_MAPPING[category]
     end
 
     def update_category_post_counts!

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -2,7 +2,7 @@
 
 class PostPresenter < Presenter
   attr_reader :pool
-  delegate :post_show_sidebar_tag_list_html, :split_tag_list_text, :inline_tag_list_html, to: :tag_set_presenter
+  delegate :split_tag_list_text, :inline_tag_list_html, to: :tag_set_presenter
 
   def self.preview(post, options = {})
     if post.nil?

--- a/app/presenters/tag_set_presenter.rb
+++ b/app/presenters/tag_set_presenter.rb
@@ -32,25 +32,6 @@ class TagSetPresenter < Presenter
     html.html_safe
   end
 
-  def post_show_sidebar_tag_list_html(current_query: "", highlighted_tags:)
-    html = +""
-
-    TagCategory::SPLIT_HEADER_LIST.each do |category|
-      typetags = tags_for_category(category)
-
-      if typetags.any?
-        html << %{<h2 class="#{category}-tag-list-header tag-list-header" data-category="#{category}">#{TagCategory::HEADER_MAPPING[category]}</h2>}
-        html << %{<ul class="#{category}-tag-list">}
-        typetags.each do |tag|
-          html << build_list_item(tag, current_query: current_query, highlight: highlighted_tags.include?(tag.name))
-        end
-        html << "</ul>"
-      end
-    end
-
-    html.html_safe
-  end
-
   # compact (horizontal) list, as seen in the /comments index.
   def inline_tag_list_html(link_type = :tag)
     html = TagCategory::CATEGORIZED_LIST.map do |category|

--- a/app/views/posts/partials/show/_tag_list.html.erb
+++ b/app/views/posts/partials/show/_tag_list.html.erb
@@ -1,0 +1,48 @@
+<% TagCategory::SPLIT_HEADER_LIST.each do |category_name| %>
+  <% typetags = post.categorized_tags[category_name] %>
+  <% next unless typetags %>
+
+  <h2 class="<%= category_name %>-tag-list-header tag-list-header" data-category="<%= category_name %>"><%= TagCategory::HEADER_MAPPING[category_name] %></h2>
+  <ul class="<%= category_name %>-tag-list">
+    <% typetags.each do |tag| %>
+      <li class="category-<%= tag.category %>">
+        <a
+          class="wiki-link"
+          rel="nofollow"
+          href="<%= (tag.category == Tag.categories.artist ? "/artists/show_or_new?name=" : "/wiki_pages/show_or_new?title=") + tag.name %>"
+        >?</a>
+
+        <% if query.present? %>
+          <a rel="nofollow" href="/posts?tags=#{u(current_query)}+#{u(name)}" class="search-inc-tag">+</a>
+          <a rel="nofollow" href="/posts?tags=#{u(current_query)}+-#{u(name)}" class="search-exl-tag">–</a>
+        <% end %>
+
+        <a
+          rel="nofollow"
+          class="search-tag"
+          <%= "itemprop=author" if tag.category == Tag.categories.artist %>
+          href="<%= posts_path(tags: tag.name) %>"
+        >
+          <%= tag.name.tr("_", " ") %>
+          <% if post.uploader_linked_artists.include?(tag.name) %>
+            <i title="Uploaded by the artist" class="highlight fa-regular fa-circle-check"></i>
+          <% end %>
+        </a>
+
+        <% is_underused_tag = tag.post_count <= 1 && tag.category == Tag.categories.general %>
+        <% post_count = tag.post_count %>
+        <% if post_count > 1_000 %>
+          <% post_count = tag.post_count > 10_000 ? "#{post_count / 1_000}k" : format("%.1fk", (tag.post_count / 1_000.0)) %>
+        <% end %>
+
+        <span
+          data-count='#{count}'
+          class="color-muted post-count<%= is_underused_tag ? " low-post-count" : "" %>"
+          <% if is_underused_tag %>
+            title="New general tag detected. Check the spelling or populate it now."
+          <% end %>
+        ><%= post_count %></span>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,7 +6,7 @@
       <%= render "posts/partials/index/blacklist", post_id: @post.id %>
 
       <section id="tag-list">
-        <%= @post.presenter.post_show_sidebar_tag_list_html(current_query: params[:q], highlighted_tags: @post.uploader_linked_artists.map(&:name)) %>
+        <%= render partial: "/posts/partials/show/tag_list", locals: { post: @post, query: params[:q] } %>
       </section>
 
       <section id="post-information">

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -4,7 +4,7 @@
 
     <ul>
       <li>Count: <%= @tag.post_count %></li>
-      <li>Category: <%= @tag.category_name %></li>
+      <li>Category: <%= @tag.category_name.capitalize %></li>
     </ul>
   </div>
 </div>

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -75,7 +75,7 @@ class TagTest < ActiveSupport::TestCase
   context "A tag" do
     should "know its category name" do
       @tag = create(:artist_tag)
-      assert_equal("Artist", @tag.category_name)
+      assert_equal("artist", @tag.category_name)
     end
 
     should "reset its category after updating" do


### PR DESCRIPTION
Eliminates a duplicate database query.
Previously, the site would send separate queries for looking up tag categories and for finding artist tags.

Also makes the sidebar tag list easier to deal with.