### PR TITLE
[DB] Use a static statement timeout instead of a user level specific one

### DIFF
--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -34,7 +34,6 @@ class SessionLoader
       end
       raise AuthenticationFailure.new(ban_message)
     end
-    set_statement_timeout
     update_last_logged_in_at
     update_last_ip_addr
     set_time_zone
@@ -51,12 +50,7 @@ class SessionLoader
     cookies.encrypted[:remember].present?
   end
 
-private
-
-  def set_statement_timeout
-    timeout = CurrentUser.user.statement_timeout
-    ActiveRecord::Base.connection.execute("set statement_timeout = #{timeout}")
-  end
+  private
 
   def load_remember_token
     begin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -632,13 +632,7 @@ class User < ApplicationRecord
     end
 
     def statement_timeout
-      if is_former_staff?
-        9_000
-      elsif is_privileged?
-        6_000
-      else
-        3_000
-      end
+      3_000
     end
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,6 +2,8 @@ default: &default
   adapter: postgresql
   timeout: 5000
   username: e621
+  variables:
+    statement_timeout: 3000
 
 development:
   <<: *default


### PR DESCRIPTION
Previously, the server would set a statement timeout value on every session load.
Approximately two million times an hour.

I am not convinced that letting privileged+ users run slightly more complex queries is worth it.