### PR TITLE
[Autocomplete] Fix key handling

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -574,9 +574,13 @@ class Autocompleter {
         this.close();
         break;
       case "Tab":
-        if (this.selectedIndex < 0 && this.results.length > 0) {
+        if (this.results.length > 0) {
           event.preventDefault();
-          this.selectItem(this.results[0]);
+          if (this.selectedIndex >= 0) {
+            this.selectItem(this.results[this.selectedIndex]);
+          } else {
+            this.selectItem(this.results[0]);
+          }
         }
         break;
     }

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -563,9 +563,9 @@ class Autocompleter {
         this.navigateUp();
         break;
       case "Enter":
-        event.preventDefault();
-        event.stopPropagation();
         if (this.selectedIndex >= 0) {
+          event.preventDefault();
+          event.stopPropagation();
           this.selectItem(this.results[this.selectedIndex]);
         }
         break;

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -625,8 +625,14 @@ class Autocompleter {
 
       if (this.query !== currentQuery) return;
 
+      let newSelectedIndex = -1;
+      if (this.selectedIndex >= 0 && this.selectedIndex < this.results.length) {
+        const currentSelectedItem = this.results[this.selectedIndex];
+        newSelectedIndex = results.findIndex(item => item.name === currentSelectedItem.name);
+      }
+
       this.results = results;
-      this.selectedIndex = -1;
+      this.selectedIndex = newSelectedIndex;
       this.render();
 
       if (this.results.length > 0) {

--- a/app/javascript/src/javascripts/autocomplete.js
+++ b/app/javascript/src/javascripts/autocomplete.js
@@ -494,8 +494,22 @@ class Autocompleter {
 
     Autocompleter.instances.add(this);
 
+    this.attachInput();
     this.createDropdown();
     this.bindEvents();
+  }
+
+  attachInput () {
+    this.originalAutocomplete = this.input.getAttribute("autocomplete");
+    this.input.setAttribute("autocomplete", "off");
+  }
+
+  detachInput () {
+    if (this.originalAutocomplete !== null) {
+      this.input.setAttribute("autocomplete", this.originalAutocomplete);
+    } else {
+      this.input.removeAttribute("autocomplete");
+    }
   }
 
   createDropdown () {
@@ -506,6 +520,12 @@ class Autocompleter {
     this.dropdown.setAttribute("aria-label", "Autocomplete results");
 
     document.body.appendChild(this.dropdown);
+  }
+
+  destroyDropdown () {
+    if (this.dropdown && this.dropdown.parentNode) {
+      this.dropdown.remove();
+    }
   }
 
   positionDropdown () {
@@ -534,6 +554,16 @@ class Autocompleter {
 
     this.dropdown.addEventListener("mousedown", this.handleDropdownMousedown);
     this.dropdown.addEventListener("click", this.handleDropdownClick);
+  }
+
+  unbindEvents () {
+    this.input.removeEventListener("input", this.handleInput);
+    this.input.removeEventListener("keydown", this.handleKeydown);
+    this.input.removeEventListener("blur", this.handleBlur);
+    this.input.removeEventListener("focus", this.handleFocus);
+
+    this.dropdown.removeEventListener("mousedown", this.handleDropdownMousedown);
+    this.dropdown.removeEventListener("click", this.handleDropdownClick);
   }
 
   handleInput () {
@@ -738,19 +768,11 @@ class Autocompleter {
     this.close();
     clearTimeout(this.debounceTimer);
 
-    this.input.removeEventListener("input", this.handleInput);
-    this.input.removeEventListener("keydown", this.handleKeydown);
-    this.input.removeEventListener("blur", this.handleBlur);
-    this.input.removeEventListener("focus", this.handleFocus);
-
-    this.dropdown.removeEventListener("mousedown", this.handleDropdownMousedown);
-    this.dropdown.removeEventListener("click", this.handleDropdownClick);
+    this.unbindEvents();
+    this.detachInput();
+    this.destroyDropdown();
 
     Autocompleter.instances.delete(this);
-
-    if (this.dropdown && this.dropdown.parentNode) {
-      this.dropdown.remove();
-    }
   }
 }
 


### PR DESCRIPTION
Fixes various key handling problems with the new autocomplete.

- Enter can now be pressed to search when no entry is selected
- Tab can now be used to select an entry even when a selection exists
- Selection is now preserved, if the list updates but contains the previously selected item

Fixes #1386
Fixes #1414 