### PR TITLE
[Wiki] Use wiki path to link to artist page 

### DIFF
--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -28,7 +28,7 @@
         <% end %>
 
         <% if wiki_content.artist %>
-          <p><%= link_to "View artist", wiki_content.artist %></p>
+          <p><%= link_to "View artist", show_or_new_artists_path(name: wiki_content.title) %></p>
         <% end %>
 
         <%= wiki_page_alias_and_implication_list(wiki_content) %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -28,7 +28,7 @@
         <% end %>
 
         <% if wiki_content.artist %>
-          <p><%= link_to "View artist", show_or_new_artists_path(name: wiki_content.title) %></p>
+          <p><%= link_to "View artist", show_or_new_artists_path(name: wiki_content.artist.name) %></p>
         <% end %>
 
         <%= wiki_page_alias_and_implication_list(wiki_content) %>


### PR DESCRIPTION
Wrap the link to the artist page with the `show_or_new_artists_path` rather than linking directly to the value of the artist name. 