### PR TITLE
[UI] Added correction for inputs expecting a single id that are given a full URL instead (fixes #1375)

### DIFF
--- a/app/helpers/form_search_helper.rb
+++ b/app/helpers/form_search_helper.rb
@@ -13,7 +13,7 @@ module FormSearchHelper
       defaults: { required: false },
       html: { class: "inline-form" },
     }) do |f|
-      id_input = f.input(:id, label: "ID", hide_unless_value: true)
+      id_input = f.input(:id, label: "ID", hide_unless_value: true, input_html: { class: "id-input", "multi-value" => "comma" })
       created_at_input = f.input(:created_at, hide_unless_value: true)
       updated_at_input = f.input(:updated_at, hide_unless_value: true)
       id_input + created_at_input + updated_at_input + capture { yield(f) } + f.submit("Search")

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -170,11 +170,11 @@ Utility.validateIdInput = function (event) {
   }
   if (hmv) {
     const initialV = e.value;
-    const re = RegExp(`${s0}(?:${s1}/([0-9]+)|.+?${s2}-([0-9]+))`, "g");
+    const re = RegExp(`([0-9]+)|[\\s,]*${s0}(?:${s1}/([0-9]+)|.+?${s2}-([0-9]+))`, "gy");
     let values = [];
     e.value = "";
     for (let match = re.exec(initialV); match; match = re.exec(initialV)) {
-      values.push(Utility.presence(match[1]) || match[2]);
+      values.push(Utility.presence(match[1]) || Utility.presence(match[2]) || match[3]);
     }
     e.value = values.join(mv == "space" ? " " : ",");
     if (Utility.isBlank(e.value) && e.hasAttribute("required")) {

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -119,6 +119,8 @@ Utility.presence = (e) => (Utility.isPresent(e) ? e : undefined);
  * ```
  * @param {FocusEvent} event The event.
  */ // IDEA: Leverage [HTML's `pattern` attribute](<https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern>)?
+// IDEA: Make clearing invalid input an attribute toggle?
+// IDEA: Fire on submit w/ `SubmitEvent.submitter`?
 Utility.validateIdInput = function (event) {
   /** @type {HTMLInputElement|HTMLTextAreaElement} */
   const e = event.target;

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -57,9 +57,9 @@ Utility.intersect = function (a, b) {
   b = b.slice(0).sort();
   var result = [];
   while (a.length > 0 && b.length > 0) {
-    if (a[ 0 ] < b[ 0 ]) {
+    if (a[0] < b[0]) {
       a.shift();
-    } else if (a[ 0 ] > b[ 0 ]) {
+    } else if (a[0] > b[0]) {
       b.shift();
     } else {
       result.push(a.shift());
@@ -118,18 +118,18 @@ Utility.presence = (e) => (Utility.isPresent(e) ? e : undefined);
  * <%= f.input :post_ids_string, as: :text, label: "Posts", input_html: { class: "id-input", "multi-value" => "space" } %>
  * ```
  * @param {FocusEvent} event The event.
- */ //IDEA: Leverage [HTML's `pattern` attribute](<https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern>)?
+ */ // IDEA: Leverage [HTML's `pattern` attribute](<https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern>)?
 Utility.validateIdInput = function (event) {
   /** @type {HTMLInputElement|HTMLTextAreaElement} */
   const e = event.target;
   e.classList.remove("invalid-input");
   // If it's not an applicable element or is properly formatted or is permissibly omitted, abort.
   if (
-    !(e instanceof HTMLInputElement || e instanceof HTMLTextAreaElement) ||
-    !e.classList.contains("id-input") ||
-    /^[0-9]+$/.test(e.value) ||
-    (e.getAttribute("multi-value") == "space" ? /^[0-9 ]+$/.test(e.value) : e.hasAttribute("multi-value") && /^[0-9,]+$/.test(e.value)) ||
-    ((e.value?.length || 0) === 0 && !e.hasAttribute("required"))) {
+    !(e instanceof HTMLInputElement || e instanceof HTMLTextAreaElement)
+    || !e.classList.contains("id-input")
+    || /^[0-9]+$/.test(e.value)
+    || (e.getAttribute("multi-value") == "space" ? /^[0-9 ]+$/.test(e.value) : e.hasAttribute("multi-value") && /^[0-9,]+$/.test(e.value))
+    || ((e.value?.length || 0) === 0 && !e.hasAttribute("required"))) {
     return;
   }
   // If there's only non-numeric characters in the input, mark invalid & abort.
@@ -142,8 +142,7 @@ Utility.validateIdInput = function (event) {
   if (hmv && /^[0-9\s,]+$/.test(e.value)) {
     if (mv == "space") {
       e.value = e.value.replaceAll(/[,\s]+/g, " ").trim();
-    }
-    else /* if (mv == "comma") */ {
+    } else /* if (mv == "comma") */ {
       e.value = e.value.trim().replaceAll(/[,\s]+/g, ",");
     }
     return;
@@ -165,8 +164,8 @@ Utility.validateIdInput = function (event) {
       break;
 
     default:
-      s1 = "[^0-9]*"
-      s2 = "[^-0-9]*"
+      s1 = "[^0-9]*";
+      s2 = "[^-0-9]*";
       break;
   }
   if (hmv) {
@@ -175,7 +174,7 @@ Utility.validateIdInput = function (event) {
     let values = [];
     e.value = "";
     for (let match = re.exec(initialV); match; match = re.exec(initialV)) {
-      values.push(Utility.presence(match[ 1 ]) || match[ 2 ]);
+      values.push(Utility.presence(match[1]) || match[2]);
     }
     e.value = values.join(mv == "space" ? " " : ",");
     if (Utility.isBlank(e.value) && e.hasAttribute("required")) {
@@ -189,7 +188,7 @@ Utility.validateIdInput = function (event) {
         e.className += " invalid-input";
       return;
     }
-    e.value = Utility.presence(match[ 1 ]) || match[ 2 ];
+    e.value = Utility.presence(match[1]) || match[2];
   }
 };
 
@@ -201,7 +200,7 @@ $.fn.selectEnd = function () {
 };
 
 $(function () {
-  $('.id-input').on("focusout", Utility.validateIdInput);
+  $(".id-input").on("focusout", Utility.validateIdInput);
 
   $(window).on("danbooru:notice", function (event, msg) {
     Utility.notice(msg);

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -57,9 +57,9 @@ Utility.intersect = function (a, b) {
   b = b.slice(0).sort();
   var result = [];
   while (a.length > 0 && b.length > 0) {
-    if (a[0] < b[0]) {
+    if (a[ 0 ] < b[ 0 ]) {
       a.shift();
-    } else if (a[0] > b[0]) {
+    } else if (a[ 0 ] > b[ 0 ]) {
       b.shift();
     } else {
       result.push(a.shift());
@@ -83,7 +83,7 @@ Utility.regexp_escape = RegExp.escape || function (string) {
  * property) that has 0 elements, or a `string` of only whitespace characters; `false` otherwise.
  */
 Utility.isBlank = function (e) {
-  return e === undefined || e === null || (e.length !== undefined && (e.length === 0 || (typeof(e) === "string" && e.trim().length === 0)));
+  return e === undefined || e === null || (e.length !== undefined && (e.length === 0 || (typeof e === "string" && e.trim().length === 0)));
 };
 
 /**
@@ -98,7 +98,7 @@ Utility.isPresent = (e) => !Utility.isBlank(e);
  * @param {any} e The object to check.
  * @returns The object if it's not blank (see `isBlank`); `undefined` otherwise.
  */
-Utility.presence = (e) => Utility.isPresent(e) ? e : undefined;
+Utility.presence = (e) => (Utility.isPresent(e) ? e : undefined);
 
 /**
  * Validates that a text input element expecting an id that receives a URL has its value replaced
@@ -128,7 +128,7 @@ Utility.validateIdInput = function (event) {
     !(e instanceof HTMLInputElement || e instanceof HTMLTextAreaElement) ||
     !e.classList.contains("id-input") ||
     /^[0-9]+$/.test(e.value) ||
-    (e.getAttribute("multi-value") == "space" ? /^[0-9 ]+$/.test(e.value): e.hasAttribute("multi-value") && /^[0-9,]+$/.test(e.value)) ||
+    (e.getAttribute("multi-value") == "space" ? /^[0-9 ]+$/.test(e.value) : e.hasAttribute("multi-value") && /^[0-9,]+$/.test(e.value)) ||
     ((e.value?.length || 0) === 0 && !e.hasAttribute("required"))) {
     return;
   }
@@ -163,7 +163,7 @@ Utility.validateIdInput = function (event) {
       s1 = "forum_posts?";
       s2 = "forum_post";
       break;
-  
+
     default:
       s1 = "[^0-9]*"
       s2 = "[^-0-9]*"
@@ -175,7 +175,7 @@ Utility.validateIdInput = function (event) {
     let values = [];
     e.value = "";
     for (let match = re.exec(initialV); match; match = re.exec(initialV)) {
-      values.push(Utility.presence(match[1]) || match[2]);
+      values.push(Utility.presence(match[ 1 ]) || match[ 2 ]);
     }
     e.value = values.join(mv == "space" ? " " : ",");
     if (Utility.isBlank(e.value) && e.hasAttribute("required")) {
@@ -189,7 +189,7 @@ Utility.validateIdInput = function (event) {
         e.className += " invalid-input";
       return;
     }
-    e.value = Utility.presence(match[1]) || match[2];
+    e.value = Utility.presence(match[ 1 ]) || match[ 2 ];
   }
 };
 

--- a/app/javascript/src/styles/base/_colors.scss
+++ b/app/javascript/src/styles/base/_colors.scss
@@ -18,6 +18,8 @@ $form-disabled-background: #DDD;
 $button-background: white;
 $button-hover-background: darken($button-background, 10%);
 $form-submit-button-background: #eee;
+$form-invalid-input-background: #f07e7e;
+$form-invalid-input-border: #e00;
 
 // Page Header
 $page-header-sign-in-link-color: #e00;

--- a/app/javascript/src/styles/common/forms.scss
+++ b/app/javascript/src/styles/common/forms.scss
@@ -94,3 +94,11 @@ input:disabled {
     }
   }
 }
+
+// #region Invalid Input
+// TODO: Avoid immediately having required elements show up as wrong before user interaction.
+.invalid-input/* , input:invalid */ {
+  background-color: $form-invalid-input-background;
+  border: 3px solid $form-invalid-input-border;
+}
+// #endregion Invalid Input

--- a/app/views/admin/destroyed_posts/index.html.erb
+++ b/app/views/admin/destroyed_posts/index.html.erb
@@ -5,7 +5,7 @@
       <%= f.input :destroyer_ip_addr, label: "Destroyer IP Address" %>
       <%= f.user :uploader %>
       <%= f.input :uploader_ip_addr, label: "Uploader IP Address" %>
-      <%= f.input :post_id, label: "Post ID" %>
+      <%= f.input :post_id, label: "Post ID", input_html: { class: "id-input", "multi-value" => "comma" } %>
       <%= f.input :md5 %>
     <% end %>
 

--- a/app/views/pools/edit.html.erb
+++ b/app/views/pools/edit.html.erb
@@ -5,10 +5,10 @@
     <%= custom_form_for(@pool) do |f| %>
       <%= error_messages_for "pool" %>
 
-      <%= f.input :name, :as => :string, :input_html => { :value => @pool.pretty_name } %>
+      <%= f.input :name, as: :string, input_html: { :value => @pool.pretty_name } %>
       <%= f.input :description, as: :dtext, limit: Danbooru.config.pool_descr_max_size, allow_color: false %>
-      <%= f.input :post_ids_string, as: :text, label: "Posts" %>
-      <%= f.input :category, :collection => ["series", "collection"], :include_blank => false %>
+      <%= f.input :post_ids_string, as: :text, label: "Posts", input_html: { class: "id-input", "multi-value" => "space" } %>
+      <%= f.input :category, collection: %w[series collection], include_blank: false %>
       <%= f.input :is_active %>
       <%= f.button :submit %>
     <% end %>

--- a/app/views/pools/new.html.erb
+++ b/app/views/pools/new.html.erb
@@ -2,13 +2,13 @@
   <div id="c-new">
     <h2>New Pool</h2>
 
-    <p style="font-weight: bold;">Before creating a pool, read the <%= link_to "pool guidelines", wiki_page_path(:id => "e621:pools") %>.</p>
+    <p style="font-weight: bold;">Before creating a pool, read the <%= link_to "pool guidelines", wiki_page_path(id: "e621:pools") %>.</p>
 
     <%= custom_form_for(@pool) do |f| %>
-      <%= f.input :name, :as => :string, :required => true %>
+      <%= f.input :name, as: :string, required: true %>
       <%= f.input :description, as: :dtext, limit: Danbooru.config.pool_descr_max_size, allow_color: false %>
-      <%= f.input :post_ids_string, as: :text, label: "Posts" %>
-      <%= f.input :category, :collection => ["series", "collection"], :include_blank => true, :selected => "", :required => true %>
+      <%= f.input :post_ids_string, as: :text, label: "Posts", input_html: { class: "id-input", "multi-value" => "space" } %>
+      <%= f.input :category, collection: %w[series collection], include_blank: true, selected: "", required: true %>
       <%= f.input :is_active %>
       <%= f.button :submit, "Submit" %>
     <% end %>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -72,7 +72,7 @@
 <tab-entry tab="<%= tab_name %>" group="profile" search="update change user avatar profile image pfp">
   <tab-head><%= form.label :avatar_id, "Avatar Post ID" %></tab-head>
   <tab-body>
-    <%= form.input_field :avatar_id, as: :string, label: false %>
+    <%= form.input_field :avatar_id, as: :string, label: false, class: "id-input" %>
   </tab-body>
   <tab-hint>
     The image with this ID will be set as your avatar.


### PR DESCRIPTION
Fixes #1375 
Tested; works for single & multiple values.
Not added to all applicable fields; can be merged as-is with these being added at a later point. Detailed instructions for applying to other elements added to `Utility.validateIdInput`'s doc comment.
To add:
- [ ] Post
   - [ ] Edit
      - [ ] Parent ID
   - [ ] Upload
      - [ ] Parent ID
- [x] User
   - [ ] Search
   - [x] Edit
      - [x] Avatar ID
- [ ] IQDB Queries
- [ ] Post Flags
- [ ] Post Replacements
- [ ] Pools
   - [x] Edit
      - [x] Posts
   - [x] New
      - [x] Posts
   - [ ] Search
      - [ ] ID
      - [ ] Creator ID
- [ ] Sets
   - [ ] Edit
   - [ ] New
      - [ ] Posts
   - [ ] Search
      - [x] ID
      - [ ] Creator ID