### PR TITLE
[DMails] Add usernames to the API output

### DIFF
--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -128,8 +128,23 @@ class Dmail < ApplicationRecord
     end
   end
 
+  module ApiMethods
+    def to_name
+      to.pretty_name
+    end
+
+    def from_name
+      from.pretty_name
+    end
+
+    def method_attributes
+      super + %i[to_name from_name]
+    end
+  end
+
   include AddressMethods
   include FactoryMethods
+  include ApiMethods
   extend SearchMethods
 
   def user_not_limited

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -130,11 +130,11 @@ class Dmail < ApplicationRecord
 
   module ApiMethods
     def to_name
-      to.pretty_name
+      to&.pretty_name
     end
 
     def from_name
-      from.pretty_name
+      from&.pretty_name
     end
 
     def method_attributes


### PR DESCRIPTION
Addresses #662.
DMails had been bulk-loading user data for a while now, no reason to not include the usernames in the API output.