### PR TITLE
[Users] Loading feedbacks should only require one query, not three

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -102,17 +102,14 @@ module PostsHelper
   end
 
   def user_record_meta(user)
-    positive = user.positive_feedback_count
-    neutral = user.neutral_feedback_count
-    negative = user.negative_feedback_count
+    feedback = user.feedback_pieces
+    return "" if feedback[:active] == 0
 
-    return "" if (positive + neutral + negative) == 0
-    positive_html = %{<span class="user-feedback-positive">#{positive}</span>}.html_safe if positive > 0
-    neutral_html = %{<span class="user-feedback-neutral">#{neutral}</span>}.html_safe if neutral > 0
-    negative_html = %{<span class="user-feedback-negative">#{negative}</span>}.html_safe if negative > 0
-    list_html = "#{positive_html} #{neutral_html} #{negative_html}".strip
-
-    link_to(%{(#{list_html})}.html_safe,  user_feedbacks_path(search: { user_id: user.id}))
+    link_to(user_feedbacks_path(search: { user_id: user.id }), class: "user-feedback-list") do
+      concat tag.span(feedback[:positive], class: "user-feedback-positive") if feedback[:positive] > 0
+      concat tag.span(feedback[:neutral], class: "user-feedback-neutral") if feedback[:neutral] > 0
+      concat tag.span(feedback[:negative], class: "user-feedback-negative") if feedback[:negative] > 0
+    end
   end
 
   private

--- a/app/javascript/src/styles/views/posts/_posts.scss
+++ b/app/javascript/src/styles/views/posts/_posts.scss
@@ -4,6 +4,8 @@
   @import "index/index.desktop";
 }
 
+@import "show/show";
+
 // Features
 @import "index/partials/mode_menu";
 @import "index/partials/wiki_excerpt";

--- a/app/javascript/src/styles/views/posts/show/_show.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.scss
@@ -1,0 +1,3 @@
+body.c-posts.a-show {
+  @import "partials/post_information";
+}

--- a/app/javascript/src/styles/views/posts/show/partials/_post_information.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_post_information.scss
@@ -1,0 +1,10 @@
+#post-information {
+
+  .user-feedback-list {
+    word-break: break-all;
+    span { margin: 0.125rem; }
+  
+    &::before { content: "("; }
+    &::after { content: ")"; }
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -746,6 +746,9 @@ class User < ApplicationRecord
       user_status.ticket_count
     end
 
+    ## !DB
+    # UserFeedback entries for the user.
+    # Preferable to using individual methods below, since these are almost always displayed together.
     def feedback_pieces
       @feedback_pieces ||= begin
         count = {
@@ -753,6 +756,8 @@ class User < ApplicationRecord
           negative: 0,
           neutral: 0,
           positive: 0,
+
+          active: 0,
         }
 
         feedback.each do |one|
@@ -764,24 +769,26 @@ class User < ApplicationRecord
           count[one.category.to_sym] += 1
         end
 
+        count[:active] = count[:negative] + count[:neutral] + count[:positive]
+
         count
       end
     end
 
     def positive_feedback_count
-      feedback.active.positive.count
+      feedback_pieces[:positive]
     end
 
     def neutral_feedback_count
-      feedback.active.neutral.count
+      feedback_pieces[:neutral]
     end
 
     def negative_feedback_count
-      feedback.active.negative.count
+      feedback_pieces[:negative]
     end
 
     def deleted_feedback_count
-      feedback.deleted.count
+      feedback_pieces[:deleted]
     end
 
     def post_replacement_rejected_count
@@ -966,5 +973,12 @@ class User < ApplicationRecord
     elsif name =~ /\A[0-9]+\z/
       "cannot consist of numbers only"
     end
+  end
+
+  def reload(options = nil)
+    super
+    @upload_limit_pieces = nil
+    @feedback_pieces = nil
+    self
   end
 end


### PR DESCRIPTION
This had already been somewhat fixed with the profile page rework.
However, the issue remained in the users API, and on the post profile page for staff members.