### PR TITLE
[Blacklist] Allowed `username` to blacklist users like `user` & `userid`

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -398,7 +398,7 @@ class User < ApplicationRecord
     def is_blacklisting_user?(user)
       return false if blacklisted_tags.blank?
       bltags = blacklisted_tags.split("\n").map(&:downcase)
-      strings = %W[user:#{user.name.downcase} user:!#{user.id} userid:#{user.id}]
+      strings = %W[user:#{user.name.downcase} user:!#{user.id} username:#{user.name.downcase} userid:#{user.id}]
       strings.any? { |str| bltags.include?(str) }
     end
   end


### PR DESCRIPTION
Previously wouldn't blacklist users if `username:<user_name>` was used.