### PR TITLE
[Uploads] Improve image corruption detection for GIFs

### DIFF
--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -133,17 +133,14 @@ module FileMethods
   # * APNG: not implemented, could defer to ffmpeg if needed.
   # * Other file types: assumed to be non-corrupt.
   def is_corrupt?(file_path)
-    if is_gif?
-      is_corrupt_gif?(file_path)
-    elsif is_image?
-      begin
-        Vips::Image.new_from_file(file_path, fail: true).stats
-        false
-      rescue Vips::Error
-        true
-      end
-    else
+    return false unless is_image?
+    return is_corrupt_gif?(file_path) if is_gif?
+
+    begin
+      Vips::Image.new_from_file(file_path, fail: true).stats
       false
+    rescue Vips::Error
+      true
     end
   end
 end

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -114,11 +114,36 @@ module FileMethods
     nil
   end
 
-  def is_corrupt?(file_path)
-    image = Vips::Image.new_from_file(file_path, fail: true)
-    image.stats
-    false
-  rescue
+  def is_corrupt_gif?(file_path)
+    i = 0
+    loop do
+      Vips::Image.gifload(file_path, page: i, fail: true).stats
+      i += 1
+    end
+  rescue Vips::Error => e
+    # Invalid page number indicates we've reached the end of the frames.
+    # Any other error indicates corruption.
+    return false if e.message =~ /bad page number/
     true
+  end
+
+  # Verify whether the file at the provided path is corrupt.
+  # * Regular images: attempt to load the image with libvips.
+  # * GIFs: attempt to load each frame with libvips.
+  # * APNG: not implemented, could defer to ffmpeg if needed.
+  # * Other file types: assumed to be non-corrupt.
+  def is_corrupt?(file_path)
+    if is_gif?
+      is_corrupt_gif?(file_path)
+    elsif is_image?
+      begin
+        Vips::Image.new_from_file(file_path, fail: true).stats
+        false
+      rescue Vips::Error
+        true
+      end
+    else
+      false
+    end
   end
 end


### PR DESCRIPTION
Fixes #1385.

Loads each GIF frame consecutively.
More performant than trying to load the whole thing at once, especially for long GIFs.