### PR TITLE
[Uploads] Fix duplicate param in uploads controller

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -72,7 +72,7 @@ class UploadsController < ApplicationController
 
   def upload_params
     permitted_params = %i[
-      file direct_url source tag_string rating parent_id description description as_pending
+      file direct_url source tag_string rating parent_id description as_pending
     ]
 
     permitted_params << :locked_tags if CurrentUser.is_admin?


### PR DESCRIPTION
For some reason, `description` was listed twice. This removed one of them. That is all. A tiny refactor. 