### PR TITLE
[Posts] Add a way to safely delete posts that have unprocessed videos

### DIFF
--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -21,10 +21,6 @@ module Moderator
       def delete
         @post = ::Post.find(params[:id])
 
-        if @post.is_video? && (@post.video_sample_list.empty? || @post.video_sample_list[:manifest] != 2)
-          raise ::User::PrivilegeError, "Video samples are in the wrong format. Please regenerate them before deleting."
-        end
-
         if params[:commit] == "Delete"
           @post.delete!(params[:reason], move_favorites: params[:move_favorites].present?)
           @post.copy_sources_to_parent if params[:copy_sources].present?

--- a/app/logical/storage_manager/local.rb
+++ b/app/logical/storage_manager/local.rb
@@ -36,6 +36,13 @@ class StorageManager::Local < StorageManager
     end
     return unless post.is_video?
 
+    # Delete wrongly formatted video files
+    # TODO: VCJ2 remove this once all files are converted
+    unless post.generated_samples.nil?
+      delete_old_video_files(post.md5, post.file_ext)
+      post.update_column(:generated_samples, nil)
+    end
+
     # Move variants
     post.video_sample_list[:variants].each_key do |ext|
       path = file_path(post, ext, :scaled, false, scale_factor: "alt")

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -314,6 +314,9 @@ class Post < ApplicationRecord
           sample_data[:manifest] = 2
 
           sample_data[:original] = video_samples["original"]
+          sample_data[:original][:size] = file_size
+          sample_data[:original][:width] = image_width
+          sample_data[:original][:height] = image_height
           sample_data[:original][:url] = (visible? ? file_url : nil)
           sample_data[:original].symbolize_keys!
 


### PR DESCRIPTION
It's only needed while the bulk of the videos on the site are getting processed.
But if we don't have this, Mairo will likely just kill me.