### PR TITLE
[TagPreview] Fix alias json and display name

### DIFF
--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tag-preview-tag">
     <div class="main-tag">
-      <tag-link :name="tag.resolved || tag.name" :tagType="tag.category"></tag-link>
+      <tag-link :name="tag.alias || tag.resolved || tag.name" :tagType="tag.category"></tag-link>
       <span v-if="!tag.id" class="invalid">invalid</span>
       <span v-else-if="tag.implied" class="implied">implied</span>
       <span v-else-if="tag.post_count === 0" class="empty">empty</span>

--- a/app/logical/tags_preview.rb
+++ b/app/logical/tags_preview.rb
@@ -48,12 +48,12 @@ class TagsPreview
     seen = Set.new
 
     (@raw_names + @aliases.values + @implications.values.flatten).uniq.filter_map do |raw_name|
-      resolved = @resolved_names[raw_name]
+      resolved = @resolved_names[raw_name] || raw_name
 
       next if seen.include?(resolved)
       seen << resolved
 
-      canonical = @aliases[resolved]
+      canonical = @aliases[resolved] || resolved
       tag = @tags[canonical]
 
       {


### PR DESCRIPTION
Adjusts output tags to show aliased name rather than original name.
Also fixes the output json for alias tags (which failed to resolve previously).

No further filtering is required because the display was already filtered by its very implementation.
Alias tags are returned and cached in case a third-party developer or first-party future changes want to replace the input with the resulting alias, but this is not taking place currently.