### PR TITLE
[Home] Rework the mascot positioning

### DIFF
--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -3,11 +3,12 @@ body.c-static.a-home {
   background-color: themed("bg-color", #012e57);
   background-image: themed("bg-image");
 
-  background-position-y: 3.75rem;
+  background-size: 100vw;
+  @include window-larger-than(500px) { background-size: 500px; }
+  @include window-larger-than(50rem) { background-size: 750px; }
 
-  @include window-larger-than(50rem) {
-    background-position-y: unset;
-  }
+  background-position-y: 3.5rem;
+  @include window-larger-than(50rem) { background-position-y: unset; }
 
   #page {
     background: none;

--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -1,25 +1,38 @@
 body.c-static.a-home {
-  background: #012e57 no-repeat center 0;
+  background: #012e57; // I am certain this was needed for something
   background-color: themed("bg-color", #012e57);
-  background-image: themed("bg-image");
-
-  background-size: 100vw;
-  @include window-larger-than(500px) { background-size: 500px; }
-  @include window-larger-than(50rem) { background-size: 750px; }
-
-  background-position-y: 3.5rem;
-  @include window-larger-than(50rem) { background-position-y: unset; }
 
   #page {
     background: none;
-    margin: 20rem auto 0;
+    margin: 0 auto;
     width: 100%;
     max-width: 480px;
-    padding: 0;
-  
-    @include window-larger-than(50rem) {
-      margin-top: 25rem;
-    }
+    padding: 0 0.5rem 0.5rem;
+    box-sizing: border-box;
+  }
+
+  #a-home {
+    display: flex;
+    flex-flow: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+
+  // Mascots
+  .mascot-section {
+    background-image: themed("bg-image");
+
+    display: flex;
+    width: min(750px, 100vw);
+    height: min(750px, 100vw);
+    margin-bottom: max(-300px, -40vw); // search form 40% up the mascot image
+
+    background-size: contain; // Scale the image down with the container
+    background-position: center center;
+    background-repeat: no-repeat;
+
+    @include window-larger-than(50rem) { margin-top: -3.5rem; }
   }
 
 
@@ -30,9 +43,11 @@ body.c-static.a-home {
     backdrop-filter: blur(8px);
 
     padding: 1rem;
-    margin: 0.5rem;
     @include st-radius;
     text-align: center;
+
+    box-sizing: border-box;
+    width: 100%;
   }
 
 
@@ -135,19 +150,17 @@ body.c-static.a-home {
   .home-footer-top {
     background-color: rgba(15, 15, 15, 0.5);
     backdrop-filter: blur(8px);
-    margin: 3rem 0 0;
+    margin: 0.5rem 0 0;
     padding: 1rem;
     gap: 0.5rem;
 
     display: flex;
     justify-content: space-between;
     align-items: center;
+    box-sizing: border-box;
+    width: 100%;
 
     @include st-radius-top;
-
-    @include window-larger-than(480px) {
-      margin: 0.5rem 0.5rem 0;
-    }
 
     a#mascot-swap {
 
@@ -172,14 +185,12 @@ body.c-static.a-home {
     background: #1f3c67;
     text-align: center;
 
-    margin: 0;
+    margin-top: -0.5rem;
     padding: 0.5rem;
+    box-sizing: border-box;
+    width: 100%;
 
     @include st-radius-bottom;
-
-    @include window-larger-than(480px) {
-      margin: 0 0.5rem;
-    }
 
     .home-footer-counter img {
       height: 4rem;

--- a/app/models/mascot.rb
+++ b/app/models/mascot.rb
@@ -80,7 +80,7 @@ class Mascot < ApplicationRecord
 
   def self.search(params)
     q = super
-    q.order("lower(artist_name)")
+    q.order("created_at asc")
   end
 
   def method_attributes

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -3,6 +3,8 @@
     var mascots = <%= Mascot.active_for_browser.to_json.html_safe %>;
   <% end -%>
 
+  <section class="mascot-section"></section>
+
   <section class="home-section">
     <%= form_tag(posts_path, method: "get", id: "home-search-form") do %>
 


### PR DESCRIPTION
Previously, the mascot image on the home page did not account for how it would look on mobile devices.
Since the image would remain the same size regardless of the screen resolution, parts of it would be cut off by the viewport.
In some cases, that created an interesting visual. In others, it would just look awkward.

I have reworked the mascot display to remain consistently sized compared to the size of the viewport regardless of the screen size.

Old vs new version:
<img width="360" height="800" alt="old" src="https://github.com/user-attachments/assets/6ca97805-4e19-4f13-a065-39355711c06b" /> <img width="360" height="800" alt="new" src="https://github.com/user-attachments/assets/e62c5596-b9f3-4f06-abb4-426b707d8973" />