### PR TITLE
[Posts] Rework animated file detection

### DIFF
--- a/app/logical/apng_inspector.rb
+++ b/app/logical/apng_inspector.rb
@@ -39,7 +39,7 @@ class ApngInspector
       chunkheader = +""
       while file.read(8, chunkheader)
         # ensure that first 8 bytes from chunk were read properly
-        if chunkheader == nil || chunkheader.bytesize < 8
+        if chunkheader.nil? || chunkheader.bytesize < 8
           return false
         end
 
@@ -103,10 +103,9 @@ class ApngInspector
   def parse_actl(len, file)
     return -1 if len != 8
     framedata = file.read(4)
-    if framedata == nil || framedata.length != 4
+    if framedata.nil? || framedata.length != 4
       return -1
     end
     framedata.unpack1("N")
   end
-
 end

--- a/app/logical/apng_inspector.rb
+++ b/app/logical/apng_inspector.rb
@@ -3,7 +3,7 @@
 class ApngInspector
   attr_reader :frames
 
-  PNG_MAGIC_NUMBER = ["89504E470D0A1A0A"].pack('H*')
+  PNG_MAGIC_NUMBER = ["89504E470D0A1A0A"].pack("H*")
 
   def initialize(file_path)
     @file_path = file_path
@@ -11,35 +11,34 @@ class ApngInspector
     @animated = false
   end
 
-  #PNG file consists of 8-byte magic number, followed by arbitrary number of chunks
-  #Each chunk has the following structure:
-  #4-byte length (unsigned int, can be zero)
-  #4-byte name (ASCII string consisting of letters A-z)
-  #(length)-byte data
-  #4-byte CRC
+  # PNG file consists of 8-byte magic number, followed by arbitrary number of chunks
+  # Each chunk has the following structure:
+  # 4-byte length (unsigned int, can be zero)
+  # 4-byte name (ASCII string consisting of letters A-z)
+  # (length)-byte data
+  # 4-byte CRC
   #
-  #Any data after chunk named IEND is irrelevant
-  #APNG frame count is inside a chunk named acTL, in first 4 bytes of data.
+  # Any data after chunk named IEND is irrelevant
+  # APNG frame count is inside a chunk named acTL, in first 4 bytes of data.
 
-
-  #This function calls associated block for each PNG chunk
-  #parameters passed are |chunk_name, chunk_length, file_descriptor|
-  #returns true if file is read succesfully from start to IEND,
-  #or if 100 000 chunks are read; returns false otherwise.
+  # This function calls associated block for each PNG chunk
+  # parameters passed are |chunk_name, chunk_length, file_descriptor|
+  # returns true if file is read succesfully from start to IEND,
+  # or if 100 000 chunks are read; returns false otherwise.
   def each_chunk
     iend_reached = false
-    File.open(@file_path, 'rb') do |file|
-      #check if file is not PNG at all
+    File.open(@file_path, "rb") do |file|
+      # check if file is not PNG at all
       return false if file.read(8) != PNG_MAGIC_NUMBER
 
       chunks = 0
 
-      #We could be dealing with large number of chunks,
-      #so the code should be optimized to create as few objects as possible.
-      #All literal strings are frozen and read() function uses string buffer.
+      # We could be dealing with large number of chunks,
+      # so the code should be optimized to create as few objects as possible.
+      # All literal strings are frozen and read() function uses string buffer.
       chunkheader = +""
       while file.read(8, chunkheader)
-        #ensure that first 8 bytes from chunk were read properly
+        # ensure that first 8 bytes from chunk were read properly
         if chunkheader == nil || chunkheader.bytesize < 8
           return false
         end
@@ -50,40 +49,39 @@ class ApngInspector
         return false if chunk_name =~ /[^A-Za-z]/
         yield chunk_name, chunk_len, file
 
-        #no need to read further if IEND is reached
+        # no need to read further if IEND is reached
         if chunk_name == "IEND"
           iend_reached = true
           break
         end
 
-        #check if we processed too many chunks already
-        #if we did, file is probably maliciously formed
-        #fail gracefully without marking the file as corrupt
+        # check if we processed too many chunks already
+        # if we did, file is probably maliciously formed
+        # fail gracefully without marking the file as corrupt
         chunks += 1
-        if chunks > 100000
+        if chunks > 100_000
           iend_reached = true
           break
         end
 
-        #jump to the next chunk - go forward by chunk length + 4 bytes CRC
-        file.seek(current_pos+chunk_len+4, IO::SEEK_SET)
+        # jump to the next chunk - go forward by chunk length + 4 bytes CRC
+        file.seek(current_pos + chunk_len + 4, IO::SEEK_SET)
       end
     end
-    return iend_reached
+    iend_reached
   end
 
   def inspect!
     actl_corrupted = false
 
     read_success = each_chunk do |name, len, file|
-      if name == "acTL"
-        framecount = parse_actl(len, file)
-        if framecount < 1
-          actl_corrupted = true
-        else
-          @animated = true
-          @frames = framecount
-        end
+      next unless name == "acTL"
+      framecount = parse_actl(len, file)
+      if framecount < 1
+        actl_corrupted = true
+      else
+        @animated = true
+        @frames = framecount
       end
     end
 
@@ -101,14 +99,14 @@ class ApngInspector
 
   private
 
-    #return number of frames in acTL or -1 on failure
-    def parse_actl(len, file)
-      return -1 if len != 8
-      framedata = file.read(4)
-      if framedata == nil || framedata.length != 4
-        return -1
-      end
-      framedata.unpack1("N")
+  # return number of frames in acTL or -1 on failure
+  def parse_actl(len, file)
+    return -1 if len != 8
+    framedata = file.read(4)
+    if framedata == nil || framedata.length != 4
+      return -1
     end
+    framedata.unpack1("N")
+  end
 
 end

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -53,7 +53,7 @@ module FileMethods
   end
 
   def is_animated_png_file?(file_path)
-    is_png? && ApngInspector.new(file_path).inspect!.animated?
+    is_png? && ApngInspector.animated_quick?(file_path)
   end
 
   def is_animated_gif_file?(file_path)

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module FileMethods
-  def is_image?
-    is_png? || is_jpg? || is_gif?
-  end
+  # === File Type methods ===
 
   def is_png?
     file_ext == "png"
@@ -29,27 +27,44 @@ module FileMethods
     file_ext == "mp4"
   end
 
+  def is_image?
+    is_png? || is_jpg? || is_gif?
+  end
+
   def is_video?
     is_webm? || is_mp4?
   end
 
-  def is_animated_png?(file_path)
+  # === Animation Methods ===
+
+  def is_animated_png?
+    is_png? && is_animated?
+  end
+
+  def is_animated_gif?
+    is_gif? && is_animated?
+  end
+
+  def is_animated_file?(file_path)
+    return true if is_video?
+    return is_animated_gif_file?(file_path) if is_gif?
+    return is_animated_png_file?(file_path) if is_png?
+    false
+  end
+
+  def is_animated_png_file?(file_path)
     is_png? && ApngInspector.new(file_path).inspect!.animated?
   end
 
-  def is_animated_gif?(file_path)
+  def is_animated_gif_file?(file_path)
     return false unless is_gif?
 
-    # Check whether the gif has multiple frames by trying to load the second frame.
-    result = Vips::Image.gifload(file_path, page: 1) rescue $ERROR_INFO
-    if result.is_a?(Vips::Image)
-      true
-    elsif result.is_a?(Vips::Error) && result.message =~ /bad page number/
-      false
-    else
-      raise result
-    end
+    image = Vips::Image.new_from_file(file_path, access: :sequential, n: 1)
+    n_pages = image.get_typeof("n-pages") == 0 ? 1 : image.get("n-pages")
+    n_pages.to_i > 1
   end
+
+  # === Other Methods ===
 
   def is_ai_generated?(file_path)
     return false if !is_image?

--- a/app/logical/file_validator.rb
+++ b/app/logical/file_validator.rb
@@ -45,7 +45,7 @@ class FileValidator
     if record.file_size > max_size
       record.errors.add(:file_size, "is too large. Maximum allowed for this file type is #{ApplicationController.helpers.number_to_human_size(max_size)}")
     end
-    if record.is_animated_png?(file_path) && record.file_size > Danbooru.config.max_apng_file_size
+    if record.is_animated_png_file?(file_path) && record.file_size > Danbooru.config.max_apng_file_size
       record.errors.add(:file_size, "is too large. Maximum allowed for this file type is #{ApplicationController.helpers.number_to_human_size(Danbooru.config.max_apng_file_size)}")
     end
   end

--- a/app/logical/image_sampler.rb
+++ b/app/logical/image_sampler.rb
@@ -22,7 +22,7 @@ module ImageSampler
     # Generate samples
     # Animated GIFs and APNGs are not needed, Flash files are not supported.
     # All video files need samples to be used as a poster in the player.
-    return if post.is_gif? || post.is_animated_png?(post.file_path)
+    return if post.is_gif? || post.is_animated_png?
     return unless post.is_video? || dimensions.min > Danbooru.config.large_image_width || dimensions.max > Danbooru.config.large_image_width * 2
     sample(image, dimensions, background: post.bg_color).each do |ext, file|
       path = sm.post_file_path(post, :"sample_#{ext}")

--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -63,6 +63,7 @@ class UploadService
       p.uploader_ip_addr = upload.uploader_ip_addr
       p.parent_id = upload.parent_id
       p.duration = upload.video_duration(upload.file.path)
+      p.is_animated = p.is_animated_file?(upload.file.path)
 
       if !upload.uploader.can_upload_free? || (!upload.uploader.can_approve_posts? && p.avoid_posting_artists.any?) || upload.upload_as_pending?
         p.is_pending = true

--- a/app/logical/upload_service/utils.rb
+++ b/app/logical/upload_service/utils.rb
@@ -60,8 +60,8 @@ class UploadService
       return "" unless Danbooru.config.enable_dimension_autotagging?
 
       tags = []
-      tags += %w[animated_gif animated] if upload.is_animated_gif?(file.path)
-      tags += %w[animated_png animated] if upload.is_animated_png?(file.path)
+      tags += %w[animated_gif animated] if upload.is_animated_gif_file?(file.path)
+      tags += %w[animated_png animated] if upload.is_animated_png_file?(file.path)
       tags += ["animated"] if upload.is_webm? || upload.is_mp4?
       tags += ["ai_generated"] if upload.is_ai_generated?(file.path)
       tags.join(" ")

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -780,7 +780,7 @@ class Post < ApplicationRecord
     def add_automatic_tags(tags)
       return tags unless Danbooru.config.enable_dimension_autotagging?
 
-      tags -= %w[thumbnail low_res hi_res absurd_res superabsurd_res huge_filesize wide_image tall_image long_image flash webm mp4 long_playtime short_playtime]
+      tags -= %w[thumbnail low_res hi_res absurd_res superabsurd_res huge_filesize wide_image tall_image long_image flash webm mp4 long_playtime short_playtime animated_gif animated_png]
 
       if has_dimensions?
         tags << "superabsurd_res" if image_width >= 10_000 && image_height >= 10_000
@@ -803,12 +803,11 @@ class Post < ApplicationRecord
       tags << "flash" if is_flash?
       tags << "webm" if is_webm?
 
-      tags << "long_playtime" if is_video? && duration >= 30
-      tags << "short_playtime" if is_video? && duration < 30
+      tags << "long_playtime" if is_animated? && duration >= 30
+      tags << "short_playtime" if is_animated? && duration < 30
 
-      # TODO: Automatically add animated_* tags without re-testing them on every edit
-      tags -= ["animated_gif"] unless is_gif?
-      tags -= ["animated_png"] unless is_png?
+      tags << "animated_gif" if is_gif? && is_animated?
+      tags << "animated_png" if is_png? && is_animated?
 
       tags
     end
@@ -1921,7 +1920,7 @@ class Post < ApplicationRecord
   include PostIndex
 
   BOOLEAN_ATTRIBUTES = %w[
-    _has_embedded_notes
+    is_animated
     _has_cropped
     hide_from_anonymous
     hide_from_search_engines

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -217,6 +217,11 @@ class PostReplacement < ApplicationRecord
       processor = UploadService::Replacer.new(post: post, replacement: self)
       processor.process!(penalize_current_uploader: penalize_current_uploader)
       PostEvent.add(post.id, CurrentUser.user, :replacement_accepted, { replacement_id: id, old_md5: post.md5, new_md5: md5 })
+
+      # Recalculate post attributes, just in case
+      post.is_animated = is_animated_file?(replacement_file_path)
+      post.duration = video_duration(replacement_file_path) if post.is_video?
+
       post.update_index
     end
 

--- a/db/fixes/129_1_clear_unused_post_attributes.rb
+++ b/db/fixes/129_1_clear_unused_post_attributes.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+# We intend to re-use several boolean attributes in the future.
+# Some posts may already have them set, so it's best to clear them all out.
+Post.without_timeout do
+  fixed = 0
+  Post.in_batches(load: true, order: :desc).each_with_index do |group, index|
+    group.each do |post|
+      post._has_embedded_notes = false
+      post._has_cropped = false
+
+      if post.changed?
+        post.save(validate: false)
+        fixed += 1
+      end
+    end
+
+    puts "batch #{index} fixed #{fixed}"
+  end
+end

--- a/db/fixes/129_posts_set_animated.rb
+++ b/db/fixes/129_posts_set_animated.rb
@@ -6,18 +6,22 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config",
 # We intend to re-use several boolean attributes in the future.
 # Some posts may already have them set, so it's best to clear them all out.
 Post.without_timeout do
+  queue = Sidekiq::Queue.new("high_prio")
   fixed = 0
+
   Post.in_batches(load: true, order: :desc).each_with_index do |group, index|
+    puts "batch #{index} fixed #{fixed} (queue size: #{queue.size})"
+
+    # Wait for the queue to drain
+    sleep 2 while queue.size > 1_000
+
     group.each do |post|
-      post._has_embedded_notes = false
-      post._has_cropped = false
+      post.is_animated = post.file_path.present? ? post.is_animated_file?(post.file_path) : false
 
       if post.changed?
         post.save(validate: false)
         fixed += 1
       end
     end
-
-    puts "batch #{index} fixed #{fixed}"
   end
 end

--- a/test/models/upload_service_test.rb
+++ b/test/models/upload_service_test.rb
@@ -76,6 +76,12 @@ class UploadServiceTest < ActiveSupport::TestCase
         assert_match(/animated_png/, upload.tag_string)
       end
 
+      should "not tag static png files" do
+        service = @build_service.call(file: fixture_file_upload("bread-static.png"))
+        upload = service.start!
+        assert_no_match(/animated_png/, upload.tag_string)
+      end
+
       should "tag animated gif files" do
         service = @build_service.call(file: fixture_file_upload("bread-animated.gif"))
         upload = service.start!

--- a/test/unit/apng_inspector_test.rb
+++ b/test/unit/apng_inspector_test.rb
@@ -10,54 +10,54 @@ class DTextTest < ActiveSupport::TestCase
   end
   context "APNG inspector" do
     should "correctly parse normal APNG file" do
-      apng = inspect('normal_apng.png')
+      apng = inspect("normal_apng.png")
       assert_equal(14, apng.frames)
       assert_equal(true, apng.animated?)
       assert_equal(false, apng.corrupted?)
     end
 
     should "recognize 1-frame APNG as animated" do
-      apng = inspect('single_frame.png')
+      apng = inspect("single_frame.png")
       assert_equal(1, apng.frames)
       assert_equal(true, apng.animated?)
       assert_equal(false, apng.corrupted?)
     end
 
     should "correctly parse normal PNG file" do
-      apng = inspect('not_apng.png')
+      apng = inspect("not_apng.png")
       assert_equal(false, apng.animated?)
       assert_equal(false, apng.corrupted?)
     end
 
     should "handle empty file" do
-      apng = inspect('empty.png')
+      apng = inspect("empty.png")
       assert_equal(false, apng.animated?)
       assert_equal(true, apng.corrupted?)
     end
 
     should "handle corrupted files" do
-      apng = inspect('iend_missing.png')
+      apng = inspect("iend_missing.png")
       assert_equal(false, apng.animated?)
       assert_equal(true, apng.corrupted?)
-      apng = inspect('misaligned_chunks.png')
+      apng = inspect("misaligned_chunks.png")
       assert_equal(false, apng.animated?)
       assert_equal(true, apng.corrupted?)
-      apng = inspect('broken.png')
+      apng = inspect("broken.png")
       assert_equal(false, apng.animated?)
       assert_equal(true, apng.corrupted?)
     end
 
     should "handle incorrect acTL chunk" do
-      apng = inspect('actl_wronglen.png')
+      apng = inspect("actl_wronglen.png")
       assert_equal(false, apng.animated?)
       assert_equal(true, apng.corrupted?)
-      apng = inspect('actl_zero_frames.png')
+      apng = inspect("actl_zero_frames.png")
       assert_equal(false, apng.animated?)
       assert_equal(true, apng.corrupted?)
     end
 
     should "handle non-png files" do
-      apng = inspect('jpg.png')
+      apng = inspect("jpg.png")
       assert_equal(false, apng.animated?)
       assert_equal(true, apng.corrupted?)
     end

--- a/test/unit/apng_inspector_test.rb
+++ b/test/unit/apng_inspector_test.rb
@@ -62,4 +62,21 @@ class DTextTest < ActiveSupport::TestCase
       assert_equal(true, apng.corrupted?)
     end
   end
+
+  context "animated_quick? helper" do
+    should "return true for animated APNGs" do
+      assert_equal true, ApngInspector.animated_quick?(file_fixture("apng/normal_apng.png"))
+      assert_equal true, ApngInspector.animated_quick?(file_fixture("apng/single_frame.png"))
+    end
+
+    should "return false for non-animated PNGs" do
+      assert_equal false, ApngInspector.animated_quick?(file_fixture("apng/not_apng.png"))
+    end
+
+    should "return false for empty and (some) corrupted files" do
+      assert_equal false, ApngInspector.animated_quick?(file_fixture("apng/empty.png"))
+      assert_equal false, ApngInspector.animated_quick?(file_fixture("apng/actl_zero_frames.png"))
+      assert_equal false, ApngInspector.animated_quick?(file_fixture("apng/jpg.png"))
+    end
+  end
 end

--- a/test/unit/file_methods_test.rb
+++ b/test/unit/file_methods_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FileMethodsTest < ActiveSupport::TestCase
+  class Dummy
+    include FileMethods
+
+    attr_accessor :file_ext
+
+    def initialize(file_ext)
+      @file_ext = file_ext
+    end
+  end
+
+  def subject_for(ext)
+    Dummy.new(ext)
+  end
+
+  context "is_animated_gif?" do
+    should "return true for an animated gif" do
+      path = file_fixture("bread-animated.gif")
+      result = subject_for("gif").is_animated_gif_file?(path.to_s)
+      assert_equal true, result
+    end
+
+    should "return false for a static gif" do
+      path = file_fixture("bread-static.gif")
+      result = subject_for("gif").is_animated_gif_file?(path.to_s)
+      assert_equal false, result
+    end
+  end
+
+  context "is_animated_png?" do
+    should "return true for an animated apng" do
+      path = file_fixture("apng/normal_apng.png")
+      result = subject_for("png").is_animated_png_file?(path.to_s)
+      assert_equal true, result
+    end
+
+    should "return false for a non-animated png" do
+      path = file_fixture("apng/not_apng.png")
+      result = subject_for("png").is_animated_png_file?(path.to_s)
+      assert_equal false, result
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1370.

In short, whether the file is animated is now saved into a boolean attribute on the post model.
This allows us to consistently apply `animated_gif`, `animated_png`, and in the future `animated_webp` tags without having to re-test the image file.

Tasks:
* [ ] Test replacement handling: animated with non-animated