### PR TITLE
[Users] Add an option to clear a user's favorites

### DIFF
--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -148,6 +148,8 @@ class ModActionDecorator < ApplicationDecorator
       "#{vals['disabled'] ? 'Disabled' : 'Enabled'} uploading for #{user}"
     when "user_name_change"
       "Changed name of #{user}"
+    when "user_flush_favorites"
+      "Cleared favorites of #{user}"
 
       ### User Record ###
 

--- a/app/jobs/flush_favorites_job.rb
+++ b/app/jobs/flush_favorites_job.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-class UserDeletionJob < ApplicationJob
+# This job is used to remove all of the user's favorites.
+# It is intended to be run when a user is deleted or when they request to clear their favorites.
+class FlushFavoritesJob < ApplicationJob
   queue_as :low_prio
 
   def perform(*args)
     user = User.find(args[0])
 
-    remove_favorites(user)
-  end
-
-  def remove_favorites(user)
     Favorite.without_timeout do
       Favorite.for_user(user.id).includes(:post).find_each do |fav|
         tries = 5

--- a/app/logical/user_deletion.rb
+++ b/app/logical/user_deletion.rb
@@ -18,7 +18,7 @@ class UserDeletion
     clear_user_settings
     reset_password
     create_mod_action
-    UserDeletionJob.perform_later(user.id)
+    FlushFavoritesJob.perform_later(user.id)
   end
 
   private

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -85,6 +85,7 @@ class ModAction < ApplicationRecord
     user_feedback_delete: { user_id: :integer, reason: :string, reason_was: :string, type: :string, type_was: :string, record_id: :integer },
     user_feedback_undelete: { user_id: :integer, reason: :string, reason_was: :string, type: :string, type_was: :string, record_id: :integer },
     user_feedback_destroy: { user_id: :integer, reason: :string, type: :string, record_id: :integer },
+    user_flush_favorites: { user_id: :integer },
     wiki_page_rename: { new_title: :string, old_title: :string },
     wiki_page_delete: { wiki_page: :string, wiki_page_id: :integer },
     wiki_page_lock: { wiki_page: :string },

--- a/app/views/users/partials/show/_staff_info.html.erb
+++ b/app/views/users/partials/show/_staff_info.html.erb
@@ -47,5 +47,12 @@
         <%= link_to "Revert All", new_user_revert_path(user_id: user.id) %>
       </span>
     <% end %>
+
+    <% if CurrentUser.is_admin? %>
+      <h4>Favorites</h4>
+      <span>
+        <%= link_to "Remove all", flush_favorites_user_path(user), method: :post, :data => { :confirm => "Are you certain that you want to clear this user's favorites?\nTHIS IS IRREVERSIBLE." } %>
+      </span>
+    <% end %>
   </div>
 </div>

--- a/app/views/users/partials/show/_staff_info.html.erb
+++ b/app/views/users/partials/show/_staff_info.html.erb
@@ -51,7 +51,7 @@
     <% if CurrentUser.is_admin? %>
       <h4>Favorites</h4>
       <span>
-        <%= link_to "Remove all", flush_favorites_user_path(user), method: :post, :data => { :confirm => "Are you certain that you want to clear this user's favorites?\nTHIS IS IRREVERSIBLE." } %>
+        <%= link_to "Remove all", flush_favorites_user_path(user), method: :post, data: { confirm: "Are you certain that you want to clear this user's favorites?\nTHIS IS IRREVERSIBLE." } %>
       </span>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -309,6 +309,7 @@ Rails.application.routes.draw do
     member do
       get :upload_limit
       get :toggle_uploads
+      post :flush_favorites
       get :fix_counts
     end
 


### PR DESCRIPTION
Being able to clear favorites is an often-requested feature.
We might let users be able to do this on their own at some point. But for now, it's admin-only.