### PR TITLE
[Pools] Fixes to the "add to pool" dialog

### DIFF
--- a/app/controllers/pool_elements_controller.rb
+++ b/app/controllers/pool_elements_controller.rb
@@ -1,40 +1,71 @@
 # frozen_string_literal: true
 
 class PoolElementsController < ApplicationController
-  respond_to :html, :json, :js
+  respond_to :json
   before_action :member_only
 
   def create
-    @pool = Pool.find_by_name(params[:pool_name]) || Pool.find_by_id(params[:pool_id])
+    @pool = Pool.find_by(name: params[:pool_name]) || Pool.find(params[:pool_id])
+    raise ActiveRecord::RecordNotFound if @pool.blank?
+    @post = Post.find(params[:post_id])
+    raise ActiveRecord::RecordNotFound if @post.blank?
 
-    if @pool.present?
-      @post = Post.find(params[:post_id])
-      @pool.with_lock do
-        @pool.add(@post.id)
-        @pool.save
-      end
-      append_pool_to_session(@pool)
-    else
-      @error = "That pool does not exist"
+    @pool.with_lock do
+      @pool.add(@post.id)
+      @pool.save
     end
+
+    if @pool.errors.any?
+      flash[:notice] = @pool.errors.full_messages.join("; ")
+    else
+      append_pool_to_session(@pool)
+      flash[:notice] = "Post added to pool ##{@pool.id}"
+    end
+
+    respond_with(@pool, location: post_path(@post))
   end
 
   def destroy
-    @pool = Pool.find(params[:pool_id])
+    @pool = Pool.find_by(name: params[:pool_name]) || Pool.find(params[:pool_id])
     @post = Post.find(params[:post_id])
+    raise ActiveRecord::RecordNotFound if @post.blank?
+
     @pool.with_lock do
       @pool.remove!(@post)
       @pool.save
     end
-    respond_with(@pool, :location => post_path(@post))
+
+    if @pool.errors.any?
+      flash[:notice] = @pool.errors.full_messages.join("; ")
+    else
+      flash[:notice] = "Post removed from pool ##{@pool.id}"
+    end
+
+    respond_with(@pool, location: post_path(@post))
+  end
+
+  def recent
+    pool_ids = session[:recent_pool_ids].to_s.scan(/\d+/)
+    unless pool_ids.any?
+      render json: []
+      return
+    end
+
+    # Fetch pool names, preserving the order
+    ids = pool_ids.map(&:to_i)
+    names_by_id = Pool.where(id: ids).pluck(:id, :name).to_h
+    pools = ids.map { |id| (name = names_by_id[id]) && { id: id, name: name } }.compact
+
+    render json: pools
   end
 
   private
 
   def append_pool_to_session(pool)
     recent_pool_ids = session[:recent_pool_ids].to_s.scan(/\d+/)
+    recent_pool_ids.delete(pool.id.to_s) # Push to end of list
     recent_pool_ids << pool.id.to_s
-    recent_pool_ids = recent_pool_ids.slice(1, 5) if recent_pool_ids.size > 5
-    session[:recent_pool_ids] = recent_pool_ids.uniq.join(",")
+    recent_pool_ids = recent_pool_ids.last(5) if recent_pool_ids.size > 5
+    session[:recent_pool_ids] = recent_pool_ids.join(",")
   end
 end

--- a/app/javascript/src/javascripts/pools.js
+++ b/app/javascript/src/javascripts/pools.js
@@ -18,15 +18,58 @@ Pool.initialize_add_to_pool_link = function () {
   $(".add-to-pool").on("click.danbooru", function (event) {
     event.preventDefault();
 
-    if (!poolDialog)
+    if (!poolDialog) {
       poolDialog = new Dialog("#add-to-pool-dialog");
+      loadRecentPools();
+    }
     poolDialog.toggle();
   });
 
-  $("#recent-pools li").on("click.danbooru", function (e) {
-    e.preventDefault();
-    $("#pool_name").val($(this).attr("data-value"));
+  $("#recent-pools").on("click.danbooru", "li", (event) => {
+    event.preventDefault();
+    $("#pool_name").val($(event.currentTarget).attr("data-value"));
   });
+
+  // Form submission
+  $("#add-to-pool-dialog").on("submit", handleAddToPool);
+  function handleAddToPool (event) {
+    event.preventDefault();
+    const pool_name = $("#pool_name").val();
+    const post_id = $("#post_id").val();
+
+    $.ajax({
+      type: "POST",
+      url: "/pool_element",
+      data: {
+        pool_name: pool_name,
+        post_id: post_id,
+        format: "json",
+      },
+    }).done(() => {
+      window.location.reload();
+    }).fail((data) => {
+      Utility.error(`Error: ${data.status == 404 ? "Not Found" : data.responseText}`);
+    });
+
+    return false;
+  }
+
+  // Load recent pools when the dialog is shown
+  function loadRecentPools () {
+    $.ajax({
+      type: "GET",
+      url: "/pool_element/recent",
+      dataType: "json",
+    }).done((data) => {
+      const recentPoolsList = $("#recent-pools");
+      if (data.length === 0) return;
+
+      data.forEach((pool) => {
+        recentPoolsList.append(`<li data-value="${pool.name}" role="button"><a href="/pools/${pool.id}">${pool.name}</a></li>`);
+      });
+      $(".add-to-pool-recent").show();
+    });
+  }
 };
 
 Pool.initialize_simple_edit = function () {

--- a/app/javascript/src/styles/specific/pools.scss
+++ b/app/javascript/src/styles/specific/pools.scss
@@ -1,20 +1,3 @@
-div#add-to-pool-dialog {
-  font-size: 0.8em;
-
-  form {
-    margin-bottom: 1em;
-  }
-
-  li {
-    margin-left: 1em;
-    cursor: pointer;
-  }
-
-  .hint {
-    display: block;
-  }
-}
-
 div#c-pools {
   div#a-show {
     #blacklist-box {

--- a/app/javascript/src/styles/views/application/_dialog.scss
+++ b/app/javascript/src/styles/views/application/_dialog.scss
@@ -34,6 +34,7 @@
       display: flex;
       @include st-radius-top;
       cursor: grab;
+      height: 2rem; // Hardcoded height for drag calculations
 
       background-color: themed("color-section-darken-5");
 

--- a/app/javascript/src/styles/views/posts/show/partials/_add_to_pool.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_add_to_pool.scss
@@ -1,22 +1,13 @@
 #add-to-pool-dialog, #add-to-set-dialog {
-  &.simple_form { padding: 0; }
-  .add-to-pool-inputs {
+  display: flex;
+  flex-flow: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+
+  div.input { margin: 0; }
+  .add-to-pool-inputs, .add-to-pool-recent {
     padding: 0.5rem;
     background: themed("color-section-lighten-5");
-    margin: 0.5rem 0.5rem 0;
     @include st-radius;
   }
-  .add-to-pool-submit {
-    padding: 0.5rem;
-  }
-
-  select { width: 100%; }
-  input[type="text"] {
-    width: 100%;
-    box-sizing: border-box;
-    max-width: unset;
-  }
-  .hint { max-width: unset; }
-
-  div.input:last-child { margin-bottom: 0; }
 }

--- a/app/javascript/src/styles/views/posts/show/partials/_notes.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_notes.scss
@@ -195,6 +195,7 @@
   textarea {
     width: 100%;
     box-sizing: border-box;
+    resize: none;
   }
 
   div.note-editor-help {

--- a/app/views/pool_elements/_new.html.erb
+++ b/app/views/pool_elements/_new.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(pool_element_path, :class => "simple_form", :remote => true, :format => :js, id: "add-to-pool-dialog", data: { title: "Add to Pool", width: "250" }) do %>
+<%= form_tag(pool_element_path, :class => "simple_form", id: "add-to-pool-dialog", data: { title: "Add to Pool", width: "250" }) do %>
   <%= hidden_field_tag "post_id", @post.id %>
 
   <div class="input add-to-pool-inputs">
@@ -7,18 +7,12 @@
     <span id="pool-name-hint" class="hint">Search for a pool containing (<%= link_to "see full list", gallery_pools_path %>)</span>
   </div>
 
+  <div class="add-to-pool-recent" style="display: none;">
+    <b>Recent Pools</b>
+    <ul id="recent-pools"></ul>
+  </div>
+
   <div class="input add-to-pool-submit">
     <%= submit_tag "Submit", class: "st-button" %>
-  </div>
-<% end %>
-
-<% if recent_updated_pools.any? %>
-  <div>
-    <h3>Recent Pools</h3>
-    <ul id="recent-pools">
-      <% recent_updated_pools.each do |pool| %>
-        <%= tag.li(pool.pretty_name, data: { value: pool.name }) %>
-      <% end %>
-    </ul>
   </div>
 <% end %>

--- a/app/views/pool_elements/create.js.erb
+++ b/app/views/pool_elements/create.js.erb
@@ -1,5 +1,0 @@
-<% if @error %>
-  $(window).trigger("danbooru:error", "<%= j @error.to_s %>");
-<% else %>
-  location.reload();
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,7 +226,9 @@ Rails.application.routes.draw do
     end
     resource :order, only: %i[edit], controller: "pool_orders"
   end
-  resource :pool_element, only: %i[create destroy]
+  resource :pool_element, only: %i[create destroy] do
+    get :recent, on: :collection
+  end
   resources :pool_versions, only: %i[index] do
     member do
       get :diff

--- a/test/functional/pool_elements_controller_test.rb
+++ b/test/functional/pool_elements_controller_test.rb
@@ -15,14 +15,14 @@ class PoolElementsControllerTest < ActionDispatch::IntegrationTest
 
     context "create action" do
       should "add a post to a pool" do
-        post_auth pool_element_path, @user, params: {:pool_id => @pool.id, :post_id => @post.id, :format => "json"}
+        post_auth pool_element_path, @user, params: { pool_id: @pool.id, post_id: @post.id, format: "json" }
         @pool.reload
         assert_equal([@post.id], @pool.post_ids)
       end
 
       should "add a post to a pool once and only once" do
         as(@user) { @pool.add!(@post) }
-        post_auth pool_element_path, @user, params: {:pool_id => @pool.id, :post_id => @post.id, :format => "json"}
+        post_auth pool_element_path, @user, params: { pool_id: @pool.id, post_id: @post.id, format: "json" }
         @pool.reload
         assert_equal([@post.id], @pool.post_ids)
       end
@@ -34,7 +34,7 @@ class PoolElementsControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "remove a post from a pool" do
-        delete_auth pool_element_path, @user, params: {:pool_id => @pool.id, :post_id => @post.id, :format => "json"}
+        delete_auth pool_element_path, @user, params: { pool_id: @pool.id, post_id: @post.id, format: "json" }
         @pool.reload
         assert_equal([], @pool.post_ids)
       end
@@ -44,7 +44,7 @@ class PoolElementsControllerTest < ActionDispatch::IntegrationTest
         as(@user) do
           @pool.remove!(@post)
         end
-        delete_auth pool_element_path, @user, params: {:pool_id => @pool.id, :post_id => @post.id, :format => "json"}
+        delete_auth pool_element_path, @user, params: { pool_id: @pool.id, post_id: @post.id, format: "json" }
         @pool.reload
         assert_equal([], @pool.post_ids)
       end


### PR DESCRIPTION
Multiple fixes here.

1. The "add to pool" dialog box would not reload the page when the form is submitted. The issue was with the CSP rules blocking the execution of a script returned from the controller. I have reworked the controller to bypass this situation altogether.
2. The "add to pool" dialog gave the user an option to quickly select from a list of recently used pools. Unfortunately, this feature was implemented in a way that caused database queries to be executed even if the user never opened the dialog window. I have implemented an AJAX-based solution to load the recently used pools dynamically.
3. While fixing issue 2, I have discovered that if the contents of a dialog changed height, they would overflow the dialog itself. Since it is required to set rigidly defined dialog dimensions, I have implemented a solution that updates those whenever the dialog content changes sizes.