### PR TITLE
[Pools] Do not create pool versions if nothing was changed

### DIFF
--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -95,7 +95,7 @@ class Pool < ApplicationRecord
 
   module VersionMethods
     def create_version(updater: CurrentUser.user, updater_ip_addr: CurrentUser.ip_addr)
-      return unless new_record? || saved_change_to_watched_attributes?
+      return unless saved_change_to_watched_attributes?
       PoolVersion.queue(self, updater, updater_ip_addr)
     end
 
@@ -109,6 +109,8 @@ class Pool < ApplicationRecord
       self.post_ids = version.post_ids
       self.name = version.name
       self.description = version.description
+      self.is_active = version.is_active
+      self.category = version.category
       save
     end
   end

--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -2,7 +2,7 @@
 
 class PoolVersion < ApplicationRecord
   user_status_counter :pool_edit_count, foreign_key: :updater_id
-  belongs_to :updater, :class_name => "User"
+  belongs_to :updater, class_name: "User"
   before_validation :fill_version, on: :create
   before_validation :fill_changes, on: :create
 
@@ -35,16 +35,16 @@ class PoolVersion < ApplicationRecord
   extend SearchMethods
 
   def self.queue(pool, updater, updater_ip_addr)
-    self.create({
-                    pool_id: pool.id,
-                    post_ids: pool.post_ids,
-                    updater_id: updater.id,
-                    updater_ip_addr: updater_ip_addr,
-                    description: pool.description,
-                    name: pool.name,
-                    is_active: pool.is_active?,
-                    category: pool.category
-                })
+    create({
+      pool_id: pool.id,
+      post_ids: pool.post_ids,
+      updater_id: updater.id,
+      updater_ip_addr: updater_ip_addr,
+      description: pool.description,
+      name: pool.name,
+      is_active: pool.is_active?,
+      category: pool.category,
+    })
   end
 
   def self.calculate_version(pool_id)
@@ -52,7 +52,7 @@ class PoolVersion < ApplicationRecord
   end
 
   def fill_version
-    self.version = PoolVersion.calculate_version(self.pool_id)
+    self.version = PoolVersion.calculate_version(pool_id)
   end
 
   def fill_changes
@@ -85,6 +85,6 @@ class PoolVersion < ApplicationRecord
   end
 
   def pretty_name
-    name&.tr("_", " ") || '(Unknown Name)'
+    name&.tr("_", " ") || "(Unknown Name)"
   end
 end

--- a/app/views/pool_versions/_revert_listing.html.erb
+++ b/app/views/pool_versions/_revert_listing.html.erb
@@ -10,6 +10,7 @@
         <% if CurrentUser.is_admin? %>
           <th>IP Address</th>
         <% end %>
+        <th>Active?</th>
         <th>Date</th>
         <% if CurrentUser.is_member? %>
           <th></th>
@@ -33,6 +34,7 @@
               <%= link_to_ip pool_version.updater_ip_addr %>
             </td>
           <% end %>
+          <td><%= pool_version.is_active? ? "Yes" : "No" %></td>
           <td><%= compact_time pool_version.updated_at %></td>
           <% if CurrentUser.is_member? %>
             <td>


### PR DESCRIPTION
Minor refactoring of the pool model, for good measure.
Also, properly displayed whether the pool is active or not in the version history.

Fixes #1308