### PR TITLE
[PostVersions] Prevent an error caused by an orphaned post version

### DIFF
--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -124,7 +124,8 @@ class PostVersion < ApplicationRecord
   end
 
   def diff(version = nil)
-    latest_tags = post.tag_array + parent_rating_tags(post)
+    # There is precisely one orphaned post version, but better safe than sorry.
+    latest_tags = post.nil? ? tag_array : post.tag_array + parent_rating_tags(post)
 
     new_tags = tag_array + parent_rating_tags(self)
 
@@ -167,6 +168,9 @@ class PostVersion < ApplicationRecord
       obsolete_added_tags: [],
       unchanged_tags: [],
     }
+
+    # There is precisely one orphaned post version, but better safe than sorry.
+    return delta if post.nil?
 
     latest_tags = post.tag_array
     latest_tags << "rating:#{post.rating}" if post.rating.present?


### PR DESCRIPTION
This was removed in e4ce4f312fdfef9d5d4da4336148060b1e9bb4a7 for some reason.
And yet, we do have at least one orphaned post version: https://e621.net/post_versions.json?search[id]=27800522

That said, the post version in question is going to get removed anyways, but it's best to keep these safeguards in case there are more cases like this.