### PR TITLE
[IQDB] Deal with the file not being found in a more graceful way

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -31,6 +31,8 @@ class IqdbQueriesController < ApplicationController
         render json: @matches, root: "posts"
       end
     end
+  rescue Downloads::File::Error
+    render_expected_error(404, "File not found or too large")
   rescue IqdbProxy::Error => e
     render_expected_error(500, e.message)
   end


### PR DESCRIPTION
Occasionally, people submit files that do not exist to the IQDB.
Sometimes, those files do exist, but Twitter insists on being difficult.
Either way, they should not be spamming the error log with this.