### PR TITLE
[UI] Unify the logic for closing dropdown menus

### DIFF
--- a/app/javascript/src/javascripts/navigation.js
+++ b/app/javascript/src/javascripts/navigation.js
@@ -1,3 +1,5 @@
+import Offclick from "./utility/offclick";
+
 const Navigation = {};
 
 Navigation.init = function () {
@@ -13,27 +15,20 @@ Navigation.init = function () {
   });
 
 
-  // Profile menu, both desktop and mobile
-  let avatarMenuOpen = false;
-
   // regular click
+  let offclickHandler = null;
   $(".simple-avatar").on("click", (event) => {
     event.preventDefault();
 
-    avatarMenuOpen = !avatarMenuOpen;
-    simpleMenu.toggleClass("hidden");
+    // Register offclick handler on the first use
+    if (offclickHandler === null)
+      offclickHandler = Offclick.register(".simple-avatar", ".simple-avatar-menu", () => {
+        simpleMenu.addClass("hidden");
+      });
+
+    offclickHandler.disabled = !offclickHandler.disabled;
+    simpleMenu.toggleClass("hidden", offclickHandler.disabled);
     wrapper.removeClass("nav-toggled");
-  });
-
-  // click outside the menu
-  $(window).on("mouseup", (event) => {
-    if (!avatarMenuOpen) return;
-
-    const target = $(event.target);
-    if (target.closest(".nav-controls").length > 0) return;
-
-    simpleMenu.addClass("hidden");
-    avatarMenuOpen = false;
   });
 };
 

--- a/app/javascript/src/javascripts/post_search.js
+++ b/app/javascript/src/javascripts/post_search.js
@@ -1,5 +1,6 @@
 import LStorage from "./utility/storage";
 import Page from "./utility/page";
+import Offclick from "./utility/offclick";
 
 const PostSearch = {};
 
@@ -69,34 +70,25 @@ PostSearch.initialize_controls = function () {
     LStorage.Posts.Fullscreen = fullscreen;
   });
 
-  // Menu toggle
-  let settingsVisible = false;
-  const menu = $(".search-settings-container"),
-    menuButton = $("#search-settings");
-  menuButton.on("click", () => {
-    settingsVisible = !settingsVisible;
-    menu.toggleClass("active", settingsVisible);
-    menuButton.toggleClass("active", settingsVisible);
+  // Menu open / close
+  const offclickHandler = Offclick.register("#search-settings", ".search-settings-container", () => {
+    menu.removeClass("active");
+    menuButton.removeClass("active");
+  });
+
+  const menu = $(".search-settings-container");
+  const menuButton = $("#search-settings").on("click", () => {
+    const state = offclickHandler.disabled;
+    menu.toggleClass("active", state);
+    menuButton.toggleClass("active", state);
+    offclickHandler.disabled = !state;
   });
 
   $("#search-settings-close").on("click", (event) => {
     event.preventDefault();
     menu.removeClass("active");
     menuButton.removeClass("active");
-    settingsVisible = false;
-  });
-
-  // click outside the menu
-  $(window).on("mouseup", (event) => {
-    if (!settingsVisible) return;
-
-    const target = $(event.target);
-    if (target.closest(".search-settings-container").length > 0 || target.is("#search-settings"))
-      return;
-
-    menu.removeClass("active");
-    menuButton.removeClass("active");
-    settingsVisible = false;
+    offclickHandler.disabled = true;
   });
 
   // Menu toggles

--- a/app/javascript/src/javascripts/utility/offclick.js
+++ b/app/javascript/src/javascripts/utility/offclick.js
@@ -1,0 +1,75 @@
+/**
+ * Offclick handler
+ * Handles the logic for closing menus when clicking outside of them.
+ * Usage:
+ *   const offclickHandler = Offclick.register("#menu-button", ".menu-container", () => {
+ *     // Close the menu
+ *   });
+ */
+export default class Offclick {
+
+  registry = [];
+  globalDisabled = true;
+
+  constructor () {
+    $(window).on("mouseup", (event) => {
+      if (this.globalDisabled) return;
+      if (event.button !== 0) return; // Only left click
+
+      const target = $(event.target);
+
+      for (const entry of this.registry) {
+        if (entry.disabled) continue;
+
+        if (target.closest(entry.menuSelector).length > 0 // Click inside the menu
+            || target.is(entry.buttonSelector) // Click the button itself
+            || target.parents(entry.buttonSelector).length > 0) // Click inside one of the button's children
+          continue;
+
+        entry.callback();
+        entry.disabled = true;
+      }
+    });
+  }
+
+  // If all entries are disabled, skip processing clicks.
+  recalculateGlobalDisabled () {
+    this.globalDisabled = this.registry.every(entry => entry.disabled);
+  }
+
+  // Singleton pattern
+  static _instance = null;
+  static get instance() {
+    if (this._instance === null)
+      this._instance = new Offclick();
+    return this._instance;
+  }
+
+  /**
+   * Register a new offclick handler.
+   * @param {string} buttonSelector The selector for the button that toggles the menu.
+   * @param {*} menuSelector The selector for the menu container.
+   * @param {*} callback The callback to invoke when clicking outside the menu.
+   * @returns {Object} An object with a `disabled` property that can be toggled to enable/disable the offclick handler.
+   */
+  static register (buttonSelector, menuSelector, callback) {
+    const entry = {
+      buttonSelector: buttonSelector,
+      menuSelector: menuSelector,
+      callback: callback,
+      disabled: true, // Unused, but without it the linter complains
+      _disabled: true, // Actual storage for the disabled state
+    };
+
+    Object.defineProperty(entry, "disabled", {
+      get () { return this._disabled; },
+      set (value) {
+        this._disabled = value;
+        Offclick.instance.recalculateGlobalDisabled();
+      },
+    });
+
+    this.instance.registry.push(entry);
+    return entry;
+  }
+}

--- a/app/javascript/src/javascripts/utility/offclick.js
+++ b/app/javascript/src/javascripts/utility/offclick.js
@@ -48,8 +48,8 @@ export default class Offclick {
   /**
    * Register a new offclick handler.
    * @param {string} buttonSelector The selector for the button that toggles the menu.
-   * @param {*} menuSelector The selector for the menu container.
-   * @param {*} callback The callback to invoke when clicking outside the menu.
+   * @param {string} menuSelector The selector for the menu container.
+   * @param {Function} callback The callback to invoke when clicking outside the menu.
    * @returns {Object} An object with a `disabled` property that can be toggled to enable/disable the offclick handler.
    */
   static register (buttonSelector, menuSelector, callback) {

--- a/app/javascript/src/javascripts/views/PostsShowToolbar.js
+++ b/app/javascript/src/javascripts/views/PostsShowToolbar.js
@@ -3,6 +3,7 @@ import Favorite from "../models/Favorite";
 import PostVote from "../models/PostVote";
 import Post from "../posts";
 import Utility from "../utility";
+import Offclick from "../utility/offclick";
 import Page from "../utility/page";
 import LStorage from "../utility/storage";
 
@@ -169,8 +170,16 @@ export default class PostsShowToolbar {
   // Fullscreen / download menu
   initOverflowMenu () {
     const menu = $(".ptbr-etc-menu");
+    let offclickHandler = null;
     $(".ptbr-etc-toggle").on("click", () => {
-      menu.toggleClass("hidden");
+      // Register offclick handler on the first use
+      if (offclickHandler === null)
+        offclickHandler = Offclick.register(".ptbr-etc-toggle", ".ptbr-etc-menu", () => {
+          menu.addClass("hidden");
+        });
+
+      offclickHandler.disabled = !offclickHandler.disabled;
+      menu.toggleClass("hidden", offclickHandler.disabled);
     });
 
     const button = $(".ptbr-etc-download").on("click.e6.prepare", async (event) => {


### PR DESCRIPTION
Fixes #1318, among other things.
The logic for closing dropdown menus after clicking outside of the menu area is now handled by one class.