### PR TITLE
[Pools] Replace jquery-ui sortable

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,13 +10,6 @@ export { default as $ } from "jquery";
 import Rails from "@rails/ujs";
 Rails.start();
 
-require("jquery-ui/ui/widgets/sortable");
-require("jquery-ui/ui/widgets/resizable");
-require("jquery-ui/themes/base/core.css");
-require("jquery-ui/themes/base/sortable.css");
-require("jquery-ui/themes/base/resizable.css");
-require("jquery-ui/themes/base/theme.css");
-
 require("../src/styles/base.scss");
 
 // Utilities

--- a/app/javascript/src/javascripts/pools.js
+++ b/app/javascript/src/javascripts/pools.js
@@ -1,15 +1,12 @@
-import Utility from "./utility";
 import Dialog from "./utility/dialog";
+import Page from "./utility/page";
+import Sortable from "./utility/sortable";
 
 let Pool = {};
 
 Pool.initialize_all = function () {
   if ($("#c-posts").length && $("#a-show").length) {
     this.initialize_add_to_pool_link();
-  }
-
-  if ($("#c-pool-orders").length) {
-    this.initialize_simple_edit();
   }
 };
 
@@ -29,28 +26,24 @@ Pool.initialize_add_to_pool_link = function () {
   });
 };
 
-Pool.initialize_simple_edit = function () {
-  $("#sortable").sortable({
-    placeholder: "ui-state-placeholder",
-  });
-  $("#sortable").disableSelection();
+Pool.initialize_pool_ordering = function () {
+  if (!Page.matches("pool-orders", "edit")) return;
 
-  $("#ordering-form").submit(function (e) {
-    e.preventDefault();
-    $.ajax({
-      type: "post",
-      url: e.target.action,
-      data: $("#sortable").sortable("serialize") + "&" + $(e.target).serialize() + "&format=json",
-    }).done(() => {
-      window.location.href = e.target.action;
-    }).fail((data) => {
-      Utility.error(`Error: ${data.responseText}`);
-    });
-  });
+  const orderForm = $("#ordering-form"),
+    idInput = $("#pool_post_ids_string");
+  const originalIDs = idInput.val();
+
+  new Sortable($("ul.sortable"), { onReorder: (orderedIDs) => {
+    const idString = orderedIDs.join(" ");
+    idInput.val(idString);
+
+    orderForm.toggleClass("changed", idString !== originalIDs);
+  }});
 };
 
-$(document).ready(function () {
+$(() => {
   Pool.initialize_all();
+  Pool.initialize_pool_ordering();
 });
 
 export default Pool;

--- a/app/javascript/src/javascripts/utility/sortable.js
+++ b/app/javascript/src/javascripts/utility/sortable.js
@@ -1,0 +1,274 @@
+/**
+ * HTML5 drag-and-drop sortable utility for grid layouts.
+ *
+ * Provides intuitive drag-and-drop reordering with visual feedback via placeholders.
+ * Uses CSS Grid/Flexbox compatible positioning and CSS-based styling.
+ *
+ * @example
+ * const sortable = new Sortable(containerEl, {
+ *   itemSelector: "li.thumbnail",
+ *   idDataKey: "postId",
+ *   onReorder: (ids) => console.log("New order:", ids)
+ * });
+ *
+ * // Get current order
+ * const currentOrder = sortable.getOrderedIds();
+ *
+ * // Update after DOM changes
+ * sortable.refresh();
+ *
+ * // Cleanup
+ * sortable.destroy();
+ */
+export default class Sortable {
+
+  /**
+   * Create a new Sortable instance.
+   *
+   * @param {Element|jQuery} container Container element holding sortable items
+   * @param {Object} [options={}] Configuration options
+   * @param {string} [options.itemSelector="li"] CSS selector for sortable items within container
+   * @param {string} [options.idDataKey="id"] Data attribute key for item IDs (e.g., "postId" for data-post-id)
+   * @param {Function} [options.onReorder] Callback fired when items are reordered, receives array of IDs
+   */
+  constructor (container, options = {}) {
+    if (!container) throw new Error("Sortable: container is required");
+    this.$container = $(container);
+
+    this.settings = {
+      itemSelector: options.itemSelector || "li",
+      idDataKey: options.idDataKey || "id",
+      onReorder: typeof options.onReorder === "function" ? options.onReorder : null,
+    };
+
+    this.state = {
+      draggingId: null,
+      draggingEl: null,
+      lastTarget: null,
+      lastBefore: null,
+    };
+
+    this.$container.find(this.settings.itemSelector).attr("draggable", "true");
+    this.bindAll();
+  }
+
+  getItems () {
+    const nodes = Array.from(this.$container.find(this.settings.itemSelector));
+    return nodes.filter((el) => !this.$placeholder || el !== this.$placeholder[0]);
+  }
+
+  getId (el) {
+    const val = el.dataset[this.settings.idDataKey];
+    return val != null ? String(val) : null;
+  }
+
+  /** Clean up the sortable instance and remove all event listeners. */
+  destroy () {
+    this.unbindAll();
+    this.$container.find(this.settings.itemSelector).removeAttr("draggable");
+    if (this.$placeholder) this.destroyPlaceholder();
+  }
+
+  /**
+   * Get the current order of sortable items as an array of IDs.
+   *
+   * @returns {string[]} Array of item IDs in their current DOM order
+   * @example
+   * const order = sortable.getOrderedIds();
+   * // Returns: ["post-123", "post-456", "post-789"]
+   */
+  getOrderedIds () {
+    return this.getItems()
+      .map((el) => this.getId(el))
+      .filter((v) => v != null && v !== "");
+  }
+
+
+  // ======================================== //
+  // ====== Dragged Item Event Handlers ===== //
+  // ======================================== //
+
+  bindAll () {
+    this.$container.on("dragstart.sortable", this.settings.itemSelector, (evt) => this.onItemDragStart(evt));
+    this.$container.on("dragend.sortable", this.settings.itemSelector, (evt) => this.onItemDragEnd(evt));
+    this.$container.on("dragover.sortable", this.settings.itemSelector, (evt) => this.onItemDragOver(evt));
+  }
+
+  unbindAll () {
+    this.$container.off("dragstart.sortable dragend.sortable dragover.sortable");
+  }
+
+  /**
+   * Refresh the sortable after DOM changes.
+   *
+   * Call this method when items are added, removed, or modified in the container
+   * to ensure new items become draggable and event listeners are properly bound.
+   *
+   * @example
+   * // After adding new items to the container
+   * container.append('<li data-id="new-item">New Item</li>');
+   * sortable.refresh();
+   */
+  refresh () {
+    this.unbindAll();
+
+    // Apply draggable attribute to new items
+    this.$container.find(this.settings.itemSelector).attr("draggable", "true");
+    this.bindAll();
+  }
+
+  onItemDragStart (event) {
+    const el = event.currentTarget;
+    const $el = $(el);
+
+    this.state = {
+      draggingId: this.getId(el),
+      draggingEl: el,
+      lastTarget: null,
+      lastBefore: null,
+    };
+
+    const nativeEvent = event.originalEvent || event;
+    if (nativeEvent.dataTransfer) {
+      nativeEvent.dataTransfer.effectAllowed = "move";
+      nativeEvent.dataTransfer.setData("text/plain", this.state.draggingId || "");
+    }
+
+    // Replace the dragged element with a placeholder to avoid layout shifts
+    const $ph = this.showPlaceholder(el);
+    $ph.insertBefore($el);
+    $el.addClass("dragging");
+  }
+
+  onItemDragEnd (event) {
+    this.state = {
+      draggingId: null,
+      draggingEl: null,
+      lastTarget: null,
+      lastBefore: null,
+    };
+
+    this.hidePlaceholder();
+    $(event.currentTarget).removeClass("dragging");
+  }
+
+  onItemDragOver (event) {
+    event.preventDefault();
+    const el = event.currentTarget;
+
+    const nativeEvent = event.originalEvent || event;
+    if (nativeEvent.dataTransfer) nativeEvent.dataTransfer.dropEffect = "move";
+
+    // Not dragging anything, ignore
+    if (!this.state.draggingId) return;
+
+    const rect = el.getBoundingClientRect();
+    const before = (nativeEvent.clientX - rect.left) < rect.width / 2;
+
+    if (this.state.lastTarget === el && this.state.lastBefore === before)
+      return; // Already positioned here
+
+    // Show placeholder on first use, or resize if target changed
+    if (!this.$placeholder) this.showPlaceholder(el);
+    else if (this.state.lastTarget !== el) {
+      this.sizePlaceholder(el);
+      this.$placeholder.show();
+    }
+
+    // Position placeholder around target
+    const ph = this.$placeholder[0];
+    if (before) {
+      if (ph.nextSibling !== el) this.$placeholder.insertBefore(el);
+    } else {
+      if (el.nextSibling !== ph) this.$placeholder.insertAfter(el);
+    }
+
+    this.state.lastTarget = el;
+    this.state.lastBefore = before;
+  }
+
+
+  // ======================================== //
+  // ========== Placeholder Methods ========= //
+  // ======================================== //
+
+  createPlaceholder (refEl) {
+    if (this.$placeholder) return;
+
+    const tag = refEl?.tagName || "DIV";
+
+    this.$placeholder = $(`<${tag}>`)
+      .addClass("sortable-drop-target")
+      .attr({
+        "aria-hidden": "true",
+        "draggable": "false",
+      })
+      .hide();
+
+    // Bind placeholder events once
+    this.bindPlaceholderEvents();
+  }
+
+  showPlaceholder (refEl) {
+    if (!refEl) return null;
+
+    if (!this.$placeholder) this.createPlaceholder(refEl);
+    this.sizePlaceholder(refEl);
+    this.$placeholder.show();
+
+    return this.$placeholder;
+  }
+
+  hidePlaceholder () {
+    if (!this.$placeholder) return;
+    this.$placeholder.detach().hide();
+  }
+
+  destroyPlaceholder () {
+    if (!this.$placeholder) return;
+
+    this.unbindPlaceholderEvents();
+    this.$placeholder.remove();
+    this.$placeholder = null;
+  }
+
+  sizePlaceholder (refEl) {
+    if (!refEl || !this.$placeholder) return;
+
+    // Match the size of the reference element
+    const rect = refEl.getBoundingClientRect();
+    this.$placeholder.css({ width: `${rect.width}px`, height: `${rect.height}px` });
+  }
+
+  bindPlaceholderEvents () {
+    if (!this.$placeholder) return;
+
+    this.$placeholder.on("dragover.sortable", (event) => {
+      event.preventDefault();
+      const nativeEvent = event.originalEvent || event;
+      if (nativeEvent.dataTransfer)
+        nativeEvent.dataTransfer.dropEffect = "move";
+    });
+
+    this.$placeholder.on("drop.sortable", (event) => {
+      event.preventDefault();
+      const nativeEvent = event.originalEvent || event;
+
+      const draggedId = this.state.draggingId || (nativeEvent.dataTransfer ? nativeEvent.dataTransfer.getData("text/plain") : "");
+      if (!draggedId) return;
+      const dragged = this.state.draggingEl || this.getItems().find((n) => this.getId(n) === draggedId);
+      if (!dragged) return;
+
+      $(dragged).insertBefore(this.$placeholder).removeClass("dragging");
+      this.hidePlaceholder();
+
+      if (this.settings.onReorder)
+        this.settings.onReorder(this.getOrderedIds());
+    });
+  }
+
+  unbindPlaceholderEvents () {
+    if (!this.$placeholder) return;
+    this.$placeholder.off(".sortable");
+  }
+}

--- a/app/javascript/src/javascripts/utility/sortable.js
+++ b/app/javascript/src/javascripts/utility/sortable.js
@@ -227,7 +227,7 @@ export default class Sortable {
     const tag = refEl?.tagName || "DIV";
 
     this.$placeholder = $(`<${tag}>`)
-      .addClass("sortable-drop-target")
+      .addClass("sortable-placeholder")
       .attr({
         "aria-hidden": "true",
         "draggable": "false",

--- a/app/javascript/src/javascripts/utility/sortable.js
+++ b/app/javascript/src/javascripts/utility/sortable.js
@@ -132,15 +132,31 @@ export default class Sortable {
   }
 
   onItemDragEnd (event) {
+    const dragged = this.state.draggingEl || event.currentTarget;
+    let committed = false;
+
+    // If the placeholder is still attached, the browser likely didn't fire drop on it.
+    // Act as if the item was dropped on the placeholder.
+    const ph = this.$placeholder && this.$placeholder[0];
+    if (ph && ph.parentNode && dragged && dragged !== ph) {
+      ph.parentNode.insertBefore(dragged, ph);
+      committed = true;
+    }
+    this.hidePlaceholder();
+
+    if (committed) {
+      if (dragged && dragged.classList) dragged.classList.remove("dragging");
+      this._rebuildIndex();
+      if (this.settings.onReorder)
+        this.settings.onReorder(this.order);
+    } else $(event.currentTarget).removeClass("dragging");
+
     this.state = {
       draggingId: null,
       draggingEl: null,
       lastTarget: null,
       lastBefore: null,
     };
-
-    this.hidePlaceholder();
-    $(event.currentTarget).removeClass("dragging");
   }
 
   onItemDragOver (event) {

--- a/app/javascript/src/javascripts/utility/sortable.js
+++ b/app/javascript/src/javascripts/utility/sortable.js
@@ -104,8 +104,6 @@ export default class Sortable {
     // Apply draggable attribute to new items
     this.$container.find(this.settings.itemSelector).attr("draggable", "true");
     this.bindAll();
-
-    // Rebuild caches after refresh
     this._rebuildIndex();
   }
 
@@ -186,21 +184,21 @@ export default class Sortable {
       this.$placeholder.show();
     } else if (this.state.lastTarget !== el) {
       this.sizePlaceholder(el, rect);
-      if (!this.$placeholder.is(":visible"))
-        this.$placeholder.show();
+      this.$placeholder.show();
+    }
+
+    // Position placeholder around target
+    const ph = this.$placeholder[0];
+    if (el.parentNode) {
+      if (before) {
+        if (ph.nextSibling !== el) el.parentNode.insertBefore(ph, el);
+      } else {
+        if (el.nextSibling !== ph) el.parentNode.insertBefore(ph, el.nextSibling);
+      }
     }
 
     this.state.lastTarget = el;
     this.state.lastBefore = before;
-
-    // Position placeholder around target
-    const ph = this.$placeholder[0];
-    if (!el.parentNode) return;
-    if (before) {
-      if (ph.nextSibling !== el) el.parentNode.insertBefore(ph, el);
-    } else {
-      if (el.nextSibling !== ph) el.parentNode.insertBefore(ph, el.nextSibling);
-    }
   }
 
   // ======================================== //

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -47,6 +47,7 @@
 @import "views/artists/artists";
 @import "views/maintenance/maintenance";
 @import "views/mascots/mascots";
+@import "views/pools/pools";
 @import "views/post_flags/post_flags";
 @import "views/posts/posts";
 @import "views/static/static";

--- a/app/javascript/src/styles/specific/pools.scss
+++ b/app/javascript/src/styles/specific/pools.scss
@@ -25,29 +25,3 @@ div#c-pools {
     }
   }
 }
-
-div#c-pool-orders {
-  div#a-edit {
-    ul.ui-sortable {
-      list-style-type: none;
-
-      li {
-        cursor: pointer;
-        margin-right: 20px;
-        margin-bottom: 20px;
-        min-width: 150px;
-        min-height: 150px;
-        padding: 10px;
-        display: inline-block;
-      }
-
-      li.ui-state-default {
-        background: none;
-      }
-
-      li.ui-state-placeholder {
-        background: none;
-      }
-    }
-  }
-}

--- a/app/javascript/src/styles/views/application/_application.scss
+++ b/app/javascript/src/styles/views/application/_application.scss
@@ -4,4 +4,5 @@
 @import "dmail_notice";
 @import "feedback_badge";
 @import "level_badge";
+@import "sortable";
 @import "tos_warning";

--- a/app/javascript/src/styles/views/application/_sortable.scss
+++ b/app/javascript/src/styles/views/application/_sortable.scss
@@ -9,7 +9,10 @@ ul.sortable {
     overflow: hidden;
     cursor: grab;
 
-    &.dragging { display: none; }
+    &.dragging {
+      display: none;
+      pointer-events: none;
+    }
 
     article.thumbnail {
       img {

--- a/app/javascript/src/styles/views/application/_sortable.scss
+++ b/app/javascript/src/styles/views/application/_sortable.scss
@@ -1,0 +1,39 @@
+ul.sortable {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, var(--thumb-image-size, 150px));
+  gap: 0.5rem;
+
+  li.sortable-thumbnail {
+    width: var(--thumb-image-size, 150px);
+    height: var(--thumb-image-size, 150px);
+    overflow: hidden;
+    cursor: grab;
+
+    &.dragging { display: none; }
+
+    article.thumbnail {
+      img {
+        width: var(--thumb-image-size, 150px);
+        height: var(--thumb-image-size, 150px);
+        object-fit: cover;
+      }
+      .desc { display: none; }
+    }
+  }
+
+  .sortable-drop-target {
+    width: var(--thumb-image-size, 150px);
+    height: var(--thumb-image-size, 150px);
+    border: 2px dashed var(--accent, #888);
+    border-radius: 4px;
+    box-sizing: border-box;
+    pointer-events: auto;
+    background: repeating-linear-gradient(
+      45deg,
+      rgba(0,0,0,0.04),
+      rgba(0,0,0,0.04) 8px,
+      rgba(0,0,0,0.06) 8px,
+      rgba(0,0,0,0.06) 16px
+    );
+  }
+}

--- a/app/javascript/src/styles/views/application/_sortable.scss
+++ b/app/javascript/src/styles/views/application/_sortable.scss
@@ -15,6 +15,7 @@ ul.sortable {
     }
 
     article.thumbnail {
+      a { cursor: inherit; }
       img {
         width: var(--thumb-image-size, 150px);
         height: var(--thumb-image-size, 150px);
@@ -24,19 +25,14 @@ ul.sortable {
     }
   }
 
-  .sortable-drop-target {
+  .sortable-placeholder {
     width: var(--thumb-image-size, 150px);
     height: var(--thumb-image-size, 150px);
-    border: 2px dashed var(--accent, #888);
-    border-radius: 4px;
     box-sizing: border-box;
+
+    background: rgba(0, 124, 186, 0.1);
+    border: 2px dashed #007cba;
+    @include st-radius;
     pointer-events: auto;
-    background: repeating-linear-gradient(
-      45deg,
-      rgba(0,0,0,0.04),
-      rgba(0,0,0,0.04) 8px,
-      rgba(0,0,0,0.06) 8px,
-      rgba(0,0,0,0.06) 16px
-    );
   }
 }

--- a/app/javascript/src/styles/views/pools/_order.scss
+++ b/app/javascript/src/styles/views/pools/_order.scss
@@ -1,0 +1,17 @@
+#ordering-form {
+  padding: 0.5rem 1rem;
+  margin: 0.5rem auto;
+
+  width: min-content;
+  background-color: themed("color-section-lighten-5");
+  box-shadow: 0 0 0.25rem themed("color-foreground");
+  @include st-radius;
+
+  &.changed {
+    position: sticky;
+    bottom: 0.25rem;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10; // Above thumbnail labels
+  }
+}

--- a/app/javascript/src/styles/views/pools/_pools.scss
+++ b/app/javascript/src/styles/views/pools/_pools.scss
@@ -1,0 +1,1 @@
+@import "order";

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -5,16 +5,17 @@
 
     <%= render "posts/partials/common/inline_blacklist" %>
 
-    <ul id="sortable">
+    <ul class="sortable">
       <% @pool.posts.paginate(1, limit: 1_000).each do |post| %>
-        <li class="ui-state-default" id="pool[post_ids]_<%= post.id %>">
-          <%= PostPresenter.preview(post).presence || "Hidden: Post ##{post.id}" %>
+        <li class="sortable-thumbnail" data-id="<%= post.id %>">
+          <%= PostPresenter.preview(post, { show_deleted: true }).presence || "Hidden: Post ##{post.id}" %>
         </li>
       <% end %>
     </ul>
 
     <%= custom_form_for(@pool, html: { id: "ordering-form" }) do |f| %>
-      <%= f.submit "Save" %>
+      <%= f.hidden_field :post_ids_string, id: "pool_post_ids_string", value: @pool.post_ids_string %>
+      <%= f.submit "Save Order", class: "st-button submit" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Fixes #1368.
Also fixes #453 and thus also #1314.

Replaces the jquery-ui dependent pool ordering with a custom-made version.

**Changes and Fixes:**
* [x] Throttle dragover events
* [x] Switch to vanilla JS DOM manipulation for better performance on large item sets
* [x] Add an id -> element cache for faster lookups
* [x] Fix handling items getting dropped somewhere other than the placeholder
