### PR TITLE
[Users] Replace the CSS wiki link on the settings page to avoid a redirect

### DIFF
--- a/app/views/users/partials/edit/_advanced.html.erb
+++ b/app/views/users/partials/edit/_advanced.html.erb
@@ -161,6 +161,6 @@
     <%= form.input_field :custom_style, label: false, rows: 8 %>
   </tab-body>
   <tab-hint>
-    Apply <a href="https://en.wikipedia.org/wiki/Cascading_Style_Sheets">CSS Styles</a> to the whole website.
+    Apply <a href="https://en.wikipedia.org/wiki/CSS">CSS Styles</a> to the whole website.
   </tab-hint>
 </tab-entry>


### PR DESCRIPTION
Not a huge deal, just slightly inconvenient.