### PR TITLE
[PostReplacements] Fix not being able to replace posts that are smaller than 256px

### DIFF
--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -60,6 +60,11 @@ class PostReplacementsController < ApplicationController
     @post_replacement = PostReplacement.find(params[:id])
     @post_replacement.approve!(penalize_current_uploader: params[:penalize_current_uploader])
 
+    if @post_replacement.errors.any?
+      render plain: "Replacement approval failed: #{@post_replacement.errors.full_messages.join('; ')}", status: 400
+      return
+    end
+
     respond_with(@post_replacement) do |format|
       format.html { render_partial_safely("post_replacements/partials/show/post_replacement", post_replacement: @post_replacement) }
       format.json

--- a/app/logical/file_validator.rb
+++ b/app/logical/file_validator.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class FileValidator
-  attr_reader :record, :file_path
+  attr_reader :record, :file_path, :test_resolution
 
-  def initialize(record, file_path)
+  def initialize(record, file_path, test_resolution: true)
     @record = record
     @file_path = file_path
+    @test_resolution = test_resolution
   end
 
   def validate(max_file_sizes: Danbooru.config.max_file_sizes, max_width: Danbooru.config.max_image_width, max_height: Danbooru.config.max_image_height, min_width: Danbooru.config.min_image_width)
@@ -20,7 +21,7 @@ class FileValidator
       validate_colorspace(video)
       validate_sar(video)
     end
-    validate_resolution(max_width, max_height, min_width)
+    validate_resolution(max_width, max_height, min_width) if @test_resolution
   end
 
   def validate_file_integrity

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -25,7 +25,7 @@ class PostReplacement < ApplicationRecord
     end
   end
   validate on: :create do |replacement|
-    FileValidator.new(replacement, replacement_file.path).validate
+    FileValidator.new(replacement, replacement_file.path, test_resolution: !is_backup).validate
     throw :abort if errors.any?
   end
   validate :no_pending_duplicates, on: :create
@@ -209,6 +209,10 @@ class PostReplacement < ApplicationRecord
       if is_rejected? # We need to undo the rejection count
         UserStatus.for_user(creator_id).update_all("post_replacement_rejected_count = post_replacement_rejected_count - 1")
       end
+
+      # Validate the replacement file before processing
+      FileValidator.new(self, replacement_file_path).validate
+      return if errors.any?
 
       processor = UploadService::Replacer.new(post: post, replacement: self)
       processor.process!(penalize_current_uploader: penalize_current_uploader)


### PR DESCRIPTION
This creates another issue with backups of these posts not being restorable.
But that should not be a problem.