### PR TITLE
[Post] Use post_path for md5 redirect

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,7 +10,7 @@ class PostsController < ApplicationController
     if params[:md5].present?
       @post = Post.find_by!(md5: params[:md5])
       respond_with(@post) do |format|
-        format.html { redirect_to(@post) }
+        format.html { redirect_to post_path(@post) }
       end
     else
       @post_set = PostSets::Post.new(tag_query, params[:page], limit: params[:limit], random: params[:random])


### PR DESCRIPTION
Use `post_path` wrap on the post object when using the `md5` parameter for posts. 