### PR TITLE
[Posts] Fix the download button in the toolbar

### DIFF
--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -56,6 +56,7 @@ module IconHelper
       <rect width="4" height="4" x="3" y="10"/><rect width="4" height="4" x="10" y="10"/><rect width="4" height="4" x="17" y="10"/>
       <rect width="4" height="4" x="3" y="17"/><rect width="4" height="4" x="10" y="17"/><rect width="4" height="4" x="17" y="17"/>
     ),
+    hexagon: %(<path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>),
 
     # Pagination
     chevron_left: %(<path d="m15 18-6-6 6-6"/>),

--- a/app/javascript/src/javascripts/views/PostsShowToolbar.js
+++ b/app/javascript/src/javascripts/views/PostsShowToolbar.js
@@ -179,14 +179,12 @@ export default class PostsShowToolbar {
       if (button.attr("pending") == "true") return;
       button.attr("pending", "true");
 
-      button.attr("pending", "true");
-
       const url = PostsShowToolbar.currentPost.file.url;
       console.log("downloading", url);
 
       fetch(url, {
-        headers: new Headers({ "Origin": location.origin }),
         mode: "cors",
+        credentials: "include",
       })
         .then(response => response.blob())
         .then(blob => {

--- a/app/javascript/src/javascripts/views/PostsShowToolbar.js
+++ b/app/javascript/src/javascripts/views/PostsShowToolbar.js
@@ -36,9 +36,7 @@ export default class PostsShowToolbar {
     });
 
     // Initialize fullscreen menu toggle
-    $(".ptbr-fullscreen").each((_index, element) => {
-      this.initFullscreenMenuToggle($(element));
-    });
+    this.initOverflowMenu();
   }
 
 
@@ -169,10 +167,40 @@ export default class PostsShowToolbar {
   }
 
   // Fullscreen / download menu
-  initFullscreenMenuToggle (wrapper) {
-    const menu = wrapper.find(".ptbr-fullscreen-menu");
-    wrapper.find(".ptbr-fullscreen-toggle").on("click", () => {
+  initOverflowMenu () {
+    const menu = $(".ptbr-etc-menu");
+    $(".ptbr-etc-toggle").on("click", () => {
       menu.toggleClass("hidden");
+    });
+
+    const button = $(".ptbr-etc-download").on("click.e6.prepare", async (event) => {
+      event.preventDefault();
+
+      if (button.attr("pending") == "true") return;
+      button.attr("pending", "true");
+
+      button.attr("pending", "true");
+
+      const url = PostsShowToolbar.currentPost.file.url;
+      console.log("downloading", url);
+
+      fetch(url, {
+        headers: new Headers({ "Origin": location.origin }),
+        mode: "cors",
+      })
+        .then(response => response.blob())
+        .then(blob => {
+          let blobUrl = window.URL.createObjectURL(blob);
+          button.attr({
+            href: blobUrl,
+            pending: "false",
+          }).off("click.e6.prepare");
+          button[0].click();
+        })
+        .catch(e => {
+          Utility.error("Failed to download post file.", e);
+          button.attr("pending", "false");
+        });
     });
   }
 }

--- a/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
@@ -145,43 +145,11 @@
 
 // Fullscreen button
 #ptbr-wrapper .ptbr-fullscreen {
-  display: flex;
-  position: relative;
-  gap: 0.5rem;
-}
-
-#ptbr-wrapper .ptbr-fullscreen-button {
   display: none;
-  font-family: "Roboto", Verdana, Geneva, sans-serif;
-
   @include window-larger-than(40rem) { display: flex; }
 }
-
-#ptbr-wrapper .ptbr-fullscreen-menu {
-  display: flex;
-  flex-flow: column;
-  gap: 0.25rem;
-
-  position: absolute;
-  right: 0;
-  top: 2rem;
-  padding: 0.25rem 0.25rem;
-  margin-top: 0.5rem;
-
-  background: themed("color-section");
-  @include st-radius;
-
-  &.hidden { display: none; }
-
-  // Mobile-only buttons
-  @include window-larger-than(40rem) {
-    .ptbr-fullscreen-menu-a { display: none; }
-    .ptbr-notes-button { display: none; }
-  }
-
-  .st-button {
-    font-family: "Roboto", Verdana, Geneva, sans-serif;
-  }
+#ptbr-wrapper .ptbr-fullscreen-button {
+  font-family: "Roboto", Verdana, Geneva, sans-serif;
 }
 
 
@@ -217,6 +185,69 @@
 
   &[enabled="false"] { &:after { content: "Notes: Off"; } }
 }
+
+
+// Overflow menu
+#ptbr-wrapper .ptbr-etc {
+  display: flex;
+  position: relative;
+  gap: 0.5rem;
+}
+
+#ptbr-wrapper .ptbr-etc-menu {
+  display: flex;
+  flex-flow: column;
+  gap: 0.25rem;
+
+  position: absolute;
+  right: 0;
+  top: 2rem;
+  padding: 0.25rem 0.25rem;
+  margin-top: 0.5rem;
+
+  background: themed("color-section");
+  @include st-radius;
+
+  &.hidden { display: none; }
+
+  // Mobile-only buttons
+  @include window-larger-than(40rem) {
+    .ptbr-etc-fullscreen { display: none; }
+    .ptbr-notes-button { display: none; }
+  }
+
+  .st-button {
+    font-family: "Roboto", Verdana, Geneva, sans-serif;
+  }
+
+  // Download button
+  .ptbr-etc-download {
+    min-width: 6rem;
+    align-items: center;
+
+    svg {
+      display: none;
+      height: 1rem;
+      width: 1rem;
+
+      animation: spin-animation ease-in-out 1s infinite;
+    }
+    span {
+      text-align: center;
+    }
+
+    &[pending="true"] {
+      svg { display: inline; }
+      span { display: none; }
+    }
+
+    @keyframes spin-animation {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+  }
+}
+
 
 
 // Section holding SVG filters

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -88,12 +88,18 @@
     >
       View
     </a>
-    <button class="st-button kinetic ptbr-fullscreen-toggle">
+  </div>
+
+  <div class="ptbr-etc">
+    <button class="st-button kinetic ptbr-etc-toggle">
       <%= svg_icon(:ellipsis_v) %>
     </button>
-    <div class="ptbr-fullscreen-menu hidden">
-      <a href="<%= @post.file_url %>" class="st-button ptbr-fullscreen-menu-a">Fullscreen</a>
-      <a href="<%= @post.file_url %>" class="st-button ptbr-fullscreen-menu-b" download>Download</a>
+    <div class="ptbr-etc-menu hidden">
+      <a href="<%= @post.file_url %>" class="st-button ptbr-etc-fullscreen">Fullscreen</a>
+      <a href="<%= @post.file_url %>" class="st-button ptbr-etc-download" download="<%= @post.md5 %>.<%= @post.file_ext %>" pending="false">
+        <%= svg_icon(:hexagon) %>
+        <span>Download</span>
+      </a>
       <button class="st-button ptbr-notes-button" enabled="true"></button>
     </div>
   </div>


### PR DESCRIPTION
The download button would not work in its original implementation due to the image file being cross-origin.  
As a workaround, clicking on that button the first time will now fetch the file contents and turn them into a blob.