### PR TITLE
[Tags] Don't show categories that the current user can't edit on the edit form

### DIFF
--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -37,14 +37,8 @@ class TagCategory
     "Lore" => 8,
   }.freeze
 
-  MEMBER_EDITABLE_MAPPING = {
-    "General" => 0,
-    "Artist" => 1,
-    "Contributor" => 2,
-    "Copyright" => 3,
-    "Character" => 4,
-    "Species" => 5,
-  }.freeze
+  MEMBER_EDITABLE_CATEGORIES = %w[General Artist Contributor Copyright Character Species].freeze
+  MEMBER_EDITABLE_MAPPING = CANONICAL_MAPPING.select { |k, _| MEMBER_EDITABLE_CATEGORIES.include?(k) }.freeze
 
   REVERSE_MAPPING = {
     0 => "general",

--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -37,6 +37,15 @@ class TagCategory
     "Lore" => 8,
   }.freeze
 
+  MEMBER_EDITABLE_MAPPING = {
+    "General" => 0,
+    "Artist" => 1,
+    "Contributor" => 2,
+    "Copyright" => 3,
+    "Character" => 4,
+    "Species" => 5,
+  }.freeze
+
   REVERSE_MAPPING = {
     0 => "general",
     1 => "artist",

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -7,7 +7,7 @@
       <% if @tag.is_locked? %>
         <p>This tag is category locked</p>
       <% else %>
-        <%= f.input :category, collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: false %>
+        <%= f.input :category, collection: CurrentUser.is_privileged? ? TagCategory::CANONICAL_MAPPING.to_a : TagCategory::MEMBER_EDITABLE_MAPPING.to_a, include_blank: false %>
       <% end %>
 
       <% if CurrentUser.is_admin? %>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -15,7 +15,7 @@
     <% if @wiki_page.new_record? || @wiki_page.tag.present? %>
       <%= f.input :category_id, 
         label: "Tag Category", 
-        collection: TagCategory::CANONICAL_MAPPING.to_a, 
+        collection: CurrentUser.is_privileged? ? TagCategory::CANONICAL_MAPPING.to_a : TagCategory::MEMBER_EDITABLE_MAPPING.to_a, 
         include_blank: @wiki_page.tag.blank?,
         disabled: !@wiki_page.category_editable_by? %>
 


### PR DESCRIPTION
As a way to reduce confusion, don't show tag categories to users who can't utilize them anyways.