### PR TITLE
[Post] Rework the favorite transfer process

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -31,6 +31,12 @@ class FavoritesController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
+    
+    if @post.favorites_transfer_in_progress?
+      render_expected_error(423, "Post favorites are being transferred, please try again later")
+      return
+    end
+    
     FavoriteManager.add!(user: CurrentUser.user, post: @post)
 
     render json: { post_id: @post.id, favorite_count: @post.fav_count }
@@ -40,6 +46,12 @@ class FavoritesController < ApplicationController
 
   def destroy
     @post = Post.find(params[:id])
+    
+    if @post.favorites_transfer_in_progress?
+      render_expected_error(423, "Post favorites are being transferred, please try again later")
+      return
+    end
+    
     FavoriteManager.remove!(user: CurrentUser.user, post: @post)
 
     render json: { post_id: @post.id, favorite_count: @post.fav_count }

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -31,12 +31,12 @@ class FavoritesController < ApplicationController
 
   def create
     @post = Post.find(params[:post_id])
-    
+
     if @post.favorites_transfer_in_progress?
       render_expected_error(423, "Post favorites are being transferred, please try again later")
       return
     end
-    
+
     FavoriteManager.add!(user: CurrentUser.user, post: @post)
 
     render json: { post_id: @post.id, favorite_count: @post.fav_count }
@@ -46,12 +46,12 @@ class FavoritesController < ApplicationController
 
   def destroy
     @post = Post.find(params[:id])
-    
+
     if @post.favorites_transfer_in_progress?
       render_expected_error(423, "Post favorites are being transferred, please try again later")
       return
     end
-    
+
     FavoriteManager.remove!(user: CurrentUser.user, post: @post)
 
     render json: { post_id: @post.id, favorite_count: @post.fav_count }

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -25,9 +25,9 @@ module Moderator
           @post.delete!(params[:reason])
           @post.copy_sources_to_parent if params[:copy_sources].present?
           @post.copy_tags_to_parent if params[:copy_tags].present?
-          @post.parent.save if params[:copy_tags].present? || params[:copy_sources].present?
           @post.give_favorites_to_parent if params[:move_favorites].present?
           @post.give_post_sets_to_parent if params[:move_favorites].present?
+          @post.parent.save if params[:copy_tags].present? || params[:copy_sources].present?
         end
 
         redirect_to(post_path(@post, q: params[:q].presence))

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -22,10 +22,12 @@ module Moderator
         @post = ::Post.find(params[:id])
 
         if params[:commit] == "Delete"
-          @post.delete!(params[:reason], move_favorites: params[:move_favorites].present?)
+          @post.delete!(params[:reason])
           @post.copy_sources_to_parent if params[:copy_sources].present?
           @post.copy_tags_to_parent if params[:copy_tags].present?
           @post.parent.save if params[:copy_tags].present? || params[:copy_sources].present?
+          @post.give_favorites_to_parent if params[:move_favorites].present?
+          @post.give_post_sets_to_parent if params[:move_favorites].present?
         end
 
         redirect_to(post_path(@post, q: params[:q].presence))
@@ -45,6 +47,7 @@ module Moderator
         @post = ::Post.find(params[:id])
         if params[:commit] == "Submit"
           @post.give_favorites_to_parent
+          @post.give_post_sets_to_parent
         end
         redirect_to(post_path(@post))
       end

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -27,7 +27,7 @@ module Moderator
           @post.copy_tags_to_parent if params[:copy_tags].present?
           @post.give_favorites_to_parent if params[:move_favorites].present?
           @post.give_post_sets_to_parent if params[:move_favorites].present?
-          @post.parent.save if params[:copy_tags].present? || params[:copy_sources].present?
+          @post.parent.save if params[:copy_tags].present? || params[:copy_sources].present? || params[:move_favorites].present?
         end
 
         redirect_to(post_path(@post, q: params[:q].presence))

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -25,9 +25,9 @@ module Moderator
           @post.delete!(params[:reason])
           @post.copy_sources_to_parent if params[:copy_sources].present?
           @post.copy_tags_to_parent if params[:copy_tags].present?
-          @post.give_favorites_to_parent if params[:move_favorites].present?
-          @post.give_post_sets_to_parent if params[:move_favorites].present?
-          @post.parent.save if params[:copy_tags].present? || params[:copy_sources].present? || params[:move_favorites].present?
+          @post.give_favorites_to_parent if params[:move_favorites] == "true"
+          @post.give_post_sets_to_parent if params[:move_favorites] == "true"
+          @post.parent.save if params[:copy_tags].present? || params[:copy_sources].present? || params[:move_favorites] == "true"
         end
 
         redirect_to(post_path(@post, q: params[:q].presence))

--- a/app/javascript/src/javascripts/mod_queue.js
+++ b/app/javascript/src/javascripts/mod_queue.js
@@ -59,14 +59,11 @@ $(function () {
   $(document).on("click.danbooru", ".quick-mod .detailed-rejection-link", ModQueue.detailed_rejection_dialog);
 
 
-  $(".delete-with-reason-link").on("click", function (e) {
-    e.preventDefault();
-    const post_id = $(e.target).attr("data-post-id");
-    const prompt = $(e.target).data("prompt");
-    const reason = $(e.target).data("reason");
-
-    if (confirm(`Delete post for ${prompt}?`))
-      Post.delete_with_reason(post_id, reason, true);
+  $(".delete-with-reason-link").on("click", function (event) {
+    event.preventDefault();
+    const data = event.target.dataset;
+    if (!confirm(`Delete post for ${data.prompt}?`)) return;
+    Post.delete_with_reason(data.postId, data.reason, { reload_after_delete: true, move_favorites: data.moveFavs === "true" });
   });
 });
 

--- a/app/javascript/src/javascripts/post_mode_menu.js
+++ b/app/javascript/src/javascripts/post_mode_menu.js
@@ -222,7 +222,7 @@ PostModeMenu.click = function (e) {
   } else if (s === "lock-note") {
     Post.update(post_id, {"post[is_note_locked]": "1"});
   } else if (s === "delete") {
-    Post.delete_with_reason(post_id, $("#quick-mode-reason").val(), false);
+    Post.delete_with_reason(post_id, $("#quick-mode-reason").val());
   } else if (s === "undelete") {
     Post.undelete(post_id);
   } else if (s === "unflag") {

--- a/app/javascript/src/javascripts/posts.js
+++ b/app/javascript/src/javascripts/posts.js
@@ -735,14 +735,16 @@ Post.update = function (post_id, params) {
   }, { name: "Post.update" });
 };
 
-Post.delete_with_reason = function (post_id, reason, reload_after_delete) {
+Post.delete_with_reason = function (post_id, reason, options = {}) {
+  const { reload_after_delete = false, move_favorites = false } = options;
+
   Post.notice_update("inc");
   let error = false;
   TaskQueue.add(() => {
     $.ajax({
       type: "POST",
       url: `/moderator/post/posts/${post_id}/delete.json`,
-      data: {commit: "Delete", reason: reason, move_favorites: true},
+      data: {commit: "Delete", reason: reason, move_favorites: move_favorites},
     }).fail(function (data) {
       if (data.responseJSON && data.responseJSON.reason) {
         $(window).trigger("danbooru:error", "Error: " + data.responseJSON.reason);

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -76,6 +76,24 @@ div#c-posts {
       background-color: themed("color-danger-darken-10");
       border: 1px solid themed("color-foreground");
     }
+
+    .delete-with-reason-link[data-move-favs="true"] {
+      position: relative;
+      margin-bottom: 0.75rem;
+
+      &::after {
+        content: "+ transfer favorites to parent post";
+        position: absolute;
+        left: 0;
+        font-size: 0.75rem;
+        bottom: -0.75rem;
+        line-height: 0.75rem;
+        color: var(--color-text-muted);
+        right: 0;
+        text-align: center;
+        pointer-events: none;
+      }
+    }
   }
 
   div.nav-notice {

--- a/app/jobs/transfer_favorites_job.rb
+++ b/app/jobs/transfer_favorites_job.rb
@@ -2,17 +2,144 @@
 
 class TransferFavoritesJob < ApplicationJob
   queue_as :low_prio
+  sidekiq_options lock: :until_executing
 
   def perform(*args)
     @post = Post.find_by(id: args[0])
     @user = User.find_by(id: args[1])
-    unless @post && @user
-      # Something went wrong and there is nothing we can do inside the job.
-      return
-    end
+    return unless @post && @user
 
     CurrentUser.scoped(@user) do
-      @post.give_favorites_to_parent!
+      transfer_favorites!(@post)
+    end
+  end
+
+  private
+
+  def transfer_favorites!(post)
+    parent = post.parent
+    return false unless parent
+
+    user_ids = post.fav_string.scan(/fav:(\d+)/).flatten.map(&:to_i)
+    return false if user_ids.empty?
+
+    # Prevent concurrent favorite operations
+    transfer_flag = Post.flag_value_for("favorites_transfer_in_progress")
+    post.update_columns(bit_flags: post.bit_flags | transfer_flag)
+    parent.update_columns(bit_flags: parent.bit_flags | transfer_flag)
+
+    begin
+      existing_parent_user_ids = parent.fav_string.scan(/fav:(\d+)/).flatten.map(&:to_i)
+      new_user_ids = user_ids - existing_parent_user_ids
+
+      # 1. Delete all child favorites
+      Favorite.without_timeout do
+        Favorite.where(post_id: post.id).delete_all
+      end
+
+      # 2. Insert new parent favorites
+      if new_user_ids.any?
+        new_favorites = new_user_ids.map do |user_id|
+          {
+            post_id: parent.id,
+            user_id: user_id,
+            created_at: Time.current,
+          }
+        end
+        Favorite.without_timeout do
+          Favorite.insert_all(new_favorites)
+        end
+      end
+
+      # 3. Update post and user data
+      update_post_favorites_data(post, parent, user_ids, new_user_ids)
+      update_user_favorite_counts(user_ids, new_user_ids)
+
+      # 4. Safety check: Clean up any orphaned favorites that weren't caught by fav_string parsing
+      cleanup_orphaned_child_favorites(post)
+
+      # 5. Create post events
+      PostEvent.add(post.id, CurrentUser.user, :favorites_moved, { parent_id: parent.id })
+      PostEvent.add(parent.id, CurrentUser.user, :favorites_received, { child_id: post.id })
+
+      # 6. Schedule index updates
+      post.update_index(queue: :low_prio)
+      parent.update_index(queue: :low_prio)
+    ensure
+      post.reload
+      parent.reload
+      post.update_columns(bit_flags: post.bit_flags & ~transfer_flag)
+      parent.update_columns(bit_flags: parent.bit_flags & ~transfer_flag)
+    end
+
+    true
+  end
+
+  # Update the fav_string and fav_count for both child and parent posts.
+  def update_post_favorites_data(child_post, parent_post, _removed_user_ids, added_user_ids)
+    # Remove all favorites from child post
+    child_post.update_columns(
+      fav_string: "",
+      fav_count: 0,
+      updated_at: Time.current,
+    )
+
+    # Add new favorites to parent post
+    if added_user_ids.any?
+      current_fav_string = parent_post.fav_string || ""
+      current_fav_parts = current_fav_string.split
+      new_fav_parts = added_user_ids.map { |user_id| "fav:#{user_id}" }
+      all_fav_parts = (current_fav_parts + new_fav_parts).uniq
+
+      parent_post.update_columns(
+        fav_string: all_fav_parts.join(" "),
+        fav_count: all_fav_parts.length,
+        updated_at: Time.current,
+      )
+    end
+  end
+
+  # Update user favorite counts by calculating net changes.
+  # Only adjusts counts for users with actual net gain/loss to avoid redundant operations.
+  def update_user_favorite_counts(removed_user_ids, added_user_ids)
+    users_with_net_loss = removed_user_ids - added_user_ids # parent already favorited: user loses a favorite
+    users_with_net_gain = added_user_ids - removed_user_ids # child not favorited somehow, shouldn't happen
+
+    if users_with_net_loss.any?
+      UserStatus.without_timeout do
+        users_with_net_loss.each_slice(5000) do |batch|
+          UserStatus.where(user_id: batch).update_all("favorite_count = favorite_count - 1")
+        end
+      end
+    end
+
+    if users_with_net_gain.any?
+      UserStatus.without_timeout do
+        users_with_net_gain.each_slice(5000) do |batch|
+          UserStatus.where(user_id: batch).update_all("favorite_count = favorite_count + 1")
+        end
+      end
+    end
+  end
+
+  # Clean up any orphaned favorite records not captured by fav_string parsing.
+  # Recalculates affected user favorite counts.
+  def cleanup_orphaned_child_favorites(child_post)
+    orphaned_favorites = Favorite.where(post_id: child_post.id)
+    return unless orphaned_favorites.exists?
+    orphaned_user_ids = orphaned_favorites.pluck(:user_id)
+
+    Rails.logger.warn("TransferFavoritesJob: Found #{orphaned_favorites.count} orphaned favorites for post #{child_post.id} not in fav_string. User IDs: #{orphaned_user_ids}")
+
+    Favorite.without_timeout do
+      orphaned_favorites.delete_all
+    end
+
+    if orphaned_user_ids.any?
+      Rails.logger.warn("TransferFavoritesJob: Recalculating favorite_count for #{orphaned_user_ids.count} users with orphaned favorites")
+      UserStatus.without_timeout do
+        UserStatus.where(user_id: orphaned_user_ids).update_all("favorite_count = (SELECT COUNT(*) FROM favorites WHERE favorites.user_id = user_statuses.user_id)")
+      end
     end
   end
 end

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -68,28 +68,4 @@ class FavoriteManager
       raise e
     end
   end
-
-  # Transfers all favorites from a post to its parent post.
-  def self.give_to_parent!(post)
-    # TODO: Much better and more intelligent logic can exist for this
-    parent = post.parent
-    return false unless parent
-    post.favorites.each do |fav|
-      tries = 5
-      begin
-        FavoriteManager.remove!(user: fav.user, post: post)
-        FavoriteManager.add!(user: fav.user, post: parent, force: true)
-      rescue ActiveRecord::SerializationFailure
-        tries -= 1
-        if tries > 0
-          retry
-        else
-          Rails.logger.warn("Failed to transfer favorite from post #{post.id} to parent #{parent.id} for user #{fav.user.id}")
-        end
-      rescue Favorite::Error => e
-        Rails.logger.warn("Failed to transfer favorite from post #{post.id} to parent #{parent.id} for user #{fav.user.id}: #{e.message}")
-      end
-    end
-    true
-  end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Favorite < ApplicationRecord
-  class Error < Exception
+  class Error < StandardError
   end
+
   class HiddenError < User::PrivilegeError
     def initialize(msg = "This users favorites are hidden")
       super
@@ -12,5 +13,5 @@ class Favorite < ApplicationRecord
   belongs_to :post
   belongs_to :user
   user_status_counter :favorite_count, foreign_key: :user_id
-  scope :for_user, ->(user_id) {where("user_id = #{user_id.to_i}")}
+  scope :for_user, ->(user_id) { where("user_id = #{user_id.to_i}") }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1373,14 +1373,6 @@ class Post < ApplicationRecord
       TransferFavoritesJob.perform_later(id, CurrentUser.id)
     end
 
-    def give_favorites_to_parent!
-      return if parent.nil?
-
-      FavoriteManager.give_to_parent!(self)
-      PostEvent.add(id, CurrentUser.user, :favorites_moved, { parent_id: parent_id })
-      PostEvent.add(parent_id, CurrentUser.user, :favorites_received, { child_id: id })
-    end
-
     def parent_exists?
       Post.exists?(parent_id)
     end
@@ -1960,6 +1952,7 @@ class Post < ApplicationRecord
     _has_cropped
     hide_from_anonymous
     hide_from_search_engines
+    favorites_transfer_in_progress
   ].freeze
   has_bit_flags BOOLEAN_ATTRIBUTES
 

--- a/app/views/posts/partials/show/content/notices/_notices.html.erb
+++ b/app/views/posts/partials/show/content/notices/_notices.html.erb
@@ -5,14 +5,14 @@
     <%= render "posts/partials/show/content/notices/flag_reasons", post: post %>
 
     <% if CurrentUser.can_approve_posts? %>
-      <div>
+      <div data-reason="<%= post.pending_flag&.reason %>">
         <%= link_to "Delete", confirm_delete_moderator_post_post_path(post, q: params[:q]), class: "button btn-neutral" %>
          | <%= tag.a "Unflag", href: "#", class: "unflag-post-link button btn-neutral", data: { pid: post.id, type: "none" } %>
         <% if post.is_approvable? %>
            | <%= tag.a "Unflag+approve", href: "#", class: "unflag-post-link button btn-neutral", data: { pid: post.id, type: "approve" } %>
         <% end %>
         <% unless post.pending_flag&.reason =~ /uploading_guidelines/ %>
-           | <%= tag.a "Delete with given reason", href: "#", class: "delete-with-reason-link button btn-neutral", data: { "post-id": post.id, "reason": "", "prompt": "given reason" } %>
+           | <%= tag.a "Delete with given reason", href: "#", class: "delete-with-reason-link button btn-neutral", data: { "post-id": post.id, "reason": "", "prompt": "given reason", "move-favs": !!(post.pending_flag&.reason =~ /Inferior/) } %>
         <% end %>
         <% if !post.parent_id.nil? && post.pending_flag&.reason =~ %r{Inferior version/duplicate of post #\d+} %>
            | <%= tag.a "Move flag to parent", href: "#", class: "move-flag-to-parent-link button btn-neutral", data: { "pid": post.id, "parent-id": post.parent_id } %>

--- a/app/views/posts/partials/show/content/notices/_notices.html.erb
+++ b/app/views/posts/partials/show/content/notices/_notices.html.erb
@@ -12,7 +12,7 @@
            | <%= tag.a "Unflag+approve", href: "#", class: "unflag-post-link button btn-neutral", data: { pid: post.id, type: "approve" } %>
         <% end %>
         <% unless post.pending_flag&.reason =~ /uploading_guidelines/ %>
-           | <%= tag.a "Delete with given reason", href: "#", class: "delete-with-reason-link button btn-neutral", data: { "post-id": post.id, "reason": "", "prompt": "given reason", "move-favs": !!(post.pending_flag&.reason =~ /Inferior/) } %>
+           | <%= tag.a "Delete with given reason", href: "#", class: "delete-with-reason-link button btn-neutral", data: { "post-id": post.id, "reason": "", "prompt": "given reason", "move-favs": (post.pending_flag&.reason =~ /Inferior/).present? } %>
         <% end %>
         <% if !post.parent_id.nil? && post.pending_flag&.reason =~ %r{Inferior version/duplicate of post #\d+} %>
            | <%= tag.a "Move flag to parent", href: "#", class: "move-flag-to-parent-link button btn-neutral", data: { "pid": post.id, "parent-id": post.parent_id } %>

--- a/test/unit/post_event_test.rb
+++ b/test/unit/post_event_test.rb
@@ -48,7 +48,11 @@ class PostEventTest < ActiveSupport::TestCase
         @post.undelete!
       end
 
-      assert_post_events_created(@janitor, [:favorites_moved, :favorites_received]) do
+      assert_post_events_created(@janitor, %i[favorites_moved favorites_received]) do
+        # Add some favorites to the child post first
+        favorite_user = create(:user)
+        FavoriteManager.add!(user: favorite_user, post: @post)
+
         TransferFavoritesJob.new.perform @post.id, @janitor.id
       end
 


### PR DESCRIPTION
 * Do favorite/set moving AFTER the rest of the moves. This _might_ fix the deadlock on deletions.
 * Consistency: Manual favorite moves also should move sets, like deletion does.

My theory is the favorite/set moving job is taking too long, and it deadlocks any other moves (sources/tags). If this is true, then having them take place last should significantly reduce the chances of it happening. Hard to tell if this will work on a small scale.

Edit: Going to add some more tooling here that should make transferring items easier and clearer, even if the fix doesn't work