### PR TITLE
[Favorites] Display zero results instead of an error if favorites are hidden

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -14,10 +14,11 @@ class FavoritesController < ApplicationController
       @user = User.find(user_id)
 
       if @user.hide_favorites?
-        raise Favorite::HiddenError
+        @post_set = PostSets::Post.new("limit:0")
+      else
+        @post_set = PostSets::Favorites.new(@user, params[:page], limit: params[:limit])
       end
 
-      @post_set = PostSets::Favorites.new(@user, params[:page], limit: params[:limit])
       @posts = PostsDecorator.decorate_collection(@post_set.posts)
       respond_with(@posts) do |fmt|
         fmt.json do


### PR DESCRIPTION
Keeps the layout of the favorites page consistent, in addition to not indicating that the user actually has favorites.