### PR TITLE
[Misc] Add eslint to vscode tasks

### DIFF
--- a/.vscode/run-in-container.sh
+++ b/.vscode/run-in-container.sh
@@ -11,6 +11,8 @@ if [ -n "${REMOTE_CONTAINERS:-}" ] || [ -n "${DEVCONTAINER:-}" ] || [ -n "${CODE
 else # outside the devcontainer
   if [ "$#" -eq 1 ]; then  # for tests/rubocop, there are no extra args
     exec docker compose run --rm "$@"
+  elif [ "$1" = "linter" ]; then # eslint breaks if you pass arguments
+    exec docker compose run --rm "$1"
   else
     service="$1"
     shift

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,13 @@
       "group": "test"
     },
     {
+      "label": "e621: run_eslint_all",
+      "type": "shell",
+      "command": ".vscode/run-in-container.sh linter yarn run lint",
+      "detail": "Run eslint on all files",
+      "group": "test"
+    },
+    {
       "label": "e621: run_tests_all",
       "type": "shell",
       "command": ".vscode/run-in-container.sh tests bundle exec rails test",


### PR DESCRIPTION
Added the eslint command to the VSCode tasks. Needed to add an exception in `run-in-container.sh` to maintain comparability with tasks outside of the container. 