### PR TITLE
Improved Search Error Reporting

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
       render_unsupported_format
     when Danbooru::Paginator::PaginationError
       render_expected_error(410, exception.message)
-    when TagQuery::CountExceededError, TagQuery::DepthExceededError
+    when TagQuery::CountExceededError, TagQuery::DepthExceededError, TagQuery::InvalidTagError
       render_expected_error(422, exception.message)
     when FeatureUnavailable
       render_expected_error(400, "This feature isn't available")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
       render_unsupported_format
     when Danbooru::Paginator::PaginationError
       render_expected_error(410, exception.message)
-    when TagQuery::CountExceededError
+    when TagQuery::CountExceededError, TagQuery::DepthExceededError
       render_expected_error(422, exception.message)
     when FeatureUnavailable
       render_expected_error(400, "This feature isn't available")


### PR DESCRIPTION
Added handling of `TagQuery::DepthExceededError` & `TagQuery::InvalidTagError` to preexisting `TagQuery::CountExceededError` handling. E.g. Go from
![image](https://github.com/user-attachments/assets/d5557da5-ddc6-484a-a735-9e96ed7a0682)
to 
![image](https://github.com/user-attachments/assets/ed66ee52-35bf-41ab-a6a9-549325df81be)