### PR TITLE
[PostFlags] Quality of life fixes for flag notes

### DIFF
--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -53,6 +53,7 @@ class PostFlagsController < ApplicationController
   def search_params
     # creator_id and creator_name are special cased in the model search function
     permitted_params = %i[reason_matches creator_id creator_name post_id post_tags_match type is_resolved]
+    permitted_params += %i[note] if CurrentUser.is_staff?
     permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params
   end

--- a/app/javascript/src/javascripts/post_flags.js
+++ b/app/javascript/src/javascripts/post_flags.js
@@ -1,8 +1,12 @@
 const PostFlags = {};
 
 PostFlags.init = function () {
-  $(".post-flag-note").on("click", (event) => {
-    $(event.currentTarget).toggleClass("expanded");
+  for (const container of $(".post-flag-note")) {
+    if (container.clientHeight > 72) $(container).addClass("expandable");
+  }
+
+  $(".post-flag-note-header").on("click", (event) => {
+    $(event.currentTarget).parents(".post-flag-note").toggleClass("expanded");
   });
 };
 

--- a/app/javascript/src/styles/specific/post_flags.scss
+++ b/app/javascript/src/styles/specific/post_flags.scss
@@ -8,20 +8,45 @@ div#c-post-flags {
   }
 }
 
-.dtext-container.post-flag-note {
-  background: themed("color-section");
-  padding: 0.25rem 0.5rem;
-  margin: 0.25rem 0.5rem;
+.post-flag-note {
+  background: themed("color-section-lighten-5");
+  margin: 0.5rem 0;
+  @include st-radius;
 
-  border: 1px solid themed("color-section-lighten-5");
-  border-left: 0.25rem solid themed("color-dtext-quote");
-  border-radius: 0.25rem;
+  &-header {
+    display: none; // flex
+    gap: 0.25rem;
 
-  max-height: 1.5rem;
-  cursor: pointer;
+    padding: 0.5rem;
+    font-size: 1rem;
+    font-weight: bold;
+    cursor: pointer;
 
-  &.expanded {
-    max-height: unset;
+    svg {
+      width: 1.5rem;
+      height: 1.5rem;
+      margin: -0.25rem;
+    }
+  }
+
+  &-body {
+    padding: 0.5rem;
+  }
+
+  &.expandable {
+    .post-flag-note-header { display: flex; }
+    .post-flag-note-body {
+      padding-top: 0;
+      display: none;
+    }
+    &.expanded {
+      .post-flag-note-header svg {
+        transform: rotate(90deg);
+      }
+      .post-flag-note-body {
+        display: block;
+      }
+    }
   }
 }
 

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -193,4 +193,9 @@ class PostFlag < ApplicationRecord
     # Deletions also create flags, but they create a deletion event instead
     PostEvent.add(post.id, CurrentUser.user, :flag_created, { reason: reason }) unless is_deletion
   end
+
+  def can_see_note?(user = CurrentUser.user)
+    return true if user.is_staff?
+    creator_id == user.id
+  end
 end

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -61,6 +61,10 @@ class PostFlag < ApplicationRecord
         q = q.post_tags_match(params[:post_tags_match])
       end
 
+      if params[:note].present?
+        q = q.attribute_matches(:note, params[:note])
+      end
+
       if params[:ip_addr].present?
         q = q.where("creator_ip_addr <<= ?", params[:ip_addr])
       end

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -8,6 +8,7 @@
   ], include_blank: true %>
   <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true %>
   <% if CurrentUser.is_janitor? %>
+    <%= f.input :note %>
     <%= f.user :creator %>
   <% end %>
   <% if CurrentUser.is_admin? %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -24,9 +24,12 @@
               <div class="dtext-container">
                 <%= format_text post_flag.reason %>
               </div>
-              <% if post_flag.note.present? && CurrentUser.is_staff? %>
-                <div class="dtext-container post-flag-note">
-                  <%= format_text post_flag.note %>
+              <% if post_flag.note.present? && post_flag.can_see_note? %>
+                <div class="post-flag-note">
+                  <div class="post-flag-note-header"><%= svg_icon(:chevron_right) %> Notes</div>
+                  <div class="dtext-container post-flag-note-body">
+                    <%= format_text post_flag.note %>
+                  </div>
                 </div>
               <% end %>
             </td>

--- a/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
+++ b/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
@@ -18,9 +18,12 @@
         <span class="resolved">RESOLVED</span>
       <% end %>
       
-      <% if flag.note.present? && CurrentUser.is_staff? %>
-        <div class="dtext-container post-flag-note">
-          <%= format_text flag.note %>
+      <% if flag.note.present? && flag.can_see_note? %>
+        <div class="post-flag-note">
+          <div class="post-flag-note-header"><%= svg_icon(:chevron_right) %> Notes</div>
+          <div class="dtext-container post-flag-note-body">
+            <%= format_text flag.note %>
+          </div>
         </div>
       <% end %>
     </li>


### PR DESCRIPTION
Reworked the flag note UI to be more user-friendly.
The full note is shown if it's fairly short – 2 lines or less. Otherwise, it is collapsed into a standard DText section element.
This fixes multiple usability issues reported by the staff team.

By popular demand, added a search input for the flag notes.