### PR TITLE
[UI] Fix the menu toggle button sometimes acting as a link

### DIFF
--- a/app/javascript/src/styles/common/navigation.scss
+++ b/app/javascript/src/styles/common/navigation.scss
@@ -52,6 +52,7 @@ nav.navigation {
     & > a {
       display: flex;
       padding: 0.625rem 0.5rem;
+      cursor: pointer;
 
       & > span {
         display: flex;

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -15,7 +15,7 @@
   </menu>
 
   <menu class="nav-controls desktop">
-    <a role="button" href="" id="nav-toggle" class="nav-controls-toggle">
+    <a role="button" id="nav-toggle" class="nav-controls-toggle">
       <span>
         <%= svg_icon(:hamburger, class: "off") %>
         <%= svg_icon(:times, class: "on") %>


### PR DESCRIPTION
Clicking on the button before the script fully loaded would cause the browser to reload the page.