### PR TITLE
Enable Bio Scrolling on Mobile

### DIFF
--- a/app/javascript/src/styles/views/users/show/partials/_about.scss
+++ b/app/javascript/src/styles/views/users/show/partials/_about.scss
@@ -18,6 +18,7 @@ tabs-menu, tabs-content {
   .content {
     position: relative;
     max-height: 25rem;
+    overflow-y: auto;
     &.expanded { max-height: unset; }
     @include window-larger-than(50rem) { max-height: unset; }
 


### PR DESCRIPTION
This pull request addresses a usability issue on e621’s mobile experience by adding `overflow-y: auto;` to the `.profile-readmore .content` selector in `_about.scss`. This change enables scrolling for lengthy user profiles on mobile devices, ensuring full content accessibility without altering the existing desktop or expanded profile behavior.

## Problem

The `.profile-readmore .content` section, limited by `max-height: 25rem` on mobile, truncates long profiles, preventing users from viewing complete bios or details.

## Solution

By adding `overflow-y: auto;` to `.profile-readmore .content`, this change allows mobile users to scroll through profiles exceeding the `max-height` limit. This solution:

- Enables seamless scrolling for long profiles on mobile.
- Preserves existing behavior for `.expanded` profiles and larger screens (`window-larger-than(50rem)`), where `max-height: unset` applies.
- Maintains a clean UI by showing scrollbars only when necessary.

## Technical Details

**File**: `_about.scss`
**Selector**: `.profile-readmore .content`
**Change**: Added `overflow-y: auto;`.

**Before:**

```SCSS
.profile-readmore {
  flex-flow: column;
  align-items: start;

  .content {
    position: relative;
    max-height: 25rem;
    &.expanded { max-height: unset; }
    @include window-larger-than(50rem) { max-height: unset; }
    /* ... other styles ... */
  }
}
```

**After:**

```SCSS
.profile-readmore {
  flex-flow: column;
  align-items: start;

  .content {
    position: relative;
    max-height: 25rem;
    overflow-y: auto; /* Enables scrolling overflowed content */
    &.expanded { max-height: unset; }
    @include window-larger-than(50rem) { max-height: unset; }
    /* ... other styles ... */
  }
}
```

## Acknowledgments

A shout-out to the people the hold up the foundation of e621:

- The **artists**, for giving boorus a reason to exist in the first place.
- The **community**, because e621 would be nothing more than yet another Danbooru fork without them.

**Signed**,
A long-time user