### PR TITLE
[Replacements] Modify index and partial for some workflows

### DIFF
--- a/app/javascript/src/styles/specific/post_replacements.scss
+++ b/app/javascript/src/styles/specific/post_replacements.scss
@@ -52,4 +52,24 @@ div#c-post-replacements {
   #avoid-posting-notice ul {
     margin-left: 1em;
   }
+  .replacement-sources {
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-all;
+  }
+
+  .replacement-sources ul {
+    padding-left: 1.2em;
+    margin: 0;
+    list-style: disc;
+  }
+
+
+  .replacement-sources-link {
+    word-break: break-all;
+    overflow-wrap: anywhere;
+    white-space: normal;
+    max-width: 100%;
+    display: block;
+  }
 }

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -133,6 +133,18 @@ class ApplicationRecord < ActiveRecord::Base
         q
       end
 
+      # Searches for a user both by id and name to exclude from the query.
+      # Accepts a block to modify the query when one of the params is present and yields the ids.
+      # This is useful for excluding the current user from a query.
+      def where_not_user(db_field, query_field, params)
+        q = all
+        with_resolved_user_ids(query_field, params) do |user_ids|
+          q = yield(q, user_ids) if block_given?
+          q = q.where.not(to_where_hash(db_field, user_ids))
+        end
+        q
+      end
+
       def apply_basic_order(params)
         case params[:order]
         when "id_asc"

--- a/app/views/post_replacements/_search.html.erb
+++ b/app/views/post_replacements/_search.html.erb
@@ -10,4 +10,5 @@
   <%= f.input :file_name, label: "File Name" %>
   <%= f.input :source, label: "Source" %>
   <%= f.input :penalized, label: "Penalized?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :order, label: "Order", collection: [["Created At", "created_at"], ["Updated At", "updated_at"]], include_blank: true %>
 <% end %>

--- a/app/views/post_replacements/partials/show/_post_replacement.html.erb
+++ b/app/views/post_replacements/partials/show/_post_replacement.html.erb
@@ -5,8 +5,12 @@
   <td><%= replacement_thumbnail(post_replacement) %></td>
   <td>
     <dt>Version</dt>
+    <dd class="replacement-compact-row">
+      <%= link_to(post_replacement.post_id.to_s, post_path(post_replacement.post_id)) %>:<%= post_replacement.sequence_number %>
+    </dd>
     <dd>
-      <%= link_to(post_replacement.post_id.to_s, post_path(post_replacement.post_id)) %>:<%= post_replacement.sequence_number %></dd>
+      <% unless post_replacement.is_current?%> (<%= link_to("Post file", post_replacement.post.file_url) %>) <% end %>
+    </dd>
     <dt>Status</dt>
     <dd class="replacement-compact-row">
       <% if post_replacement.status == "pending" %>

--- a/db/fixes/127_generate_missing_replacement_rejection_info.rb
+++ b/db/fixes/127_generate_missing_replacement_rejection_info.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+PostReplacement.where(approver_id: nil, status: "rejected").find_in_batches(batch_size: 10_000) do |batch|
+  next if batch.empty?
+
+  updates = []
+
+  batch.each do |replacement|
+    event = PostEvent.where(
+      action: "replacement_rejected",
+    ).where(
+      "extra_data ->> 'replacement_id' = ?", replacement.id.to_s
+    ).order(created_at: :desc).first
+
+    if event&.creator_id.present?
+      updates << { id: replacement.id, approver_id: event.creator_id }
+    end
+  end
+
+  updates.each do |update|
+    PostReplacement.where(
+      id: update[:id],
+      approver_id: nil,
+      status: "rejected",
+    ).update_all(approver_id: update[:approver_id])
+  end
+end


### PR DESCRIPTION
Hopefully, I can put the rest of the changes off for the mobile redesign. These changes are necessary to accommodate the workflows of using the `post_replacements` view, rather than searching `pending_replacements:true`, along with a few QOL features requested for further improving workflows. 
Changes made: 
- Add link to the current version's file to any non-current replacement, labeled "post file'
- Add more advanced search capabilities\*
  - User filtering: 
    - Add a method to search for _not_ a user in application records, utilize the method for user fields in replacement
     - Allow negating by prefixing user name or id with `!`. Searching only `!` also allows for searching `nil` fields. 
    - Allow searching by name or id (automatic if name is only numbers)
    - Abstract away the logic for all of this into a new method
  - Ordering
    - Add ordering options of "created at" and "updated at" 
- Add a db fix to populate the `handler` on older rejected replacements. Tested locally. 
- Made source links overflow to the next line, rather than force their width


\* I'm actually testing the waters here. I want to upgrade all commit searches with some basic features (reverse direction ordering, inverting some fields). 