### PR TITLE
[Wiki Preview] Fixed block elements not rendering correctly

### DIFF
--- a/app/javascript/src/styles/views/posts/index/partials/_wiki_excerpt.scss
+++ b/app/javascript/src/styles/views/posts/index/partials/_wiki_excerpt.scss
@@ -35,8 +35,7 @@
     // Gradient overlay
     // Is aligned w/ the parent element, but defaults to the `.styled-dtext` positioning
     &::before {
-      content: "."; // Makes it render
-      color: transparent; // Hides the content
+      content: ""; // Makes it render
       display: block;
       background: linear-gradient(to bottom, transparent, var(--color-section));
 
@@ -52,8 +51,8 @@
       
       box-sizing: border-box;
       padding: 0;
-	    height: 100%;
-	    width: 100%;
+      height: 100%;
+      width: 100%;
     }
 
     min-height: 0rem;

--- a/app/javascript/src/styles/views/posts/index/partials/_wiki_excerpt.scss
+++ b/app/javascript/src/styles/views/posts/index/partials/_wiki_excerpt.scss
@@ -38,20 +38,20 @@
       content: "."; // Makes it render
       color: transparent; // Hides the content
       display: block;
-	    background: linear-gradient(to bottom, transparent, var(--color-section));
+      background: linear-gradient(to bottom, transparent, var(--color-section));
 
       // Account for left padding if not using `position: relative` on `.styled-dtext` by using `left: 0;`, & if the absence of a `top` value stops working, `top: 3rem;` + whatever top padding there is seemed to work, but is less resilient to change.
-	    position: absolute;
+      position: absolute;
 
       // Needs to match `.styled-dtext`
-	    max-height: 0rem;
-	    min-height: 0rem;
+      max-height: 0rem;
+      min-height: 0rem;
       // Needs to animate w/ `.styled-dtext`
       transition: max-height 0.25s;
       overflow: hidden;
       
-	    box-sizing: border-box;
-	    padding: 0;
+      box-sizing: border-box;
+      padding: 0;
 	    height: 100%;
 	    width: 100%;
     }

--- a/app/javascript/src/styles/views/posts/index/partials/_wiki_excerpt.scss
+++ b/app/javascript/src/styles/views/posts/index/partials/_wiki_excerpt.scss
@@ -30,10 +30,31 @@
 
   // body
   .styled-dtext {
-    background: linear-gradient(to top, themed("color-section"), themed("color-text"));
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
+    // Needed for the gradient overlay to work (for when height is between max & min; & helps w/ positioning)
+    position: relative;
+    // Gradient overlay
+    // Is aligned w/ the parent element, but defaults to the `.styled-dtext` positioning
+    &::before {
+      content: "."; // Makes it render
+      color: transparent; // Hides the content
+      display: block;
+	    background: linear-gradient(to bottom, transparent, var(--color-section));
+
+      // Account for left padding if not using `position: relative` on `.styled-dtext` by using `left: 0;`, & if the absence of a `top` value stops working, `top: 3rem;` + whatever top padding there is seemed to work, but is less resilient to change.
+	    position: absolute;
+
+      // Needs to match `.styled-dtext`
+	    max-height: 0rem;
+	    min-height: 0rem;
+      // Needs to animate w/ `.styled-dtext`
+      transition: max-height 0.25s;
+      overflow: hidden;
+      
+	    box-sizing: border-box;
+	    padding: 0;
+	    height: 100%;
+	    width: 100%;
+    }
 
     min-height: 0rem;
     max-height: 0rem;
@@ -88,7 +109,7 @@
 
   &.open{
     .wiki-excerpt-toggle svg { transform: rotate(90deg); }
-    .styled-dtext {
+    .styled-dtext, .styled-dtext::before {
       max-height: 10rem;
       min-height: 2rem;
     }


### PR DESCRIPTION
Fixes [topic #57893](https://e621.net/forum_topics/57893) & [this](https://discord.com/channels/431908090883997698/1392682818890498059/1413209787747008672).
From
<img width="1123" height="165" alt="image" src="https://github.com/user-attachments/assets/213c273f-b60e-4491-bb99-aa310d37ab0d" />

To
<img width="1091" height="105" alt="image" src="https://github.com/user-attachments/assets/9b3592c4-bc58-4de6-9d0a-a84fc12faf45" />
Tested.