### PR TITLE
[CI] Run tests only if other checks succeed

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,7 +52,10 @@ jobs:
 
   tests:
     runs-on: ubuntu-22.04
-    needs: docker-build
+    needs:
+      - docker-build
+      - rubocop
+      - eslint
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
If rubocop or eslint checks fails, something has to be fixed regardless.
No need to run tests multiple times. Our actions usage is high enough as it is.