### PR TITLE
[Favorites] Rework the created_at index to also use user_id

### DIFF
--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -76,7 +76,7 @@ class UserPresenter
   end
 
   def favorites
-    ids = Favorite.where(user_id: user.id).order(created_at: :desc).limit(50).pluck(:post_id)[0..7]
+    ids = Favorite.where(user_id: user.id).order(created_at: :desc).limit(8).pluck(:post_id)
     posts = Post.where(id: ids).sort_by { |post| ids.index(post.id) }
     PostsDecorator.decorate_collection(posts)
   end

--- a/db/migrate/20250429022022_replace_favorites_index.rb
+++ b/db/migrate/20250429022022_replace_favorites_index.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReplaceFavoritesIndex < ActiveRecord::Migration[7.1]
+  def change
+    Favorite.without_timeout do
+      remove_index :favorites, :created_at
+
+      add_index :favorites, %i[user_id created_at]
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3729,13 +3729,6 @@ CREATE INDEX index_edit_histories_on_versionable_id_and_versionable_type ON publ
 
 
 --
--- Name: index_favorites_on_created_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_favorites_on_created_at ON public.favorites USING btree (created_at);
-
-
---
 -- Name: index_favorites_on_post_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3747,6 +3740,13 @@ CREATE INDEX index_favorites_on_post_id ON public.favorites USING btree (post_id
 --
 
 CREATE INDEX index_favorites_on_user_id ON public.favorites USING btree (user_id);
+
+
+--
+-- Name: index_favorites_on_user_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_favorites_on_user_id_and_created_at ON public.favorites USING btree (user_id, created_at);
 
 
 --
@@ -4703,6 +4703,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250429022022'),
 ('20250423141854'),
 ('20250414000142'),
 ('20250328035855'),


### PR DESCRIPTION
Based on my local testing, this should be significantly more performant.

Removed the previously used "pick 50 and select 8" approach of fetching the latest favorites.
It was originally used to force postgres to use an index – in this case, it is no longer required.