### PR TITLE
[Mascots] Add previews to the mascot management page

### DIFF
--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -47,6 +47,7 @@
 @import "views/application/application";
 @import "views/artists/artists";
 @import "views/maintenance/maintenance";
+@import "views/mascots/mascots";
 @import "views/post_flags/post_flags";
 @import "views/posts/posts";
 @import "views/static/static";

--- a/app/javascript/src/styles/views/mascots/_mascots.scss
+++ b/app/javascript/src/styles/views/mascots/_mascots.scss
@@ -1,0 +1,29 @@
+.mascot-preview {
+  background-size: contain;
+  background-position: top center;
+  background-repeat: no-repeat;
+
+  border: 1px solid themed("color-background");
+  @include st-radius;
+
+  height: 9rem;
+  width: 16rem;
+  position: relative;
+  margin: 0.5rem 0;
+
+  & &-search {
+    position: absolute;
+    top: 60%;
+    left: 15%;
+
+    width: 70%;
+    height: 2rem;
+  }
+}
+
+.mascot-thumbnail {
+  height: 2rem;
+  width: 2rem;
+  margin: -0.5rem 0;
+  object-fit: cover;
+}

--- a/app/views/mascots/edit.html.erb
+++ b/app/views/mascots/edit.html.erb
@@ -1,6 +1,15 @@
 <div class="c-mascots">
   <div class="a-edit">
     <h1>Edit Mascot</h1>
+    <div
+      class="mascot-preview"
+      style="background-image: url('<%= @mascot.url_path %>'); background-color: <%= @mascot.background_color %>;">
+      <div
+        class="mascot-preview-search"
+        style="background-color: <%= @mascot.foreground_color %>;"
+      ></div>
+    </div>
+    
     <%= render "form", mascot: @mascot %>
   </div>
 </div>

--- a/app/views/mascots/index.html.erb
+++ b/app/views/mascots/index.html.erb
@@ -23,7 +23,10 @@
         <% @mascots.each do |mascot| %>
           <tr>
             <td><%= mascot.id %></td>
-            <td><%= link_to mascot.display_name, mascot.url_path %></td>
+            <td>
+              <img src="<%= mascot.url_path %>" alt="<%= mascot.display_name %>" class="mascot-thumbnail" />
+              <%= link_to mascot.display_name, mascot.url_path %>
+            </td>
             <td><%= mascot.background_color %></td>
             <td><%= mascot.foreground_color %></td>
             <td><%= mascot.artist_name %></td>


### PR DESCRIPTION
<img width="593" height="621" alt="Screenshot 2025-09-19 171529" src="https://github.com/user-attachments/assets/93a58d01-1c56-41cb-bc6a-27b8a3258e5a" />
