### PR TITLE
[Misc] Minor fixes for the FurID page

### DIFF
--- a/app/javascript/src/javascripts/furid.js
+++ b/app/javascript/src/javascripts/furid.js
@@ -45,18 +45,26 @@ FurID.initialize = async function () {
   });
 
   io.observe(document.getElementById("furid_end_of_content"));
+
+  // Load more content to fill up the entire screen if necessary
+  if (FurID.manifest[FurID.page] != undefined && FurID.wrapper.innerHeight() < window.innerHeight) {
+    FurID.loadMore();
+  }
 };
 
 FurID.loadMore = function () {
   if (!FurID.manifest[FurID.page]) return;
 
   for (const one of FurID.manifest[FurID.page]) {
-    $("<img />")
+    const image = $("<img />")
       .attr({
         src: FurID.baseURL + one,
         loading: "lazy",
       })
-      .appendTo(FurID.wrapper);
+      .appendTo(FurID.wrapper)
+      .one("error", () => {
+        image.remove();
+      });
   }
 
   FurID.page++;


### PR DESCRIPTION
* Load another page of images if the window large enough to not trigger intersection observer
* Remove images if they fail to load