### PR TITLE
[Posts] Disable auto-tagging AI generated posts

### DIFF
--- a/app/logical/upload_service/utils.rb
+++ b/app/logical/upload_service/utils.rb
@@ -67,7 +67,7 @@ class UploadService
       tags += %w[animated_png animated] if upload.is_animated_png?(file.path)
       tags += %w[animated_webp animated] if upload.is_animated_webp?(file.path)
       tags += ["animated"] if upload.is_webm? || upload.is_mp4?
-      tags += ["ai_generated"] if Danbooru.config.auto_flag_ai_posts? && upload.is_ai_generated?(file.path)
+      # tags += ["ai_generated"] if upload.is_ai_generated?(file.path)[:score] >= 50
       tags.join(" ")
     end
 

--- a/test/unit/ai_methods_test.rb
+++ b/test/unit/ai_methods_test.rb
@@ -170,4 +170,11 @@ class AiMethodsTest < ActiveSupport::TestCase
     assert_match(/ai generator:\s*.+/i, result[:reason])
     assert_operator result[:score], :>=, 70
   end
+
+  test "fixture bread-static.png is not AI generated" do
+    path = file_fixture("bread-static.png").to_s
+    result = is_ai_generated?(path)
+    assert_equal 0, result[:score]
+    assert_equal "no ai signals", result[:reason]
+  end
 end


### PR DESCRIPTION
Previously, due to a bug all posts ended up tagged as AI generated.
Since we now auto-flag such posts, the tagging isn't really necessary.