### PR TITLE
[Notes] Fix note visibility issues

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -1,4 +1,5 @@
 import Utility from "./utility";
+import PostsShowToolbar from "./views/PostsShowToolbar";
 
 let Note = {
   Box: {
@@ -538,6 +539,7 @@ let Note = {
       if (Note.TranslationMode.active) {
         Note.TranslationMode.stop(e);
       } else {
+        PostsShowToolbar.toggleNotes(true);
         Note.TranslationMode.start(e);
       }
     },

--- a/app/javascript/src/javascripts/views/PostsShowToolbar.js
+++ b/app/javascript/src/javascripts/views/PostsShowToolbar.js
@@ -82,15 +82,17 @@ export default class PostsShowToolbar {
 
   // Notes toggle button
   initNotesToggle(button) {
-    const container = $("#note-container");
-    container.toggleClass("hidden", !LStorage.Posts.Notes);
-    button.attr("enabled", LStorage.Posts.Notes);
+    PostsShowToolbar.toggleNotes();
 
     button.on("click", () => {
-      LStorage.Posts.Notes = !LStorage.Posts.Notes;
-      container.toggleClass("hidden", !LStorage.Posts.Notes);
-      button.attr("enabled", LStorage.Posts.Notes);
+      LStorage.Posts.Notes = !(button.attr("enabled") == "true");
+      PostsShowToolbar.toggleNotes();
     });
+  }
+
+  static toggleNotes(visible = LStorage.Posts.Notes) {
+    $("#note-container").attr("enabled", visible);
+    $(".ptbr-notes-button").attr("enabled", visible);
   }
 
 }

--- a/app/javascript/src/styles/specific/notes.scss
+++ b/app/javascript/src/styles/specific/notes.scss
@@ -4,9 +4,7 @@ div#note-container {
   position: absolute;
   z-index: 50;
 
-  &[data-resizing=true] {
-    display: none;
-  }
+  &[enabled="false"] { display: none; }
 
   &.hidden { visibility: hidden !important; }
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -58,7 +58,7 @@
         <%= render "ads/leaderboard", tag_string: @post.ad_tag_string %>
 
         <%= tag.section(id: "image-container", class: "blacklistable", **PostPresenter.data_attributes(@post, include_post: true)) do -%>
-          <div id="note-container" class="hidden"></div>
+          <div id="note-container" enabled="false"></div>
           <div id="note-preview"></div>
           <%= render "posts/partials/show/content/embedded/embedded", post: @post %>
         <% end -%>


### PR DESCRIPTION
The recent release had a couple bugs regarding note visibility.
Most notably, attempting to add notes to a post that has none was impossible.
Additionally, the note toggle button had issues if the note area was enabled elsewhere.
