### PR TITLE
[Post Search] `order:rank` alternative/replacement (`order:hot`)

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,8 +2,7 @@
 
 module PostsHelper
   def discover_mode?
-    # params[:tags] =~ /order:rank/
-    params[:tags] =~ /order:(?>rank|hot)/
+    params[:tags] =~ /order:hot/
   end
 
   def next_page_url

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -2,7 +2,8 @@
 
 module PostsHelper
   def discover_mode?
-    params[:tags] =~ /order:rank/
+    # params[:tags] =~ /order:rank/
+    params[:tags] =~ /order:(?>rank|hot)/
   end
 
   def next_page_url

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -324,6 +324,9 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
       order.push({ _score: :desc })
 
     when "rank"
+      order.push({ _score: :desc })
+      must.push({ range: { score: { gt: 0 } } })
+      # must.push({ range: { created_at: { gte: 2.days.ago } } })
       @function_score = {
         script_score: {
           script: { # date2005_05_24 = DateTime.new(2005,05,24,12).to_time.to_i
@@ -332,9 +335,6 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
           },
         },
       }
-      must.push({ range: { score: { gt: 0 } } })
-      # must.push({ range: { created_at: { gte: 2.days.ago } } })
-      order.push({ _score: :desc })
 
     when "random"
       order.push({ _score: :desc })

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -134,7 +134,6 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
     "tagcount_asc" => [{ tag_count: :asc }],
     "comment_bumped" => [{ comment_bumped_at: { order: :desc, missing: :_last } }, { id: :desc }],
     "comment_bumped_asc" => [{ comment_bumped_at: { order: :asc, missing: :_last } }, { id: :desc }],
-    # "rank" => [{ _score: :desc }],
     # "random" => [{ _score: :desc }],
   }).freeze.each_value(&:freeze)
 
@@ -322,19 +321,6 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
                                          { gte: two_days_ago }
                                        end } })
       order.push({ _score: :desc })
-
-    when "rank"
-      order.push({ _score: :desc })
-      must.push({ range: { score: { gt: 0 } } })
-      # must.push({ range: { created_at: { gte: 2.days.ago } } })
-      @function_score = {
-        script_score: {
-          script: { # date2005_05_24 = DateTime.new(2005,05,24,12).to_time.to_i
-            params: { log3: Math.log(3), date2005_05_24: 1_116_936_000 }, # rubocop:disable Naming/VariableNumber
-            source: "Math.log(doc['score'].value) / params.log3 + (doc['created_at'].value.millis / 1000 - params.date2005_05_24) / 35000",
-          },
-        },
-      }
 
     when "random"
       order.push({ _score: :desc })

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -75,7 +75,9 @@ class TagQuery
     commenter comm noter noteupdater
   ].concat(CATEGORY_METATAG_MAP.keys).freeze
 
-  METATAGS = %w[md5 order limit child randseed ratinglocked notelocked statuslocked].concat(
+  # OPTIMIZE: Check what's best
+  # Should avoid additional array allocations
+  METATAGS = %w[md5 order limit child randseed hot_from ratinglocked notelocked statuslocked].concat(
     NEGATABLE_METATAGS, COUNT_METATAGS, BOOLEAN_METATAGS
   ).freeze
 
@@ -209,7 +211,7 @@ class TagQuery
   # Therefore, these are pulled out of groups and placed on the top level of searches.
   #
   # Note that this includes all valid prefixes.
-  GLOBAL_METATAGS = %w[order -order limit randseed].freeze
+  GLOBAL_METATAGS = %w[order -order limit randseed hot_from].freeze
 
   # The values for the `status` metatag that will override the automatic hiding of deleted posts
   # from search results. Other tags do also alter this behavior; specifically, a `deletedby` or
@@ -1389,6 +1391,8 @@ class TagQuery
       when "date", "-date", "~date" then add_to_query(type, :date, ParseValue.date_range(g2))
 
       when "age", "-age", "~age" then add_to_query(type, :age, ParseValue.invert_range(ParseValue.range(g2, :age)))
+
+      when "hot_from" then q[:hot_from] = ParseValue.date_from(g2)
 
       when "tagcount", "-tagcount", "~tagcount" then add_to_query(type, :post_tag_count, ParseValue.range(g2))
 

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -135,15 +135,13 @@ class TagQuery
   ].concat(COUNT_METATAGS, CATEGORY_METATAG_MAP.keys).freeze
 
   # All possible valid values for `order` metatags; used for autocomplete.
-  # * With the exception of `rank`, `random`, & `hot`, all values have an option to invert the order.
+  # * With the exception of `random` & `hot`, all values have an option to invert the order.
   # * With the exception of `portrait`/`landscape`, all invertible values have a bare, `_asc`, & `_desc` variant.
   # * With the exception of `id`, all bare invertible values are equivalent to their `_desc`-suffixed counterparts.
   #
   # Add non-reversible entries to the array literal here.
-  #
-  # IDEA: Add `rank_asc` option
   ORDER_METATAGS = %w[
-    rank random hot
+    random hot
   ].concat(
     ORDER_INVERTIBLE_ALIASES
       .keys.concat(ORDER_INVERTIBLE_ROOTS)
@@ -170,7 +168,7 @@ class TagQuery
     CATEGORY_METATAG_MAP.keys.flat_map { |e| [e, -"#{e}_asc"] }, # Remove the resolved forms of the full tag category forms
   )).freeze
 
-  # Should currently just be `rank`, `random`, & `hot`; not a constant due to only current use being tests.
+  # Should currently just be `random` & `hot`; not a constant due to only current use being tests.
   def self.order_non_invertible_roots
     (ORDER_METATAGS - ORDER_INVERTIBLE_ALIASES
     .keys.concat(ORDER_INVERTIBLE_ROOTS)
@@ -191,7 +189,7 @@ class TagQuery
   # In the general case, tags have a `_asc` suffix appended/removed.
   #
   # NOTE: With the exception of `id_desc`, values ending in `_desc` are equivalent to the same string
-  # with that suffix removed; as such, these keys, along with `id_asc`, `rank`, `random`, & `hot`,
+  # with that suffix removed; as such, these keys, along with `id_asc`, `random`, & `hot`,
   # are not included in this hash.
   ORDER_VALUE_INVERSIONS = ORDER_INVERTIBLE_ROOTS[1..].flat_map { |str| [str, -"#{str}_asc"] }.push(*ORDER_NON_SUFFIXED_ALIASES.keys, "id", "id_desc").index_with do |e|
     case e

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -75,8 +75,6 @@ class TagQuery
     commenter comm noter noteupdater
   ].concat(CATEGORY_METATAG_MAP.keys).freeze
 
-  # OPTIMIZE: Check what's best
-  # Should avoid additional array allocations
   METATAGS = %w[md5 order limit child randseed hot_from ratinglocked notelocked statuslocked].concat(
     NEGATABLE_METATAGS, COUNT_METATAGS, BOOLEAN_METATAGS
   ).freeze

--- a/app/views/posts/partials/common/_secondary_links.html.erb
+++ b/app/views/posts/partials/common/_secondary_links.html.erb
@@ -3,7 +3,6 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "Listing", posts_path %>
   <%= subnav_link_to "Upload", new_upload_path %>
-  <!-- <%= subnav_link_to "Hot", posts_path(tags: "order:rank", d: "1") %> -->
   <%= subnav_link_to "Hot", posts_path(tags: "order:hot", d: "1") %>
   <%= subnav_link_to("Popular", popular_index_path) %>
   <% unless CurrentUser.is_anonymous? %>

--- a/app/views/posts/partials/common/_secondary_links.html.erb
+++ b/app/views/posts/partials/common/_secondary_links.html.erb
@@ -3,7 +3,8 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "Listing", posts_path %>
   <%= subnav_link_to "Upload", new_upload_path %>
-  <%= subnav_link_to "Hot", posts_path(tags: "order:rank", d: "1") %>
+  <!-- <%= subnav_link_to "Hot", posts_path(tags: "order:rank", d: "1") %> -->
+  <%= subnav_link_to "Hot", posts_path(tags: "order:hot", d: "1") %>
   <%= subnav_link_to("Popular", popular_index_path) %>
   <% unless CurrentUser.is_anonymous? %>
     <%= subnav_link_to "Favorites", favorites_path %>

--- a/app/views/posts/partials/index/_related.html.erb
+++ b/app/views/posts/partials/index/_related.html.erb
@@ -2,7 +2,6 @@
   <h3>Related</h3>
   <ul id="related-list">
     <% if discover_mode? %>
-      <!-- <li id="secondary-links-posts-hot"><%= link_to "Hot", posts_path(:tags => "order:rank") %></li> -->
       <li id="secondary-links-posts-hot"><%= link_to "Hot", posts_path(:tags => "order:hot") %></li>
       <li id="secondary-links-posts-popular"><%= link_to "Popular", popular_index_path %></li>
     <% end %>

--- a/app/views/posts/partials/index/_related.html.erb
+++ b/app/views/posts/partials/index/_related.html.erb
@@ -2,7 +2,8 @@
   <h3>Related</h3>
   <ul id="related-list">
     <% if discover_mode? %>
-      <li id="secondary-links-posts-hot"><%= link_to "Hot", posts_path(:tags => "order:rank") %></li>
+      <!-- <li id="secondary-links-posts-hot"><%= link_to "Hot", posts_path(:tags => "order:rank") %></li> -->
+      <li id="secondary-links-posts-hot"><%= link_to "Hot", posts_path(:tags => "order:hot") %></li>
       <li id="secondary-links-posts-popular"><%= link_to "Popular", popular_index_path %></li>
     <% end %>
 

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -20,7 +20,6 @@
           <%= svg_icon(:sparkles) %>
           <span>Latest</span>
         </a>
-        <!-- <a href="<%= posts_path(tags: "order:rank") %>" tags="order:rank"> -->
         <a href="<%= posts_path(tags: "order:hot") %>" tags="order:hot">
           <%= svg_icon(:flame) %>
           <span>Popular</span>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -20,7 +20,8 @@
           <%= svg_icon(:sparkles) %>
           <span>Latest</span>
         </a>
-        <a href="<%= posts_path(tags: "order:rank") %>" tags="order:rank">
+        <!-- <a href="<%= posts_path(tags: "order:rank") %>" tags="order:rank"> -->
+        <a href="<%= posts_path(tags: "order:hot") %>" tags="order:hot">
           <%= svg_icon(:flame) %>
           <span>Popular</span>
         </a>

--- a/test/unit/elastic_post_query_builder_test.rb
+++ b/test/unit/elastic_post_query_builder_test.rb
@@ -72,6 +72,7 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
       "tagcount_asc" => [[{ tag_count: :asc }], [{ tag_count: :desc }]],
       "rank" => [[{ _score: :desc }]],
       "random" => [[{ _score: :desc }]],
+      "hot" => [[{ _score: :desc }]],
       "portrait" => [[{ aspect_ratio: :asc }], [{ aspect_ratio: :desc }]],
       "landscape" => [[{ aspect_ratio: :desc }], [{ aspect_ratio: :asc }]],
     },
@@ -410,7 +411,7 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
         end.each do |p|
           q = -"#{p}order:#{k}"
           r = ElasticPostQueryBuilder.new(q, **DEFAULT_PARAM)
-          comparison = 2.days.ago if k == "rank"
+          comparison = 2.days.ago if %w[rank hot].include?(k)
           msg = -"val: #{k}, TQ(#{q}).q:#{TagQuery.new(q).q}"
           assert_equal(p == "-" ? v.last : v.first, r.order, msg)
 
@@ -418,12 +419,13 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
           case k
           when /\Acomm(?>ent)?_bumped(?>_(?>a|de)sc)?\z/
             assert_includes(r.must, { exists: { field: "comment_bumped_at" } }, msg)
-          when "rank"
+          when "rank", "hot" # TODO: Test with `hot_from`
             assert_includes(r.must, { range: { score: { gt: 0 } } }, msg)
             datetime_ago = nil
             assert(r.must.any? { |x| datetime_ago ||= x[:range]&.fetch(:created_at, nil)&.fetch(:gte, nil) }, msg)
             assert_in_delta(comparison, datetime_ago, TIME_DELTA, msg)
           # FIXME: Find a way to test the function score and assert these commented out lines
+          # TODO: Check with `hot`
           #   assert_equals({
           #     script_score: {
           #       script: {

--- a/test/unit/elastic_post_query_builder_test.rb
+++ b/test/unit/elastic_post_query_builder_test.rb
@@ -410,7 +410,7 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
         end.each do |p|
           q = -"#{p}order:#{k}"
           r = ElasticPostQueryBuilder.new(q, **DEFAULT_PARAM)
-          comparison = 2.days.ago if k == hot
+          comparison = 2.days.ago if k == "hot"
           msg = -"val: #{k}, TQ(#{q}).q:#{TagQuery.new(q).q}"
           assert_equal(p == "-" ? v.last : v.first, r.order, msg)
 

--- a/test/unit/elastic_post_query_builder_test.rb
+++ b/test/unit/elastic_post_query_builder_test.rb
@@ -70,9 +70,9 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
       "tagcount" => [[{ tag_count: :desc }], [{ tag_count: :asc }]],
       "tagcount_desc" => [[{ tag_count: :desc }], [{ tag_count: :asc }]],
       "tagcount_asc" => [[{ tag_count: :asc }], [{ tag_count: :desc }]],
+      "hot" => [[{ _score: :desc }]],
       "rank" => [[{ _score: :desc }]],
       "random" => [[{ _score: :desc }]],
-      "hot" => [[{ _score: :desc }]],
       "portrait" => [[{ aspect_ratio: :asc }], [{ aspect_ratio: :desc }]],
       "landscape" => [[{ aspect_ratio: :desc }], [{ aspect_ratio: :asc }]],
     },
@@ -422,8 +422,9 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
           when "rank", "hot" # TODO: Test with `hot_from`
             assert_includes(r.must, { range: { score: { gt: 0 } } }, msg)
             datetime_ago = nil
-            assert(r.must.any? { |x| datetime_ago ||= x[:range]&.fetch(:created_at, nil)&.fetch(:gte, nil) }, msg)
-            assert_in_delta(comparison, datetime_ago, TIME_DELTA, msg)
+            # TODO: Remove conditional if rank is bounded again
+            assert(r.must.any? { |x| datetime_ago ||= x[:range]&.fetch(:created_at, nil)&.fetch(:gte, nil) }, msg) if k == "hot"
+            assert_in_delta(comparison, datetime_ago, TIME_DELTA, msg) if k == "hot"
           # FIXME: Find a way to test the function score and assert these commented out lines
           # TODO: Check with `hot`
           #   assert_equals({

--- a/test/unit/elastic_post_query_builder_test.rb
+++ b/test/unit/elastic_post_query_builder_test.rb
@@ -71,7 +71,6 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
       "tagcount_desc" => [[{ tag_count: :desc }], [{ tag_count: :asc }]],
       "tagcount_asc" => [[{ tag_count: :asc }], [{ tag_count: :desc }]],
       "hot" => [[{ _score: :desc }]],
-      "rank" => [[{ _score: :desc }]],
       "random" => [[{ _score: :desc }]],
       "portrait" => [[{ aspect_ratio: :asc }], [{ aspect_ratio: :desc }]],
       "landscape" => [[{ aspect_ratio: :desc }], [{ aspect_ratio: :asc }]],
@@ -411,7 +410,7 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
         end.each do |p|
           q = -"#{p}order:#{k}"
           r = ElasticPostQueryBuilder.new(q, **DEFAULT_PARAM)
-          comparison = 2.days.ago if %w[rank hot].include?(k)
+          comparison = 2.days.ago if k == hot
           msg = -"val: #{k}, TQ(#{q}).q:#{TagQuery.new(q).q}"
           assert_equal(p == "-" ? v.last : v.first, r.order, msg)
 
@@ -419,12 +418,11 @@ class ElasticPostQueryBuilderTest < ActiveSupport::TestCase
           case k
           when /\Acomm(?>ent)?_bumped(?>_(?>a|de)sc)?\z/
             assert_includes(r.must, { exists: { field: "comment_bumped_at" } }, msg)
-          when "rank", "hot" # TODO: Test with `hot_from`
+          when "hot" # TODO: Test with `hot_from`
             assert_includes(r.must, { range: { score: { gt: 0 } } }, msg)
             datetime_ago = nil
-            # TODO: Remove conditional if rank is bounded again
-            assert(r.must.any? { |x| datetime_ago ||= x[:range]&.fetch(:created_at, nil)&.fetch(:gte, nil) }, msg) if k == "hot"
-            assert_in_delta(comparison, datetime_ago, TIME_DELTA, msg) if k == "hot"
+            assert(r.must.any? { |x| datetime_ago ||= x[:range]&.fetch(:created_at, nil)&.fetch(:gte, nil) }, msg)
+            assert_in_delta(comparison, datetime_ago, TIME_DELTA, msg)
           # FIXME: Find a way to test the function score and assert these commented out lines
           # TODO: Check with `hot`
           #   assert_equals({

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1909,7 +1909,6 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts.reverse, "order:chartags")
       assert_tag_match(posts.reverse, "order:copytags")
       assert_tag_match(posts.reverse, "order:hot")
-      assert_tag_match(posts.reverse, "order:rank")
       assert_tag_match(posts.reverse, "order:note_count")
       assert_tag_match(posts.reverse, "order:note_count_desc")
       assert_tag_match(posts.reverse, "order:notes")

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1881,9 +1881,9 @@ class PostTest < ActiveSupport::TestCase
           fav_count: n,
           file_size: 1.megabyte * n,
           # posts[0] is portrait, posts[1] is landscape. posts[1].mpixels > posts[0].mpixels.
-          image_height: 100*n*n,
-          image_width: 100*(3-n)*n,
-          tag_string: tags[n-1],
+          image_height: 100 * n * n,
+          image_width: 100 * (3 - n) * n,
+          tag_string: tags[n - 1],
         )
 
         create(:comment, post: p, do_not_bump_post: false)
@@ -1908,6 +1908,7 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts.reverse, "order:arttags")
       assert_tag_match(posts.reverse, "order:chartags")
       assert_tag_match(posts.reverse, "order:copytags")
+      assert_tag_match(posts.reverse, "order:hot")
       assert_tag_match(posts.reverse, "order:rank")
       assert_tag_match(posts.reverse, "order:note_count")
       assert_tag_match(posts.reverse, "order:note_count_desc")

--- a/test/unit/tag_query_test.rb
+++ b/test/unit/tag_query_test.rb
@@ -1208,6 +1208,7 @@ class TagQueryTest < ActiveSupport::TestCase
       end
 
       # TODO: Add these
+      # when "hot_from" then q[:hot_from] = ParseValue.date_from(g2)
       # when "date", "-date", "~date" then add_to_query(type, :date, ParseValue.date_range(g2))
       # when "age", "-age", "~age" then add_to_query(type, :age, ParseValue.invert_range(ParseValue.range(g2, :age)))
       # when "source", "-source", "~source" add_to_query(type, :sources, g2, any_none_key: :source, wildcard: true) { "#{g2}*" }


### PR DESCRIPTION
Fixes [forum #58375](https://e621.net/forum_topics/58375).
* Adds an ordering method (`order:hot`)
* Removes the 2 day restriction from `order:rank`
* Replaces all current uses of `order:rank` w/ `order:hot` (e.g. `Hot` page)
* Added `hot_from` metatag to define starting range for `order:hot`

Similarly to `order:rank`, `order:hot` seeks to order posts uploaded in the past 2 days based on both their score & how recently they were posted; however, while the `rank` algorithm is arguably inconsistent and is viewed as confusing, this replacement algorithm used in `hot` is far more consistent, self-explanatory, & predictable. As shown [here](https://www.desmos.com/calculator/ammxws6vsl), this algorithm simply scales a post's score by how deep into the 2 day range it is, with posts uploaded 2 days ago having their resultant score being halved. This way, an extremely high-scoring post won't be placed after a post that has less than half it's score. As shown in the graph, the curve of the scaling can be adjusted by changing `ElasticPostQueryBuilder::RANK_EXPONENT`. The current scale has been chosen to have posts' effective scores decay at a fairly steady rate while still being smooth.
* An exponent of 0 removes the impact of score altogether
* An exponent of 0<x<1 makes the rate of change increase over time
* An exponent of 1 results in a linear decay
* An exponent of >1 makes the rate of change decrease over time

This PR also replaces the prior usage of `order:rank` & both removes the time restrictions from `order:rank` & adds the `hot_from` metatag to enable direct comparisons of their output at any point in time (use `order:rank date:<x+2>_days_ago..<x>_days_ago` to restrict to the same time frame).