### PR TITLE
[Search] Fixed `status` bug

### DIFF
--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -15,7 +15,7 @@ module PostSets
       @public_tag_array = TagQuery.scan_search(tags, error_on_depth_exceeded: true)
       @tag_array = @public_tag_array.dup
       @tag_array << "rating:s" if CurrentUser.safe_mode?
-      @tag_array << "-status:deleted" if TagQuery.should_hide_deleted_posts?(tags, at_any_level: true)
+      # @tag_array << "-status:deleted" unless TagQuery.has_metatag?(tags, at_any_level: true)
       @page = page
       # limit should have been hoisted by scan_search
       @limit = limit || TagQuery.fetch_metatag(tag_array, "limit", at_any_level: false)

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -124,6 +124,8 @@ class TagQuery
     deletedby -deletedby ~deletedby
   ].freeze
 
+  STATUS_VALUES = %w[all any pending modqueue deleted flagged active].freeze
+
   # Used for quickly profiling optimizations, tweaking desired behavior, etc. Should be removed
   # after reviews are completed.
   # * `COUNT_TAGS_WITH_SCAN_RECURSIVE` [`false`]: Use `TagQuery.scan_recursive` to increment
@@ -1272,12 +1274,12 @@ class TagQuery
       when "status"
         q[:status] = g2.downcase
         q[:status_must_not] = nil
-        q[:show_deleted] ||= q[:status].in?(OVERRIDE_DELETED_FILTER_STATUS_VALUES)
+        q[:show_deleted] ||= q[:status].in?(STATUS_VALUES)
 
       when "-status"
         q[:status_must_not] = g2.downcase
         q[:status] = nil
-        q[:show_deleted] ||= q[:status_must_not].in?(OVERRIDE_DELETED_FILTER_STATUS_VALUES)
+        q[:show_deleted] ||= q[:status_must_not].in?(STATUS_VALUES)
 
       when "filetype", "-filetype", "~filetype", "type", "-type", "~type" then add_to_query(type, :filetype, g2)
 

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1274,12 +1274,12 @@ class TagQuery
       when "status"
         q[:status] = g2.downcase
         q[:status_must_not] = nil
-        q[:show_deleted] ||= q[:status].in?(STATUS_VALUES)
+        q[:show_deleted] ||= q[:status].in?(OVERRIDE_DELETED_FILTER_STATUS_VALUES)
 
       when "-status"
         q[:status_must_not] = g2.downcase
         q[:status] = nil
-        q[:show_deleted] ||= q[:status_must_not].in?(STATUS_VALUES)
+        q[:show_deleted] ||= q[:status_must_not].in?(OVERRIDE_DELETED_FILTER_STATUS_VALUES)
 
       when "filetype", "-filetype", "~filetype", "type", "-type", "~type" then add_to_query(type, :filetype, g2)
 

--- a/test/unit/tag_query_test.rb
+++ b/test/unit/tag_query_test.rb
@@ -660,7 +660,7 @@ class TagQueryTest < ActiveSupport::TestCase
 
   # TODO: Add more test cases for group parsing
   # TODO: Add more test cases for metatag parsing
-  context "Parsing a query:" do
+  context "Parsing:" do
     should "correctly handle up to 40 standard tags" do
       expected_result = {
         tags: {
@@ -763,7 +763,7 @@ class TagQueryTest < ActiveSupport::TestCase
       assert_equal(%w[acb azb], TagQuery.new("( a*b )")[:tags][:should])
     end
 
-    context "W/ metatags:" do
+    context "Metatags:" do
       should "match w/ case insensitivity" do
         %w[id:2 Id:2 ID:2 iD:2].map { |e| TagQuery.new(e)[:post_id] }.all?(2)
       end
@@ -925,6 +925,48 @@ class TagQueryTest < ActiveSupport::TestCase
               assert_not(result.hide_deleted_posts?)
             end
           end
+        end
+      end
+
+      should "correctly handle status" do
+        TagQuery::STATUS_VALUES.each do |x| # rubocop:disable Metrics/BlockLength
+          result = TagQuery.new(-"status:#{x}")
+          assert_equal(x, result[:status])
+          assert_nil(result[:status_must_not])
+          result = TagQuery.new(-"status:active status:#{x}")
+          assert_equal(true, result[:show_deleted])
+          assert_equal(x, result[:status])
+          assert_nil(result[:status_must_not])
+          assert_not(result.hide_deleted_posts?)
+          result = TagQuery.new(-"status:#{x} status:active")
+          assert_equal(true, result[:show_deleted])
+          assert_equal("active", result[:status])
+          assert_nil(result[:status_must_not])
+          assert_not(result.hide_deleted_posts?)
+          result = TagQuery.new(-"-status:modqueue status:#{x}")
+          assert_equal(x, result[:status])
+          result = TagQuery.new("status:#{x} -status:modqueue")
+          assert_equal("modqueue", result[:status_must_not])
+          assert_nil(result[:status])
+
+          result = TagQuery.new(-"-status:#{x}")
+          assert_equal(x, result[:status_must_not])
+          assert_nil(result[:status])
+          result = TagQuery.new(-"-status:active -status:#{x}")
+          assert_equal(true, result[:show_deleted])
+          assert_equal(x, result[:status_must_not])
+          assert_nil(result[:status])
+          assert_not(result.hide_deleted_posts?)
+          result = TagQuery.new(-"-status:#{x} -status:active")
+          assert_equal(true, result[:show_deleted])
+          assert_equal("active", result[:status_must_not])
+          assert_nil(result[:status])
+          assert_not(result.hide_deleted_posts?)
+          result = TagQuery.new(-"-status:modqueue -status:#{x}")
+          assert_nil(result[:status])
+          result = TagQuery.new("-status:#{x} -status:modqueue")
+          assert_equal("modqueue", result[:status_must_not])
+          assert_nil(result[:status])
         end
       end
 

--- a/test/unit/tag_query_test.rb
+++ b/test/unit/tag_query_test.rb
@@ -967,6 +967,8 @@ class TagQueryTest < ActiveSupport::TestCase
           result = TagQuery.new("-status:#{x} -status:modqueue")
           assert_equal("modqueue", result[:status_must_not])
           assert_nil(result[:status])
+
+          # assert_includes(ElasticPostQueryBuilder.new("status:pending", resolve_aliases: true, free_tags_count: 0, enable_safe_mode: false, always_show_deleted: false).create_query_obj, { term: { pending: true } })
         end
       end
 


### PR DESCRIPTION
Since `status` only allows 1 value, I added a check to stop a valid value from being overwritten by a bad value, but I used an array w/ only some of the valid values