### PR TITLE
[TagPreview] Add new tag preview

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -13,18 +13,15 @@ class TagsController < ApplicationController
   end
 
   def index
-    @tags = Tag.search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @tags = Tag.search(search_params).paginate(params[:page], limit: params[:limit], search_count: params[:search])
 
     respond_with(@tags)
   end
 
   def preview
-    @preview = TagsPreview.new(tags: params[:tags])
-    respond_to do |format|
-      format.json do
-        render json: @preview.serializable_hash
-      end
-    end
+    tag_names = params[:name].to_s.split(",").map(&:strip).compact_blank.join(" ")
+    @preview = TagsPreview.new(tags: tag_names)
+    render plain: @preview.serializable_hash.to_json, content_type: "application/json"
   end
 
   def show

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -19,8 +19,8 @@ class TagsController < ApplicationController
   end
 
   def preview
-    tag_names = params[:name].to_s.split(",").map(&:strip).compact_blank.join(" ")
-    @preview = TagsPreview.new(tags: tag_names)
+    # This endpoint needs to be a POST request, because long tag strings will exceed the browser URL length limit.
+    @preview = TagsPreview.new(tags: params[:tags])
     render plain: @preview.serializable_hash.to_json, content_type: "application/json"
   end
 

--- a/app/javascript/src/javascripts/tag_editor.vue
+++ b/app/javascript/src/javascripts/tag_editor.vue
@@ -1,190 +1,158 @@
 <template>
-    <div>
-        <textarea class="tag-textarea" id="post_tag_string" v-model="tags" rows="5" data-autocomplete="tag-edit"
-                  ref="otherTags" name="post[tag_string]" :spellcheck="false" @keyup="updateTagCount"></textarea>
-        <tag-preview :tags="preview.tags" :loading="preview.loading"></tag-preview>
-        <div class="related-tag-functions">
-            Related:
-            <a href="#" @click.prevent="findRelated()">Tags</a> |
-            <a href="#" @click.prevent="findRelated(1)">Artists</a> |
-            <a href="#" @click.prevent="findRelated(2)">Contributors</a> |
-            <a href="#" @click.prevent="findRelated(3)">Copyrights</a> |
-            <a href="#" @click.prevent="findRelated(4)">Characters</a> |
-            <a href="#" @click.prevent="findRelated(5)">Species</a> |
-            <a href="#" @click.prevent="findRelated(7)">Metatags</a>
-        </div>
-        <div>
-            <h3>Related Tags <a href="#" @click.prevent="toggleRelated">{{ relatedText }}</a></h3>
-            <related-tags v-show="expandRelated" :tags="tagsArray" :related="relatedTags"
-                          :loading="loadingRelated"
-                          @tag-active="pushTag"></related-tags>
-        </div>
+  <div>
+    <textarea class="tag-textarea" id="post_tag_string" v-model="tags" rows="5" data-autocomplete="tag-edit"
+      ref="otherTags" name="post[tag_string]" :spellcheck="false" @keyup="updateTagCount"></textarea>
+    <tag-preview :tags="tags" />
+    <div class="related-tag-functions">
+      Related:
+      <a href="#" @click.prevent="findRelated()">Tags</a> |
+      <a href="#" @click.prevent="findRelated(1)">Artists</a> |
+      <a href="#" @click.prevent="findRelated(2)">Contributors</a> |
+      <a href="#" @click.prevent="findRelated(3)">Copyrights</a> |
+      <a href="#" @click.prevent="findRelated(4)">Characters</a> |
+      <a href="#" @click.prevent="findRelated(5)">Species</a> |
+      <a href="#" @click.prevent="findRelated(7)">Metatags</a>
     </div>
+    <div>
+      <h3>Related Tags <a href="#" @click.prevent="toggleRelated">{{ relatedText }}</a></h3>
+      <related-tags v-show="expandRelated" :tags="tagsArray" :related="relatedTags" :loading="loadingRelated"
+        @tag-active="pushTag"></related-tags>
+    </div>
+  </div>
 </template>
 
 <script>
-  import { nextTick } from 'vue';
-  import relatedTags from './uploader/related.vue';
-  import tagPreview from './uploader/tag_preview.vue';
-  import Post from './posts';
-  import Autocomplete from "./autocomplete.js.erb";
-  import Utility from "./utility.js";
+import { nextTick } from 'vue';
+import relatedTags from './uploader/related.vue';
+import tagPreview from './uploader/tag_preview.vue';
+import Post from './posts';
+import Autocomplete from "./autocomplete.js.erb";
+import Utility from "./utility.js";
 
-  function tagSorter(a, b) {
-    return a.name > b.name ? 1 : -1;
-  }
+function tagSorter(a, b) {
+  return a.name > b.name ? 1 : -1;
+}
 
-  export default {
-    components: {
-      'related-tags': relatedTags,
-      'tag-preview': tagPreview
-    },
-    data() {
-      return {
-        preview: {
-          loading: false,
-          show: false,
-          tags: []
-        },
-        expandRelated: true,
-        tags: window.uploaderSettings.postTags,
-        relatedTags: [],
-        loadingRelated: false,
-      };
-    },
-    mounted() {
-      setTimeout(() => {
-        // Work around that browsers seem to take a few frames to acknowledge that the element is there before it can be focused.
-        const el = this.$refs.otherTags;
-        el.style.height = el.scrollHeight + "px";
-        el.focus();
-        el.scrollIntoView();
-      }, 20);
-      if(Utility.meta("enable-auto-complete") !== "true")
-        return;
-      Autocomplete.initialize_tag_autocomplete();
-    },
-    computed: {
-      tagsArray() {
-        return this.tags.toLowerCase().replace(/\r?\n|\r/g, ' ').split(' ');
+export default {
+  components: {
+    'related-tags': relatedTags,
+    'tag-preview': tagPreview
+  },
+  data() {
+    return {
+      preview: {
+        loading: false,
+        show: false,
+        tags: []
       },
-      relatedText() {
-        return this.expandRelated ? "<<" : ">>";
-      }
+      expandRelated: true,
+      tags: window.uploaderSettings.postTags,
+      relatedTags: [],
+      loadingRelated: false,
+    };
+  },
+  mounted() {
+    setTimeout(() => {
+      // Work around that browsers seem to take a few frames to acknowledge that the element is there before it can be focused.
+      const el = this.$refs.otherTags;
+      el.style.height = el.scrollHeight + "px";
+      el.focus();
+      el.scrollIntoView();
+    }, 20);
+    if (Utility.meta("enable-auto-complete") !== "true")
+      return;
+    Autocomplete.initialize_tag_autocomplete();
+  },
+  computed: {
+    tagsArray() {
+      return this.tags.toLowerCase().replace(/\r?\n|\r/g, ' ').split(' ');
     },
-    watch: {
-      tags: {
-        immediate: true,
-        handler() {
-          clearTimeout(this._tagPreviewDebounce);
-          this._tagPreviewDebounce = setTimeout(() => {
-            this.fetchTagPreview();
-          }, 1000);
-        }
-      }
-    },
-    methods: {
-      updateTagCount() {
-        Post.update_tag_count({target: $("#post_tag_string")});
-      },
-      toggleRelated() {
-        this.expandRelated = !this.expandRelated;
-      },
-      pushTag(tag, add) {
-        this.preview.show = false;
-        if (add) {
-          const tags = this.tags.toLowerCase().trim().replace(/\r?\n|\r/g, ' ').split(' ');
-          if (tags.indexOf(tag) === -1) {
-            // Ensure that input ends with a space, and if not, add one.
-            if(this.tags.length && (this.tags[this.tags.length-1] !== ' '))
-              this.tags += ' ';
-            this.tags += tag + ' ';
-          }
-        } else {
-          const groups = this.tags.toLowerCase().split(/\r?\n|\r/g);
-          for (let i = 0; i < groups.length; ++i) {
-            const tags = groups[i].trim().split(' ').filter(function (e) {
-              return e.trim().length
-            });
-            const tagIdx = tags.indexOf(tag);
-            if (add) {
-              if (tagIdx === -1)
-                tags.push(tag);
-            } else {
-              if (tagIdx === -1)
-                continue;
-              tags.splice(tagIdx, 1);
-            }
-            groups[i] = tags.join(' ');
-          }
-          this.tags = groups.join('\n') + ' ';
-        }
-        nextTick(function() {
-          Post.update_tag_count({target: $("#post_tag_string")});
-        })
-      },
-      fetchTagPreview() {
-        if (this.preview.loading) return;
-      
-        this.preview.loading = true;
-      
-        const tagList = this.tags.toLowerCase().replace(/\r?\n|\r/g, ' ').trim().split(/\s+/).join(',');
-      
-        $.ajax(`/tags/preview.json?name=${encodeURIComponent(tagList)}`, {
-          method: "GET",
-          success: (result) => {
-            this.preview.loading = false;
-            this.preview.tags = result;
-          },
-          error: (result) => {
-            this.preview.loading = false;
-            this.preview.tags = [];
-            Danbooru.error("Error loading tag preview " + JSON.stringify(result));
-          },
-        });
-      },
-      findRelated(categoryId) {
-        const self = this;
-        self.expandRelated = true;
-        const convertResponse = function (respData) {
-          const sortedRelated = [];
-          for (const key in respData) {
-            if (!respData.hasOwnProperty(key))
-              continue;
-            if (!respData[key].length)
-              continue;
-            sortedRelated.push({title: 'Related: ' + key, tags: respData[key].sort(tagSorter)});
-          }
-          return sortedRelated;
-        };
-        const getSelectedTags = function () {
-          const field = self.$refs.otherTags;
-          if (typeof field['selectionStart'] === 'undefined')
-            return null;
-          const length = field.selectionEnd - field.selectionStart;
-          if (length)
-            return field.value.substr(field.selectionStart, length);
-          return null;
-        };
-        this.loadingRelated = true;
-        this.relatedTags = [];
-        const selectedTags = getSelectedTags();
-        const params = selectedTags ? {query: selectedTags} : {query: this.tags};
-
-        if (categoryId)
-          params['category_id'] = categoryId;
-        $.ajax("/related_tag/bulk.json", {
-          method: 'POST',
-          type: 'POST',
-          data: params,
-          dataType: 'json',
-          success: function (data) {
-            self.relatedTags = convertResponse(data);
-          }
-        }).always(function() {
-          self.loadingRelated = false;
-        });
-      }
+    relatedText() {
+      return this.expandRelated ? "<<" : ">>";
     }
-  };
+  },
+  methods: {
+    updateTagCount() {
+      Post.update_tag_count({ target: $("#post_tag_string") });
+    },
+    toggleRelated() {
+      this.expandRelated = !this.expandRelated;
+    },
+    pushTag(tag, add) {
+      this.preview.show = false;
+      if (add) {
+        const tags = this.tags.toLowerCase().trim().replace(/\r?\n|\r/g, ' ').split(' ');
+        if (tags.indexOf(tag) === -1) {
+          // Ensure that input ends with a space, and if not, add one.
+          if (this.tags.length && (this.tags[this.tags.length - 1] !== ' '))
+            this.tags += ' ';
+          this.tags += tag + ' ';
+        }
+      } else {
+        const groups = this.tags.toLowerCase().split(/\r?\n|\r/g);
+        for (let i = 0; i < groups.length; ++i) {
+          const tags = groups[i].trim().split(' ').filter(function (e) {
+            return e.trim().length
+          });
+          const tagIdx = tags.indexOf(tag);
+          if (add) {
+            if (tagIdx === -1)
+              tags.push(tag);
+          } else {
+            if (tagIdx === -1)
+              continue;
+            tags.splice(tagIdx, 1);
+          }
+          groups[i] = tags.join(' ');
+        }
+        this.tags = groups.join('\n') + ' ';
+      }
+      nextTick(function () {
+        Post.update_tag_count({ target: $("#post_tag_string") });
+      })
+    },
+    findRelated(categoryId) {
+      const self = this;
+      self.expandRelated = true;
+      const convertResponse = function (respData) {
+        const sortedRelated = [];
+        for (const key in respData) {
+          if (!respData.hasOwnProperty(key))
+            continue;
+          if (!respData[key].length)
+            continue;
+          sortedRelated.push({ title: 'Related: ' + key, tags: respData[key].sort(tagSorter) });
+        }
+        return sortedRelated;
+      };
+      const getSelectedTags = function () {
+        const field = self.$refs.otherTags;
+        if (typeof field['selectionStart'] === 'undefined')
+          return null;
+        const length = field.selectionEnd - field.selectionStart;
+        if (length)
+          return field.value.substr(field.selectionStart, length);
+        return null;
+      };
+      this.loadingRelated = true;
+      this.relatedTags = [];
+      const selectedTags = getSelectedTags();
+      const params = selectedTags ? { query: selectedTags } : { query: this.tags };
+
+      if (categoryId)
+        params['category_id'] = categoryId;
+      $.ajax("/related_tag/bulk.json", {
+        method: 'POST',
+        type: 'POST',
+        data: params,
+        dataType: 'json',
+        success: function (data) {
+          self.relatedTags = convertResponse(data);
+        }
+      }).always(function () {
+        self.loadingRelated = false;
+      });
+    }
+  }
+};
 </script>

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -53,9 +53,7 @@ export default {
         success: (result) => {
           for (const tag of result) {
             if (tag.alias && tag.name !== tag.alias) continue;
-
-            const input = tag.from || tag.name;
-            this.tagCache[input] = tag;
+            this.tagCache[tag.name] = tag;
           }
           this.loading = false;
         },

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -1,45 +1,40 @@
 <template>
-    <div>
-        <div v-show="loading">Fetching tags...</div>
-        <div class="related-tags flex-wrap">
-            <div class="related-items" v-for="sTags, i in splitTags" :key="i">
-                <tag-preview-tag v-for="tag, $idx in sTags" :key="$idx" :tag="tag"></tag-preview-tag>
-            </div>
-        </div>
-        <div>
-            <a href="#" @click.prevent="close">Close Preview</a>
-        </div>
+  <div>
+    <div v-show="loading">Fetching tags...</div>
+    <div class="tag-preview">
+      <tag-preview-tag
+        v-for="(tag, i) in tags"
+        :key="i"
+        :tag="tag"
+      ></tag-preview-tag>
     </div>
+  </div>
 </template>
 
 <script>
-  import tagPreviewTag from './tag_preview_tag.vue';
+import tagPreviewTag from './tag_preview_tag.vue';
 
-  export default {
-    props: ['tags', 'loading'],
-    components: {
-      'tag-preview-tag': tagPreviewTag
+export default {
+  props: ['tags', 'loading'],
+  components: {
+    'tag-preview-tag': tagPreviewTag,
+  },
+  computed: {
+    splitTags() {
+      const sorted = [...this.tags].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+
+      const chunkArray = (arr, size) => {
+        const chunks = [];
+        for (let i = 0; i < arr.length; i += size) {
+          chunks.push(arr.slice(i, i + size));
+        }
+        return chunks;
+      };
+
+      return chunkArray(sorted, 15);
     },
-    methods: {
-      close: function () {
-        this.$emit('close');
-      }
-    },
-    computed: {
-      splitTags: function () {
-        var newTags = this.tags.concat([]);
-        newTags.sort(function (a, b) {
-          return a.a === b.a ? 0 : (a.a < b.a ? -1 : 1);
-        });
-        var chunkArray = function (arr, size) {
-          var chunks = [];
-          for (var i = 0; i < arr.length; i += size) {
-            chunks.push(arr.slice(i, i + size));
-          }
-          return chunks;
-        };
-        return chunkArray(newTags, 15);
-      }
-    }
-  }
+  },
+};
 </script>

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -52,7 +52,6 @@ export default {
         data: { tags: missing.join(' ') },
         success: (result) => {
           for (const tag of result) {
-            if (tag.alias && tag.name !== tag.alias) continue;
             this.tagCache[tag.name] = tag;
           }
           this.loading = false;

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tag-preview-tag">
     <div class="main-tag">
-      <tag-link :name="tag.name" :tagType="tag.category"></tag-link>
+      <tag-link :name="tag.resolved || tag.name" :tagType="tag.category"></tag-link>
       <span v-if="!tag.id" class="invalid">invalid</span>
       <span v-else-if="tag.implied" class="implied">implied</span>
       <span v-else-if="tag.post_count === 0" class="empty">empty</span>

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -5,7 +5,7 @@
       <span v-if="!tag.id" class="invalid">invalid</span>
       <span v-else-if="tag.implied" class="implied">implied</span>
       <span v-else-if="tag.post_count === 0" class="empty">empty</span>
-      <span v-else :class="{'post-count': true, 'underused': tag.post_count == 1 && tag.category == 0}">{{ tag.post_count }}</span>
+      <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ tag.post_count }}</span>
     </div>
   </div>
 </template>

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -1,24 +1,22 @@
 <template>
-  <span v-if="tag.type === 'alias'" class="tag-preview tag-preview-alias">
-    <del><tag-link :name="tag.a" :tagType="tag.tagTypeA"></tag-link></del>
-    → <tag-link :name="tag.b" :tagType="tag.tagTypeB"></tag-link>
-  </span>
-  <span v-else-if="tag.type === 'implication'" class="tag-preview tag-preview-implication">
-    <tag-link :name="tag.a" :tagType="tag.tagTypeA"></tag-link>
-    ⇒ <tag-link :name="tag.b" :tagType="tag.tagTypeB"></tag-link>
-  </span>
-  <span v-else class="tag-preview">
-    <tag-link :name="tag.a" :tagType="tag.tagTypeA"></tag-link>
-  </span>
+  <div class="tag-preview-tag">
+    <div class="main-tag">
+      <tag-link :name="tag.name" :tagType="tag.category"></tag-link>
+      <span v-if="!tag.id" class="invalid">invalid</span>
+      <span v-else-if="tag.implied" class="implied">implied</span>
+      <span v-else-if="tag.post_count === 0" class="empty">empty</span>
+      <span v-else :class="{'post-count': true, 'underused': tag.post_count == 1 && tag.category == 0}">{{ tag.post_count }}</span>
+    </div>
+  </div>
 </template>
 
 <script>
 import tagLink from "./tag_link.vue";
 
 export default {
+  props: ["tag"],
   components: {
     "tag-link": tagLink,
   },
-  props: ["tag"],
-}
+};
 </script>

--- a/app/javascript/src/javascripts/uploader/uploader.vue.erb
+++ b/app/javascript/src/javascripts/uploader/uploader.vue.erb
@@ -148,15 +148,10 @@
                         You must provide at least <b>{{4 - tagCount}}</b> more tags. Tags in other sections count
                         towards this total.
                     </div>
-                    <div v-show="!tagPreview.show">
-                        <textarea class="tag-textarea" id="post_tags" v-model="tagEntries.other" rows="5"
-                                  ref="otherTags" data-autocomplete="tag-edit"></textarea>
-                    </div>
-                    <div v-show="tagPreview.show">
-                        <tag-preview :tags="tagPreview.tags" :loading="tagPreview.loading"
-                                     @close="previewFinalTags"></tag-preview>
-                    </div>
-
+                    <textarea class="tag-textarea" id="post_tags" v-model="tagEntries.other" rows="5"
+                              ref="otherTags" data-autocomplete="tag-edit"></textarea>
+                    <tag-preview :tags="tagPreview.tags" :loading="tagPreview.loading"
+                                @close="previewFinalTags"></tag-preview>
                     <div class="related-tag-functions">
                         Related:
                         <a href="#" @click.prevent="findRelated()">Tags</a> |
@@ -165,8 +160,7 @@
                         <a href="#" @click.prevent="findRelated(3)">Copyrights</a> |
                         <a href="#" @click.prevent="findRelated(4)">Characters</a> |
                         <a href="#" @click.prevent="findRelated(5)">Species</a> |
-                        <a href="#" @click.prevent="findRelated(7)">Metatags</a> |
-                        <a href="#" @click.prevent="previewFinalTags">Preview Final Tags</a>
+                        <a href="#" @click.prevent="findRelated(7)">Metatags</a>
                     </div>
                 </div>
             </div>
@@ -549,34 +543,29 @@
         this.tagEntries[this.normalMode ? input : "other"] = tagsB.join(" ") + " ";
       },
 
-      previewFinalTags() {
-        if (this.tagPreview.loading)
-          return;
-        if (this.tagPreview.show) {
-          this.tagPreview.show = false;
-          return;
-        }
+      fetchTagPreview() {
+        if (this.tagPreview.loading) return;
+
         this.tagPreview.loading = true;
-        this.tagPreview.show = true;
-        this.tagPreview.tags = [];
-        const self = this;
-        const data = {tags: this.tags};
-        jQuery.ajax("/tags/preview.json", {
-          method: 'POST',
-          type: 'POST',
-          data: data,
-          success: function (result) {
-            self.tagPreview.loading = false;
-            self.tagPreview.tags = result;
+
+        const tagList = this.tags.toLowerCase().replace(/\r?\n|\r/g, ' ').trim().split(/\s+/).join(',');
+
+        $.ajax(`/tags/preview.json?name=${encodeURIComponent(tagList)}`, {
+          method: "GET",
+          success: (result) => {
+            this.tagPreview.loading = false;
+            this.tagPreview.tags = result;
+            this.tagPreview.show = true;
           },
-          error: function (result) {
-            self.tagPreview.loading = false;
-            self.tagPreview.tags = [];
-            self.tagPreview.show = false;
-            Danbooru.error('Error loading tag preview ' + result);
-          }
-        })
+          error: (result) => {
+            this.tagPreview.loading = false;
+            this.tagPreview.tags = [];
+            this.tagPreview.show = true;
+            Danbooru.error("Error loading tag preview " + JSON.stringify(result));
+          },
+        });
       },
+
       findRelated(categoryId) {
         const self = this;
         if (self.loadingRelated)
@@ -652,6 +641,17 @@
       duplicatePath: function () {
         return `/posts/${this.duplicateId}`;
       }
-    }
+    },
+    watch: {
+      tags: {
+        immediate: true,
+        handler() {
+          clearTimeout(this._tagPreviewDebounce);
+          this._tagPreviewDebounce = setTimeout(() => {
+            this.fetchTagPreview();
+          }, 1000);
+        }
+      }
+    },
   }
 </script>

--- a/app/javascript/src/javascripts/uploader/uploader.vue.erb
+++ b/app/javascript/src/javascripts/uploader/uploader.vue.erb
@@ -150,8 +150,7 @@
                     </div>
                     <textarea class="tag-textarea" id="post_tags" v-model="tagEntries.other" rows="5"
                               ref="otherTags" data-autocomplete="tag-edit"></textarea>
-                    <tag-preview :tags="tagPreview.tags" :loading="tagPreview.loading"
-                                @close="previewFinalTags"></tag-preview>
+                    <tag-preview :tags="tags" />
                     <div class="related-tag-functions">
                         Related:
                         <a href="#" @click.prevent="findRelated()">Tags</a> |
@@ -347,12 +346,6 @@
           other: "",      // other: '',
         },
 
-        tagPreview: {
-          loading: false,
-          show: false,
-          tags: []
-        },
-
         allowLockedTags: window.uploaderSettings.allowLockedTags,
         lockedTags: '',
         allowRatingLock: window.uploaderSettings.allowRatingLock,
@@ -499,7 +492,6 @@
         });
       },
       pushTag(tag, add) {
-        this.tagPreview.show = false;
         const isCheck = typeof this.checkboxes.all[tag] !== "undefined";
         // In advanced mode we need to push these into the tags area because there are no checkboxes or other
         // tag fields so we can't see them otherwise.
@@ -526,7 +518,6 @@
        * @param {string} input Which of the tagEntries the tags should be added to
        */
       importTags(tags, input) {
-        this.tagPreview.show = false;
         const tagsA = (tags + "").trim().split(" ").filter(n => n);
 
         // Dedupe
@@ -542,30 +533,6 @@
         // Without a space at the end, vue panics
         this.tagEntries[this.normalMode ? input : "other"] = tagsB.join(" ") + " ";
       },
-
-      fetchTagPreview() {
-        if (this.tagPreview.loading) return;
-
-        this.tagPreview.loading = true;
-
-        const tagList = this.tags.toLowerCase().replace(/\r?\n|\r/g, ' ').trim().split(/\s+/).join(',');
-
-        $.ajax(`/tags/preview.json?name=${encodeURIComponent(tagList)}`, {
-          method: "GET",
-          success: (result) => {
-            this.tagPreview.loading = false;
-            this.tagPreview.tags = result;
-            this.tagPreview.show = true;
-          },
-          error: (result) => {
-            this.tagPreview.loading = false;
-            this.tagPreview.tags = [];
-            this.tagPreview.show = true;
-            Danbooru.error("Error loading tag preview " + JSON.stringify(result));
-          },
-        });
-      },
-
       findRelated(categoryId) {
         const self = this;
         if (self.loadingRelated)
@@ -640,17 +607,6 @@
       },
       duplicatePath: function () {
         return `/posts/${this.duplicateId}`;
-      }
-    },
-    watch: {
-      tags: {
-        immediate: true,
-        handler() {
-          clearTimeout(this._tagPreviewDebounce);
-          this._tagPreviewDebounce = setTimeout(() => {
-            this.fetchTagPreview();
-          }, 1000);
-        }
       }
     },
   }

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -50,6 +50,7 @@ div.related-tags {
   }
 }
 
+
 div.tag-preview {
   box-sizing: border-box;
 
@@ -59,6 +60,8 @@ div.tag-preview {
   overflow: hidden;
 
   width: 100%;
+  max-height: 50vh;
+  overflow-y: auto;
   margin-top: 0.5em;
   margin-bottom: 1em;
   padding: 2px;

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -71,10 +71,6 @@ div.tag-preview {
     padding: 1px;
     padding-right: 5px;
 
-    // background: rgba(1, 1, 1, 0.15);
-    // border: 1px solid rgba(0, 0, 0, 0.15);
-    // border-radius: 2px;
-
     & .implied {
       color: themed("palette-text-green");
     }

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -1,18 +1,19 @@
-
-
 div.related-tags {
-  width: 100%;
-  margin-bottom: 1em;
-  background: themed("color-section-lighten-5");
-  overflow: hidden;
-  border-radius: $border-radius-half;
   display: flex;
   flex-wrap: wrap;
+  overflow: hidden;
+
+  width: 100%;
+  margin: 1em 0;
+
+  background: themed("color-section-lighten-5");
+  border-radius: $border-radius-half;
 
   .related-section {
     display: flex;
     flex-direction: row;
     flex: 0 1 10%;
+
     padding: 5px 10px;
 
     .related-title {
@@ -24,17 +25,22 @@ div.related-tags {
   .related-items {
     display: flex;
     flex-direction: column;
+
     margin: 0 -5px;
     padding: 0 5px;
 
     .related-item {
-      border: 1px solid rgba(0, 0, 0, 0.15);
-      background: rgba(1, 1, 1, 0.15);
-      border-radius: 2px;
-      padding: 0 5px;
-      max-width: 15rem;
-      word-wrap: break-word;
       overflow-wrap: break-word;
+
+      max-width: 15rem;
+      padding: 0 5px;
+
+      background: rgba(1, 1, 1, 0.15);
+
+      border: 1px solid rgba(0, 0, 0, 0.15);
+      border-radius: 2px;
+
+      word-wrap: break-word;
     }
   }
 
@@ -42,26 +48,47 @@ div.related-tags {
     background: themed("color-active-tag");
     color: white;
   }
+}
 
-  .tag-preview {
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: rgba(1, 1, 1, 0.15);
-    border-radius: 2px;
-    padding: 3px;
-    margin-right: 5px;
-    box-sizing: border-box;
+div.tag-preview {
+  box-sizing: border-box;
 
-    .tag-preview-alias {
-      background-color: rgba(150, 0, 0, 0.25);
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 16rem);
+
+  overflow: hidden;
+
+  width: 100%;
+  margin-top: 0.5em;
+  margin-bottom: 1em;
+  padding: 2px;
+
+  background: themed("color-section-lighten-5");
+
+  border-radius: $border-radius-half;
+
+  .tag-preview-tag {
+    padding: 1px;
+    padding-right: 5px;
+
+    // background: rgba(1, 1, 1, 0.15);
+    // border: 1px solid rgba(0, 0, 0, 0.15);
+    // border-radius: 2px;
+
+    & .implied {
+      color: themed("palette-text-green");
     }
 
-    .tag-preview-implication {
-      background-color: rgba(0, 150, 0, 0.25);
+    & .empty,
+    .underused,
+    .invalid {
+      color: themed("palette-text-red");
     }
   }
 }
 
-@media only screen and (orientation: portrait), (max-width: 1100px) {
+@media only screen and (orientation: portrait),
+(max-width: 1100px) {
   .related-section {
     flex: 0 1 50%;
   }

--- a/app/logical/tags_preview.rb
+++ b/app/logical/tags_preview.rb
@@ -2,43 +2,45 @@
 
 class TagsPreview
   def initialize(tags: nil)
-    @tags = TagQuery.scan(tags).map { |x| { a: x.downcase, type: "tag" } }
-    aliases
-    implications
-    tag_types
+    @tag_names = TagQuery.scan(tags).map(&:downcase).compact_blank.uniq
+    resolve_aliases
+    resolve_implications
+    load_tags
   end
 
-  def aliases
-    names = @tags.pluck(:a).compact_blank
-    aliased = TagAlias.to_aliased_with_originals(names).reject { |k, v| k == v }
-    @tags.map! do |tag|
-      if aliased[tag[:a]]
-        { a: tag[:a], b: aliased[tag[:a]], type: "alias" }
-      else
-        tag
-      end
+  def resolve_aliases
+    @aliases = TagAlias.to_aliased_with_originals(@tag_names)
+    @aliased_names = @aliases.values.uniq
+  end
+
+  def resolve_implications
+    @reverse_implications = Hash.new { |h, k| h[k] = [] }
+    @implications = TagImplication.descendants_with_originals(@aliased_names).transform_values(&:to_a).tap do |imp|
+      imp.each { |a, d| d.each { |b| @reverse_implications[b] << a } }
     end
   end
 
-  def implications
-    names = @tags.map { |tag| tag[:b] || tag[:a] }
-    implications = TagImplication.descendants_with_originals(names)
-    implications.each do |implication, descendants|
-      @tags += descendants.map { |descendant| { a: implication, b: descendant, type: "implication" } }
-    end
-  end
-
-  def tag_types
-    names = @tags.map { |tag| [tag[:a], tag[:b]] }.flatten.compact.uniq
-    categories = Tag.categories_for(names)
-    @tags.map! do |tag|
-      tag[:tagTypeA] = categories.fetch(tag[:a], -1)
-      tag[:tagTypeB] = categories.fetch(tag[:b], -1) if tag[:b]
-      tag
-    end
+  def load_tags
+    all_names = (@aliased_names + @implications.values.flatten).uniq
+    @tags = Tag.where(name: all_names).index_by(&:name)
   end
 
   def serializable_hash(*)
-    @tags
+    all_tag_names = (@aliased_names + @implications.values.flatten).uniq
+
+    all_tag_names.map do |name|
+      tag = @tags[name]
+
+      {
+        id: tag&.id,
+        name: name,
+        alias: (@aliases.key(name) if @aliases.key(name) != name),
+        category: tag&.category,
+        post_count: tag&.post_count || 0,
+        implied: @aliased_names.exclude?(name),
+        implied_by: Array(@reverse_implications[name]).map(&:to_s),
+        implies: Array(@implications[name]).map(&:to_s),
+      }.compact
+    end
   end
 end

--- a/app/logical/tags_preview.rb
+++ b/app/logical/tags_preview.rb
@@ -34,7 +34,9 @@ class TagsPreview
   end
 
   def resolve_implications
-    @implications = TagImplication.descendants_with_originals(@aliased_names)
+    @implications = TagImplication
+                    .descendants_with_originals(@aliased_names)
+                    .transform_values(&:to_a)
   end
 
   def load_tags

--- a/app/logical/tags_preview.rb
+++ b/app/logical/tags_preview.rb
@@ -56,7 +56,7 @@ class TagsPreview
         post_count: tag&.post_count,
         alias: (@aliases[name] if @aliases.key?(name) && @aliases[name] != name),
         implies: (@implications[name].map(&:to_s) if @implications.key?(name)),
-        from: @name_from[name]
+        from: @name_from[name],
       }.compact
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,7 +285,7 @@ Rails.application.routes.draw do
   resources :tags, constraints: id_name_constraint do
     resource :correction, :only => [:new, :create, :show], :controller => "tag_corrections"
     collection do
-      post :preview
+      get :preview
     end
   end
   resources :tag_type_versions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -285,7 +285,7 @@ Rails.application.routes.draw do
   resources :tags, constraints: id_name_constraint do
     resource :correction, :only => [:new, :create, :show], :controller => "tag_corrections"
     collection do
-      get :preview
+      post :preview
     end
   end
   resources :tag_type_versions


### PR DESCRIPTION
Adds a new tag preview that updates automatically, 
in functionality identical to re6's live tag preview but in visuals more similar to e6's vanilla design. 

This removes the old "Preview final tags" button and repurposes it's endpoint.

Below is a preview of the new tag preview:

![image](https://github.com/user-attachments/assets/44a43c56-e980-4ed8-b433-84d62a14a10b)
