### PR TITLE
[Hotkeys] Disable hotkeys when a video is focused

### DIFF
--- a/app/javascript/src/javascripts/hotkeys.js
+++ b/app/javascript/src/javascripts/hotkeys.js
@@ -171,7 +171,7 @@ export default class Hotkeys {
     });
 
 
-    function isInputFocused () { return $(document.activeElement).is("input, textarea"); }
+    function isInputFocused () { return $(document.activeElement).is("input, textarea, video"); }
     function formatKey (input) {
       if (/^\w{1}$/.test(input)) return input.toUpperCase();
 


### PR DESCRIPTION
The video player has its own hotkeys (seeking, pause/play, volume) that were being overridden by the hotkey script.