### PR TITLE
[ESLint] Enable ESLint formatting in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,4 +21,10 @@
     "javascript"
   ],
   "eslint.format.enable": true,
+  "[javascript]": {
+  	"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+  	"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,4 +20,5 @@
   "eslint.validate": [
     "javascript"
   ],
+  "eslint.format.enable": true,
 }


### PR DESCRIPTION
The setting is off by default, so it only uses the JS/TS language support for formatting by default. https://discordapp.com/channels/431908090883997698/1393442162305138758/1425476601508003910