### PR TITLE
[Posts] Rework the way related tags are displayed on the index page

### DIFF
--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -75,5 +75,16 @@ module PostSets
     def presenter
       @presenter ||= ::PostSetPresenters::Post.new(self)
     end
+
+    def related_tags
+      @related_tags ||= begin
+        tag_array = RelatedTagCalculator.calculate_from_posts_to_array(posts).map(&:first)
+        tag_data = Tag.where(name: tag_array).select(:name, :post_count, :category).index_by(&:name)
+
+        tag_array.map do |name|
+          tag_data[name] || Tag.new(name: name).freeze
+        end
+      end
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -905,14 +905,14 @@ class Post < ApplicationRecord
     # List of post tags, grouped by their category.
     # Sends a db request to look up the tag data.
     def categorized_tags
-      return @categorized_tags if @categorized_tags
+      @categorized_tags ||= begin
+        tag_data = Tag.where(name: tag_array).select(:name, :post_count, :category).index_by(&:name)
+        ordered = tag_array.map do |name|
+          tag_data[name] || Tag.new(name: name).freeze
+        end
 
-      tag_data ||= Tag.where(name: tag_array).select(:name, :post_count, :category).index_by(&:name)
-      ordered = tag_array.map do |name|
-        tag_data[name] || Tag.new(name: name).freeze
+        ordered.group_by(&:category_name)
       end
-
-      @categorized_tags ||= ordered.group_by(&:category_name)
     end
 
     ##

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,11 +12,12 @@
       <% end %>
       <%= render "posts/partials/index/blacklist" %>
 
-      <section id="tag-box">
-        <h3>Tags</h3>
-        <!-- TODO: Lock off these extra items? -->
-        <%= @post_set.presenter.post_index_sidebar_tag_list_html(current_query: params[:tags]) %>
-      </section>
+      <% if @post_set.related_tags.any? %>
+        <section id="tag-box">
+          <h3>Tags</h3>
+          <%= render partial: "/posts/partials/index/sidebar/tag_list", locals: { post_set: @post_set, query: params[:tags] } %>
+        </section>
+      <% end %>
 
       <%= render "posts/partials/index/related" %>
     </div>

--- a/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
+++ b/app/views/posts/partials/common/sidebar/_tag_list_item.html.erb
@@ -1,0 +1,38 @@
+<li class="category-<%= tag.category %>">
+  <a
+    class="wiki-link"
+    rel="nofollow"
+    href="<%= (tag.category == Tag.categories.artist ? "/artists/show_or_new?name=" : "/wiki_pages/show_or_new?title=") + tag.name %>"
+  >?</a>
+
+  <% if query.present? %>
+    <a rel="nofollow" href="/posts?tags=#{u(current_query)}+#{u(name)}" class="search-inc-tag">+</a>
+    <a rel="nofollow" href="/posts?tags=#{u(current_query)}+-#{u(name)}" class="search-exl-tag">–</a>
+  <% end %>
+
+  <a
+    rel="nofollow"
+    class="search-tag"
+    <%= "itemprop=author" if tag.category == Tag.categories.artist %>
+    href="<%= posts_path(tags: tag.name) %>"
+  >
+    <%= tag.name.tr("_", " ") %>
+    <% if post.present? && post.uploader_linked_artists.include?(tag.name) %>
+      <%= svg_icon(:chexagon, class: "chexagon", title: "Uploaded by the artist") %>
+    <% end %>
+  </a>
+
+  <% is_underused_tag = tag.post_count <= 1 && tag.category == Tag.categories.general %>
+  <% post_count = tag.post_count %>
+  <% if post_count > 1_000 %>
+    <% post_count = tag.post_count > 10_000 ? "#{post_count / 1_000}k" : format("%.1fk", (tag.post_count / 1_000.0)) %>
+  <% end %>
+
+  <span
+    data-count='#{count}'
+    class="color-muted post-count<%= is_underused_tag ? " low-post-count" : "" %>"
+    <% if is_underused_tag %>
+      title="New general tag detected. Check the spelling or populate it now."
+    <% end %>
+  ><%= post_count %></span>
+</li>

--- a/app/views/posts/partials/index/sidebar/_tag_list.html.erb
+++ b/app/views/posts/partials/index/sidebar/_tag_list.html.erb
@@ -1,0 +1,3 @@
+<ul>
+  <%= render partial: "/posts/partials/common/sidebar/tag_list_item", collection: @post_set.related_tags, as: :tag, locals: { post: nil, tag: tag, query: query } %>
+</ul>

--- a/app/views/posts/partials/show/sidebar/_tag_list.html.erb
+++ b/app/views/posts/partials/show/sidebar/_tag_list.html.erb
@@ -4,45 +4,6 @@
 
   <h5 class="<%= category_name %>-tag-list-header tag-list-header" data-category="<%= category_name %>"><%= TagCategory::HEADER_MAPPING[category_name] %></h5>
   <ul class="<%= category_name %>-tag-list">
-    <% typetags.each do |tag| %>
-      <li class="category-<%= tag.category %>">
-        <a
-          class="wiki-link"
-          rel="nofollow"
-          href="<%= (tag.category == Tag.categories.artist ? "/artists/show_or_new?name=" : "/wiki_pages/show_or_new?title=") + tag.name %>"
-        >?</a>
-
-        <% if query.present? %>
-          <a rel="nofollow" href="/posts?tags=#{u(current_query)}+#{u(name)}" class="search-inc-tag">+</a>
-          <a rel="nofollow" href="/posts?tags=#{u(current_query)}+-#{u(name)}" class="search-exl-tag">–</a>
-        <% end %>
-
-        <a
-          rel="nofollow"
-          class="search-tag"
-          <%= "itemprop=author" if tag.category == Tag.categories.artist %>
-          href="<%= posts_path(tags: tag.name) %>"
-        >
-          <%= tag.name.tr("_", " ") %>
-          <% if post.uploader_linked_artists.include?(tag.name) %>
-            <%= svg_icon(:chexagon, class: "chexagon", title: "Uploaded by the artist") %>
-          <% end %>
-        </a>
-
-        <% is_underused_tag = tag.post_count <= 1 && tag.category == Tag.categories.general %>
-        <% post_count = tag.post_count %>
-        <% if post_count > 1_000 %>
-          <% post_count = tag.post_count > 10_000 ? "#{post_count / 1_000}k" : format("%.1fk", (tag.post_count / 1_000.0)) %>
-        <% end %>
-
-        <span
-          data-count='#{count}'
-          class="color-muted post-count<%= is_underused_tag ? " low-post-count" : "" %>"
-          <% if is_underused_tag %>
-            title="New general tag detected. Check the spelling or populate it now."
-          <% end %>
-        ><%= post_count %></span>
-      </li>
-    <% end %>
+    <%= render partial: "/posts/partials/common/sidebar/tag_list_item", collection: typetags, as: :tag, locals: { post: nil, tag: tag, query: query } %>
   </ul>
 <% end %>


### PR DESCRIPTION
Match the related tags display on the index page to the post's tags on the show page.
Visuals should be identical - but the back-end is different.