### PR TITLE
[DText] Prevent the dtext content from overflowing the page

### DIFF
--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -7,6 +7,7 @@
 .styled-dtext {
   font-size: 1rem;
   line-height: 1.25rem;
+  word-break: break-word;
 
   @include window-larger-than(800px) {
     font-size: 0.9rem;


### PR DESCRIPTION
Accounting for both exceptionally long links and deliberate spam.
![Screenshot 2025-03-30 212308](https://github.com/user-attachments/assets/8542f27e-87d5-479c-aff1-7def59a38910)
