### PR TITLE
[PostVotes] Avoid timing out while calculating the hourly post vote limit

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -498,9 +498,17 @@ class User < ApplicationRecord
                          nil, 7.days)
     create_user_throttle(:comment_vote, ->{ Danbooru.config.comment_vote_limit - CommentVote.for_user(id).where("created_at > ?", 1.hour.ago).count },
                          :general_bypass_throttle?, 3.days)
-    create_user_throttle(:post_vote, ->{ Danbooru.config.post_vote_limit - PostVote.for_user(id).where("created_at > ?", 1.hour.ago).count },
-                         :general_bypass_throttle?, nil)
-    create_user_throttle(:post_flag, ->{ Danbooru.config.post_flag_limit - PostFlag.for_creator(id).where("created_at > ?", 1.hour.ago).count },
+    create_user_throttle(:post_vote, -> {
+      # This looks horrid, but it does seem to be the fastest way to check if the user has hit the hourly post vote limit.
+      # With a limited dataset, this query is about 3-4 times faster than a straightforward count.
+      result = ApplicationRecord.connection.execute(ApplicationRecord.sanitize_sql([
+        "SELECT COUNT(*) FROM ( SELECT post_id FROM post_votes WHERE user_id = ? AND created_at > ? LIMIT ? ) as a;",
+        id, 1.hour.ago, Danbooru.config.post_vote_limit + 1,
+      ]))
+      return false if result.blank?
+      Danbooru.config.post_vote_limit - result[0].count
+    }, :general_bypass_throttle?, nil)
+    create_user_throttle(:post_flag, -> { Danbooru.config.post_flag_limit - PostFlag.for_creator(id).where("created_at > ?", 1.hour.ago).count },
                          :can_approve_posts?, 3.days)
     create_user_throttle(:ticket, ->{ Danbooru.config.ticket_limit - Ticket.for_creator(id).where("created_at > ?", 1.hour.ago).count },
                          :general_bypass_throttle?, 3.days)

--- a/db/migrate/20250430193448_add_post_votes_compond_index.rb
+++ b/db/migrate/20250430193448_add_post_votes_compond_index.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddPostVotesCompondIndex < ActiveRecord::Migration[7.1]
-  def change
-    add_index :post_votes, %i[user_id created_at], order: { user_id: :asc, created_at: :asc }
-  end
-end

--- a/db/migrate/20250430193448_add_post_votes_compond_index.rb
+++ b/db/migrate/20250430193448_add_post_votes_compond_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPostVotesCompondIndex < ActiveRecord::Migration[7.1]
+  def change
+    add_index :post_votes, %i[user_id created_at], order: { user_id: :asc, created_at: :asc }
+  end
+end

--- a/db/migrate/20250430193448_add_post_votes_compound_index.rb
+++ b/db/migrate/20250430193448_add_post_votes_compound_index.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPostVotesCompoundIndex < ActiveRecord::Migration[7.1]
+  def change
+    add_index :post_votes, %i[user_id created_at]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4156,6 +4156,13 @@ CREATE INDEX index_post_votes_on_user_id ON public.post_votes USING btree (user_
 
 
 --
+-- Name: index_post_votes_on_user_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_votes_on_user_id_and_created_at ON public.post_votes USING btree (user_id, created_at);
+
+
+--
 -- Name: index_post_votes_on_user_id_and_post_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4703,6 +4710,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250430193448'),
 ('20250429022022'),
 ('20250423141854'),
 ('20250414000142'),


### PR DESCRIPTION
Non-privileged users are limited to 3000 post votes per hour.
That means that on every post vote, the site must check whether the user has hit that limit.
And with some users having hundreds of thousands of votes, this slows down the requests a lot.

This PR addresses this issue by introducing a better search index, and also improving the vote lookup process.