### PR TITLE
[Config] Added option for `db_export_path` that hides `DB Export` on the site map when blank

### DIFF
--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -33,7 +33,7 @@
         <li><%= link_to("API Documentation", help_page_path(id: "api")) %></li>
         <li><%= link_to("Stats", stats_path) %></li>
         <% if Danbooru.config.db_export_path.present? %>
-          <li><%= link_to("DB Export", "/#{Danbooru.config.db_export_path}/") %></li>
+          <li><%= link_to("DB Export", Danbooru.config.db_export_path) %></li>
         <% end %>
       </ul>
       <ul>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -33,7 +33,7 @@
         <li><%= link_to("API Documentation", help_page_path(id: "api")) %></li>
         <li><%= link_to("Stats", stats_path) %></li>
         <% if Danbooru.config.db_export_path.present? %>
-          <li><%= link_to("DB Export", "/db_export/") %></li>
+          <li><%= link_to("DB Export", "/#{Danbooru.config.db_export_path}/") %></li>
         <% end %>
       </ul>
       <ul>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -32,7 +32,9 @@
         <li><%= link_to("Keyboard Shortcuts", keyboard_shortcuts_path) %></li>
         <li><%= link_to("API Documentation", help_page_path(id: "api")) %></li>
         <li><%= link_to("Stats", stats_path) %></li>
-        <li><%= link_to("DB Export", "/db_export/") %></li>
+        <% if Danbooru.config.db_export_path.present? %>
+          <li><%= link_to("DB Export", "/db_export/") %></li>
+        <% end %>
       </ul>
       <ul>
         <li><h3>Artists</h3></li>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -65,6 +65,11 @@ module Danbooru
       "Anonymous"
     end
 
+    # The path of the daily DB exports. Hidden from the site map if `nil`.
+    def db_export_path
+      "/db_export/"
+    end
+
     def levels
       {
         "Anonymous" => 0,


### PR DESCRIPTION
Downstream forks ([cough](https://e6ai.net/static/site_map) [cough](https://e6ai.net/db_export/)) might not have db exports (or db exports on a different path); this resolves that.

Untested.