### PR TITLE
[PWA] Update manifest.json to add `start_url`

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,1 +1,1 @@
-{"name":"e621","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#00549e","background_color":"#021131","display":"standalone"}
+{"name":"e621","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#00549e","background_color":"#021131","display":"standalone","start_url": "./"}


### PR DESCRIPTION
Seems like the [PWA isn't being served](https://discord.com/channels/431908090883997698/784719781726257153/1400850099139248269) due to [this](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/start_url#start_url).
> [!NOTE]
> Currently untested (though it seemingly couldn't make it worse).