### PR TITLE
[Notes] Fix the note toggle button visibility issues

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -541,6 +541,7 @@ let Note = {
         Note.TranslationMode.stop(e);
       } else {
         PostsShowToolbar.toggleNotes(true);
+        $(".ptbr-notes, .ptbr-notes-button").removeClass("hidden");
         Note.TranslationMode.start(e);
       }
     },

--- a/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
@@ -176,6 +176,7 @@
 #ptbr-wrapper .ptbr-notes {
   display: none;  // In the hamburger menu on mobile
   @include window-larger-than(40rem) { display: flex; }
+  &.hidden { display: none; }
 }
 
 #ptbr-wrapper .ptbr-notes-button {
@@ -246,6 +247,8 @@
       100% { transform: rotate(360deg); }
     }
   }
+
+  .ptbr-notes-button.hidden { display: none; }
 }
 
 

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -54,8 +54,8 @@
   </div>
 <% end %>
 
-<% if @post.visible? && @post.has_notes? %>
-  <div class="ptbr-notes">
+<% if @post.visible? %>
+  <div class="ptbr-notes <%= @post.has_notes? ? "" : "hidden"%>">
     <button
       class="st-button kinetic ptbr-notes-button"
       enabled="true"
@@ -100,7 +100,7 @@
         <%= svg_icon(:hexagon) %>
         <span>Download</span>
       </a>
-      <button class="st-button ptbr-notes-button" enabled="true"></button>
+      <button class="st-button ptbr-notes-button <%= @post.has_notes? ? "" : "hidden"%>" enabled="true"></button>
     </div>
   </div>
 <% end %>

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -55,7 +55,7 @@
 <% end %>
 
 <% if @post.visible? %>
-  <div class="ptbr-notes <%= @post.has_notes? ? "" : "hidden"%>">
+  <div class="<%= @post.has_notes? ? "ptbr-notes" : "ptbr-notes hidden" %>">
     <button
       class="st-button kinetic ptbr-notes-button"
       enabled="true"


### PR DESCRIPTION
The note toggle button in the overflow menu was always on, while the regular toggle had no way of appearing if the user added a new note to the post.
This PR fixes both of these issues.