### PR TITLE
[Post] Allow post descriptions to use dtext color tag

### DIFF
--- a/app/views/posts/partials/show/content/_description.html.erb
+++ b/app/views/posts/partials/show/content/_description.html.erb
@@ -1,6 +1,6 @@
 <details id="description" <%= "open" unless CurrentUser.description_collapsed_initially? %>>
   <summary>Description</summary>
   <div>
-    <%= format_text(@post.description, max_thumbs: 0) %>
+    <%= format_text(@post.description, max_thumbs: 0, allow_color: true) %>
   </div>
 </details>


### PR DESCRIPTION
Fixes issue where post descriptions allow dtext coloring in the editor preview, but do hide it when showing the description page. 

Post descriptions now show colors in them. 