### PR TITLE
[ForumTopics] Optimize forum topic database requests

### DIFF
--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -10,6 +10,24 @@ class ForumPostsController < ApplicationController
   before_action :ensure_lockdown_disabled, except: %i[index show search]
   skip_before_action :api_check
 
+  def index
+    @query = ForumPost.visible(CurrentUser.user).search(search_params)
+    @forum_posts = @query
+                   .includes(:topic)
+                   .includes(:creator)
+                   .includes(:updater)
+                   .paginate(params[:page], limit: params[:limit], search_count: params[:search])
+    respond_with(@forum_posts)
+  end
+
+  def show
+    if request.format == "text/html" && @forum_post.id == @forum_post.topic.original_post.id
+      redirect_to(forum_topic_path(@forum_post.topic, page: params[:page]))
+    else
+      respond_with(@forum_post)
+    end
+  end
+
   def new
     @forum_post = ForumPost.new(forum_post_params(:create))
     respond_with(@forum_post)
@@ -20,21 +38,7 @@ class ForumPostsController < ApplicationController
     respond_with(@forum_post)
   end
 
-  def index
-    @query = ForumPost.visible(CurrentUser.user).search(search_params)
-    @forum_posts = @query.includes(:topic).paginate(params[:page], limit: params[:limit], search_count: params[:search])
-    respond_with(@forum_posts)
-  end
-
   def search
-  end
-
-  def show
-    if request.format == "text/html" && @forum_post.id == @forum_post.topic.original_post.id
-      redirect_to(forum_topic_path(@forum_post.topic, :page => params[:page]))
-    else
-      respond_with(@forum_post)
-    end
   end
 
   def create

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -298,7 +298,11 @@ class ApplicationRecord < ActiveRecord::Base
           end
 
           define_method :creator_name do
-            User.id_to_name(creator_id)
+            if association(:creator).loaded?
+              creator.name
+            else
+              User.id_to_name(creator_id)
+            end
           end
         end
       end
@@ -312,7 +316,11 @@ class ApplicationRecord < ActiveRecord::Base
           end
 
           define_method :updater_name do
-            User.id_to_name(updater_id)
+            if association(:updater).loaded?
+              updater.name
+            else
+              User.id_to_name(creator_id)
+            end
           end
         end
       end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -92,6 +92,9 @@ class ForumPost < ApplicationRecord
     bulk_update_request || tag_alias || tag_implication
   end
 
+  # AIBURs must be bulk loaded whenever more than one
+  # forum post is displayed. Otherwise, this results
+  # in N+3 database queries for every forum post.
   def votable?
     TagAlias.where(forum_post_id: id).exists? ||
       TagImplication.where(forum_post_id: id).exists? ||
@@ -218,5 +221,9 @@ class ForumPost < ApplicationRecord
     end
 
     true
+  end
+
+  def method_attributes
+    super + %i[creator_name updater_name]
   end
 end

--- a/app/views/application/_update_notice.html.erb
+++ b/app/views/application/_update_notice.html.erb
@@ -1,6 +1,6 @@
 <%# record %>
 
-<% if record.respond_to?(:updater) && record.updater != record.creator  %>
+<% if record.respond_to?(:updater) && record.updater_id != record.creator_id  %>
   <p class="info">Updated by <%= link_to_user record.updater %> <%= time_ago_in_words_tagged(record.updated_at) %></p>
 <% elsif record.updated_at - record.created_at > 5.minutes %>
   <p class="info">Updated <%= time_ago_in_words_tagged(record.updated_at) %></p>

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -74,7 +74,9 @@
             </li>
           <% end %>
         </menu>
-        <% if forum_post.votable? %>
+        <% if @votable_posts.present? %>
+          <%= render "forum_post_votes/list", votes: forum_post.votes, forum_post: forum_post if @votable_posts.include? forum_post.id %>
+        <% elsif forum_post.votable? %>
           <%= render "forum_post_votes/list", votes: forum_post.votes, forum_post: forum_post %>
         <% end %>
         <% if forum_post.editable_by?(CurrentUser.user) %>


### PR DESCRIPTION
Forum topic pages are a mess.
They oftentimes require literally hundreds of database queries to load all the data.

Changes in this PR:
* Bulk load creator and updater data to avoid N+1 queries for every forum post on the page
* Bulk load AIBUR data to avoid N+3 queries when determining whether each forum post is votable

Every forum post _still_ re-calculates its page number in the topic on every page load.
But that is less of an issue... and would require more work to fix properly.