### PR TITLE
[Post] Fix delreason breaking on paging

### DIFF
--- a/app/logical/post_search_context.rb
+++ b/app/logical/post_search_context.rb
@@ -6,7 +6,7 @@ class PostSearchContext
   def initialize(params)
     tags = params[:q].presence || params[:tags].presence || ""
     tags += " rating:s" if CurrentUser.safe_mode?
-    tags += " -status:deleted" unless TagQuery.has_metatag?(tags, "status", "-status")
+    tags += " -status:deleted" unless TagQuery.has_metatag?(tags, "status", "-status", "delreason", "-delreason")
     pagination_mode = params[:seq] == "prev" ? "a" : "b"
     @post = Post.tag_match(tags).paginate("#{pagination_mode}#{params[:id]}", limit: 1).first || Post.find(params[:id])
   end


### PR DESCRIPTION


Bug Summary: Using post navigation (prev/next) leads back to the same post. 
Bug Circumstances: Post is first/last on page (clicking the button goes to a new page), and `delreason` is in query

Cause: Searches automatically allow `status:deleted` when `delreason` is in the query. `PostSearchContext` didn't get the memo, and only checked for the `status` metatag. 

Fix: add `delreason` to the exceptions for automatically adding `-status:deleted` in `PostSearchContext` 