### PR TITLE
[UI] Make the secondary navbar scroll on overflow

### DIFF
--- a/app/javascript/src/styles/common/navigation.scss
+++ b/app/javascript/src/styles/common/navigation.scss
@@ -368,7 +368,7 @@ nav.navigation, html.nav-toggled nav.navigation {
       border-radius: 0.25rem 0 0 0.25rem;
       overflow-y: unset;
 
-      overflow: hidden; // Silly fix for too many links
+      overflow-x: scroll; // Silly fix for too many links
       z-index: 1; // above the avatar
 
       li {

--- a/app/javascript/src/styles/common/navigation.scss
+++ b/app/javascript/src/styles/common/navigation.scss
@@ -366,9 +366,12 @@ nav.navigation, html.nav-toggled nav.navigation {
 
       padding: 0 0.25rem;
       border-radius: 0.25rem 0 0 0.25rem;
-      overflow-y: unset;
-
+      overflow-y: hidden;
       overflow-x: scroll; // Silly fix for too many links
+      /* Hide scrollbar */
+      -ms-overflow-style: none; /* IE and Edge */
+      scrollbar-width: none; /* Firefox */
+      &::-webkit-scrollbar { display: none; }
       z-index: 1; // above the avatar
 
       li {


### PR DESCRIPTION
<img width="636" height="877" alt="image" src="https://github.com/user-attachments/assets/3792f650-677d-42f1-bcba-9febd3a31fd2" />
There's cases where the mobile UI doesn't kick in although it should (e.g. my phone), & small fixes like this help minimize problems there while not affecting the desktop experience.

I should note that this has only been tested on Firefox & Chrome for Linux; it seemed to not impact the desktop experience on either.