### PR TITLE
[Posts] Prevent the mp4 uploads from overwriting the original file

### DIFF
--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -494,7 +494,7 @@ Post.resize_video = function (post, target_size) {
   function original_sources () {
     if (!post || !post.file) return;
 
-    // This feels exceptionally stupid, but it should work
+    // I feel like there is a better way of doing this
     let codecs = [ "video/webm; codecs=\"vp9\"", "video/mp4" ];
     let alternate = 1;
     if (post.file.ext == "mp4") {

--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -492,9 +492,19 @@ Post.resize_video = function (post, target_size) {
   let desired_classes = [];
 
   function original_sources () {
-    target_sources.push({type: "video/webm; codecs=\"vp9\"", url: post?.file?.url});
-    if (typeof post?.sample?.alternates?.original !== "undefined")
-      target_sources.push({type: "video/mp4", url: post?.sample?.alternates?.original?.urls[1]});
+    if (!post || !post.file) return;
+
+    // This feels exceptionally stupid, but it should work
+    let codecs = [ "video/webm; codecs=\"vp9\"", "video/mp4" ];
+    let alternate = 1;
+    if (post.file.ext == "mp4") {
+      codecs = codecs.reverse();
+      alternate = 0;
+    }
+
+    target_sources.push({type: codecs[0], url: post.file.url});
+    if (typeof post.sample?.alternates?.original !== "undefined")
+      target_sources.push({type: codecs[1], url: post.sample?.alternates?.original?.urls[alternate]});
   }
 
   switch (target_size) {

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -127,7 +127,7 @@ class PostPresenter < Presenter
           type: 'video',
           height: post.image_height,
           width: post.image_width,
-          urls: post.visible? ? [nil, post.file_url_ext('mp4')] : [nil, nil]
+          urls: post.visible? ? [post.file_url_ext("webm"), post.file_url_ext("mp4")] : [nil, nil],
       }
     end
     Danbooru.config.image_rescales.each do |k,v|

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -55,7 +55,7 @@ class PostSerializer < ActiveModel::Serializer
           type: 'video',
           height: fixed_dims[1],
           width: fixed_dims[0],
-          urls: object.visible? ? [nil, object.file_url_ext('mp4')] : [nil, nil]
+          urls: object.visible? ? [object.file_url_ext("webm"), object.file_url_ext("mp4")] : [nil, nil],
       }
     end
     Danbooru.config.image_rescales.each do |k,v|


### PR DESCRIPTION
Since the video conversion job was hardcoded to created mp4 versions, it did not properly deal with mp4 uploads.
Thus, videos that used the AV1 codec would be converted to h264, overwriting the original file.