### PR TITLE
[Tickets] Prevent long ticket titles from overflowing the page

### DIFF
--- a/app/javascript/src/styles/common/tables.scss
+++ b/app/javascript/src/styles/common/tables.scss
@@ -18,6 +18,7 @@ table.striped {
 
         &.full-width-link {
           padding: 0;
+          word-break: break-word;
 
           > a {
             width: 100%;


### PR DESCRIPTION
Only really a concern if the ticket has no spaces in it, which is a rare occurrence.
![Screenshot 2025-03-15 082520](https://github.com/user-attachments/assets/39506753-0840-4f66-a7a9-0d31ab228f36)
