### PR TITLE
[ArtistUrls] Avoid fetching notes when rendering JSON

### DIFF
--- a/app/controllers/artist_urls_controller.rb
+++ b/app/controllers/artist_urls_controller.rb
@@ -7,7 +7,7 @@ class ArtistUrlsController < ApplicationController
   def index
     @artist_urls = ArtistUrl.includes(:artist).search(search_params).paginate(params[:page], limit: params[:limit], search_count: params[:search])
     respond_with(@artist_urls) do |format|
-      format.json { render json: @artist_urls.to_json(include: :artist) }
+      format.json { render json: @artist_urls.to_json(include: { artist: { except: :notes } }) }
     end
   end
 end


### PR DESCRIPTION
This was causing N+1 queries for the sake of something that's generally unnecessary.