### PR TITLE
[Mascots] Add a customizable foreground color.

### DIFF
--- a/app/controllers/mascots_controller.rb
+++ b/app/controllers/mascots_controller.rb
@@ -13,14 +13,14 @@ class MascotsController < ApplicationController
     @mascot = Mascot.new
   end
 
+  def edit
+    @mascot = Mascot.find(params[:id])
+  end
+
   def create
     @mascot = Mascot.create(mascot_params.merge(creator: CurrentUser.user))
     ModAction.log(:mascot_create, { id: @mascot.id }) if @mascot.valid?
     respond_with(@mascot, location: mascots_path)
-  end
-
-  def edit
-    @mascot = Mascot.find(params[:id])
   end
 
   def update
@@ -40,6 +40,6 @@ class MascotsController < ApplicationController
   private
 
   def mascot_params
-    params.fetch(:mascot, {}).permit(%i[mascot_file display_name background_color artist_url artist_name available_on_string active])
+    params.fetch(:mascot, {}).permit(%i[mascot_file display_name background_color foreground_color artist_url artist_name available_on_string active])
   end
 end

--- a/app/controllers/mascots_controller.rb
+++ b/app/controllers/mascots_controller.rb
@@ -40,6 +40,6 @@ class MascotsController < ApplicationController
   private
 
   def mascot_params
-    params.fetch(:mascot, {}).permit(%i[mascot_file display_name background_color foreground_color artist_url artist_name available_on_string active])
+    params.fetch(:mascot, {}).permit(%i[mascot_file display_name background_color foreground_color is_layered artist_url artist_name available_on_string active])
   end
 end

--- a/app/javascript/src/javascripts/mascots.js
+++ b/app/javascript/src/javascripts/mascots.js
@@ -6,11 +6,15 @@ const Mascots = {
 };
 
 Mascots.showMascot = function (mascot) {
-  $("body").css({
+  const $body = $("body").css({
     "--bg-image": `url("${mascot.background_url}")`,
     "--bg-color": mascot.background_color,
     "--fg-color": mascot.foreground_color,
   });
+
+  if (mascot.is_layered)
+    $body.attr("layered", "true");
+  else $body.removeAttr("layered");
 
   $("#mascot-artist")
     .text("Mascot by ")

--- a/app/javascript/src/javascripts/mascots.js
+++ b/app/javascript/src/javascripts/mascots.js
@@ -9,6 +9,7 @@ Mascots.showMascot = function (mascot) {
   $("body").css({
     "--bg-image": `url("${mascot.background_url}")`,
     "--bg-color": mascot.background_color,
+    "--fg-color": mascot.foreground_color,
   });
 
   $("#mascot-artist")

--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -148,7 +148,7 @@ body.c-static.a-home {
 
   // Footer
   .home-footer-top {
-    background-color: var(--fg-color, #0f0f0f80);;
+    background-color: var(--fg-color, #0f0f0f80);
     backdrop-filter: blur(8px);
     margin: 0.5rem 0 0;
     padding: 1rem;

--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -24,14 +24,23 @@ body.c-static.a-home {
     background-image: themed("bg-image");
 
     display: flex;
-    width: min(750px, 100vw);
-    height: min(750px, 100vw);
-    margin-bottom: max(-300px, -40vw); // search form 40% up the mascot image
+    $mascot-size: 750px;
+    width: min($mascot-size, 100vw);
+    height: min($mascot-size, 100vw);
+
+    // Position the search form 60% down the image.
+    // Extra 0.5rem is needed to clear the flexbox gap.
+    margin-bottom: calc(max(0 - ($mascot-size * 0.4), -40vw) - 0.5rem);
 
     background-size: contain; // Scale the image down with the container
     background-position: center center;
     background-repeat: no-repeat;
 
+    // Layering over the searchbar
+    z-index: 1;
+    pointer-events: none;
+
+    // Offset for the navbar
     @include window-larger-than(50rem) { margin-top: -3.75rem; }
   }
 
@@ -48,7 +57,11 @@ body.c-static.a-home {
 
     box-sizing: border-box;
     width: 100%;
+    z-index: 1;
   }
+
+  // Mascot layering over the searchbar
+  &[layered="true"] .home-search-section { z-index: 0; }
 
 
   // Search
@@ -159,6 +172,7 @@ body.c-static.a-home {
     align-items: center;
     box-sizing: border-box;
     width: 100%;
+    z-index: 1;
 
     @include st-radius-top;
 
@@ -189,6 +203,7 @@ body.c-static.a-home {
     padding: 0.5rem;
     box-sizing: border-box;
     width: 100%;
+    z-index: 1;
 
     @include st-radius-bottom;
 

--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -32,14 +32,14 @@ body.c-static.a-home {
     background-position: center center;
     background-repeat: no-repeat;
 
-    @include window-larger-than(50rem) { margin-top: -3.5rem; }
+    @include window-larger-than(50rem) { margin-top: -3.75rem; }
   }
 
 
   // Common
   .home-section {
     // Frosted glass effect
-    background-color: rgba(15, 15, 15, 0.5);
+    background-color: var(--fg-color, #0f0f0f80);
     backdrop-filter: blur(8px);
 
     padding: 1rem;
@@ -148,7 +148,7 @@ body.c-static.a-home {
 
   // Footer
   .home-footer-top {
-    background-color: rgba(15, 15, 15, 0.5);
+    background-color: var(--fg-color, #0f0f0f80);;
     backdrop-filter: blur(8px);
     margin: 0.5rem 0 0;
     padding: 1rem;

--- a/app/models/mascot.rb
+++ b/app/models/mascot.rb
@@ -6,7 +6,7 @@ class Mascot < ApplicationRecord
   array_attribute :available_on, parse: /[^,]+/, join_character: ","
   attr_accessor :mascot_file
 
-  validates :display_name, :background_color, :artist_url, :artist_name, presence: true
+  validates :display_name, :background_color, :foreground_color, :artist_url, :artist_name, presence: true
   validates :artist_url, format: { with: %r{\Ahttps?://}, message: "must start with http:// or https://" }
   validates :mascot_file, presence: true, on: :create
   validate :set_file_properties
@@ -38,7 +38,7 @@ class Mascot < ApplicationRecord
     Cache.fetch("active_mascots", expires_in: 1.day) do
       query = Mascot.where(active: true).where("? = ANY(available_on)", Danbooru.config.app_name)
       mascots = query.map do |mascot|
-        mascot.slice(:id, :background_color, :artist_url, :artist_name).merge(background_url: mascot.url_path)
+        mascot.slice(:id, :background_color, :foreground_color, :artist_url, :artist_name).merge(background_url: mascot.url_path)
       end
       mascots.index_by { |mascot| mascot["id"] }
     end
@@ -80,7 +80,7 @@ class Mascot < ApplicationRecord
 
   def self.search(params)
     q = super
-    q.order("created_at asc")
+    q.order("id asc")
   end
 
   def method_attributes

--- a/app/models/mascot.rb
+++ b/app/models/mascot.rb
@@ -38,7 +38,7 @@ class Mascot < ApplicationRecord
     Cache.fetch("active_mascots", expires_in: 1.day) do
       query = Mascot.where(active: true).where("? = ANY(available_on)", Danbooru.config.app_name)
       mascots = query.map do |mascot|
-        mascot.slice(:id, :background_color, :foreground_color, :artist_url, :artist_name).merge(background_url: mascot.url_path)
+        mascot.slice(:id, :background_color, :foreground_color, :is_layered, :artist_url, :artist_name).merge(background_url: mascot.url_path)
       end
       mascots.index_by { |mascot| mascot["id"] }
     end

--- a/app/views/mascots/_form.html.erb
+++ b/app/views/mascots/_form.html.erb
@@ -3,6 +3,7 @@
   <%= f.input :mascot_file, as: :file, input_html: { accept: "image/png,image/jpeg,.png,.jpg,.jpeg" } %>
   <%= f.input :display_name %>
   <%= f.input :background_color %>
+  <%= f.input :foreground_color %>
   <%= f.input :artist_url %>
   <%= f.input :artist_name %>
   <%= f.input :available_on_string, label: "Available on", hint: "Separated by a comma, don't include spaces before/after" %>

--- a/app/views/mascots/_form.html.erb
+++ b/app/views/mascots/_form.html.erb
@@ -4,6 +4,7 @@
   <%= f.input :display_name %>
   <%= f.input :background_color %>
   <%= f.input :foreground_color %>
+  <%= f.input :is_layered, label: "Layered", as: :boolean, hint: "The mascot image will be layered above the search form." %>
   <%= f.input :artist_url %>
   <%= f.input :artist_name %>
   <%= f.input :available_on_string, label: "Available on", hint: "Separated by a comma, don't include spaces before/after" %>

--- a/app/views/mascots/index.html.erb
+++ b/app/views/mascots/index.html.erb
@@ -5,8 +5,10 @@
     <table class="striped">
       <thead>
         <tr>
+          <th>ID</th>
           <th>Name</th>
           <th>Background Color</th>
+          <th>Foreground Color</th>
           <th>Artist Name</th>
           <th>Artist URL</th>
           <th>Active</th>
@@ -20,11 +22,13 @@
       <tbody>
         <% @mascots.each do |mascot| %>
           <tr>
+            <td><%= mascot.id %></td>
             <td><%= link_to mascot.display_name, mascot.url_path %></td>
             <td><%= mascot.background_color %></td>
+            <td><%= mascot.foreground_color %></td>
             <td><%= mascot.artist_name %></td>
             <td><%= mascot.artist_url %></td>
-            <td><%= mascot.active %></td>
+            <td><%= svg_icon(:chexagon, width: 12, height: 12) if mascot.active %></td>
             <td><%= mascot.available_on_string %></td>
             <td><%= compact_time mascot.created_at %></td>
             <% if CurrentUser.user.is_admin? %>

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -5,7 +5,7 @@
 
   <section class="mascot-section"></section>
 
-  <section class="home-section">
+  <section class="home-section home-search-section">
     <%= form_tag(posts_path, method: "get", id: "home-search-form") do %>
 
       <!-- Primary Searchbar -->

--- a/db/migrate/20250830192056_add_mascot_colors.rb
+++ b/db/migrate/20250830192056_add_mascot_colors.rb
@@ -3,11 +3,13 @@
 class AddMascotColors < ActiveRecord::Migration[7.1]
   def up
     add_column :mascots, :foreground_color, :string, null: false, default: "#0f0f0f80"
+    add_column :mascots, :is_layered, :boolean, null: false, default: false
     change_column_default :mascots, :background_color, "#012e57"
   end
 
   def down
     remove_column :mascots, :foreground_color
+    remove_column :mascots, :is_layered
     change_column_default :mascots, :background_color, nil
   end
 end

--- a/db/migrate/20250830192056_add_mascot_colors.rb
+++ b/db/migrate/20250830192056_add_mascot_colors.rb
@@ -1,0 +1,4 @@
+class AddMascotColors < ActiveRecord::Migration[7.1]
+  def change
+  end
+end

--- a/db/migrate/20250830192056_add_mascot_colors.rb
+++ b/db/migrate/20250830192056_add_mascot_colors.rb
@@ -1,4 +1,13 @@
+# frozen_string_literal: true
+
 class AddMascotColors < ActiveRecord::Migration[7.1]
-  def change
+  def up
+    add_column :mascots, :foreground_color, :string, null: false, default: "#0f0f0f80"
+    change_column_default :mascots, :background_color, "#012e57"
+  end
+
+  def down
+    remove_column :mascots, :foreground_color
+    change_column_default :mascots, :background_color, nil
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1014,7 +1014,8 @@ CREATE TABLE public.mascots (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     available_on character varying[] DEFAULT '{}'::character varying[] NOT NULL,
-    foreground_color character varying DEFAULT '#0f0f0f80'::character varying NOT NULL
+    foreground_color character varying DEFAULT '#0f0f0f80'::character varying NOT NULL,
+    is_layered boolean DEFAULT false NOT NULL
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1007,13 +1007,14 @@ CREATE TABLE public.mascots (
     display_name character varying NOT NULL,
     md5 character varying NOT NULL,
     file_ext character varying NOT NULL,
-    background_color character varying NOT NULL,
+    background_color character varying DEFAULT '#012e57'::character varying NOT NULL,
     artist_url character varying NOT NULL,
     artist_name character varying NOT NULL,
     active boolean DEFAULT true NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    available_on character varying[] DEFAULT '{}'::character varying[] NOT NULL
+    available_on character varying[] DEFAULT '{}'::character varying[] NOT NULL,
+    foreground_color character varying DEFAULT '#0f0f0f80'::character varying NOT NULL
 );
 
 
@@ -4733,6 +4734,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250830192056'),
 ('20250826165528'),
 ('20250611041221'),
 ('20250604020028'),


### PR DESCRIPTION
Done on request from the folks at e6ai. Less relevant to e621.
Allows the foreground color (ex. search box, news) to be customized depending on the mascot.