### PR TITLE
[Uploads] Increase the preview image size

### DIFF
--- a/app/javascript/src/javascripts/uploader/uploader.vue.erb
+++ b/app/javascript/src/javascripts/uploader/uploader.vue.erb
@@ -1,6 +1,6 @@
 <template>
     <div class="flex-grid-outer">
-        <div class="col box-section" style="flex: 2 0 0;">
+        <div class="col box-section">
             <div class="flex-grid border-bottom">
                 <div class="col">
                     <label class="section-label" for="post_file">File</label>


### PR DESCRIPTION
This is a suggestion based on experience, I'd understand if you do not approve.
Increases the preview image size by removing the flex attribute of the div, making the left (tags and description) and right (preview) evenly sized, allowing to better see the image and tag the details.

Before
![image](https://github.com/user-attachments/assets/263e4143-0239-40bd-8545-805f4eff429f)
After
![image](https://github.com/user-attachments/assets/00317799-fa69-4458-97a1-f29d6864bf7b)
