### PR TITLE
[TagPreview] Improve Tag Preview

### DIFF
--- a/app/javascript/src/javascripts/uploader/tag_link.vue
+++ b/app/javascript/src/javascripts/uploader/tag_link.vue
@@ -1,11 +1,19 @@
 <template>
   <a :class="'tag-type-' + tagType" :href="'/wiki_pages/show_or_new?title=' + name" target="_blank">
-    {{ name }}
+    {{ displayName }}
   </a>
 </template>
 
 <script>
   export default {
-    props: ["tagType", "name"],
+    props: ["tagType", "name", "wrap"],
+    computed: {
+      displayName() {
+        if (this.wrap) {
+          return this.name.replace(/_/g, '_\u200B');
+        }
+        return this.name;
+      }
+    }
   }
 </script>

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -1,14 +1,15 @@
 <template>
-  <div>
-    <div v-if="loading && tagRecords.length === 0">Fetching tags...</div>
-    <div class="tag-preview">
+  <div class="tag-preview-area" :disabled="!enabled">
+    <div class="tag-preview" v-if="tagRecords.length && enabled">
       <tag-preview-tag v-for="(tag, i) in tagRecords" :key="i" :tag="tag"></tag-preview-tag>
     </div>
+    <a href="#" @click.prevent="togglePreview()">{{ enabled ? 'Hide' : 'Show' }} tag preview</a>
   </div>
 </template>
 
 <script>
 import tagPreviewTag from './tag_preview_tag.vue';
+import LStorage from '../utility/storage';
 
 export default {
   props: ['tags'],
@@ -20,6 +21,7 @@ export default {
       loading: false,
       tagCache: {},
       _tagPreviewDebounce: null,
+      enabled: LStorage.Posts.TagPreview,
     };
   },
   computed: {
@@ -70,12 +72,21 @@ export default {
       handler() {
         clearTimeout(this._tagPreviewDebounce);
         this._tagPreviewDebounce = setTimeout(() => {
-          this.fetchTagPreview();
+          if (this.enabled) {
+            this.fetchTagPreview();
+          }
         }, 1000);
       }
     }
   },
   methods: {
+    togglePreview() {
+      this.enabled = !this.enabled;
+      LStorage.Posts.TagPreview = this.enabled;
+      if (this.enabled) {
+        this.fetchTagPreview();
+      }
+    },
     fetchTagPreview() {
       const missing = this.tagsArray.filter(t => !this.tagCache[t]);
       if (missing.length === 0) return;

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -39,7 +39,9 @@ export default {
         result.push(tag);
 
         if (tag.implies && Array.isArray(tag.implies)) {
-          implications.add(...tag.implies);
+          for (const implication of tag.implies) {
+            implications.add(implication);
+          }
         }
       }
 

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -49,8 +49,8 @@ export default {
         if (tag.implies && Array.isArray(tag.implies)) {
           for (const implied of tag.implies) {
             const impliedTag = this.tagCache[implied];
-            if (impliedTag) {
-              result.set(implied, impliedTag);
+            if (impliedTag && !result.has(implied)) {
+              result.set(implied, { ...impliedTag, implied: true });
               if (impliedTag.alias) {
                 aliases.add(impliedTag.alias);
               }

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -27,7 +27,41 @@ export default {
       return [...new Set(this.tags.toLowerCase().replace(/\r?\n|\r/g, ' ').trim().split(/\s+/).filter(Boolean))];
     },
     tagRecords() {
-      return this.tagsArray.map(t => this.tagCache[t]).filter(Boolean);
+      const result = new Map();
+      const aliases = new Set();
+
+      for (const input of this.tagsArray) {
+        const tag = this.tagCache[input];
+        if (!tag) continue;
+
+        result.set(input, tag);
+
+        if (tag.alias) {
+          aliases.add(tag.alias);
+          const aliased = this.tagCache[tag.alias];
+          if (aliased) {
+            result.set(tag.alias, aliased);
+          }
+        }
+
+        if (tag.implies && Array.isArray(tag.implies)) {
+          for (const implied of tag.implies) {
+            const impliedTag = this.tagCache[implied];
+            if (impliedTag) {
+              result.set(implied, impliedTag);
+              if (impliedTag.alias) {
+                aliases.add(impliedTag.alias);
+              }
+            }
+          }
+        }
+      }
+
+      for (const alias of aliases) {
+        result.delete(alias);
+      }
+
+      return Array.from(result.values());
     },
   },
   watch: {

--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -103,7 +103,9 @@ export default {
         },
         error: (result) => {
           this.loading = false;
-          Danbooru.error("Error loading tag preview " + JSON.stringify(result));
+          let details = result.responseText || "Unknown error";
+          Danbooru.error("Error loading tag preview: " + details);
+          console.error("Tag preview error:", result);
         },
       });
     },

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -3,6 +3,7 @@
     <div class="main-tag">
       <tag-link :name="formatTagName(tag.alias || tag.resolved || tag.name)" :tagType="tag.category"></tag-link>
       <span v-if="!tag.id" class="invalid">invalid</span>
+      <span v-if="tag.duplicate" class="duplicate">duplicate</span>
       <span v-else-if="tag.implied" class="implied">implied</span>
       <span v-else-if="tag.post_count === 0" class="empty">empty</span>
       <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tag-preview-tag">
     <div class="main-tag">
-      <tag-link :name="tag.alias || tag.resolved || tag.name" :tagType="tag.category"></tag-link>
+      <tag-link :name="formatTagName(tag.alias || tag.resolved || tag.name)" :tagType="tag.category"></tag-link>
       <span v-if="!tag.id" class="invalid">invalid</span>
       <span v-else-if="tag.implied" class="implied">implied</span>
       <span v-else-if="tag.post_count === 0" class="empty">empty</span>
@@ -21,6 +21,9 @@ export default {
   methods: {
     formatTagCount(count) {
       return new Intl.NumberFormat('en', { notation: 'compact', compactDisplay: 'short' }).format(count).toLowerCase();
+    },
+    formatTagName(name) {
+      return name.replace(/_/g, '_\u200B');
     },
   },
 };

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -5,7 +5,7 @@
       <span v-if="!tag.id" class="invalid">invalid</span>
       <span v-else-if="tag.implied" class="implied">implied</span>
       <span v-else-if="tag.post_count === 0" class="empty">empty</span>
-      <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ tag.post_count }}</span>
+      <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>
     </div>
   </div>
 </template>
@@ -17,6 +17,11 @@ export default {
   props: ["tag"],
   components: {
     "tag-link": tagLink,
+  },
+  methods: {
+    formatTagCount(count) {
+      return new Intl.NumberFormat('en', { notation: 'compact', compactDisplay: 'short' }).format(count).toLowerCase();
+    },
   },
 };
 </script>

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -7,7 +7,7 @@
        :data-alias="tag.alias"
        :data-implied="tag.implied"
        :data-count="tag.post_count">
-    <tag-link :name="formatTagName(tag.alias || tag.resolved || tag.name)" :tagType="tag.category"></tag-link>
+    <tag-link :name="tag.alias || tag.resolved || tag.name" :tagType="tag.category" :wrap="true"></tag-link>
     <span v-if="!tag.id" class="invalid">invalid</span>
     <span v-else-if="tag.duplicate" class="duplicate">duplicate</span>
     <span v-else-if="tag.implied" class="implied">implied</span>
@@ -27,9 +27,6 @@ export default {
   methods: {
     formatTagCount(count) {
       return new Intl.NumberFormat('en', { notation: 'compact', compactDisplay: 'short' }).format(count).toLowerCase();
-    },
-    formatTagName(name) {
-      return name.replace(/_/g, '_\u200B');
     },
   },
 };

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -1,13 +1,18 @@
 <template>
-  <div class="tag-preview-tag">
-    <div class="main-tag">
-      <tag-link :name="formatTagName(tag.alias || tag.resolved || tag.name)" :tagType="tag.category"></tag-link>
-      <span v-if="!tag.id" class="invalid">invalid</span>
-      <span v-if="tag.duplicate" class="duplicate">duplicate</span>
-      <span v-else-if="tag.implied" class="implied">implied</span>
-      <span v-else-if="tag.post_count === 0" class="empty">empty</span>
-      <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>
-    </div>
+  <div class="tag-preview-tag" 
+       :data-id="tag.id" 
+       :data-category="tag.category" 
+       :data-name="tag.name" 
+       :data-resolved="tag.resolved"
+       :data-alias="tag.alias"
+       :data-implied="tag.implied"
+       :data-count="tag.post_count">
+    <tag-link :name="formatTagName(tag.alias || tag.resolved || tag.name)" :tagType="tag.category"></tag-link>
+    <span v-if="!tag.id" class="invalid">invalid</span>
+    <span v-if="tag.duplicate" class="duplicate">duplicate</span>
+    <span v-else-if="tag.implied" class="implied">implied</span>
+    <span v-else-if="tag.post_count === 0" class="empty">empty</span>
+    <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>
   </div>
 </template>
 

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -9,7 +9,7 @@
        :data-count="tag.post_count">
     <tag-link :name="formatTagName(tag.alias || tag.resolved || tag.name)" :tagType="tag.category"></tag-link>
     <span v-if="!tag.id" class="invalid">invalid</span>
-    <span v-if="tag.duplicate" class="duplicate">duplicate</span>
+    <span v-else-if="tag.duplicate" class="duplicate">duplicate</span>
     <span v-else-if="tag.implied" class="implied">implied</span>
     <span v-else-if="tag.post_count === 0" class="empty">empty</span>
     <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>

--- a/app/javascript/src/javascripts/utility/storage.js
+++ b/app/javascript/src/javascripts/utility/storage.js
@@ -112,6 +112,9 @@ LStorage.Posts = {
 
   /** @returns {boolean} True if post notes are enabled */
   Notes: ["e6.posts.notes", true],
+
+  /** @returns {boolean} True if tag preview in tag editor is enabled */
+  TagPreview: ["e6.posts.tagpreview", true],
 };
 StorageUtils.bootstrapMany(LStorage.Posts);
 

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -160,6 +160,7 @@ div#c-posts {
     }
 
     textarea {
+      box-sizing: border-box;
       margin-bottom: 0.25em;
     }
 

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -87,7 +87,8 @@ div.tag-preview {
 
     & .empty,
     .underused,
-    .invalid {
+    .invalid,
+    .duplicate {
       color: themed("palette-text-red");
     }
   }

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -50,6 +50,10 @@ div.related-tags {
   }
 }
 
+div.tag-preview-area {
+  margin-top: 0.5em;
+  margin-bottom: 0.75em;
+}
 
 div.tag-preview {
   box-sizing: border-box;
@@ -62,8 +66,7 @@ div.tag-preview {
   width: 100%;
   max-height: 50vh;
   overflow-y: auto;
-  margin-top: 0.5em;
-  margin-bottom: 1em;
+  margin-bottom: 0.25em;
   padding: 2px;
 
   background: themed("color-section-lighten-5");

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -76,6 +76,10 @@ div.tag-preview {
   .tag-preview-tag {
     padding: 1px;
     padding-right: 5px;
+    
+    & .post-count {
+      color: themed("color-text-muted");
+    }
 
     & .implied {
       color: themed("palette-text-green");

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -76,7 +76,7 @@ div.tag-preview {
   .tag-preview-tag {
     padding: 1px;
     padding-right: 5px;
-    
+
     & .post-count {
       color: themed("color-text-muted");
     }

--- a/app/logical/tags_preview.rb
+++ b/app/logical/tags_preview.rb
@@ -37,6 +37,14 @@ class TagsPreview
     @implications = TagImplication
                     .descendants_with_originals(@aliased_names)
                     .transform_values(&:to_a)
+
+    implied_tags = @implications.values.flatten.uniq
+    if implied_tags.any?
+      sub_implications = TagImplication
+                         .descendants_with_originals(implied_tags)
+                         .transform_values(&:to_a)
+      @implications.merge!(sub_implications)
+    end
   end
 
   def load_tags


### PR DESCRIPTION
Adds:
- Show/hide toggle (persistent) 
- Duplicate detection
- ✨ fun html data ✨

Fixes:
- Displaying tag implications
- Error messages
- Post count being too long
- Tag names overflowing

Removes:
- Text indication fetching (less layout shifts)

Preview:
<img width="964" height="393" alt="An image showing the updated Tag Preview. Below it is a 'Hide tag preview' toggle. A very long tag 'that_one_bug_that_looks_like_a_croissant_that_you_can_freeze_and_use_as_a_platform' correctly word-wraps. The 'contrast' tag is marked 'implied'." src="https://github.com/user-attachments/assets/0da67e28-f373-4234-a9bd-c02064c165d4" />
