### PR TITLE
[Tickets] Disallow dtext colors in ticket responses

### DIFF
--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -123,7 +123,7 @@
           <% end %>
           <table>
             <tr>
-              <td><%= f.input :response, as: :dtext, limit: Danbooru.config.dmail_max_size %></td>
+              <td><%= f.input :response, as: :dtext, limit: Danbooru.config.dmail_max_size, allow_color: false %></td>
             </tr>
           </table>
           <%= tag.input name: "force_claim", type: "hidden", value: params[:force_claim] %>


### PR DESCRIPTION
Tickets currently allow color in the editor preview, however they do not present colors in the final ticket. This disables colors in the editor preview. 