### PR TITLE
[Users] Add an option for staff to reset other users' counts

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   skip_before_action :api_check
   before_action :logged_in_only, only: %i[edit upload_limit update]
   before_action :member_only, only: %i[custom_style]
-  before_action :janitor_only, only: %i[toggle_uploads]
+  before_action :janitor_only, only: %i[toggle_uploads fix_counts]
 
   def new
     raise User::PrivilegeError.new("Already signed in") unless CurrentUser.is_anonymous?
@@ -54,6 +54,15 @@ class UsersController < ApplicationController
     @user.no_uploading = !@user.no_uploading
     ModAction.log(:user_uploads_toggle, { user_id: @user.id, disabled: @user.no_uploading })
     @user.save
+
+    redirect_to user_path(@user)
+  end
+
+  def fix_counts
+    @user = User.find(User.name_or_id_to_id_forced(params[:id]))
+
+    @user.refresh_counts!
+    flash[:notice] = "Counts have been refreshed"
 
     redirect_to user_path(@user)
   end

--- a/app/views/users/partials/show/_staff_info.html.erb
+++ b/app/views/users/partials/show/_staff_info.html.erb
@@ -31,13 +31,14 @@
       | <%= link_to "Replacements", post_replacements_path(search: { creator_name: user.name }) %>
     </span>
 
-    <h4>Uploading</h4>
+    <h4>Uploads</h4>
     <span>
       <% if user.no_uploading %>
         <%= link_to "Disabled", toggle_uploads_user_path(user), class: "text-red text-bold" %>
       <% else %>
         <%= link_to "Enabled", toggle_uploads_user_path(user) %>
       <% end %>
+      | <%= link_to "Refresh counts", fix_counts_user_path(user) %>
     </span>
 
     <% if CurrentUser.is_moderator? && UserRevert.can_revert?(user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -309,6 +309,7 @@ Rails.application.routes.draw do
     member do
       get :upload_limit
       get :toggle_uploads
+      get :fix_counts
     end
 
     collection do


### PR DESCRIPTION
This used to only be accessible to the user themselves, for some reason.