### PR TITLE
[UI] Fix font color on posts when ordering pools (#1059)

### DIFF
--- a/app/javascript/src/styles/common/thumbnails.scss
+++ b/app/javascript/src/styles/common/thumbnails.scss
@@ -75,6 +75,7 @@ article.thumbnail {
 
     .rating { font-weight: 700; }
     & > a { text-align: center; } // Pool names
+    .favorites, .comments { color: palette("text-white") }
   }
 
   // Color the rating letters


### PR DESCRIPTION
Fixes #1059

Ensures the text color for favorites & comments on thumbnail details on the pool order editing page.