### PR TITLE
[TagPreview] Fix tag preview height

### DIFF
--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -34,14 +34,20 @@ export default {
 
       for (const input of this.tagsArray) {
         const tag = this.tagCache[input];
-        if (!tag) continue;
+        if (tag) {
+          result.push(tag);
 
-        result.push(tag);
-
-        if (tag.implies && Array.isArray(tag.implies)) {
-          for (const implication of tag.implies) {
-            implications.add(implication);
+          if (tag.implies && Array.isArray(tag.implies)) {
+            for (const implication of tag.implies) {
+              implications.add(implication);
+            }
           }
+        } else {
+          result.push({
+            id: -1,
+            name: input,
+            category: 0,
+          });
         }
       }
 

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -8,11 +8,11 @@
        :data-implied="tag.implied"
        :data-count="tag.post_count">
     <tag-link :name="tag.alias || tag.resolved || tag.name" :tagType="tag.category" :wrap="true"></tag-link>
-    <span v-if="!tag.id" class="invalid">invalid</span>
+    <span v-if="tag.id == null" class="invalid">invalid</span>
     <span v-else-if="tag.duplicate" class="duplicate">duplicate</span>
     <span v-else-if="tag.implied" class="implied">implied</span>
     <span v-else-if="tag.post_count === 0" class="empty">empty</span>
-    <span v-else :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>
+    <span v-else-if="tag.post_count != null" :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>
   </div>
 </template>
 

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -60,11 +60,14 @@ div.tag-preview {
 
   display: grid;
   grid-template-columns: repeat(auto-fill, 16rem);
-
-  overflow: hidden;
+  grid-auto-rows: auto;
+  align-content: start;
 
   width: 100%;
+  height: 400px;
   max-height: 50vh;
+
+  overflow: hidden;
   overflow-y: auto;
   margin-bottom: 0.25em;
   padding: 2px;


### PR DESCRIPTION
Adds:
- Tag preview now shows raw input tags while loading
- Tag preview height now static

Changes:
- Height now 400px, rather than roughly 450px on 1080p