### PR TITLE
[PostSets] Prevent set editing when above the post limit

### DIFF
--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -112,6 +112,7 @@ class PostSetsController < ApplicationController
   def add_posts
     @post_set = PostSet.find(params[:id])
     check_post_edit_access(@post_set)
+    check_set_post_limit(@post_set)
     @post_set.add(add_remove_posts_params.map(&:to_i))
     @post_set.save
     respond_with(@post_set)
@@ -120,6 +121,7 @@ class PostSetsController < ApplicationController
   def remove_posts
     @post_set = PostSet.find(params[:id])
     check_post_edit_access(@post_set)
+    check_set_post_limit(@post_set)
     @post_set.remove(add_remove_posts_params.map(&:to_i))
     @post_set.save
     respond_with(@post_set)
@@ -136,6 +138,12 @@ class PostSetsController < ApplicationController
   def check_post_edit_access(set)
     unless set.can_edit_posts?(CurrentUser.user)
       raise User::PrivilegeError
+    end
+  end
+
+  def check_set_post_limit(set)
+    unless set.post_ids.size <= Danbooru.config.set_post_limit(CurrentUser.user) + 100
+      raise "This set's post list can no longer be edited."
     end
   end
 

--- a/app/javascript/src/javascripts/post_sets.js
+++ b/app/javascript/src/javascripts/post_sets.js
@@ -57,10 +57,11 @@ PostSet.add_many_posts = function (set_id, posts = []) {
       type: "POST",
       url: "/post_sets/" + set_id + "/add_posts.json",
       data: {post_ids: posts},
-    }).fail(function (data) {
-      console.log(data, data.responseJSON, data.responseJSON.error);
-      var message = $.map(data.responseJSON.errors, (msg) => msg).join("; ");
-      $(window).trigger("danbooru:error", "Error: " + message);
+    }).fail(function (response) {
+      const data = response.responseJSON;
+      const errors = $.map(data.errors, (msg) => msg).join("; "),
+        message = data.message;
+      $(window).trigger("danbooru:error", "Error: " + (message || errors));
     }).done(function () {
       $(window).trigger("danbooru:notice", `Added ${posts.length > 1 ? (posts.length + " posts") : "post"} to <a href="/post_sets/${set_id}">set #${set_id}</a>`);
     });
@@ -119,10 +120,11 @@ PostSet.remove_many_posts = function (set_id, posts = []) {
       type: "POST",
       url: "/post_sets/" + set_id + "/remove_posts.json",
       data: { post_ids: posts },
-    }).fail(function (data) {
-      console.log(data, data.responseJSON, data.responseJSON.error);
-      var message = $.map(data.responseJSON.errors, (msg) => msg).join("; ");
-      $(window).trigger("danbooru:error", "Error: " + message);
+    }).fail(function (response) {
+      const data = response.responseJSON;
+      const errors = $.map(data.errors, (msg) => msg).join("; "),
+        message = data.message;
+      $(window).trigger("danbooru:error", "Error: " + (message || errors));
     }).done(function () {
       $(window).trigger("danbooru:notice", `Removed ${posts.length > 1 ? (posts.length + " posts") : "post"} from <a href="/post_sets/${set_id}">set #${set_id}</a>`);
     });

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -176,6 +176,10 @@ class PostSet < ApplicationRecord
       return false if user.is_blocked?
       creator_id == user.id
     end
+
+    def is_over_limit?(user)
+      post_ids.size > Danbooru.config.set_post_limit(user) - 100
+    end
   end
 
   module PostMethods

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -178,7 +178,7 @@ class PostSet < ApplicationRecord
     end
 
     def is_over_limit?(user)
-      post_ids.size > Danbooru.config.set_post_limit(user) - 100
+      post_ids.size > Danbooru.config.set_post_limit(user) + 100
     end
   end
 


### PR DESCRIPTION
There are a number of post sets that are way, way above the existing limit.
While their owners cannot add any more posts to them, it's possible that the act of removing posts from those sets causes other requests to the same table to time out.