### PR TITLE
[Search] Reveal all fields auto-hidden when empty to staff

### DIFF
--- a/app/inputs/search_form_builder.rb
+++ b/app/inputs/search_form_builder.rb
@@ -3,7 +3,7 @@
 class SearchFormBuilder < SimpleForm::FormBuilder
   def input(attribute_name, options = {}, &)
     value = value_for_attribute(attribute_name, options)
-    return "".html_safe if value.nil? && options[:hide_unless_value]
+    return "".html_safe if value.nil? && options[:hide_unless_value] && !CurrentUser.user.is_staff?
     options = insert_autocomplete(options)
     options = insert_value(value, options)
     super


### PR DESCRIPTION
For staff work, hiding this stuff is maddening. I don't remember where, but spe asked if we could stop doing this, at least for ids.
<img width="390" height="540" alt="image" src="https://github.com/user-attachments/assets/da0a057c-edff-4bca-a001-2a868fca4e72" />
