### PR TITLE
[Posts] Show reverse image search links for videos

### DIFF
--- a/app/views/posts/partials/show/sidebar/_related.html.erb
+++ b/app/views/posts/partials/show/sidebar/_related.html.erb
@@ -3,7 +3,7 @@
   <% if IqdbProxy.enabled? && @post.has_preview? %>
     <li><%= link_to "Visually similar on E6", iqdb_queries_path(search: { post_id: @post.id }), rel: "nofollow noreferrer" %></li>
   <% end %>
-  <% if @post.visible? && @post.is_image? %>
+  <% if @post.visible? %>
     <li class="list-break"></li>
     <li><a rel="nofollow noreferrer" target="_blank" href="https://lens.google.com/uploadbyurl?url=<%= @post.reverse_image_url %>&client=e621">Google</a></li>
     <li><a rel="nofollow noreferrer" target="_blank" href="https://saucenao.com/search.php?url=<%= @post.reverse_image_url %>">SauceNAO</a></li>


### PR DESCRIPTION
By popular demand.
This should work – albeit not quite as well as with static images – by providing the sample link to the reverse image search services.