### PR TITLE
[Blacklist] Fix revealing on click not working with videos

### DIFF
--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -211,6 +211,10 @@
     }
   }
 
+  // Without this, the video player intercepts clicks but
+  // does no tpass them on to the container element
+  video { pointer-events: none; }
+
   #note-container {
     display: none;
   }


### PR DESCRIPTION
The video player intercepted clicks on it and did not pass them on to the container, thus preventing the event from being fired.
This solution is very much a hack, but it's the simplest way to go around this problem.