### PR TITLE
[Comments] Fix an error caused by stickied comments

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -56,8 +56,8 @@ class PostsController < ApplicationController
       @comments = @post.comments.includes(:creator, :updater).visible(CurrentUser.user)
       @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
     else
-      @comments = {}
-      @comment_votes = {}
+      @comments = Comment.none
+      @comment_votes = CommentVote.none
     end
 
     respond_with(@post)
@@ -76,8 +76,8 @@ class PostsController < ApplicationController
       @comments = @post.comments.includes(:creator, :updater).visible(CurrentUser.user)
       @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
     else
-      @comments = {}
-      @comment_votes = {}
+      @comments = Comment.none
+      @comment_votes = CommentVote.none
     end
 
     @fixup_post_url = true


### PR DESCRIPTION
Under very specific circumstances, the posts#show page would throw an error because it would try to fetch the stickied comments when there were no comments to display to begin with.