### PR TITLE
[Uploads] Fix multiple source links being treated as one

### DIFF
--- a/app/javascript/src/styles/common/tables.scss
+++ b/app/javascript/src/styles/common/tables.scss
@@ -2,11 +2,6 @@
 table.striped {
   width: 100%;
 
-  // DText formatting fix
-  *:last-child {
-    margin: 0;
-  }
-
   td, th {
     padding: 4px 6px;
   }

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -13,7 +13,7 @@
   }
 }
 
-div#c-posts {
+div#c-posts, div#c-uploads {
   .source-link {
     overflow: hidden;
     text-overflow: ellipsis;
@@ -30,8 +30,9 @@ div#c-posts {
       }
     }
   }
+}
 
-
+div#c-posts {
   .fav-buttons {
     font-size: 14pt;
 

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -46,8 +46,7 @@
                   <ul>
                   <% upload.source.split("\n") do |source| %>
                     <li>
-                      <%= link_to_if (source =~ %r!\Ahttps?://!i), (source.presence.try(:truncate, 50) || tag.em("none")), source %>
-                      <%= link_to "»", uploads_path(search: params[:search].merge(source_matches: source)) %>
+                      <div class="source-link"><%= post_source_tag(source) %></div>
                     </li>
                   <% end %>
                   </ul>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -44,7 +44,7 @@
                 <span class="post-info">
                   <strong>Sources</strong>
                   <ul>
-                  <% upload.source.split do |source| %>
+                  <% upload.source.split("\n") do |source| %>
                     <li>
                       <%= link_to_if (source =~ %r!\Ahttps?://!i), (source.presence.try(:truncate, 50) || tag.em("none")), source %>
                       <%= link_to "»", uploads_path(search: params[:search].merge(source_matches: source)) %>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -44,7 +44,7 @@
                 <span class="post-info">
                   <strong>Sources</strong>
                   <ul>
-                  <% upload.source.split("\n") do |source| %>
+                  <% upload.source.split("\n").each do |source| %>
                     <li>
                       <div class="source-link"><%= post_source_tag(source) %></div>
                     </li>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -40,11 +40,19 @@
               <% end %>
               <br>
 
-              <span class="post-info">
-                <strong>Source</strong>
-                <%= link_to_if (upload.source =~ %r!\Ahttps?://!i), (upload.source.presence.try(:truncate, 50) || tag.em("none")), upload.source %>
-                <%= link_to "»", uploads_path(search: params[:search].merge(source_matches: upload.source)) %>
-              </span>
+              <% if upload.source.present? %>
+                <span class="post-info">
+                  <strong>Sources</strong>
+                  <ul>
+                  <% upload.source.split do |source| %>
+                    <li>
+                      <%= link_to_if (source =~ %r!\Ahttps?://!i), (source.presence.try(:truncate, 50) || tag.em("none")), source %>
+                      <%= link_to "»", uploads_path(search: params[:search].merge(source_matches: source)) %>
+                    </li>
+                  <% end %>
+                  </ul>
+                </span>
+              <% end %>
               <br>
 
               <span class="post-info">


### PR DESCRIPTION
![Screenshot 2025-05-24 151717](https://github.com/user-attachments/assets/adace856-3234-4784-b0d1-0f23c7d6c288)

The uploads index previously presumed that the posts would only have one source links, which is obviously not the case.