### PR TITLE
[AIBUR] Show information on relation type.

### DIFF
--- a/app/views/tag_alias_requests/new.html.erb
+++ b/app/views/tag_alias_requests/new.html.erb
@@ -7,6 +7,11 @@
     <p>You can request a new tag alias be created. This will create a corresponding forum topic for community
       review.</p>
 
+    <%= format_text("
+    An alias changes the input tag to the output tag on post change. For instance, `anthros` will be changed to `anthro`. 
+    If you are looking to automatically add an additional tag, create a \"Tag Implication Request\":/tag_implication_request/new instead.
+    ") %>
+
     <%= custom_form_for(:tag_alias_request, url: tag_alias_request_path) do |f| %>
       <%= f.input :antecedent_name, label: "From", autocomplete: "tag" %>
       <%= f.input :consequent_name, label: "To", autocomplete: "tag" %>

--- a/app/views/tag_implication_requests/new.html.erb
+++ b/app/views/tag_implication_requests/new.html.erb
@@ -7,6 +7,11 @@
     <p>You can request a new tag implication be created. This will create a corresponding forum topic for community
       review.</p>
 
+    <%= format_text("
+    An implication adds both the input tag and the output tag on post change. For instance, `striped_tail` will also add `tail`.
+    If you are looking to change the input tag to a different tag, create a \"Tag Alias Request\":/tag_alias_request/new instead.
+    ") %>
+
     <%= custom_form_for(:tag_implication_request, url: tag_implication_request_path) do |f| %>
       <%= f.input :antecedent_name, label: "From", autocomplete: "tag" %>
       <%= f.input :consequent_name, label: "To", autocomplete: "tag" %>


### PR DESCRIPTION
ui tweak: Add a warning about what type of tag relationship request is being made. 

This warning is made using Dtext. Changing the implementation might be a good idea, so this will be a draft for now. 