### PR TITLE
[UploadWhitelists] Add input validation to is_allowed

### DIFF
--- a/app/controllers/upload_whitelists_controller.rb
+++ b/app/controllers/upload_whitelists_controller.rb
@@ -36,9 +36,9 @@ class UploadWhitelistsController < ApplicationController
 
   def is_allowed
     begin
-      throw Addressable::URI::InvalidURIError if params[:url].blank?
+      raise Addressable::URI::InvalidURIError if params[:url].blank?
       url_parsed = Addressable::URI.heuristic_parse(params[:url])
-      throw Addressable::URI::InvalidURIError if url_parsed.nil? || url_parsed.to_s.empty?
+      raise Addressable::URI::InvalidURIError if url_parsed.nil? || url_parsed.to_s.empty?
 
       allowed, reason = UploadWhitelist.is_whitelisted?(url_parsed)
       @whitelist = {
@@ -47,7 +47,7 @@ class UploadWhitelistsController < ApplicationController
         is_allowed: allowed,
         reason: reason,
       }
-    rescue StandardError
+    rescue Addressable::URI::InvalidURIError
       @whitelist = {
         url: params[:url],
         domain: "invalid domain",

--- a/app/controllers/upload_whitelists_controller.rb
+++ b/app/controllers/upload_whitelists_controller.rb
@@ -36,22 +36,26 @@ class UploadWhitelistsController < ApplicationController
 
   def is_allowed
     begin
+      throw Addressable::URI::InvalidURIError if params[:url].blank?
       url_parsed = Addressable::URI.heuristic_parse(params[:url])
+      throw Addressable::URI::InvalidURIError if url_parsed.nil? || url_parsed.to_s.empty?
+
       allowed, reason = UploadWhitelist.is_whitelisted?(url_parsed)
       @whitelist = {
-          url: params[:url],
-          domain: url_parsed.domain,
-          is_allowed: allowed,
-          reason: reason
+        url: params[:url],
+        domain: url_parsed.domain,
+        is_allowed: allowed,
+        reason: reason,
       }
-    rescue Addressable::URI::InvalidURIError => e
+    rescue StandardError
       @whitelist = {
-          url: params[:url],
-          domain: 'invalid domain',
-          is_allowed: false,
-          reason: 'invalid domain'
+        url: params[:url],
+        domain: "invalid domain",
+        is_allowed: false,
+        reason: "invalid domain",
       }
     end
+
     respond_with(@whitelist) do |format|
       format.json { render json: @whitelist }
     end

--- a/app/models/upload_whitelist.rb
+++ b/app/models/upload_whitelist.rb
@@ -57,12 +57,15 @@ class UploadWhitelist < ApplicationRecord
   end
 
   def self.is_whitelisted?(url)
+    url = Addressable::URI.heuristic_parse(url) rescue nil # rubocop:disable Style/RescueModifier
+    return [false, "invalid url"] if url.blank?
+
     entries = Cache.fetch("upload_whitelist", expires_in: 6.hours) do
       all
     end
 
     if Danbooru.config.bypass_upload_whitelist?(CurrentUser)
-      return [true, 'bypassed']
+      return [true, "bypassed"]
     end
 
     entries.each do |x|
@@ -70,7 +73,7 @@ class UploadWhitelist < ApplicationRecord
         return [x.allowed, x.reason]
       end
     end
-    [false, "#{url.host} not in whitelist"]
+    [false, "#{url.host.presence || url} not in whitelist"]
   end
 
   extend SearchMethods

--- a/app/models/upload_whitelist.rb
+++ b/app/models/upload_whitelist.rb
@@ -73,7 +73,7 @@ class UploadWhitelist < ApplicationRecord
         return [x.allowed, x.reason]
       end
     end
-    [false, "#{url.host.presence || url} not in whitelist"]
+    [false, "#{url.host.presence || url.to_s} not in whitelist"]
   end
 
   extend SearchMethods

--- a/test/unit/upload_whitelist_test.rb
+++ b/test/unit/upload_whitelist_test.rb
@@ -11,15 +11,21 @@ class UploadWhitelistTest < ActiveSupport::TestCase
       @whitelist = create(:upload_whitelist, pattern: "*.e621.net/data/*", note: "e621")
     end
 
-    should "match" do
-      assert_equal([true, nil], UploadWhitelist.is_whitelisted?(Addressable::URI.parse("https://static1.e621.net/data/123.png")))
-      assert_equal([false, "123.com not in whitelist"], UploadWhitelist.is_whitelisted?(Addressable::URI.parse("https://123.com/what.png")))
+    should "succeed for valid URLs" do
+      assert_equal([true, nil], UploadWhitelist.is_whitelisted?("https://static1.e621.net/data/123.png"))
+    end
+
+    should "fail for invalid URLs" do
+      assert_equal([false, "invalid url"], UploadWhitelist.is_whitelisted?(""))
+      assert_equal([false, "invalid url"], UploadWhitelist.is_whitelisted?(nil))
+      assert_equal([false, "123.com not in whitelist"], UploadWhitelist.is_whitelisted?("https://123.com/what.png"))
+      assert_equal([false, "aaa not in whitelist"], UploadWhitelist.is_whitelisted?("aaa"))
     end
 
     should "bypass for admins" do
       CurrentUser.user.level = 50
       Danbooru.config.stubs(:bypass_upload_whitelist?).returns(true)
-      assert_equal([true, "bypassed"], UploadWhitelist.is_whitelisted?(Addressable::URI.parse("https://123.com/what.png")))
+      assert_equal([true, "bypassed"], UploadWhitelist.is_whitelisted?("https://123.com/what.png"))
     end
   end
 end


### PR DESCRIPTION
The upload whitelist didn't check whether the input is valid in any way, or if it's even present at all.
Which caused occasional errors.