### PR TITLE
[Utility] Added generic collapsible elements

### DIFF
--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -73,6 +73,33 @@ Utility.regexp_escape = function (string) {
   return string.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
 };
 
+/**
+ * Register on click for the next sibling element of a `.st-collapsible-header`.
+ * @param {MouseEvent} e The event args.
+ */
+Utility.st_collapse_cb_full = function (e) {
+  // HACK: Manually sets up the shrinking animation for browsers that don't support `calc-size()` by manually setting the `height` property.
+  // IDEA: Should it be cleared after expansion?
+  // Is only needed for animated ones, & can only be set on non-collapsed elements.
+  if (e.target.hasAttribute("animated") && !e.target.hasAttribute("collapsed")) {
+    /** @type {HTMLElement} */
+    const t = e.target.nextElementSibling;
+    if (!t.style.height || t.style.height === "") {
+      t.style.height = `${t.clientHeight}px`;
+      // HACK: Prevents race condition on first collapse.
+      setTimeout(() => e.target.toggleAttribute("collapsed"), 10);
+      return;
+    }
+  }
+  e.target.toggleAttribute("collapsed");
+};
+
+Utility.initialize_collapse = function () {
+  for (const element of document.querySelectorAll(".st-collapsible-header")) {
+    element.addEventListener("click", Utility.st_collapse_cb_full);
+  }
+};
+
 $.fn.selectEnd = function () {
   return this.each(function () {
     this.focus();
@@ -88,6 +115,8 @@ $(function () {
   $(window).on("danbooru:error", function (event, msg) {
     Utility.error(msg);
   });
+
+  Utility.initialize_collapse();
 });
 
 export default Utility;

--- a/app/javascript/src/styles/common/_standard_elements.scss
+++ b/app/javascript/src/styles/common/_standard_elements.scss
@@ -284,3 +284,47 @@ input[type="checkbox"].sto-toggle:checked + label.sto-toggle {
     @include st-radius;
   }
 }
+
+// #region Collapsable header
+body {
+  --st-collapsible-header-anim-speed: 1s;
+  --st-collapsible-header-indicator-spacing: .25rem;
+}
+// The following sibling element will be collapsed on toggle
+// Depends on having the sibling's `height` property set; can be handled by the corresponding
+// `Utility` callback.
+.st-collapsible-header {
+  &[indicator=arrow]::before {
+    content: "▼";
+    margin-right: var(--st-collapsible-header-indicator-spacing);
+
+    transition: rotate --st-collapsible-header-anim-speed ease;
+    rotate: 0deg;
+    display: inline-block;
+  }
+  
+  &[animated] + * {
+    transition: all --st-collapsible-header-anim-speed ease;
+    opacity: 1;
+  }
+  &[collapsed] {
+    /* #region Indicator */
+    &:not([indicator=arrow])::before {
+      content: "▶";
+      margin-right: var(--st-collapsible-header-indicator-spacing);
+    }
+    &[indicator=arrow]::before {
+      rotate: -90deg;
+    }
+    /* #endregion Indicator */
+    &:not([animated]) + * {
+      display: none;
+    }
+    &[animated] + * {
+      overflow: hidden;
+      height: 0px;
+      opacity: 0;
+    }
+  }
+}
+// #endregion Collapsable header


### PR DESCRIPTION
Adding a class of `st-collapsible-header` makes it behave like the collapsible tag lists in the sidebar of the post search/view pages. Can have a default arrow indicator that animates by adding an `indicator` attribute of value `arrow`, & can animate the collapse with an `animated` attribute. The accompanying callback triggers the state change by adding a `collapsed` attribute.