### PR TITLE
[TagPreview] Add implication tooltips

### DIFF
--- a/app/javascript/src/javascripts/uploader/tag_preview.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview.vue
@@ -30,7 +30,7 @@ export default {
     },
     tagRecords() {
       const result = [];
-      const implications = new Set();
+      const implications = new Map();
 
       for (const input of this.tagsArray) {
         const tag = this.tagCache[input];
@@ -39,7 +39,10 @@ export default {
 
           if (tag.implies && Array.isArray(tag.implies)) {
             for (const implication of tag.implies) {
-              implications.add(implication);
+              if (!implications.has(implication)) {
+                implications.set(implication, []);
+              }
+              implications.get(implication).push(tag.name);
             }
           }
         } else {
@@ -63,16 +66,16 @@ export default {
 
       // Aliases do not need to be added. They will be displayed by their original input via the alias field.
 
-      for (const implication of implications) {
+      for (const implication of implications.keys()) {
         // Any tag implied by any other is always marked as implied. 
         // This is more useful for quick relation mapping and discovery of the existence of implications.
         const current = result.find(tag => tag.name === implication);
         if (current) {
-          current.implied = true;
+          current.impliedBy = implications.get(implication);
         } else {
           const implied = this.tagCache[implication];
           if (!implied) continue;
-          result.push({ ...implied, implied: true });
+          result.push({ ...implied, impliedBy: implications.get(implication) });
         }
       }
 

--- a/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
+++ b/app/javascript/src/javascripts/uploader/tag_preview_tag.vue
@@ -5,12 +5,12 @@
        :data-name="tag.name" 
        :data-resolved="tag.resolved"
        :data-alias="tag.alias"
-       :data-implied="tag.implied"
+       :data-implied="tag.impliedBy?.join(' ')"
        :data-count="tag.post_count">
     <tag-link :name="tag.alias || tag.resolved || tag.name" :tagType="tag.category" :wrap="true"></tag-link>
     <span v-if="tag.id == null" class="invalid">invalid</span>
     <span v-else-if="tag.duplicate" class="duplicate">duplicate</span>
-    <span v-else-if="tag.implied" class="implied">implied</span>
+    <span v-else-if="tag.impliedBy && tag.impliedBy.length > 0" class="implied" :title="getImpliedTooltip(tag)">implied</span>
     <span v-else-if="tag.post_count === 0" class="empty">empty</span>
     <span v-else-if="tag.post_count != null" :class="{'post-count': true, 'underused': tag.post_count === 1 && tag.category === 0}">{{ formatTagCount(tag.post_count) }}</span>
   </div>
@@ -27,6 +27,9 @@ export default {
   methods: {
     formatTagCount(count) {
       return new Intl.NumberFormat('en', { notation: 'compact', compactDisplay: 'short' }).format(count).toLowerCase();
+    },
+    getImpliedTooltip(tag) {
+      return `Implied by ${tag.impliedBy.join(", ")}`;
     },
   },
 };


### PR DESCRIPTION
Adds:
- Hover title showing which tags cause implications

This allows desktop users to access this information, but won't work on mobile. 
Fixes #1350 for now.