### PR TITLE
[Misc] Fix an issue with renamed timezones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM ruby:3.3.1-alpine3.20 AS ruby-builder
 
-RUN apk update
-
 RUN apk --no-cache add build-base cmake git glib-dev postgresql15-dev gcompat
 
 COPY Gemfile Gemfile.lock ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:3.3.1-alpine3.20 AS ruby-builder
 
+RUN apk update
+
 RUN apk --no-cache add build-base cmake git glib-dev postgresql15-dev gcompat
 
 COPY Gemfile Gemfile.lock ./

--- a/config/initializers/timezone.rb
+++ b/config/initializers/timezone.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Fix for an timezone a bug in Rails that causes specific timezones to not be recognized in some cases.
+# Fix for a timezone a bug in Rails that causes specific timezones to not be recognized.
 # This is not an issue in development (alpine3.20), nor on the old production servers (ubuntu20).
 # However, it causes errors in the newly upgraded app4 server (unbuntu24).
 #

--- a/config/initializers/timezone.rb
+++ b/config/initializers/timezone.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Fix for a timezone a bug in Rails that causes specific timezones to not be recognized.
+# Fix for a timezone bug in Rails that causes specific timezones to not be recognized.
 # This is not an issue in development (alpine3.20), nor on the old production servers (ubuntu20).
 # However, it causes errors in the newly upgraded app4 server (unbuntu24).
 #

--- a/config/initializers/timezone.rb
+++ b/config/initializers/timezone.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Fix for an timezone a bug in Rails that causes specific timezones to not be recognized in some cases.
+# This is not an issue in development (alpine3.20), nor on the old production servers (ubuntu20).
+# However, it causes errors in the newly upgraded app4 server (unbuntu24).
+#
+# Relevant issues:
+# https://github.com/rails/rails/issues/54999
+# https://github.com/rails/rails/pull/51703
+#
+# This can be removed once the issue is patched in Rails.
+{ "Kyiv" => "Europe/Kyiv",
+  "Bad Dragon" => "America/Phoenix", # small easter egg
+  "Rangoon" => "Asia/Yangon",
+  "Greenland" => "America/Nuuk", }.each do |name, tzinfo|
+  if ActiveSupport::TimeZone::MAPPING[name] == tzinfo
+    warn("Timezone patch not necessary for #{name} at #{__FILE__}:#{__LINE__}")
+  else
+    ActiveSupport::TimeZone::MAPPING[name] = tzinfo
+  end
+end

--- a/config/initializers/timezone.rb
+++ b/config/initializers/timezone.rb
@@ -2,7 +2,7 @@
 
 # Fix for a timezone bug in Rails that causes specific timezones to not be recognized.
 # This is not an issue in development (alpine3.20), nor on the old production servers (ubuntu20).
-# However, it causes errors in the newly upgraded app4 server (unbuntu24).
+# However, it causes errors in the newly upgraded app4 server (ubuntu24).
 #
 # Relevant issues:
 # https://github.com/rails/rails/issues/54999


### PR DESCRIPTION
A bug exists in rails apps that are running on ubuntu 24 that causes some timezones to be missing from the mappings.
In turn, this results in users who have one of those timezones selected to receive errors.

This PR is a fairly low-effort fix that simply back-fills the data where necessary.

Complete list of timezones returned in ubuntu 20 vs 24:
https://gist.github.com/Sindrake/6d4d036ef0c602047a0c83dc3e71427e

Currently affected time zones:
* `Greenland` – `America/Nuuk`
* `Kyiv` – `Europe/Kyiv`
* `Rangoon` – `Asia/Yangon`