### PR TITLE
[AvoidPosting] Fix the index page making an extra database query for every artist

### DIFF
--- a/app/controllers/avoid_postings_controller.rb
+++ b/app/controllers/avoid_postings_controller.rb
@@ -7,7 +7,7 @@ class AvoidPostingsController < ApplicationController
   helper_method :search_params
 
   def index
-    @avoid_postings = AvoidPosting.search(search_params).paginate(params[:page], limit: params[:limit])
+    @avoid_postings = AvoidPosting.includes(:artist).search(search_params).paginate(params[:page], limit: params[:limit])
     respond_with(@avoid_postings)
   end
 


### PR DESCRIPTION
Yes, every DNP entry would send an extra query looking up artist info.
No idea how this was missed.