### PR TITLE
[Posts] Fix the vote/favorite buttons not activating sometimes

### DIFF
--- a/app/javascript/src/styles/common/_standard_elements.scss
+++ b/app/javascript/src/styles/common/_standard_elements.scss
@@ -83,9 +83,24 @@
   // Elements that look like physical buttons and animate on click.
   &.kinetic {
     box-shadow: 0 0.25rem themed("color-section");
+    position: relative;
     &:active, &[processing="true"].anim {
       translate: 0 0.125rem;
       box-shadow: 0 0.125rem themed("color-section");
+
+      // Cursed solution for a cursed problem.
+      // Moving the button down when active caused the javascript event to not trigger if the
+      // top 0.125rem of the button was clicked. The solution is to add an invisible element
+      // that covers that gap.
+      &::before {
+        content: "";
+        position: absolute;
+        background: transparent;
+        height: 0.25rem;
+        top: -0.125rem;
+        left: 0;
+        right: 0;
+      }
     }
   }
 }

--- a/app/javascript/src/styles/common/_standard_elements.scss
+++ b/app/javascript/src/styles/common/_standard_elements.scss
@@ -82,11 +82,14 @@
 
   // Elements that look like physical buttons and animate on click.
   &.kinetic {
-    box-shadow: 0 0.25rem themed("color-section");
+    $kinetic-shadow: 0.25rem;
+    $kinetic-active: $kinetic-shadow / 2;
+
+    box-shadow: 0 $kinetic-shadow themed("color-section");
     position: relative;
     &:active, &[processing="true"].anim {
-      translate: 0 0.125rem;
-      box-shadow: 0 0.125rem themed("color-section");
+      translate: 0 $kinetic-active;
+      box-shadow: 0 $kinetic-active themed("color-section");
 
       // Cursed solution for a cursed problem.
       // Moving the button down when active caused the javascript event to not trigger if the
@@ -96,8 +99,8 @@
         content: "";
         position: absolute;
         background: transparent;
-        height: 0.25rem;
-        top: -0.125rem;
+        height: $kinetic-shadow;
+        top: -$kinetic-active;
         left: 0;
         right: 0;
       }


### PR DESCRIPTION
A rather bizarre problem.
The kinetic buttons move down when they are in an active state, but the JS event only triggers when the mouse is released.
If the user clicks on the top 2 pixels of the button, it moves out of the way, and the JS event does not trigger.

The simplest fix is to just cover up that 2-pixel gap with an invisible element when the button is in an active state.