### PR TITLE
[Setup] Add steps to avoid permission issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 1. WSL Only: Run the following commands:
     ```
     git config core.fileMode false
-    cp -r hooks .git/hooks
+    cp -ru hooks/ .git
     ```
     This will resolve permission issues, and set up a hook that will reset file permissions to what they are supposed to be in the future.  
     If you are not using WSL, this is likely not a problem for you.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@
 1. Clone the repo with `git clone https://github.com/e621ng/e621ng.git`.
 1. `cd` into the repo.
 1. Copy the sample environment file with `cp .env.sample .env`.
+1. WSL Only: Run the following commands:
+    ```
+    git config core.fileMode false
+    cp -r hooks .git/hooks
+    ```
+    This will resolve permission issues, and set up a hook that will reset file permissions to what they are supposed to be in the future.  
+    If you are not using WSL, this is likely not a problem for you.
 1. Run the following commands:
     ```
     docker compose run --rm e621 /app/bin/setup

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Post-checkout hook to restore execute permissions for all files that should have them
+# This runs after every checkout, merge, or branch switch
+# 
+# This is necessary on WSL where core.fileMode=false, which causes Git to ignore
+# file permission changes during normal operations, but files lose their execute
+# permissions when checked out.
+
+# Only run this hook if we're in an environment that needs it
+should_run_hook() {
+  # WSL should always run this, as it always has permission issues
+  if grep -qEi "(microsoft|wsl)" /proc/version 2>/dev/null; then
+    return 0
+  fi
+    
+  # If core.fileMode is disabled, permission issues are likely
+  if [ "$(git config core.fileMode)" = "false" ]; then
+    return 0
+  fi
+    
+  # Default: don't run
+  return 1
+}
+
+if ! should_run_hook; then
+  exit 0
+fi
+
+echo "Restoring execute permissions for files"
+
+# Get all files that should have execute permissions from Git's object database and restore them on the filesystem
+git ls-tree -r HEAD | grep "^100755" | while read -r mode type hash path; do
+  if [ -f "$path" ]; then
+    chmod +x "$path" 2>/dev/null || true
+    echo "  ✓ $path"
+  fi
+done
+
+echo "Execute permissions restored."

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -28,12 +28,20 @@ fi
 
 echo "Restoring execute permissions for files"
 
-# Get all files that should have execute permissions from Git's object database and restore them on the filesystem
-git ls-tree -r HEAD | grep "^100755" | while read -r mode type hash path; do
+# Get all files that should have execute permissions from Git's object database
+# and collect them into an array for batch processing
+executable_files=()
+while read -r mode type hash path; do
   if [ -f "$path" ]; then
-    chmod +x "$path" 2>/dev/null || true
-    echo "  ✓ $path"
+    executable_files+=("$path")
   fi
-done
+done < <(git ls-tree -r HEAD | grep "^100755")
 
-echo "Execute permissions restored."
+# Apply execute permissions to all files at once if any were found
+if [ ${#executable_files[@]} -gt 0 ]; then
+  chmod +x "${executable_files[@]}" 2>/dev/null || true
+  printf "  ✓ %s\n" "${executable_files[@]}"
+  echo "Execute permissions restored for ${#executable_files[@]} files."
+else
+  echo "No executable files found to restore."
+fi


### PR DESCRIPTION
Running e621ng on WSL is a little wonky, since your options are either to have git permanently think that any file with non-standard permissions had been changed, or deal with permissions not getting pulled from remote at all.

This fix sets up a shell script as a git hook on checkout, which will find all files that are supposed to have the execute permission, and make sure that they actually do. It's also not a perfect solution, but it's better than nothing.