### PR TITLE
[Artists] Add help page to navbar

### DIFF
--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -7,6 +7,7 @@
   <% end %>
   <%= subnav_link_to "Recent changes", artist_versions_path %>
   <%= subnav_link_to "URLs", artist_urls_path %>
+  <%= subnav_link_to "Help", help_page_path(id: "sets") %>
   <% if @artist && !@artist.new_record? %>
     <li class="divider"></li>
     <%= subnav_link_to "Posts (#{@artist.tag.try(:post_count).to_i})", posts_path(tags: @artist.name) %>

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -7,7 +7,7 @@
   <% end %>
   <%= subnav_link_to "Recent changes", artist_versions_path %>
   <%= subnav_link_to "URLs", artist_urls_path %>
-  <%= subnav_link_to "Help", help_page_path(id: "sets") %>
+  <%= subnav_link_to "Help", help_page_path(id: "artists") %>
   <% if @artist && !@artist.new_record? %>
     <li class="divider"></li>
     <%= subnav_link_to "Posts (#{@artist.tag.try(:post_count).to_i})", posts_path(tags: @artist.name) %>


### PR DESCRIPTION
The [Artists](https://e621.net/artists) endpoints don't have the associated [help page](https://e621.net/help/artists) in the secondary links navbar like most other comparable paths [do](https://e621.net/post_sets); this adds it.