### PR TITLE
[Users] Fix an error with the login reminder

### DIFF
--- a/app/controllers/maintenance/user/login_reminders_controller.rb
+++ b/app/controllers/maintenance/user/login_reminders_controller.rb
@@ -7,7 +7,7 @@ module Maintenance
       end
 
       def create
-        ::User.with_email(params[:email]).each do |user|
+        ::User.with_email(params[:user][:email]).each do |user|
           next if user.is_moderator?
           LoginReminderMailer.notice(user).deliver_now
         end

--- a/app/controllers/maintenance/user/login_reminders_controller.rb
+++ b/app/controllers/maintenance/user/login_reminders_controller.rb
@@ -7,9 +7,9 @@ module Maintenance
       end
 
       def create
-        @user = ::User.with_email(params[:user][:email]).first
-        if @user
-          LoginReminderMailer.notice(@user).deliver_now
+        ::User.with_email(params[:email]).each do |user|
+          next if user.is_moderator?
+          LoginReminderMailer.notice(user).deliver_now
         end
 
         flash[:notice] = "If your email was on file, an email has been sent your way. It should arrive within the next few minutes. Make sure to check your spam folder"

--- a/test/functional/maintenance/user/login_reminders_controller_test.rb
+++ b/test/functional/maintenance/user/login_reminders_controller_test.rb
@@ -8,7 +8,7 @@ module Maintenance
       context "A login reminder controller" do
         setup do
           @user = create(:user)
-          @blank_email_user = create(:user, :email => "")
+          @blank_email_user = create(:user, email: "")
           ActionMailer::Base.delivery_method = :test
           ActionMailer::Base.deliveries.clear
         end
@@ -19,13 +19,13 @@ module Maintenance
         end
 
         should "deliver an email with the login to the user" do
-          post maintenance_user_login_reminder_path, params: {:user => {:email => @user.email}}
+          post maintenance_user_login_reminder_path, params: { user: { email: @user.email } }
           assert_equal(1, ActionMailer::Base.deliveries.size)
         end
 
         context "for a user with a blank email" do
           should "fail" do
-            post maintenance_user_login_reminder_path, params: {:user => {:email => ""}}
+            post maintenance_user_login_reminder_path, params: { user: { email: "" } }
             @blank_email_user.reload
             assert_in_delta(@blank_email_user.created_at.to_i, @blank_email_user.updated_at.to_i, 1)
             assert_equal(0, ActionMailer::Base.deliveries.size)


### PR DESCRIPTION
Occasionally, a login reminder form somehow ends up submitted without the email being specified.
Note that leaving the field blank will not accomplish this – it needs to be absent entirely.

Not sure how that happens, but this will fix the error, at least.