### PR TITLE
[Comments] Fix an error in comments not associated with any posts

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -183,13 +183,13 @@ class Comment < ApplicationRecord
 
   def can_reply?(user)
     return false if is_sticky?
-    return false if (post.is_comment_locked? || post.is_comment_disabled?) && !user.is_moderator?
+    return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
     true
   end
 
   def editable_by?(user)
     return true if user.is_admin?
-    return false if (post.is_comment_locked? || post.is_comment_disabled?) && !user.is_moderator?
+    return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
     return false if was_warned?
     creator_id == user.id
   end


### PR DESCRIPTION
There are some comments on the site that persist despite the post they were associated with being destroyed.
This PR fixes an error that only appeared for non-staff users when viewing those comments.