### PR TITLE
[PostReplacements] Change the per-post limit to only apply to pending replacements

### DIFF
--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -96,8 +96,8 @@ class PostReplacement < ApplicationRecord
       errors.add(:creator, "has already suggested too many replacements for this post today")
       throw :abort
     end
-    if post.replacements.where(creator_id: creator.id).count >= Danbooru.config.post_replacement_per_post_limit
-      errors.add(:creator, "has already suggested too many total replacements for this post")
+    if post.replacements.where(creator_id: creator.id, status: "pending").count >= Danbooru.config.post_replacement_per_post_limit
+      errors.add(:creator, "already has too many pending replacements for this post")
       throw :abort
     end
     true

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -267,7 +267,7 @@ module Danbooru
     end
 
     def post_replacement_per_post_limit
-      5
+      3
     end
 
     def remember_key

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -22,7 +22,7 @@ class PostReplacementTest < ActiveSupport::TestCase
     should "fail on too many per post total" do
       Danbooru.config.stubs(:post_replacement_per_post_limit).returns(-1)
       @replacement = @post.replacements.create(attributes_for(:png_replacement).merge(creator: @user))
-      assert_equal ["Creator has already suggested too many total replacements for this post"], @replacement.errors.full_messages
+      assert_equal ["Creator already has too many pending replacements for this post"], @replacement.errors.full_messages
     end
 
     should "fail if user has no remaining upload limit" do


### PR DESCRIPTION
There isn't really a reason to limit users to 5 replacements total per post outside of general anti-abuse measures.
Changing that restriction to only apply to pending posts will accomplish the exact same thing, but with less annoyances.