### PR TITLE
[Uploads] Fix upload limit link

### DIFF
--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -27,12 +27,12 @@
         <% end %>
       </p>
       You have <span class="post-uploads-remaining-count"><%= CurrentUser.post_upload_throttle %></span> uploads remaining this hour.
-      See <%= link_to "here", upload_limit_user_path(CurrentUser) %> for more details.
+      See <%= link_to "here", upload_limit_user_path(CurrentUser.user) %> for more details.
     </div>
   <% elsif CurrentUser.post_upload_throttle <= 5 %>
     <div id="post-uploads-remaining" class="section<% if CurrentUser.post_upload_throttle <= 0 %> background-red<% end %>" style="width:640px;">
       You have <span class="post-uploads-remaining-count"><%= CurrentUser.post_upload_throttle %></span> uploads remaining this hour.
-      See <%= link_to "here", upload_limit_user_path(CurrentUser) %> for more details.
+      See <%= link_to "here", upload_limit_user_path(CurrentUser.user) %> for more details.
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
As detailed [here](https://discordapp.com/channels/431908090883997698/460517895420772353/1396611982907543713).
The highlighted link labeled "here"
<img width="647" height="224" alt="image" src="https://github.com/user-attachments/assets/28b7f4cc-ffa6-4e71-ae94-37d1fab6e6ed" />
goes to here
<img width="322" height="199" alt="image" src="https://github.com/user-attachments/assets/0f273486-7fba-41c4-a043-633468215fe8" />

#### Note
Fix untested, but matches [this](https://github.com/e621ng/e621ng/blob/851cd5c68a922a39b7b300670b0d988b4c41693e/app/views/users/partials/show/_user_info.html.erb#L35), which works correctly.