### PR TITLE
[Users] Optimize bit_prefs search

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   # UNDER NO CIRCUMSTANCES should new boolean attributes be added or removed from the middle of the #
   # list. Deprecated / unused bitflags should be prefixed with an underscore, and left in place.    #
   # Note: some users may still have the unused flags, so repurposing them can lead to unintended    #
-  # consequences. Procede with extreme caution.                                                     #
+  # consequences. Proceed with extreme caution.                                                     #
   # ================================================================================================#
 
   # ================================================================================================#

--- a/db/migrate/20251001213309_add_indexes_on_users_bit_prefs.rb
+++ b/db/migrate/20251001213309_add_indexes_on_users_bit_prefs.rb
@@ -4,44 +4,40 @@ class AddIndexesOnUsersBitPrefs < ActiveRecord::Migration[7.2]
   disable_ddl_transaction!
 
   def up
-    # Only two flags are currently used in bit_prefs filters in searches:
-    # :can_approve_posts and :can_upload_free
-    #
-    # IMPORTANT: We hardcode positions to make this migration reproducible
-    # even if the application constants change later.
-    # As of this migration:
-    # - can_approve_posts index == 15
-    # - can_upload_free  index == 16
-    cap_idx = 15
-    cuf_idx = 16
+    # ==============================================================================================#
+    # Only two bit flags have corresponding indexes as of right now.                                #
+    # Their positions are hardcoded to make the migration reproducible.                             #
+    # * can_approve_posts  index == 15                                                              #
+    # * can_upload_free    index == 16                                                              #
+    # ==============================================================================================#
 
-    # Build integer bit masks matching how flags are stored in bigint bit_prefs.
-    cap_mask = (1 << cap_idx)
-    cuf_mask = (1 << cuf_idx)
-
+    # Build integer bit masks
+    cap_mask = (1 << 15)
+    cuf_mask = (1 << 16)
     both_mask = cap_mask | cuf_mask
 
     # Create partial indexes matching the exact predicates used by search.
-    # TRUE (include) variants — these are highly selective and useful
+    # Only the TRUE variants are needed, as they typically include far fewer rows.
+
     add_index :users, :id,
-              name: :index_users_on_cap_include,
+              name: :index_users_on_bitprefs_cap,
               where: "(bit_prefs & #{cap_mask}) = #{cap_mask}",
               algorithm: :concurrently
 
     add_index :users, :id,
-              name: :index_users_on_cuf_include,
+              name: :index_users_on_bitprefs_cuf,
               where: "(bit_prefs & #{cuf_mask}) = #{cuf_mask}",
               algorithm: :concurrently
 
     add_index :users, :id,
-              name: :index_users_on_both_include,
+              name: :index_users_on_bitprefs_both,
               where: "(bit_prefs & #{both_mask}) = #{both_mask}",
               algorithm: :concurrently
   end
 
   def down
-    remove_index :users, name: :index_users_on_both_include, algorithm: :concurrently, if_exists: true
-    remove_index :users, name: :index_users_on_cuf_include,  algorithm: :concurrently, if_exists: true
-    remove_index :users, name: :index_users_on_cap_include,  algorithm: :concurrently, if_exists: true
+    remove_index :users, name: :index_users_on_bitprefs_cap,  algorithm: :concurrently, if_exists: true
+    remove_index :users, name: :index_users_on_bitprefs_cuf,  algorithm: :concurrently, if_exists: true
+    remove_index :users, name: :index_users_on_bitprefs_both, algorithm: :concurrently, if_exists: true
   end
 end

--- a/db/migrate/20251001213309_add_indexes_on_users_bit_prefs.rb
+++ b/db/migrate/20251001213309_add_indexes_on_users_bit_prefs.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class AddIndexesOnUsersBitPrefs < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def up
+    # Only two flags are currently used in bit_prefs filters in searches:
+    # :can_approve_posts and :can_upload_free
+    #
+    # IMPORTANT: We hardcode positions to make this migration reproducible
+    # even if the application constants change later.
+    # As of this migration:
+    # - can_approve_posts index == 15
+    # - can_upload_free  index == 16
+    cap_idx = 15
+    cuf_idx = 16
+
+    # Build integer bit masks matching how flags are stored in bigint bit_prefs.
+    cap_mask = (1 << cap_idx)
+    cuf_mask = (1 << cuf_idx)
+
+    both_mask = cap_mask | cuf_mask
+
+    # Create partial indexes matching the exact predicates used by search.
+    # TRUE (include) variants — these are highly selective and useful
+    add_index :users, :id,
+              name: :index_users_on_cap_include,
+              where: "(bit_prefs & #{cap_mask}) = #{cap_mask}",
+              algorithm: :concurrently
+
+    add_index :users, :id,
+              name: :index_users_on_cuf_include,
+              where: "(bit_prefs & #{cuf_mask}) = #{cuf_mask}",
+              algorithm: :concurrently
+
+    add_index :users, :id,
+              name: :index_users_on_both_include,
+              where: "(bit_prefs & #{both_mask}) = #{both_mask}",
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :users, name: :index_users_on_both_include, algorithm: :concurrently, if_exists: true
+    remove_index :users, name: :index_users_on_cuf_include,  algorithm: :concurrently, if_exists: true
+    remove_index :users, name: :index_users_on_cap_include,  algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4550,6 +4550,27 @@ CREATE UNIQUE INDEX index_user_statuses_on_user_id ON public.user_statuses USING
 
 
 --
+-- Name: index_users_on_bitprefs_both; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_bitprefs_both ON public.users USING btree (id) WHERE ((bit_prefs & (98304)::bigint) = 98304);
+
+
+--
+-- Name: index_users_on_bitprefs_cap; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_bitprefs_cap ON public.users USING btree (id) WHERE ((bit_prefs & (32768)::bigint) = 32768);
+
+
+--
+-- Name: index_users_on_bitprefs_cuf; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_bitprefs_cuf ON public.users USING btree (id) WHERE ((bit_prefs & (65536)::bigint) = 65536);
+
+
+--
 -- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4810,6 +4831,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251001213309'),
 ('20250921011208'),
 ('20250831040648'),
 ('20250831015612'),


### PR DESCRIPTION
We have reached the point where a simple boolean attribute search times out on the users table.
For example: https://e621.net/users?search[can_approve_posts]=true

With a couple indexes and a slight tweak to the search method, performance should improve.