### PR TITLE
[TagPreview] Fix invalid tag detection

### DIFF
--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -8,7 +8,8 @@
        :data-implied="tag.implied"
        :data-count="tag.post_count">
     <tag-link :name="tag.alias || tag.resolved || tag.name" :tagType="tag.category" :wrap="true"></tag-link>
-    <span v-if="tag.id == null" class="invalid">invalid</span>
+    <span v-if="tag.id == null" class="new">new</span>
+    <span v-else-if="tag.category === 6" class="invalid">invalid</span>
     <span v-else-if="tag.duplicate" class="duplicate">duplicate</span>
     <span v-else-if="tag.implied" class="implied">implied</span>
     <span v-else-if="tag.post_count === 0" class="empty">empty</span>

--- a/app/javascript/src/styles/specific/related_tags.scss
+++ b/app/javascript/src/styles/specific/related_tags.scss
@@ -91,7 +91,8 @@ div.tag-preview {
     & .empty,
     .underused,
     .invalid,
-    .duplicate {
+    .duplicate,
+    .new {
       color: themed("palette-text-red");
     }
   }


### PR DESCRIPTION
Fixes:
- Tag preview now correctly marks category 6 tags as invalid

Changes:
- Separated logic for new tags (id == null) and invalid tags (category === 6)

Fixes #1330.