### PR TITLE
[Hotkeys] Fix the alt key overriding native browser behavior

### DIFF
--- a/app/javascript/src/javascripts/hotkeys.js
+++ b/app/javascript/src/javascripts/hotkeys.js
@@ -156,11 +156,6 @@ export default class Hotkeys {
 
       $document.trigger("e6.hotkeys.keyup", [this._heldKeys]);
       if (Hotkeys.debug) console.log("Key Up:", key, Hotkeys.buildKeybindString([...this._heldKeys]));
-
-      // Avoid default behavior
-      // Otherwise, the key could get inserted into inputs
-      event.preventDefault();
-      return false;
     });
 
 


### PR DESCRIPTION
The alt key opens the window menu in Firefox and focuses the hamburger menu button in Chrome.  
Due to an oversight, the hotkey script used to override this behavior.