### PR TITLE
[Dialog] Minor dialog enhancements

### DIFF
--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -1,11 +1,13 @@
 export default class Dialog {
 
-  /** Container to which all dialogs are appended */
+  id = 0;
+
   static _container = null;
   static containerWidth = 0;
   static containerHeight = 0;
-  /** Used to store the current timeout */
+
   static _currentTimeout = null;
+
   /** Container to which all dialogs are appended */
   static get container () {
     if (this._container !== null) return this._container;
@@ -18,7 +20,7 @@ export default class Dialog {
 
     // Fullscreen changes
     $(document).on("fullscreenchange webkitfullscreenchange mozfullscreenchange MSFullscreenChange", () => {
-      if (this._currentTimeout) clearTimeout(this._currentTimeout); // Stops quickly toggling fullscreen causing trouble
+      if (this._currentTimeout) clearTimeout(this._currentTimeout);
       this._currentTimeout = setTimeout(this.onUpdateContainerDimensions, 100); // Small delay to ensure layout has settled
     });
 
@@ -32,12 +34,10 @@ export default class Dialog {
 
   /**
    * The event handler for autonomic container resizing.
-   * 
    * Updates the container dimensions, cancels & resets the stored timeout reference (if set), & fires the `dialogContainer:resize` event if the dimensions changed.
-   * 
    * Ignores the value of `this`.
    */
-  static onUpdateContainerDimensions() {
+  static onUpdateContainerDimensions () {
     const priorWidth = Dialog.containerWidth, priorHeight = Dialog.containerHeight;
     Dialog.updateContainerDimensions();
     if (Dialog._currentTimeout) {
@@ -57,12 +57,12 @@ export default class Dialog {
   };
 
   /**
-   * 
-   * @param {string|number} value 
+   * Takes a string label or number and returns a normalized position value between 0 and 1.
+   * @param {string|number} value The position label or number to resolve.
    * @returns {number} A normalized number reflecting the bounded value (or a fallback if given bad input).
    */
-  static resolveToNormalizedPosition(value) {
-    return Dialog.normalizedPositionLabel[value] || (typeof(value) === "number" ? Math.max(Math.min(value, 1), 0) : 0.5);
+  static resolveToNormalizedPosition (value) {
+    return Dialog.normalizedPositionLabel[value] || (typeof (value) === "number" ? Math.max(Math.min(value, 1), 0) : 0.5);
   }
 
   // #region Dialog z-stacking and focus management
@@ -97,15 +97,7 @@ export default class Dialog {
   }
   // #endregion Dialog z-stacking and focus management
 
-  /**
-   * The main dialog element
-   * @type {JQuery<HTMLDivElement>?}
-   */
   $dialog = null;
-  /**
-   * Content element attached to the dialog
-   * @type {JQuery<HTMLElement>?}
-   */
   $element = null;
   dialogWidth = 0;
   dialogHeight = 0;
@@ -113,7 +105,6 @@ export default class Dialog {
     Dialog.normalizedPositionLabel["center"],
     Dialog.normalizedPositionLabel["center"],
   ];
-  id = 0;
 
   /**
    * Create a new dialog.
@@ -211,11 +202,9 @@ export default class Dialog {
   }
 
   /** Stop the rebinding. */
-  onResize(e) { e.data.obj.recalculatePosition(); }
+  onResize (e) { e.data.obj.recalculatePosition(); }
 
-  /**
-   * Recalculate the dialog's position based on the given normalized position and the container size.
-   */
+  /** Recalculate the dialog's position based on the given normalized position and the container size. */
   recalculatePosition () {
     const _max = {
       x: Dialog.containerWidth - this.dialogWidth,
@@ -223,9 +212,9 @@ export default class Dialog {
     };
 
     // Don't adjust unless it's not pinned or any part of it would be outside the container.
-    if (this.isPinned &&
-      this.xMin >= 0 && this.xMax <= _max.x &&
-      this.yMin >= 0 && this.yMax <= _max.y)
+    if (this.isPinned
+      && this.xMin >= 0 && this.xMax <= _max.x
+      && this.yMin >= 0 && this.yMax <= _max.y)
       return;
 
     const positionDef = this.currentNormalizedPosition;
@@ -305,10 +294,10 @@ export default class Dialog {
     else this.open();
   }
 
-  get xMin() { return Number(this.$dialog.css("left")); }
-  get yMin() { return Number(this.$dialog.css("top")); }
-  get xMax() { return Number(this.$dialog.css("left")) + this.dialogWidth; }
-  get yMax() { return Number(this.$dialog.css("top")) + this.dialogHeight; }
+  get xMin () { return Number(this.$dialog.css("left")); }
+  get yMin () { return Number(this.$dialog.css("top")); }
+  get xMax () { return Number(this.$dialog.css("left")) + this.dialogWidth; }
+  get yMax () { return Number(this.$dialog.css("top")) + this.dialogHeight; }
 
   _isPinned = true;
   /** True if the dialog is currently pinned */
@@ -321,7 +310,7 @@ export default class Dialog {
     }
   }
 
-  togglePin() { return this.isPinned = !this.isPinned; }
+  togglePin () { return this.isPinned = !this.isPinned; }
 
   /** Completely destroy the dialog and clean up all resources */
   destroy () {

--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -4,6 +4,8 @@ export default class Dialog {
   static _container = null;
   static containerWidth = 0;
   static containerHeight = 0;
+  // Used to store the current timeout
+  static _currentTimeout = null;
   static get container () {
     if (this._container !== null) return this._container;
 
@@ -15,7 +17,8 @@ export default class Dialog {
 
     // Fullscreen changes
     $(document).on("fullscreenchange webkitfullscreenchange mozfullscreenchange MSFullscreenChange", () => {
-      setTimeout(() => this.updateContainerDimensions(), 100); // Small delay to ensure layout has settled
+      if (this._currentTimeout) clearTimeout(this._currentTimeout); // Stops quickly toggling fullscreen causing trouble
+      this._currentTimeout = setTimeout(() => this.updateContainerDimensions(), 100); // Small delay to ensure layout has settled
     });
 
     return this._container;
@@ -74,7 +77,7 @@ export default class Dialog {
 
   /**
    * Create a new dialog.
-   * Parmeters could be passed in via a data-attribute on the element as well.
+   * Parameters could be passed in via a data-attribute on the element as well.
    * @param {JQuery<HTMLElement> | string} element Either a jQuery element or a selector string for the dialog content.
    * @param {any} params Configuration parameters.
    *   - title: Title text for the dialog header.

--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -222,7 +222,18 @@ export default class Dialog {
       y: Dialog.containerHeight - this.dialogHeight,
     };
 
+    // Don't adjust unless it's not pinned or any part of it would be outside the container.
+    if (this.isPinned &&
+      this.xMin >= 0 && this.xMax <= _max.x &&
+      this.yMin >= 0 && this.yMax <= _max.y)
+      return;
+
     const positionDef = this.currentNormalizedPosition;
+
+    const projectedPosition = {
+      x: (_max.x) * positionDef[0],
+      y: (_max.y) * positionDef[1],
+    };
 
     const positionCoords = {
       left: Math.max(0, Math.min((_max.x) * positionDef[0], _max.x)),
@@ -293,6 +304,24 @@ export default class Dialog {
     if (this.isOpen) this.close();
     else this.open();
   }
+
+  get xMin() { return Number(this.$dialog.css("left")); }
+  get yMin() { return Number(this.$dialog.css("top")); }
+  get xMax() { return Number(this.$dialog.css("left")) + this.dialogWidth; }
+  get yMax() { return Number(this.$dialog.css("top")) + this.dialogHeight; }
+
+  _isPinned = true;
+  /** True if the dialog is currently pinned */
+  get isPinned () { return this._isPinned; }
+  /** If changed to true, will trigger an update */
+  set isPinned (value) {
+    if (this._isPinned !== value) {
+      this._isPinned = value;
+      if (!value) this.recalculatePosition();
+    }
+  }
+
+  togglePin() { return this.isPinned = !this.isPinned; }
 
   /** Completely destroy the dialog and clean up all resources */
   destroy () {

--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -16,7 +16,7 @@ export default class Dialog {
     this.updateContainerDimensions();
 
     // Window dimension changes
-    $(window).on("resize orientationchange", () => this.onUpdateContainerDimensions());
+    $(window).on("resize.dialog orientationchange.dialog", () => this.onUpdateContainerDimensions());
 
     // Fullscreen changes
     $(document).on("fullscreenchange webkitfullscreenchange mozfullscreenchange MSFullscreenChange", () => {

--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -213,15 +213,15 @@ export default class Dialog {
 
     // Don't adjust unless it's not pinned or any part of it would be outside the container.
     if (this.isPinned
-      && this.xMin >= 0 && this.xMax <= _max.x
-      && this.yMin >= 0 && this.yMax <= _max.y)
+      && this.xMin >= 0 && this.xMin <= _max.x
+      && this.yMin >= 0 && this.yMin <= _max.y)
       return;
 
     const positionDef = this.currentNormalizedPosition;
 
     const positionCoords = {
-      left: Math.max(0, Math.min((_max.x) * positionDef[0], _max.x)),
-      top:  Math.max(0, Math.min((_max.y) * positionDef[1], _max.y)),
+      left: Math.max(0, Math.min(_max.x * positionDef[0], _max.x)),
+      top:  Math.max(0, Math.min(_max.y * positionDef[1], _max.y)),
     };
 
     this._updatePosition(positionCoords.left, positionCoords.top);

--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -191,8 +191,8 @@ export default class Dialog {
     if (params.position) {
       const parts = params.position.trim().split(/\s+/);
       this.currentNormalizedPosition = [
-        Dialog.resolveToNormalizedPosition(parts[0]) || Dialog.normalizedPositionLabel["center"],
-        Dialog.resolveToNormalizedPosition(parts[1]) || Dialog.normalizedPositionLabel["center"],
+        Dialog.resolveToNormalizedPosition(parts[0]),
+        Dialog.resolveToNormalizedPosition(parts[1]),
       ];
     }
 
@@ -203,7 +203,7 @@ export default class Dialog {
 
     this.recalculatePosition();
 
-    $(window).on("dialogContainer:resize", { obj: this }, this.onResize)
+    $(window).on("dialogContainer:resize", { obj: this }, this.onResize);
 
     // Start open
     // Must be called after setting width/height and position
@@ -405,15 +405,17 @@ export default class Dialog {
 
     let newX = this.dialogStartX + (event.clientX - this.dragStartX);
     let newY = this.dialogStartY + (event.clientY - this.dragStartY);
+    const maxX = Dialog.containerWidth - this.dialogWidth;
+    const maxY = Dialog.containerHeight - this.dialogHeight;
 
     // Keep dialog within container bounds
-    newX = Math.max(0, Math.min(newX, Dialog.containerWidth - this.dialogWidth));
-    newY = Math.max(0, Math.min(newY, Dialog.containerHeight - this.dialogHeight));
+    newX = Math.max(0, Math.min(newX, maxX));
+    newY = Math.max(0, Math.min(newY, maxY));
 
     // Update for next resize
     this.currentNormalizedPosition = [
-      newX / (Dialog.containerWidth - this.dialogWidth),
-      newY / (Dialog.containerHeight - this.dialogHeight),
+      (maxX > 0 ? newX / maxX : 0),
+      (maxY > 0 ? newY / maxY : 0),
     ];
 
     this._updatePosition(newX, newY);

--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -16,7 +16,7 @@ export default class Dialog {
     this.updateContainerDimensions();
 
     // Window dimension changes
-    $(window).on("resize orientationchange", this.onUpdateContainerDimensions);
+    $(window).on("resize orientationchange", () => this.onUpdateContainerDimensions());
 
     // Fullscreen changes
     $(document).on("fullscreenchange webkitfullscreenchange mozfullscreenchange MSFullscreenChange", () => {
@@ -219,11 +219,6 @@ export default class Dialog {
 
     const positionDef = this.currentNormalizedPosition;
 
-    const projectedPosition = {
-      x: (_max.x) * positionDef[0],
-      y: (_max.y) * positionDef[1],
-    };
-
     const positionCoords = {
       left: Math.max(0, Math.min((_max.x) * positionDef[0], _max.x)),
       top:  Math.max(0, Math.min((_max.y) * positionDef[1], _max.y)),
@@ -291,8 +286,8 @@ export default class Dialog {
 
   _xMin = null;
   _yMin = null;
-  get xMin () { return this._xMin == 0 ? this._xMin : this._xMin ||= Number(this.$dialog.css("left")); }
-  get yMin () { return this._yMin == 0 ? this._yMin : this._yMin ||= Number(this.$dialog.css("top")); }
+  get xMin () { return (this._xMin == 0) ? this._xMin : (this._xMin ||= parseInt(this.$dialog.css("left"))); }
+  get yMin () { return (this._yMin == 0) ? this._yMin : (this._yMin ||= parseInt(this.$dialog.css("top"))); }
   get xMax () { return this.xMin + this.dialogWidth; }
   get yMax () { return this.yMin + this.dialogHeight; }
 
@@ -310,7 +305,7 @@ export default class Dialog {
   _isPinned = true;
   /** True if the dialog is currently pinned */
   get isPinned () { return this._isPinned; }
-  /** If changed to true, will trigger an update */
+  /** If unpinned, will trigger an update */
   set isPinned (value) {
     if (this._isPinned !== value) {
       this._isPinned = value;

--- a/app/javascript/src/javascripts/utility/dialog.js
+++ b/app/javascript/src/javascripts/utility/dialog.js
@@ -240,12 +240,7 @@ export default class Dialog {
       top:  Math.max(0, Math.min((_max.y) * positionDef[1], _max.y)),
     };
 
-    this.$dialog.css({
-      width: this.dialogWidth,
-      height: this.dialogHeight,
-      left: positionCoords.left,
-      top: positionCoords.top,
-    });
+    this._updatePosition(positionCoords.left, positionCoords.top);
   }
 
   setZIndex (z) {
@@ -305,10 +300,23 @@ export default class Dialog {
     else this.open();
   }
 
-  get xMin() { return Number(this.$dialog.css("left")); }
-  get yMin() { return Number(this.$dialog.css("top")); }
-  get xMax() { return Number(this.$dialog.css("left")) + this.dialogWidth; }
-  get yMax() { return Number(this.$dialog.css("top")) + this.dialogHeight; }
+  _xMin = null;
+  _yMin = null;
+  get xMin() { return this._xMin == 0 ? this._xMin : this._xMin ||= Number(this.$dialog.css("left")); }
+  get yMin() { return this._yMin == 0 ? this._yMin : this._yMin ||= Number(this.$dialog.css("top")); }
+  get xMax() { return this.xMin + this.dialogWidth; }
+  get yMax() { return this.yMin + this.dialogHeight; }
+
+  _updatePosition(xMin, yMin, width = this.dialogWidth, height = this.dialogHeight) {
+    this._xMin = xMin;
+    this._yMin = yMin;
+    this.$dialog.css({
+      width: width,
+      height: height,
+      left: xMin,
+      top: yMin,
+    });
+  }
 
   _isPinned = true;
   /** True if the dialog is currently pinned */
@@ -408,10 +416,7 @@ export default class Dialog {
       newY / (Dialog.containerHeight - this.dialogHeight),
     ];
 
-    this.$dialog.css({
-      left: newX,
-      top: newY,
-    });
+    this._updatePosition(newX, newY);
   }
 
   /** Stop dragging the dialog */


### PR DESCRIPTION
* Initial position definition is more flexible
* Improves handling of fullscreen toggles
* Stops dialog from going offscreen from resizing/fullscreen toggles
   * Stops dialog from sliding around when resizing unless it would exceed the containers bounds; can be toggled off for prior behavior, but the UI to do so is not there.