### PR TITLE
[Misc] Fix notification toasts on the home page

### DIFF
--- a/app/views/layouts/blank.html.erb
+++ b/app/views/layouts/blank.html.erb
@@ -7,11 +7,17 @@
   <%= render "layouts/theme_include" %>
   <%= render "layouts/nav" %>
 
-  <%= render "static/tos_warning" %>
-
   <div id="page">
+    <%# Notification Toasts %>
+    <div class="ui-corner-all ui-state-highlight" id="notice" style="<%= "display: none;" unless flash[:notice] %>">
+      <span><%= format_text(flash[:notice], inline: true) %>.</span>
+      <a href="#" id="close-notice-link">close</a>
+    </div>
+
     <%= yield :layout %>
   </div>
+
+  <%= render "static/tos_warning" %>
 
   <% if Danbooru.config.fsc_modal_enabled? %>
     <script src="https://assets.freespeechcoalition.com/code/avActionModal.min.js"></script>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -23,6 +23,7 @@
       <%= render "users/validation_notice" %>
     <% end %>
 
+    <%# Notification Toasts %>
     <div class="ui-corner-all ui-state-highlight" id="notice" style="<%= "display: none;" unless flash[:notice] %>">
       <span><%= format_text(flash[:notice], inline: true) %>.</span>
       <a href="#" id="close-notice-link">close</a>


### PR DESCRIPTION
The toasts were not being displayed on the home page for some reason.
That prevented the TOS modal from sending error notifications.