### PR TITLE
[Tags] Add an option to destroy tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -2,6 +2,7 @@
 
 class TagsController < ApplicationController
   before_action :member_only, only: %i[edit update preview]
+  before_action :is_bd_staff_only, only: %i[destroy]
   respond_to :html, :json
 
   def edit
@@ -46,6 +47,22 @@ class TagsController < ApplicationController
         else
           redirect_to(tags_path(search: { name_matches: @tag.name, hide_empty: "no" }))
         end
+      end
+    end
+  end
+
+  def destroy
+    @tag = Tag.find(params[:id])
+    raise User::PrivilegeError unless @tag.deletable_by?(CurrentUser.user)
+
+    count = Post.tag_match("#{@tag.name} status:any", resolve_aliases: false).count_only
+    raise "Cannot delete tags that are present on posts" if count > 0
+
+    @tag.destroy
+
+    respond_with(@tag) do |format|
+      format.html do
+        redirect_to(tags_path, notice: @tag.valid? ? "Tag destroyed" : @tag.errors.full_messages.join("; "))
       end
     end
   end

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -253,6 +253,11 @@ class ModActionDecorator < ApplicationDecorator
     when "blip_unhide"
       "Unhid blip ##{vals['blip_id']} by #{user}"
 
+      ### Tag ###
+
+    when "tag_destroy"
+      "Destroyed tag `#{vals['name']}`"
+
       ### Alias ###
 
     when "tag_alias_create"

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -58,6 +58,7 @@ class ModAction < ApplicationRecord
     set_update: { set_id: :integer, user_id: :integer },
     set_delete: { set_id: :integer, user_id: :integer },
     set_change_visibility: { set_id: :integer, user_id: :integer, is_public: :boolean },
+    tag_destroy: { name: :string },
     tag_alias_create: { alias_id: :integer, alias_desc: :string },
     tag_alias_update: { alias_id: :integer, alias_desc: :string, change_desc: :string },
     tag_implication_create: { implication_id: :integer, implication_desc: :string },

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,6 +15,7 @@ class Tag < ApplicationRecord
   validate :user_can_change_category?, if: :category_changed?
 
   before_save :update_category, if: :category_changed?
+  after_destroy :log_destroy
 
   attr_accessor :from_wiki
 
@@ -31,6 +32,12 @@ class Tag < ApplicationRecord
 
     def value_for(string)
       TagCategory::MAPPING[string.to_s.downcase] || 0
+    end
+  end
+
+  module LogMethods
+    def log_destroy
+      ModAction.log(:tag_destroy, { name: name })
     end
   end
 
@@ -404,6 +411,11 @@ class Tag < ApplicationRecord
     true
   end
 
+  def deletable_by?(user)
+    user.is_bd_staff?
+  end
+
+  include LogMethods
   include CountMethods
   include CategoryMethods
   extend NameMethods

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -11,6 +11,17 @@
       </ul>
     </div>
 
+    <% if CurrentUser.user.is_bd_staff? %>
+      <div style="margin-bottom: 1em;">
+        <ul>
+          <li><strong>Real count:</strong> <%= link_to(@true_count, posts_path(tags: "#{@tag.name} status:any")) %>
+          <li><strong>Aliases:</strong> <%= link_to(@aliases, tag_aliases_path(search: { name_matches: @tag.name })) %>
+          <li><strong>Implications:</strong> <%=link_to(@implications, tag_implications_path(search: { name_matches: @tag.name }))  %>
+          <li><strong>Can destroy:</strong> <%= @destroyable %>
+        </ul>
+      </div>
+    <% end %>
+
     <%= form_tag(tag_correction_path(tag_id: @correction.tag.id)) do %>
       <%= hidden_field_tag "from_wiki", @from_wiki %>
       <%= submit_tag "Fix" %>
@@ -22,7 +33,7 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "Posts (#{@correction.tag.post_count})", posts_path(tags: @correction.tag.name) %>
   <%= subnav_link_to "Wiki Page", show_or_new_wiki_pages_path(title: @correction.tag.name) %>
-  <% if CurrentUser.is_bd_staff? %>
+  <% if CurrentUser.is_bd_staff? && @destroyable %>
     <%= subnav_link_to "Destroy", tag_path(@correction.tag), method: :delete, data: { confirm: "Are you sure you want to PERMANENTLY delete this tag? This cannot be undone." } %>
   <% end %>
 <% end %>

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -19,6 +19,14 @@
   </div>
 </div>
 
+<% content_for(:secondary_links) do %>
+  <%= subnav_link_to "Posts (#{@correction.tag.post_count})", posts_path(tags: @correction.tag.name) %>
+  <%= subnav_link_to "Wiki Page", show_or_new_wiki_pages_path(title: @correction.tag.name) %>
+  <% if CurrentUser.is_bd_staff? %>
+    <%= subnav_link_to "Destroy", tag_path(@correction.tag), method: :delete, data: { confirm: "Are you sure you want to PERMANENTLY delete this tag? This cannot be undone." } %>
+  <% end %>
+<% end %>
+
 <% content_for(:page_title) do %>
   Tag Correction
 <% end %>


### PR DESCRIPTION
Somewhat ill-advised, so there are restrictions on this.

* [x] BD staff only
* [x] No posts, deleted or otherwise, can have this tag
* [x] No active aliases or implications

Better info output:
* [x] Add tag deletion to the mod actions
* [x] Display anything that may block the deletion on the corrections page:
    * [x] Total number of posts, including deleted ones
    * [x] Aliases and implications, active or otherwise