### PR TITLE
[Favorites] Optimize and fix adding/removing favorites

### DIFF
--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -36,7 +36,7 @@ class FavoriteManager
       Favorite.transaction(**ISOLATION) do
         raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)
 
-        # Handle orphaned fav_string entry
+        # Handle an orphaned favorite record
         post.append_user_to_fav_string(user.id)
         post.do_not_version_changes = true
         raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -3,52 +3,75 @@
 class FavoriteManager
   ISOLATION = Rails.env.test? ? {} : { isolation: :repeatable_read }
 
+  # Add a favorite for the given user and post.
+  # @param user [User] The user adding the favorite
+  # @param post [Post] The post being favorited
+  # @param force [Boolean] Whether to bypass favorite limit checking (default: false)
+  # @raises [Favorite::Error] When user has reached favorite limit, already favorited, or post save fails
+  # @raises [ActiveRecord::SerializationFailure] When transaction conflicts cannot be resolved
   def self.add!(user:, post:, force: false)
     retries = 5
     begin
       Favorite.transaction(**ISOLATION) do
-        unless force
-          if user.favorite_count >= user.favorite_limit
-            raise Favorite::Error, "You can only keep up to #{user.favorite_limit} favorites."
-          end
+        if !force && (user.favorite_count >= user.favorite_limit)
+          raise Favorite::Error, "You can only keep up to #{user.favorite_limit} favorites."
         end
 
-        Favorite.create(:user_id => user.id, :post_id => post.id)
+        Favorite.create(user_id: user.id, post_id: post.id)
         post.append_user_to_fav_string(user.id)
         post.do_not_version_changes = true
-        post.save
+
+        raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
       end
     rescue ActiveRecord::SerializationFailure => e
       retries -= 1
-      retry if retries > 0
+      if retries > 0
+        post.reload # Re-attempt with fresh post data
+        retry
+      end
       raise e
     rescue ActiveRecord::RecordNotUnique
-      raise Favorite::Error, "You have already favorited this post" unless force
+      return if force
+
+      Favorite.transaction(**ISOLATION) do
+        raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)
+
+        # Handle orphaned fav_string entry
+        post.append_user_to_fav_string(user.id)
+        post.do_not_version_changes = true
+        raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
+      end
     end
   end
 
+  # Remove a favorite for the given user and post.
+  # @param user [User] The user removing the favorite
+  # @param post [Post] The post being unfavorited
+  # @raises [Favorite::Error] When post save fails after favorite removal
+  # @raises [ActiveRecord::SerializationFailure] When transaction conflicts cannot be resolved
   def self.remove!(user:, post:)
     retries = 5
     begin
       Favorite.transaction(**ISOLATION) do
-        unless Favorite.for_user(user.id).where(user_id: user.id, post_id: post.id).exists?
-          return
-        end
-
         Favorite.for_user(user.id).where(post_id: post.id).destroy_all
         post.delete_user_from_fav_string(user.id)
         post.do_not_version_changes = true
-        post.save
+
+        raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
       end
     rescue ActiveRecord::SerializationFailure => e
       retries -= 1
-      retry if retries > 0
+      if retries > 0
+        post.reload # Re-attempt with fresh post data
+        retry
+      end
       raise e
     end
   end
 
+  # Transfers all favorites from a post to its parent post.
   def self.give_to_parent!(post)
-    # TODO Much better and more intelligent logic can exist for this
+    # TODO: Much better and more intelligent logic can exist for this
     parent = post.parent
     return false unless parent
     post.favorites.each do |fav|
@@ -58,7 +81,13 @@ class FavoriteManager
         FavoriteManager.add!(user: fav.user, post: parent, force: true)
       rescue ActiveRecord::SerializationFailure
         tries -= 1
-        retry if tries > 0
+        if tries > 0
+          retry
+        else
+          Rails.logger.warn("Failed to transfer favorite from post #{post.id} to parent #{parent.id} for user #{fav.user.id}")
+        end
+      rescue Favorite::Error => e
+        Rails.logger.warn("Failed to transfer favorite from post #{post.id} to parent #{parent.id} for user #{fav.user.id}: #{e.message}")
       end
     end
     true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1124,7 +1124,7 @@ class Post < ApplicationRecord
       !!(fav_string =~ /(?:\A| )fav:#{user_id}(?:\Z| )/)
     end
 
-    alias is_favorited? favorited_by?
+    alias_method :is_favorited?, :favorited_by?
 
     def append_user_to_fav_string(user_id)
       # Regex is faster for large fav_strings, array include? is faster for small fav_strings.

--- a/test/unit/favorite_test.rb
+++ b/test/unit/favorite_test.rb
@@ -13,6 +13,12 @@ class FavoriteTest < ActiveSupport::TestCase
   end
 
   context "A favorite" do
+    should "be created" do
+      FavoriteManager.add!(user: @user1, post: @p1)
+      assert @p1.favorited_by?(@user1.id)
+      assert_equal(1, Favorite.count)
+    end
+
     should "delete from all tables" do
       FavoriteManager.add!(user: @user1, post: @p1)
       @user1.reload
@@ -51,6 +57,105 @@ class FavoriteTest < ActiveSupport::TestCase
       error = assert_raises(Favorite::Error) { FavoriteManager.add!(user: @user1, post: @p1) }
 
       assert_equal("You can only keep up to 0 favorites.", error.message)
+    end
+
+    should "handle remove when only fav_string entry exists" do
+      # Orphaned fav_string entry
+      @p1.append_user_to_fav_string(@user1.id)
+      @p1.save
+      assert @p1.favorited_by?(@user1.id)
+      assert_equal(0, Favorite.count)
+
+      # Cleanup
+      FavoriteManager.remove!(user: @user1, post: @p1)
+      @p1.reload
+
+      assert_not @p1.favorited_by?(@user1.id)
+      assert_equal(0, Favorite.count)
+    end
+
+    should "handle remove when only database record exists" do
+      # Orphaned database record
+      Favorite.create(user: @user1, post: @p1)
+      assert_not @p1.favorited_by?(@user1.id)
+      assert_equal(1, Favorite.count)
+
+      # Cleanup
+      FavoriteManager.remove!(user: @user1, post: @p1)
+
+      assert_not @p1.favorited_by?(@user1.id)
+      assert_equal(0, Favorite.count)
+    end
+
+    should "handle add when an orphaned database record exists" do
+      # Orphaned database record
+      Favorite.create(user: @user1, post: @p1)
+      @p1.reload
+      assert_not @p1.favorited_by?(@user1.id)
+      assert_equal(1, Favorite.count)
+
+      # Cleanup
+      assert_nothing_raised do
+        FavoriteManager.add!(user: @user1, post: @p1)
+      end
+
+      @p1.reload
+      assert @p1.favorited_by?(@user1.id)
+      assert_equal(1, Favorite.count)
+    end
+
+    should "handle hybrid approach for posts with many favorites" do
+      existing_favs = (1..1001).map { |i| "fav:#{i}" }.join(" ")
+      @p1.update_columns(fav_string: existing_favs, fav_count: 1001)
+
+      # Adding a favorite
+      FavoriteManager.add!(user: @user1, post: @p1)
+      @p1.reload
+
+      assert @p1.favorited_by?(@user1.id)
+      assert_equal(1, Favorite.count)
+      assert_equal(1002, @p1.fav_count)
+      assert_includes @p1.fav_string, "fav:#{@user1.id}"
+
+      # Removing the favorite
+      FavoriteManager.remove!(user: @user1, post: @p1)
+      @p1.reload
+
+      assert_not @p1.favorited_by?(@user1.id)
+      assert_equal(0, Favorite.count)
+      assert_equal(1001, @p1.fav_count)
+      assert_not_includes @p1.fav_string, "fav:#{@user1.id}"
+
+      # Verify original favorites
+      assert_includes @p1.fav_string, "fav:1"
+      assert_includes @p1.fav_string, "fav:1001"
+    end
+
+    should "handle hybrid approach for posts with few favorites" do
+      existing_favs = (1..500).map { |i| "fav:#{i}" }.join(" ")
+      @p1.update_columns(fav_string: existing_favs, fav_count: 500)
+
+      # Adding a favorite
+      FavoriteManager.add!(user: @user1, post: @p1)
+      @p1.reload
+
+      assert @p1.favorited_by?(@user1.id)
+      assert_equal(1, Favorite.count)
+      assert_equal(501, @p1.fav_count)
+      assert_includes @p1.fav_string, "fav:#{@user1.id}"
+
+      # Removing the favorite
+      FavoriteManager.remove!(user: @user1, post: @p1)
+      @p1.reload
+
+      assert_not @p1.favorited_by?(@user1.id)
+      assert_equal(0, Favorite.count)
+      assert_equal(500, @p1.fav_count)
+      assert_not_includes @p1.fav_string, "fav:#{@user1.id}"
+
+      # Verify original favorites
+      assert_includes @p1.fav_string, "fav:1"
+      assert_includes @p1.fav_string, "fav:500"
     end
   end
 end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1377,14 +1377,6 @@ class PostTest < ActiveSupport::TestCase
         @post = create(:post)
       end
 
-      should "periodically clean the fav_string" do
-        @post.update_column(:fav_string, "fav:1 fav:1 fav:1")
-        @post.update_column(:fav_count, 3)
-        @post.append_user_to_fav_string(2)
-        assert_equal("fav:1 fav:2", @post.fav_string)
-        assert_equal(2, @post.fav_count)
-      end
-
       # TODO: Needs to reload relationship to obtain non cached value
       should "increment the user's favorite_count" do
         assert_difference("@user.reload.favorite_count", 1) do


### PR DESCRIPTION
An attempted fix at the long-standing desynchronization issue between the Favorite records and the `fav_string` Post attribute.

Fixes to the FavoriteManager:
* Roll back the transaction when adding or removing favorites if the changes to the post cannot be saved.
  * One of the main causes of desynchronization.
  * Favorite record would get added, but something prevents the post from being saved.
* Reload post data when retrying after a serialization failure.
  * The other desync-causing issue.
  * If two favorites get added at the same time, one of them will raise a SerializationFailure and retry.
  * When retrying, it should fetch the updated post data to avoid wiping out the other favorite.
* When adding a favorite, back-fill the `fav_string` with the user's ID if a corresponding Favorite record already exists.
  * An attempt to gracefully clean up previous issues.
  * It's still not seamless, but it's better than not being able to interact with favorites from the posts#show page entirely.
* When removing a favorite, don't check for whether the corresponding Favorite record actually exists.
  * This was basically pointless, and made it impossible to fix an issue where the `fav_string` included the user's ID, but the Favorite record was missing.

Changes to the `fav_string`:
* Avoid explicit deduplication.
  The `clean_fav_string!` method call was fairly expensive, not really necessary, and didn't even fix the desync problem.
* Use array methods for most posts when adding a favorite.
  For sub-1000 favorite posts (the vast majority of posts on the site), this is actually significantly faster than regex.