### PR TITLE
[Posts] Fix the thumbnail regeneration script

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -121,9 +121,9 @@ class Post < ApplicationRecord
       sample_url
     end
 
-    def sample_url
+    def sample_url(type = :sample_jpg)
       return file_url unless has_sample?
-      storage_manager.post_file_url(self, :sample)
+      storage_manager.post_file_url(self, type)
     end
 
     def preview_file_url(type = :preview_jpg)

--- a/app/serializers/post_serializer.rb
+++ b/app/serializers/post_serializer.rb
@@ -11,12 +11,12 @@ class PostSerializer < ActiveModel::Serializer
 
   def file
     file_attributes = {
-        width: object.image_width,
-        height: object.image_height,
-        ext: object.file_ext,
-        size: object.file_size,
-        md5: object.md5,
-        url: nil
+      width: object.image_width,
+      height: object.image_height,
+      ext: object.file_ext,
+      size: object.file_size,
+      md5: object.md5,
+      url: nil,
     }
     if object.visible?
       file_attributes[:url] = object.file_url
@@ -29,9 +29,11 @@ class PostSerializer < ActiveModel::Serializer
       width: object.preview_width,
       height: object.preview_height,
       url: nil,
+      alt: nil,
     }
     if object.visible?
       preview_attributes[:url] = object.preview_file_url
+      preview_attributes[:alt] = object.preview_file_url(:preview_webp)
     end
     preview_attributes
   end
@@ -42,10 +44,12 @@ class PostSerializer < ActiveModel::Serializer
       width: object.sample_width,
       height: object.sample_height,
       url: nil,
+      alt: nil,
       alternates: object.video_sample_list,
     }
-    if object.visible?
+    if object.visible? && object.has_sample?
       sample_attributes[:url] = object.sample_url
+      sample_attributes[:alt] = object.sample_url(:sample_webp)
     end
     sample_attributes
   end

--- a/db/fixes/127_3_smart_regenerate.rb
+++ b/db/fixes/127_3_smart_regenerate.rb
@@ -7,6 +7,7 @@ puts "Regenerating post thumbnails"
 Post.without_timeout do
   sm = Danbooru.config.storage_manager
   queue = Sidekiq::Queue.new("thumb")
+  scheduled = 0
 
   Post.in_batches(load: true, order: :desc).each_with_index do |group, index|
     puts "loaded batch #{index}"
@@ -16,15 +17,24 @@ Post.without_timeout do
 
     skipped = 0
     group.each do |post|
-      if File.exist?(sm.file_path(post.md5, post.file_ext, :preview_webp))
+      if post.is_flash?
         skipped += 1
         next
       end
 
+      if File.exist?(sm.file_path(post.md5, post.file_ext, :preview_webp, protect: post.is_deleted?)) &&
+         (!post.has_sample? || File.exist?(sm.file_path(post.md5, post.file_ext, :sample_webp, protect: post.is_deleted?)))
+        skipped += 1
+        next
+      end
+
+      scheduled += 1
       PostImageSamplerJob.perform_later(post.id)
       sm.delete_crop_file(post.md5)
     end
 
     puts "queued #{group.size - skipped} jobs in batch #{index} (skipped #{skipped})"
   end
+
+  puts "finished: queued #{scheduled} jobs total"
 end


### PR DESCRIPTION
The script was needlessly regenerating thumbnails for deleted posts, and wasn't checking for missing samples.
Also exposed the webp URLs in the API, for testing purposes.