### PR TITLE
[Pools] Increase the hourly creation limit to 5

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -226,7 +226,7 @@ module Danbooru
 
     # Pools created in the last hour
     def pool_limit
-      2
+      5
     end
 
     # Pools created or edited in the last hour


### PR DESCRIPTION
By popular demand.
Setting the limit to 2 hasn't really helped us against raids or truly malicious users anyways.