### PR TITLE
[Uploads] Allow mp4s with av1

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -364,10 +364,10 @@ Autocomplete.static_metatags = {
     "any", "none"
   ],
   filetype: [
-    "jpg", "png", "gif", "swf", "webm"
+    "jpg", "png", "gif", "swf", "webm", "mp4"
   ],
   type: [
-    "jpg", "png", "gif", "swf", "webm"
+    "jpg", "png", "gif", "swf", "webm", "mp4"
   ],
 }
 

--- a/app/javascript/src/javascripts/uploader/file_input.vue
+++ b/app/javascript/src/javascripts/uploader/file_input.vue
@@ -21,7 +21,7 @@
           type="file"
           ref="post_file"
           id="file-input"
-          accept="image/png,image/apng,image/jpeg,image/gif,video/webm,.png,.apng,.jpg,.jpeg,.gif,.webm"
+          accept="image/png,image/apng,image/jpeg,image/gif,video/webm,video/mp4,.png,.apng,.jpg,.jpeg,.gif,.webm,.mp4"
           @change="updatePreviewFile"
           :disabled="disableFileUpload"
         />
@@ -222,7 +222,10 @@ export default {
       const objectUrl = URL.createObjectURL(file);
       this.disableURLUpload = true;
       this.uploadValueChanged(file);
-      this.previewChanged(objectUrl, file.type === "video/webm");
+      this.previewChanged(
+        objectUrl, 
+        ["video/webm", "video/mp4"].includes(file.type),
+      );
     },
     uploadValueChanged(value) {
       this.$emit("uploadValueChanged", value);

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -83,6 +83,8 @@ module FileMethods
         "png"
       when "video/webm"
         "webm"
+      when "video/mp4"
+        "mp4"
       else
         mime_type
       end

--- a/app/logical/file_validator.rb
+++ b/app/logical/file_validator.rb
@@ -15,6 +15,7 @@ class FileValidator
     if record.is_video?
       video = record.video(file_path)
       validate_container_format(video)
+      validate_audio_codec(video)
       validate_duration(video)
       validate_colorspace(video)
       validate_sar(video)
@@ -71,10 +72,18 @@ class FileValidator
       record.errors.add(:base, "video isn't valid")
       return
     end
-    valid_video_codec = %w[vp8 vp9 av1].include?(video.video_codec)
-    valid_container = video.container == "matroska,webm"
-    unless valid_video_codec && valid_container
-      record.errors.add(:base, "video container/codec isn't valid for webm")
+    valid_webm = video.container == "matroska,webm" && %w[vp8 vp9].include?(video.video_codec)
+    valid_mp4  = video.container == "mov,mp4,m4a,3gp,3g2,mj2" && %w[av1].include?(video.video_codec)
+    unless valid_webm || valid_mp4
+      record.errors.add(:base, "video must be WebM with VP8/VP9 or MP4 with AV1, but found #{video.container} with #{video.video_codec}")
+    end
+  end
+
+  def validate_audio_codec(video)
+    return unless video.video_codec == "av1"
+    allowed_audio_codecs = ["opus"]
+    if video.audio_codec.present? && allowed_audio_codecs.exclude?(video.audio_codec)
+      record.errors.add(:base, "video uses AV1 and must use Opus audio codec, but found #{video.audio_codec}")
     end
   end
 
@@ -83,6 +92,8 @@ class FileValidator
   end
 
   def validate_sar(video)
-    record.errors.add(:base, "video is anamorphic (#{video.sar})") unless video.sar == "1:1"
+    if video.sar.present? && video.sar != "1:1"
+      record.errors.add(:base, "video is anamorphic (SAR is #{video.sar})")
+    end
   end
 end

--- a/app/logical/file_validator.rb
+++ b/app/logical/file_validator.rb
@@ -73,6 +73,7 @@ class FileValidator
       return
     end
     valid_webm = video.container == "matroska,webm" && %w[vp8 vp9].include?(video.video_codec)
+    # In the future, we want to allow "h264".
     valid_mp4  = video.container == "mov,mp4,m4a,3gp,3g2,mj2" && %w[av1].include?(video.video_codec)
     unless valid_webm || valid_mp4
       record.errors.add(:base, "video must be WebM with VP8/VP9 or MP4 with AV1, but found #{video.container} with #{video.video_codec}")
@@ -81,9 +82,10 @@ class FileValidator
 
   def validate_audio_codec(video)
     return unless video.video_codec == "av1"
-    allowed_audio_codecs = ["opus"]
+
+    allowed_audio_codecs = %w[opus aac mp3]
     if video.audio_codec.present? && allowed_audio_codecs.exclude?(video.audio_codec)
-      record.errors.add(:base, "video uses AV1 and must use Opus audio codec, but found #{video.audio_codec}")
+      record.errors.add(:base, "video uses AV1 and must use Opus, AAC, or MP3 audio codec, but found #{video.audio_codec}")
     end
   end
 

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -363,6 +363,7 @@ module Danbooru
         "png" => 100.megabytes,
         "gif" => 20.megabytes,
         "webm" => 100.megabytes,
+        "mp4" => 100.megabytes,
       }
     end
 


### PR DESCRIPTION
This PR allows uploading mp4s as long as their video codec is av1 and their audio codec is opus.
The mp4 container format is an open container and av1 is an open format.
Only files using opus audio are allowed, as aac is non-free.

I have double-checked this with mairo.