### PR TITLE
[PostFlags] Add an optional note field

### DIFF
--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -58,6 +58,6 @@ class PostFlagsController < ApplicationController
   end
 
   def post_flag_params
-    params.fetch(:post_flag, {}).permit(%i[post_id reason_name parent_id])
+    params.fetch(:post_flag, {}).permit(%i[post_id reason_name parent_id note])
   end
 end

--- a/app/javascript/src/javascripts/post_flags.js
+++ b/app/javascript/src/javascripts/post_flags.js
@@ -1,0 +1,13 @@
+const PostFlags = {};
+
+PostFlags.init = function () {
+  $(".post-flag-note").on("click", (event) => {
+    $(event.currentTarget).toggleClass("expanded");
+  });
+};
+
+export default PostFlags;
+
+$(() => {
+  PostFlags.init();
+});

--- a/app/javascript/src/styles/specific/post_flags.scss
+++ b/app/javascript/src/styles/specific/post_flags.scss
@@ -16,6 +16,19 @@ div#c-post-flags {
   border: 1px solid themed("color-section-lighten-5");
   border-left: 0.25rem solid themed("color-dtext-quote");
   border-radius: 0.25rem;
+
+  max-height: 1.5rem;
+  cursor: pointer;
+
+  &.expanded {
+    max-height: unset;
+  }
+}
+
+  // Overrides notices style overrides
+div#c-posts div.notice .dtext-container.post-flag-note p {
+  margin-bottom: 1em;
+  &:last-child { margin-bottom: 0; }
 }
 
 body.c-post-flags.a-new {

--- a/app/javascript/src/styles/specific/post_flags.scss
+++ b/app/javascript/src/styles/specific/post_flags.scss
@@ -7,3 +7,69 @@ div#c-post-flags {
     white-space: pre-wrap;
   }
 }
+
+.dtext-container.post-flag-note {
+  background: themed("color-section");
+  padding: 0.25rem 0.5rem;
+  margin: 0.25rem 0.5rem;
+
+  border: 1px solid themed("color-section-lighten-5");
+  border-left: 0.25rem solid themed("color-dtext-quote");
+  border-radius: 0.25rem;
+}
+
+body.c-post-flags.a-new {
+  .flag-dialog-body {
+
+    // Option label
+    label {
+      font-weight: normal;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+  
+    // Option explanation
+    div.styled-dtext {
+      margin: 0.125rem 1.25rem;
+      filter: brightness(85%);
+    }
+  
+    // Align label with the explanation
+    input[type="radio"] {
+      width: 1rem;
+    }
+  
+    // Post ID input
+    .post_flag_parent_id {
+      display: flex;
+      margin: -0.5rem 0 0 1.25rem;
+    }
+
+    form.simple_form div.input {
+      label {
+        font-weight: normal;
+        margin-right: 1rem;
+        cursor: default;
+      }
+      span.error { margin-left: 1rem; }
+    }
+  
+    hr { margin: 0.75rem 1.25rem; }
+    h3 {
+      margin: 0.5rem 1.25rem;
+      font-weight: normal;
+    }
+
+    .flag-notes {
+      margin: 1rem 0;
+    }
+
+    input[type="submit"] {
+      background: themed("color-tag-artist");
+      font-size: 1.25rem;
+      padding: 0.5rem 2rem;
+      margin: 0.5rem;
+      @include st-radius;
+    }
+  }
+}

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -111,6 +111,16 @@ div#c-posts {
       background-color: themed("color-danger-darken-10");
       border: 1px solid themed("color-foreground");
     }
+
+    &.notice-flagged .dtext-container {
+      background: themed("color-section");
+      padding: 0.25rem 0.5rem;
+      margin: 0.25rem 0.5rem;
+
+      border: 1px solid themed("color-section-lighten-5");
+      border-left: 0.25rem solid themed("color-dtext-quote");
+      border-radius: 0.25rem;
+    }
   }
 
   div.nav-notice {

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -111,16 +111,6 @@ div#c-posts {
       background-color: themed("color-danger-darken-10");
       border: 1px solid themed("color-foreground");
     }
-
-    &.notice-flagged .dtext-container {
-      background: themed("color-section");
-      padding: 0.25rem 0.5rem;
-      margin: 0.25rem 0.5rem;
-
-      border: 1px solid themed("color-section-lighten-5");
-      border-left: 0.25rem solid themed("color-dtext-quote");
-      border-radius: 0.25rem;
-    }
   }
 
   div.nav-notice {
@@ -411,44 +401,4 @@ body[data-user-can-approve-posts="true"] .notice {
     h3 { padding: 0; }
   }
   p { margin-bottom: 0.25em; }
-}
-
-.flag-dialog-body {
-
-  // Option label
-  label {
-    font-weight: normal;
-    font-size: 1rem;
-    cursor: pointer;
-  }
-
-  // Option explanation
-  div.styled-dtext {
-    margin: 0.125rem 1.25rem;
-    filter: brightness(85%);
-  }
-
-  // Align label with the explanation
-  input[type="radio"] {
-    width: 1rem;
-  }
-
-  // Post ID input
-  form.simple_form div.input {
-    margin: -0.5rem 0 0 1.25rem;
-    label {
-      font-weight: normal;
-      margin-right: 1rem;
-      cursor: default;
-    }
-    &.post_flag_parent_id { display: flex }
-    span.error { margin-left: 1rem; }
-  }
-
-  hr { margin: 0.75rem 1.25rem; }
-  h3 {
-    margin: 0.5rem 1.25rem;
-    font-weight: normal;
-  }
-  input[type="submit"] { margin: 0.75rem 1rem 0.5rem; }
 }

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -15,6 +15,7 @@ class PostFlag < ApplicationRecord
   validate :validate_reason
   validate :update_reason, on: :create
   validates :reason, presence: true
+  validates :note, length: { maximum: Danbooru.config.comment_max_size }
   before_save :update_post
   after_create :create_post_event
   after_commit :index_post

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -34,6 +34,10 @@
       <% end %>
       
     <% end %>
+
+    <div>
+      <%= f.input :note, as: :dtext, label: "Notes", limit: Danbooru.config.comment_max_size %>
+    </div>
     
     <div>
       <%= f.submit "Submit" %>

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -35,8 +35,8 @@
       
     <% end %>
 
-    <div>
-      <%= f.input :note, as: :dtext, label: "Notes", limit: Danbooru.config.comment_max_size %>
+    <div class="flag-notes">
+      <%= f.input :note, as: :dtext, label: "Additional Details", limit: Danbooru.config.comment_max_size %>
     </div>
     
     <div>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -20,8 +20,15 @@
         <% @post_flags.each do |post_flag| %>
           <tr class="flag-type-<%= post_flag.type.to_s.dasherize %> flag-resolved-<%= post_flag.is_resolved? %>">
             <td><%= PostPresenter.preview(post_flag.post, show_deleted: true) %></td>
-            <td class="dtext-container">
-              <%= format_text post_flag.reason %>
+            <td>
+              <div class="dtext-container">
+                <%= format_text post_flag.reason %>
+              </div>
+              <% if post_flag.note.present? && CurrentUser.is_staff? %>
+                <div class="dtext-container post-flag-note">
+                  <%= format_text post_flag.note %>
+                </div>
+              <% end %>
             </td>
             <td>
               <%= link_to post_flag.post.flags.size, post_flags_path(search: { post_id: post_flag.post_id }) %>

--- a/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
+++ b/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (post:) -%>
 <ul>
-  <% post.flags.order(id: :desc).each do |flag| %>
+  <% post.flags.includes(:creator).order(id: :desc).each do |flag| %>
     <li>
       <%= flag.is_deletion ? "[DELETION]" : "[FLAG]" %>
       <%= format_text(flag.reason, inline: true) unless flag.reason.empty? %>

--- a/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
+++ b/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
@@ -17,6 +17,12 @@
       <% if flag.is_resolved? %>
         <span class="resolved">RESOLVED</span>
       <% end %>
+      
+      <% if flag.note && CurrentUser.is_staff? %>
+        <div class="dtext-container">
+          <%= format_text flag.note %>
+        </div>
+      <% end %>
     </li>
     <% if post.is_deleted? && flag.is_deletion && !CurrentUser.is_janitor? %>
       <% break %>

--- a/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
+++ b/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
@@ -3,7 +3,7 @@
   <% post.flags.order(id: :desc).each do |flag| %>
     <li>
       <%= flag.is_deletion ? "[DELETION]" : "[FLAG]" %>
-      <%= format_text(flag.reason, inline: true) %>
+      <%= format_text(flag.reason, inline: true) unless flag.reason.empty? %>
 
       <% if CurrentUser.can_view_flagger_on_post?(flag) %>
         - <%= link_to_user(flag.creator) %>
@@ -18,8 +18,8 @@
         <span class="resolved">RESOLVED</span>
       <% end %>
       
-      <% if flag.note && CurrentUser.is_staff? %>
-        <div class="dtext-container">
+      <% if flag.note.present? && CurrentUser.is_staff? %>
+        <div class="dtext-container post-flag-note">
           <%= format_text flag.note %>
         </div>
       <% end %>

--- a/db/migrate/20250328035855_add_post_flag_notes.rb
+++ b/db/migrate/20250328035855_add_post_flag_notes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPostFlagNotes < ActiveRecord::Migration[7.1]
+  def change
+    PostFlag.without_timeout do
+      add_column :post_flags, :note, :string
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1371,7 +1371,8 @@ CREATE TABLE public.post_flags (
     is_resolved boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone,
-    is_deletion boolean DEFAULT false NOT NULL
+    is_deletion boolean DEFAULT false NOT NULL,
+    note character varying
 );
 
 
@@ -4694,6 +4695,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250328035855'),
 ('20241114055212'),
 ('20240905160626'),
 ('20240726170041'),


### PR DESCRIPTION
By popular demand – allows users to include extra information to explain their flag.

![Screenshot 2025-04-01 081110](https://github.com/user-attachments/assets/d0bcf48b-2412-45c6-a04c-0ec74bc61257)
