### PR TITLE
[ExceptionLogs] Revamp exception log search

### DIFF
--- a/app/controllers/admin/exceptions_controller.rb
+++ b/app/controllers/admin/exceptions_controller.rb
@@ -20,7 +20,7 @@ module Admin
       end
 
       respond_with(@exception_log) do |format|
-        format.json { render json: @exception_log.to_json }
+        format.json { render json: @exception_log }
       end
     end
   end

--- a/app/controllers/admin/exceptions_controller.rb
+++ b/app/controllers/admin/exceptions_controller.rb
@@ -2,17 +2,25 @@
 
 module Admin
   class ExceptionsController < ApplicationController
+    respond_to :json, :html
     before_action :admin_only
 
     def index
-      @exception_logs = ExceptionLog.search(search_params).paginate(params[:page], limit: 100)
+      @exception_logs = ExceptionLog.search(search_params).includes(:user).paginate(params[:page], limit: 100)
+      respond_with(@exception_logs) do |format|
+        format.json { render json: @exception_logs.to_json }
+      end
     end
 
     def show
       if params[:id] =~ /\A\d+\z/
-        @exception_log = ExceptionLog.find(params[:id])
+        @exception_log = ExceptionLog.includes(:user).find(params[:id])
       else
-        @exception_log = ExceptionLog.find_by!(code: params[:id])
+        @exception_log = ExceptionLog.includes(:user).find_by!(code: params[:id])
+      end
+
+      respond_with(@exception_log) do |format|
+        format.json { render json: @exception_log.to_json }
       end
     end
   end

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -38,8 +38,9 @@ class ExceptionLog < ApplicationRecord
   end
 
   def user
-    # For reasons that are beyond me, user IDs were not being saved to the correct database column.
-    # It had been fixed now, but old records still need to be looked up from the extra_params field.
+    # Prior to March 2024, user IDs were only stored in the extra_params["user_id"] field,
+    # instead of the user_id database column. As of March 2024, this was fixed and user_id is now
+    # properly stored in the user_id column. This fallback is needed to support old records.
     return super if super.present?
     User.find_by(id: extra_params["user_id"])
   end

--- a/app/views/admin/exceptions/_secondary_links.html.erb
+++ b/app/views/admin/exceptions/_secondary_links.html.erb
@@ -1,0 +1,3 @@
+<% content_for(:secondary_links) do %>
+  <%= subnav_link_to "List", admin_exceptions_path %>
+<% end %>

--- a/app/views/admin/exceptions/index.html.erb
+++ b/app/views/admin/exceptions/index.html.erb
@@ -1,5 +1,6 @@
 <%= form_search(path: admin_exceptions_path) do |f| %>
-  <%= f.input :commit %>
+  <%= f.user :user %>
+  <%= f.input :code %>
   <%= f.input :class_name %>
   <%= f.input :without_class_name %>
 <% end %>
@@ -7,29 +8,34 @@
 <table class="striped">
   <thead>
     <tr>
-      <th style="width: 200px">Created At</th>
+      <th style="width: 125px;">Created At</th>
+      <th>User</th>
       <th>Code</th>
-      <th style="width: 100px">Commit</th>
-      <th>Controller/Action</th>
-      <th>Class Name</th>
+      <th>Error</th>
       <th>Message</th>
-      <th>Stacktrace</th>
+      <th style="width: 50px;"></th>
     </tr>
   </thead>
   <tbody>
     <% @exception_logs.each do |exception_log| %>
       <tr>
         <td><%= compact_time exception_log.created_at %></td>
+        <td><%= link_to_user(exception_log.user) %></td>
         <td><%= exception_log.code %></td>
-        <td><%= link_to exception_log.version, GitHelper.commit_url(exception_log.version) %></td>
-        <td><%= exception_log.extra_params.dig("params", "controller") %>/<%= exception_log.extra_params.dig("params", "action") %></td>
-        <td><%= exception_log.class_name %></td>
-        <td><%= truncate(exception_log.message, length: 500) %></td>
+        <td>
+          <%= exception_log.extra_params.dig("params", "controller") %>/<%= exception_log.extra_params.dig("params", "action") %>
+        </td>
+        <td>
+          <b><%= exception_log.class_name %></b><br />
+          <%= truncate(exception_log.message, length: 500) %>
+        </td>
         <td><%= link_to "View", admin_exception_path(exception_log) %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
+
+<%= render partial: "secondary_links" %>
 
 <% content_for(:page_title) do %>
   Exceptions

--- a/app/views/admin/exceptions/show.html.erb
+++ b/app/views/admin/exceptions/show.html.erb
@@ -19,6 +19,8 @@
   <pre class="box-section"><%= @exception_log.trace %></pre>
 </div>
 
+<%= render partial: "secondary_links" %>
+
 <% content_for(:page_title) do %>
   Exceptions - <%= @exception_log.code %>
 <% end %>

--- a/db/migrate/20250921011208_add_exception_log_indexes.rb
+++ b/db/migrate/20250921011208_add_exception_log_indexes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddExceptionLogIndexes < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :exception_logs, :users, column: :user_id
+    add_index :exception_logs, :user_id
+    add_index :exception_logs, :code
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3793,6 +3793,20 @@ CREATE INDEX index_edit_histories_on_versionable_id_and_versionable_type ON publ
 
 
 --
+-- Name: index_exception_logs_on_code; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_exception_logs_on_code ON public.exception_logs USING btree (code);
+
+
+--
+-- Name: index_exception_logs_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_exception_logs_on_user_id ON public.exception_logs USING btree (user_id);
+
+
+--
 -- Name: index_favorites_on_post_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4750,6 +4764,14 @@ ALTER TABLE ONLY public.post_events
 
 
 --
+-- Name: exception_logs fk_rails_c720bf523c; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.exception_logs
+    ADD CONSTRAINT fk_rails_c720bf523c FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: avoid_postings fk_rails_cccc6419c8; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4788,6 +4810,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250921011208'),
 ('20250831040648'),
 ('20250831015612'),
 ('20250830192056'),


### PR DESCRIPTION
Added user search and made exception code search more obvious.
Also added the JSON endpoint, just in case.

There is a notable issue with the user search.
Until now, the user ID was not getting logged properly. This had been fixed now, but older log entries are still not searchable this way. In the future, we'll have to either back-fill that data, or simply start deleting older exceptions from the log.

Fixes #1309.