### PR TITLE
[Blacklist] Fix the anonymous blacklist not loading correctly

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -7,7 +7,6 @@ import LStorage from "./utility/storage";
 
 let Blacklist = {};
 
-Blacklist.isAnonymous = false;
 Blacklist.isPostsShow = false;
 Blacklist.filters = {};
 
@@ -15,23 +14,6 @@ Blacklist.hiddenPosts = new Set();
 Blacklist.matchedPosts = new Set();
 
 Blacklist.ui = [];
-
-/** Import the anonymous blacklist from the LocalStorage */
-Blacklist.init_anonymous_blacklist = function () {
-  let metaTag = $("meta[name=blacklisted-tags]");
-  if (metaTag.length == 0)
-    metaTag = $("<meta>")
-      .attr({
-        name: "blacklisted-tags",
-        content: "[]",
-      })
-      .appendTo("head");
-
-  if (User.is.anonymous) {
-    Blacklist.isAnonymous = true;
-    metaTag.attr("content", LStorage.Blacklist.AnonymousBlacklist);
-  }
-};
 
 /** Set up the modal dialogue with the blacklist editor */
 Blacklist.init_blacklist_editor = function () {
@@ -63,8 +45,7 @@ Blacklist.init_blacklist_editor = function () {
 
   $("#blacklist-edit-link").on("click", function (event) {
     event.preventDefault();
-    let entries = JSON.parse(Utility.meta("blacklisted-tags") || "[]");
-    $("#blacklist-edit").val(entries.join("\n"));
+    $("#blacklist-edit").val(User.blacklist.tags.join("\n"));
     $("#blacklist-edit-dialog").dialog("open");
   });
 };
@@ -246,7 +227,6 @@ Blacklist.update_styles = function () {
 $(() => {
   Blacklist.isPostsShow = $("#image-container").length > 0;
 
-  Blacklist.init_anonymous_blacklist();
   Blacklist.init_blacklist_editor();
   Blacklist.init_reveal_on_click();
 

--- a/app/javascript/src/javascripts/models/User.js
+++ b/app/javascript/src/javascripts/models/User.js
@@ -75,6 +75,20 @@ export default class User {
         admin: data.userIsAdmin === "true",
       },
     };
+
+    // Load anonymous blacklist
+    if (this._userData.is.anonymous) {
+      try {
+        this._userData.blacklist.tags = JSON.parse(LStorage.Blacklist.AnonymousBlacklist);
+      } catch { this._userData.blacklist.tags = []; }
+
+      $("<meta>")
+        .attr({
+          name: "blacklisted-tags",
+          content: JSON.stringify(this._userData.blacklist.tags),
+        })
+        .appendTo("head");
+    }
   }
 
   static _get () {


### PR DESCRIPTION
A race condition of sorts.
Anonymous blacklist would get back-filled into the meta tag with data from local storage _after_ another script loads the data from that meta tag. Thus not accomplishing a whole lot.