### PR TITLE
[Group Search] Improve deleted filtering on grouped searches

### DIFF
--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -881,7 +881,7 @@ class TagQuery
   # Pulls the value from the first of the specified metatags found.
   #
   # ### Parameters
-  # * `tags`: The content to search through. Accepts strings and arrays.
+  # * `tags` {`String` | `String[]`}: The content to search through.
   # * `metatags`: The metatags to search. Must exactly match. Modifiers aren't accounted for (i.e.
   # `status` won't match `-status` & vice versa).
   # * `at_any_level` [`true`]: Search through groups?
@@ -930,7 +930,7 @@ class TagQuery
   # Pulls the values from the specified metatags.
   #
   # ### Parameters
-  # * `tags`: The content to search through. Accepts strings and arrays.
+  # * `tags` {`String` | `String[]`}: The content to search through.
   # * `metatags`: The metatags to search. Must exactly match. Modifiers aren't accounted for (i.e.
   # `status` won't match `-status` & vice versa).
   # * `at_any_level` [true]: Search through groups?

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1129,7 +1129,7 @@ class TagQuery
                                 0
                               end)
           next if group.blank?
-          q[:children_show_deleted] ||= group.hide_deleted_posts?(at_any_level: true) if kwargs[:process_groups]
+          q[:children_show_deleted] ||= !group.hide_deleted_posts?(at_any_level: true) if kwargs[:process_groups]
           q[:groups] ||= {}
           search_type = METATAG_SEARCH_TYPE[match[1]]
           q[:groups][search_type] ||= []

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -275,7 +275,7 @@ class TagQuery
     return false if always_show_deleted
     return query.hide_deleted_posts?(at_any_level: at_any_level) if query.is_a?(TagQuery)
     TagQuery.fetch_metatags(query, *OVERRIDE_DELETED_FILTER_METATAGS, prepend_prefix: false, at_any_level: at_any_level) do |tag, val|
-      return false unless tag.end_with?("status") && !val.in?(OVERRIDE_DELETED_FILTER_STATUS_VALUES)
+      return false unless tag.delete_prefix("-") == "status" && !val.in?(OVERRIDE_DELETED_FILTER_STATUS_VALUES)
     end
     true
   end

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1126,7 +1126,7 @@ class TagQuery
                                 0
                               end)
           next if group.blank?
-          q[:children_show_deleted] = group.hide_deleted_posts?(at_any_level: true) if kwargs[:process_groups]
+          q[:children_show_deleted] ||= group.hide_deleted_posts?(at_any_level: true) if kwargs[:process_groups]
           q[:groups] ||= {}
           search_type = METATAG_SEARCH_TYPE[match[1]]
           q[:groups][search_type] ||= []

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -227,26 +227,29 @@ class TagQuery
   # `ElasticPostQueryBuilder.always_show_deleted`.
   # * `at_any_level` [`false`]: Should groups be accounted for, or just this level?
   #
-  # Returns true unless
+  # ### Returns
+  # `true` unless
   # * `always_show_deleted`,
   # * `q[:status]`/`q[:status_must_not]` contains a value in `TagQuery::OVERRIDE_DELETED_FILTER_STATUS_VALUES`,
   # * One of the following is non-nil:
   #   * `q[:deleter]`/`q[:deleter_must_not]`/`q[:deleter_should]`
   #   * `q[:delreason]`/`q[:delreason_must_not]`/`q[:delreason_should]`, or
   # * If `at_any_level`,
-  #   * `q[:children_show_deleted]` is `true` or
-  #   * any of the subsearches in `q[:groups]` return false from
-  # `TagQuery.should_hide_deleted_posts?`
+  #   * `q[:children_show_deleted]` is `true`, or
+  #   * any of the subsearches in `q[:groups]` return `false` from `TagQuery.should_hide_deleted_posts?`
   #     * This is overridden to return `true` if the subsearches in `q[:groups]` are type `TagQuery`,
-  # as preprocessed queries should have had their resultant value elevated to this level during
-  # `process_groups`.
+  # as preprocessed queries should have had their resultant value elevated to this instance's
+  # `q[:children_show_deleted]` during group processing.
+  # ### Raises
+  # * `RuntimeError`: when `q[:children_show_deleted]` is `nil` & any element in `q[:groups]` is a
+  # `TagQuery`, as `q[:children_show_deleted]` shouldn't be `nil` if subsearches were processed.
   def hide_deleted_posts?(always_show_deleted: false, at_any_level: false)
     if always_show_deleted || q[:show_deleted]
       false
     elsif at_any_level
       if q[:children_show_deleted].nil? &&
          q[:groups].present? &&
-         [*(q[:groups][:must] || []), *(q[:groups][:must_not] || []), *(q[:groups][:should] || [])].any? { |e| e.is_a?(TagQuery) ? (raise "q[:children_show_deleted] shouldn't be nil.") : !TagQuery.should_hide_deleted_posts?(e, at_any_level: true) }
+         [*(q[:groups][:must] || []), *(q[:groups][:must_not] || []), *(q[:groups][:should] || [])].any? { |e| e.is_a?(TagQuery) ? (raise "Invalid State: q[:children_show_deleted] shouldn't be nil if subsearches were processed.") : !TagQuery.should_hide_deleted_posts?(e, at_any_level: true) }
         false
       else
         !q[:children_show_deleted]

--- a/test/unit/elastic_post_query_builder_test.rb
+++ b/test/unit/elastic_post_query_builder_test.rb
@@ -3,21 +3,21 @@
 require "test_helper"
 
 class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
+  DEFAULT_PARAM = { resolve_aliases: true, free_tags_count: 0, enable_safe_mode: false, always_show_deleted: false }.freeze
   # TODO: Add tests for proper construction
   context "While building a post query" do
     should "properly determine whether or not to hide deleted posts" do
-      p = { resolve_aliases: true, free_tags_count: 0, enable_safe_mode: false, always_show_deleted: false }
-      assert(ElasticPostQueryBuilder.new("aaa bbb", **p).hide_deleted_posts?)
-      assert_not(ElasticPostQueryBuilder.new("aaa bbb status:deleted", **p).hide_deleted_posts?)
-      assert_not(ElasticPostQueryBuilder.new("aaa bbb deletedby:someone", **p).hide_deleted_posts?)
+      assert(ElasticPostQueryBuilder.new("aaa bbb", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert_not(ElasticPostQueryBuilder.new("aaa bbb status:deleted", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert_not(ElasticPostQueryBuilder.new("aaa bbb deletedby:someone", **DEFAULT_PARAM).hide_deleted_posts?)
       # Don't overwrite
-      assert_not(ElasticPostQueryBuilder.new("aaa bbb delreason:something status:pending", **p).hide_deleted_posts?)
-      assert(ElasticPostQueryBuilder.new("( aaa bbb )", **p).hide_deleted_posts?)
-      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb status:any )", **p).hide_deleted_posts?)
-      assert(ElasticPostQueryBuilder.new("( aaa ( bbb ) )", **p).hide_deleted_posts?)
-      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb ( aaa status:any ) )", **p).hide_deleted_posts?)
-      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb ( aaa deletedby:someone ) )", **p).hide_deleted_posts?)
-      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb ( aaa delreason:something ) status:pending )", **p).hide_deleted_posts?)
+      assert_not(ElasticPostQueryBuilder.new("aaa bbb delreason:something status:pending", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert(ElasticPostQueryBuilder.new("( aaa bbb )", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb status:any )", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert(ElasticPostQueryBuilder.new("( aaa ( bbb ) )", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb ( aaa status:any ) )", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb ( aaa deletedby:someone ) )", **DEFAULT_PARAM).hide_deleted_posts?)
+      assert_not(ElasticPostQueryBuilder.new("aaa ( bbb ( aaa delreason:something ) status:pending )", **DEFAULT_PARAM).hide_deleted_posts?)
     end
   end
 
@@ -43,13 +43,13 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
     [true, false].each do |e|
       msg = -"process_groups: #{e}"
       qb = ElasticPostQueryBuilder.new("aaa ( bbb status:any )", process_groups: e, **DEFAULT_PARAM).create_query_obj
-      assert_not(cb.call(qb))
+      assert_not(cb.call(qb), msg)
       qb = ElasticPostQueryBuilder.new("aaa ( bbb ( aaa status:any ) )", process_groups: e, **DEFAULT_PARAM).create_query_obj
-      assert_not(cb.call(qb))
+      assert_not(cb.call(qb), msg)
       qb = ElasticPostQueryBuilder.new("aaa ( bbb ( aaa deletedby:someone ) )", process_groups: e, **DEFAULT_PARAM).create_query_obj
-      assert_not(cb.call(qb))
+      assert_not(cb.call(qb), msg)
       qb = ElasticPostQueryBuilder.new("aaa ( bbb ( aaa delreason:something ) status:pending )", process_groups: e, **DEFAULT_PARAM).create_query_obj
-      assert_not(cb.call(qb))
+      assert_not(cb.call(qb), msg)
     end
   end
 end

--- a/test/unit/tag_query_test.rb
+++ b/test/unit/tag_query_test.rb
@@ -1307,6 +1307,8 @@ class TagQueryTest < ActiveSupport::TestCase
         assert_not(TagQuery.should_hide_deleted_posts?("aaa bbb status:deleted"))
         assert_not(TagQuery.should_hide_deleted_posts?("aaa bbb deletedby:someone"))
         assert_not(TagQuery.should_hide_deleted_posts?("aaa bbb delreason:something"))
+        # In prior versions, deleted filtering was based of the final value of `status`/`status_must_not`, so the metatag ordering changed the results. This ensures this legacy behavior stays gone.
+        assert_not(TagQuery.should_hide_deleted_posts?("aaa bbb delreason:something status:pending"))
         assert_not(TagQuery.should_hide_deleted_posts?("aaa bbb -status:active"))
         assert(TagQuery.should_hide_deleted_posts?("aaa bbb status:modqueue"))
         assert(TagQuery.should_hide_deleted_posts?("( aaa bbb )"))
@@ -1314,39 +1316,64 @@ class TagQueryTest < ActiveSupport::TestCase
         assert(TagQuery.should_hide_deleted_posts?("( aaa ( bbb ) )"))
         assert_not(TagQuery.should_hide_deleted_posts?("aaa ( bbb ( aaa status:any ) )"))
         assert_not(TagQuery.should_hide_deleted_posts?("aaa ( bbb ( aaa deletedby:someone ) )"))
+        # In prior versions, deleted filtering was based of the final value of `status`/`status_must_not`, so the metatag ordering changed the results. This ensures this legacy behavior stays gone.
         assert_not(TagQuery.should_hide_deleted_posts?("aaa ( bbb ( aaa delreason:something ) status:pending )"))
         assert(TagQuery.should_hide_deleted_posts?("aaa ( bbb ( aaa ) status:pending )"))
         assert(TagQuery.should_hide_deleted_posts?("aaa ( bbb status:modqueue )"))
       end
 
       should "work with an array" do
-        kwargs = { hoisted_metatags: nil }.freeze
-        assert(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa bbb", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa bbb status:deleted", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa bbb deletedby:someone", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa bbb delreason:something", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa bbb -status:active", **kwargs)))
-        assert(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa bbb status:modqueue", **kwargs)))
-        assert(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("( aaa bbb )", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa ( bbb status:any )", **kwargs)))
-        assert(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("( aaa ( bbb ) )", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa ( bbb ( aaa status:any ) )", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa ( bbb ( aaa deletedby:someone ) )", **kwargs)))
-        assert_not(TagQuery.should_hide_deleted_posts?(TagQuery.scan_search("aaa ( bbb ( aaa delreason:something ) status:pending )", **kwargs)))
+        assert(TagQuery.should_hide_deleted_posts?(%w[aaa bbb]))
+        assert_not(TagQuery.should_hide_deleted_posts?(%w[aaa bbb status:deleted]))
+        assert_not(TagQuery.should_hide_deleted_posts?(%w[aaa bbb deletedby:someone]))
+        assert_not(TagQuery.should_hide_deleted_posts?(%w[aaa bbb delreason:something]))
+        assert_not(TagQuery.should_hide_deleted_posts?(%w[aaa bbb -status:active]))
+        assert(TagQuery.should_hide_deleted_posts?(%w[aaa bbb status:modqueue]))
+        assert(TagQuery.should_hide_deleted_posts?(["( aaa bbb )"]))
+        assert_not(TagQuery.should_hide_deleted_posts?(["aaa", "( bbb status:any )"]))
+        assert(TagQuery.should_hide_deleted_posts?(["( aaa ( bbb ) )"]))
+        assert_not(TagQuery.should_hide_deleted_posts?(["aaa", "( bbb ( aaa status:any ) )"]))
+        assert_not(TagQuery.should_hide_deleted_posts?(["aaa", "( bbb ( aaa deletedby:someone ) )"]))
+        # In prior versions, deleted filtering was based of the final value of `status`/`status_must_not`, so the metatag ordering changed the results. This ensures this legacy behavior stays gone.
+        assert_not(TagQuery.should_hide_deleted_posts?(["aaa", "( bbb ( aaa delreason:something ) status:pending )"]))
       end
     end
 
     should "work after parsing" do
-      assert(TagQuery.new("aaa bbb").hide_deleted_posts?)
-      assert_not(TagQuery.new("aaa bbb status:deleted").hide_deleted_posts?)
-      assert_not(TagQuery.new("aaa bbb deletedby:someone").hide_deleted_posts?)
-      assert_not(TagQuery.new("aaa bbb delreason:something status:pending").hide_deleted_posts?)
-      assert(TagQuery.new("( aaa bbb )").hide_deleted_posts?)
-      assert(TagQuery.new("aaa ( bbb status:any )").hide_deleted_posts?)
-      assert(TagQuery.new("( aaa ( bbb ) )").hide_deleted_posts?)
-      assert(TagQuery.new("aaa ( bbb ( aaa status:any ) )").hide_deleted_posts?)
-      assert(TagQuery.new("aaa ( bbb ( aaa deletedby:someone ) )").hide_deleted_posts?)
-      assert(TagQuery.new("aaa ( bbb ( aaa delreason:something ) status:pending )").hide_deleted_posts?)
+      tq = TagQuery.new("aaa bbb")
+      assert(tq.hide_deleted_posts?(at_any_level: false))
+      assert(tq.hide_deleted_posts?(at_any_level: true))
+      tq = TagQuery.new("aaa bbb status:deleted")
+      assert_not(tq.hide_deleted_posts?(at_any_level: false))
+      assert_not(tq.hide_deleted_posts?(at_any_level: true))
+      tq = TagQuery.new("aaa bbb deletedby:someone")
+      assert_not(tq.hide_deleted_posts?(at_any_level: false))
+      assert_not(tq.hide_deleted_posts?(at_any_level: true))
+      # In prior versions, deleted filtering was based of the final value of `status`/`status_must_not`, so the metatag ordering changed the results. This ensures this legacy behavior stays gone.
+      tq = TagQuery.new("aaa bbb delreason:something status:pending")
+      assert_not(tq.hide_deleted_posts?(at_any_level: false))
+      assert_not(tq.hide_deleted_posts?(at_any_level: true))
+      tq = TagQuery.new("( aaa bbb )")
+      assert(tq.hide_deleted_posts?(at_any_level: false))
+      assert(tq.hide_deleted_posts?(at_any_level: true))
+      tq = TagQuery.new("( aaa ( bbb ) )")
+      assert(tq.hide_deleted_posts?(at_any_level: false))
+      assert(tq.hide_deleted_posts?(at_any_level: true))
+      [true, false].each do |e|
+        msg = -"process_groups: #{e}"
+        tq = TagQuery.new("aaa ( bbb status:any )", process_groups: e)
+        assert(tq.hide_deleted_posts?(at_any_level: false), "#{msg}; #{tq.q}")
+        assert_not(tq.hide_deleted_posts?(at_any_level: true), "#{msg}; #{tq.q}")
+        tq = TagQuery.new("aaa ( bbb ( aaa status:any ) )", process_groups: e)
+        assert(tq.hide_deleted_posts?(at_any_level: false), "#{msg}; #{tq.q}")
+        assert_not(tq.hide_deleted_posts?(at_any_level: true), "#{msg}; #{tq.q}")
+        tq = TagQuery.new("aaa ( bbb ( aaa deletedby:someone ) )", process_groups: e)
+        assert(tq.hide_deleted_posts?(at_any_level: false), "#{msg}; #{tq.q}")
+        assert_not(tq.hide_deleted_posts?(at_any_level: true), "#{msg}; #{tq.q}")
+        tq = TagQuery.new("aaa ( bbb ( aaa delreason:something ) status:pending )", process_groups: e)
+        assert(tq.hide_deleted_posts?(at_any_level: false), "#{msg}; #{tq.q}")
+        assert_not(tq.hide_deleted_posts?(at_any_level: true), "#{msg}; #{tq.q}")
+      end
     end
   end
 


### PR DESCRIPTION
This PR mainly improves the robustness of the test suite, and fixes a small bug with deleted filter resolution that *currently has no impact on behavior*. This is ***not*** a mandatory big fix nor an urgent or pressing matter.
1. Adds & improves tests detecting incorrect deleted filtering
2. Fixes bug causing deleted filtering to be incorrectly inverted & set to the resultant value of the final group if certain constant settings are changed (specifically `ElasticPostQueryBuilder::GLOBAL_DELETED_FILTER` or passing `process_groups: true` to `TagQuery#new` in `ElasticPostQueryBuilder#initialize`)
3. Further restricts `TagQuery#should_hide_deleted_posts?` from incorrect resolution (only matters if `TagQuery::OVERRIDE_DELETED_FILTER_METATAGS` is changed to include a value ending in `status`)
4. Misc. documentation & error improvements