### PR TITLE
[Posts] Move the display options out of the way on mobile

### DIFF
--- a/app/javascript/src/styles/common/post_search.scss
+++ b/app/javascript/src/styles/common/post_search.scss
@@ -4,7 +4,15 @@
   flex-wrap: wrap;
 
   .post-search-title { flex: 1; }
-  .post-search-help { font-size: 90%; }
+  .post-search-help {
+    font-size: 90%;
+
+    // Make way for the settings button
+    margin-right: 2.5rem;
+    @include window-larger-than(50rem) {
+      margin-right: unset;
+    }
+  }
 
   form.post-search-form {
     display: flex;

--- a/app/javascript/src/styles/common/thumbnails.scss
+++ b/app/javascript/src/styles/common/thumbnails.scss
@@ -7,6 +7,7 @@ section.posts-container {
 
   // Defaults to 150px elsewhere
   --thumb-image-size: 200px;
+  --thumb-mobile-size: 33vw;
 
   @include window-larger-than(800px) {
     grid-template-columns: repeat(auto-fill, minmax(var(--thumb-image-size), 1fr));
@@ -30,11 +31,17 @@ article.thumbnail {
   position: relative;   // Position badges correctly
   overflow: hidden;
 
+  // Chrome bug that prevents the thumbnail card from spanning the full width
+  width: 100%;
+  max-width: min(var(--thumb-mobile-size, 33vw), var(--thumb-image-size, 150px));
+
   // Used in conjunction with setting the link element width and height
   // in order to ensure that the thumbnail always has the same size.
   @include window-larger-than(50rem) {
     min-width: var(--thumb-image-size, 150px);
     min-height: calc(var(--thumb-image-size, 150px) + 1rem);
+
+    width: unset;
   }
 
   // Badges
@@ -49,8 +56,8 @@ article.thumbnail {
     background: #0003;
 
     // See min-width and min-height above
-    max-width: min(33vw, var(--thumb-image-size, 150px));
-    max-height: min(33vw, var(--thumb-image-size, 150px));
+    max-width: min(var(--thumb-mobile-size, 33vw), var(--thumb-image-size, 150px));
+    max-height: min(var(--thumb-mobile-size, 33vw), var(--thumb-image-size, 150px));
 
     @include window-larger-than(50rem) {
       max-width: var(--thumb-image-size, 150px);
@@ -196,24 +203,18 @@ body[data-st-contain="true"] article.thumbnail img {
 // Thumbnail size and spacing
 body[data-st-size="s"] section.posts-container {
   --thumb-image-size: 150px;
+  --thumb-mobile-size: 25vw;
 
   @include window-smaller-than(50rem) {
     grid-template-columns: repeat(4, 1fr);
-    article.thumbnail a {
-      max-width: min(25vw, var(--thumb-image-size, 150px));
-      max-height: min(25vw, var(--thumb-image-size, 150px));
-    }
   }
 }
 
 body[data-st-size="l"] section.posts-container {
   --thumb-image-size: 256px;
+  --thumb-mobile-size: 50vw;
 
   @include window-smaller-than(50rem) {
     grid-template-columns: repeat(2, 1fr);
-    article.thumbnail a {
-      max-width: min(50vw, var(--thumb-image-size, 150px));
-      max-height: min(50vw, var(--thumb-image-size, 150px));
-    }
   }
 }

--- a/app/javascript/src/styles/views/posts/index/_index.desktop.scss
+++ b/app/javascript/src/styles/views/posts/index/_index.desktop.scss
@@ -12,7 +12,16 @@
     padding: 0.5rem 0.75rem 0.5rem 0.5rem;
 
     .search-controls {
+      top: unset;
+      bottom: -1.633rem;
+      right: 0.5rem;
+
       #search-fullscreen { display: flex; }
+      #search-settings {
+        height: inherit;
+        width: inherit;
+        svg { height: inherit;}
+      }
     }
   }
 

--- a/app/javascript/src/styles/views/posts/index/_index.scss
+++ b/app/javascript/src/styles/views/posts/index/_index.scss
@@ -52,8 +52,8 @@ body.c-posts.a-index, body.c-favorites.a-index {
       z-index: 1;
 
       position: absolute;
-      bottom: -1.633rem;
-      right: 0.5rem;
+      top: 0;
+      right: 0;
 
       padding: 0.25rem;
       gap: 0.5rem;
@@ -62,6 +62,12 @@ body.c-posts.a-index, body.c-favorites.a-index {
       border-radius: 0 0 0.25rem 0.25rem;
 
       #search-fullscreen { display: none; }
+      #search-settings {
+        height: 1.25rem;
+        width: 2rem;
+        justify-content: center;
+        svg { height: 1rem; }
+      }
 
       button {
         height: 1.5rem;


### PR DESCRIPTION
The settings button was positioned in front of the "next" button, which caused issues.
Also, fixed a Chrome bug that prevented thumbnail cards from spanning the whole width.