### PR TITLE
[Posts] Fix the submit event when pressing enter in the search form

### DIFF
--- a/app/javascript/src/javascripts/post_search.js
+++ b/app/javascript/src/javascripts/post_search.js
@@ -14,7 +14,7 @@ PostSearch.initialize_input = function ($form) {
     .on("keypress", function (event) {
       if (event.which !== 13 || event.shiftKey) return;
       event.preventDefault();
-      $textarea.closest("form").submit();
+      $textarea.closest("form").trigger("submit");
     });
 
   $(window).on("resize", recalculateInputHeight);


### PR DESCRIPTION
Evidently, `.submit()` does not properly trigger the `submit` event.