### PR TITLE
[Posts] Fix an issue caused by an ambiguous codec identifier

### DIFF
--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -529,31 +529,24 @@ Post.resize_video = function (post, target_size) {
 
   $video.empty(); // Yank any sources out of the list to prevent browsers from being pants on head.
 
+  let foundPlayable = false;
   for (const source of target_sources) {
     // canPlayType can return "probably", "maybe" or "".
     // * "maybe" means that the browser cannot determine whether it can play the file until playback is attempted.
     // * "probably" indicates that the browser thinks it can play the file, and seems to be returned only if the codec is provided.
     // * "" means that the browser cannot play the file. It will also throw an error in the console.
     if (!videoTag.canPlayType(source.type)) continue;
+    foundPlayable = true;
 
     // No need to reload the video if we are just changing the scale
     if (source.url === $video.attr("src")) break;
 
-    const wasPaused = videoTag.paused;
-    if (!wasPaused) videoTag.pause(); // Otherwise size changes won't take effect.
-    const time = videoTag.currentTime;
-
-    $video.attr("src", source.url);
-    videoTag.load(); // Forces changed source to take effect. *SOME* browsers ignore changes otherwise.
-
-    // Resume playback at the original time
-    videoTag.currentTime = time;
-    if (!wasPaused) videoTag.play();
-
+    play_video_file(videoTag, source.url);
     break;
   }
 
-  // TODO Fallback if no source was selected
+  // Fallback if no playable source was found.
+  if (!foundPlayable) play_video_file(videoTag, post.file.url);
 
   // Adjust the classes last, to prevent video from
   // getting resized before the source is set.
@@ -591,6 +584,24 @@ function calculate_original_sources (post, skipVariants = LStorage.Posts.SkipVar
   });
 
   return result;
+}
+
+/**
+ * Plays a video file in the specified video tag.
+ * @param {HTMLVideoElement} videoTag HTML tag of the video player
+ * @param {string} sourceURL New video source URL
+ */
+function play_video_file (videoTag, sourceURL) {
+  const wasPaused = videoTag.paused;
+  if (!wasPaused) videoTag.pause(); // Otherwise size changes won't take effect.
+  const time = videoTag.currentTime;
+
+  videoTag.setAttribute("src", sourceURL);
+  videoTag.load(); // Forces changed source to take effect. *SOME* browsers ignore changes otherwise.
+
+  // Resume playback at the original time
+  videoTag.currentTime = time;
+  if (!wasPaused) videoTag.play();
 }
 
 Post.resize_image = function (post, target_size) {

--- a/app/jobs/post_video_conversion_job.rb
+++ b/app/jobs/post_video_conversion_job.rb
@@ -32,7 +32,7 @@ class PostVideoConversionJob < ApplicationJob
 
       sample_data = {
         original: {
-          codec: original.video_codec,
+          codec: parse_codec_name(original.video_codec),
           fps: (original.frame_rate || 0).round(2).to_f,
         },
         variants: {},
@@ -195,7 +195,7 @@ class PostVideoConversionJob < ApplicationJob
       {
         width: video.width,
         height: video.height,
-        codec: video.video_codec == "h264" ? "avc1.4D401E" : video.video_codec,
+        codec: parse_codec_name(video.video_codec),
         fps: (video.frame_rate || 0).round(2).to_f,
         size: video.size,
       }
@@ -205,5 +205,22 @@ class PostVideoConversionJob < ApplicationJob
     ensure
       file&.close!
     end
+  end
+
+  # Converts codec names to a format understandable by the browsers.
+  # The actual resulting values may not actually be true, but attempting to extract
+  # the actual codec name from the video file is driving me up the wall.
+  def parse_codec_name(name)
+    case name
+    when "h264"
+      "avc1.4D401E"
+    when "av1"
+      "av01.0.00M.08"
+    else
+      name
+    end
+  rescue StandardError => e
+    logger.error "Error parsing codec name: #{name} - #{e.message}"
+    name
   end
 end

--- a/app/jobs/post_video_conversion_job.rb
+++ b/app/jobs/post_video_conversion_job.rb
@@ -32,7 +32,7 @@ class PostVideoConversionJob < ApplicationJob
 
       sample_data = {
         original: {
-          codec: parse_codec_name(original.video_codec),
+          codec: format_codec_name(original.video_codec),
           fps: (original.frame_rate || 0).round(2).to_f,
         },
         variants: {},
@@ -195,7 +195,7 @@ class PostVideoConversionJob < ApplicationJob
       {
         width: video.width,
         height: video.height,
-        codec: parse_codec_name(video.video_codec),
+        codec: format_codec_name(video.video_codec),
         fps: (video.frame_rate || 0).round(2).to_f,
         size: video.size,
       }
@@ -210,7 +210,7 @@ class PostVideoConversionJob < ApplicationJob
   # Converts codec names to a format understandable by the browsers.
   # The actual resulting values may not actually be true, but attempting to extract
   # the actual codec name from the video file is driving me up the wall.
-  def parse_codec_name(name)
+  def format_codec_name(name)
     case name
     when "h264"
       "avc1.4D401E"


### PR DESCRIPTION
Chrome and Edge cannot determine whether the browser can play an mp4/av1 video with the previously used `video/mp4; codecs="av1"` string for unclear reasons. Firefox has no such issues.
Instead, a codec name must include the profile and level definitions in order to be recognized.

While it's possible to build this information from the ffprobe data, simply hardcoding it would likely work just as well.