### PR TITLE
[Users] Fix overflow issues on the mobile version of the upload page

### DIFF
--- a/app/javascript/src/styles/views/users/upload_limit/_upload_limit.scss
+++ b/app/javascript/src/styles/views/users/upload_limit/_upload_limit.scss
@@ -57,6 +57,8 @@ body.c-users.a-upload-limit {
     align-items: center;
     justify-content: center;
     min-width: 1rem;
+    height: min-content;
+    margin: auto 0;
 
     text-decoration: none;
     line-height: 1rem;

--- a/app/javascript/src/styles/views/users/upload_limit/_upload_limit.scss
+++ b/app/javascript/src/styles/views/users/upload_limit/_upload_limit.scss
@@ -19,20 +19,27 @@ body.c-users.a-upload-limit {
   .upload-limit-formula {
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 0.25rem;
 
     font-size: 1rem;
     line-height: 1rem;
     margin-bottom: 1em;
 
-    .upl-element {
+    .upl-group {
       display: flex;
       align-items: center;
-      padding: 0.5rem;
-      gap: 0.5rem;
-      @include st-radius;
+      grid-gap: 0.25rem;
 
-      background: themed("color-foreground");
+      .upl-element {
+        display: flex;
+        align-items: center;
+        padding: 0.5rem;
+        gap: 0.5rem;
+        @include st-radius;
+
+        background: themed("color-foreground");
+      }
     }
   }
 
@@ -47,6 +54,7 @@ body.c-users.a-upload-limit {
 
   .upload-limit-formula abbr, .upload-limit-explanation abbr {
     display: inline-flex;
+    align-items: center;
     justify-content: center;
     min-width: 1rem;
 

--- a/app/views/users/upload_limit.html.erb
+++ b/app/views/users/upload_limit.html.erb
@@ -31,23 +31,31 @@
       <span class="upload-limit-formula">
         <span class="upl-element"><abbr class="upl-base" title="Base Upload Limit"><%= @user.base_upload_limit %></abbr></span>
 
-        <span class="upl-math"><%= svg_icon(:plus) %></span>
-        <span class="upl-element"><abbr class="upl-approved" title="Approved Posts"><%= pieces[:approved] %></abbr> / 10</span>
-
-        <span class="upl-math"><%= svg_icon(:minus) %></span>
-        <span class="upl-element">
-          <abbr class="upl-deleted" title="Deleted or Replaced Posts, Rejected Replacements&#013;<%= pieces[:deleted_ignore] %> of your Replaced Posts do not affect your upload limit">
-            <%= pieces[:deleted] %></abbr> / 4
+        <span class="upl-group">
+          <span class="upl-math"><%= svg_icon(:plus) %></span>
+          <span class="upl-element"><abbr class="upl-approved" title="Approved Posts"><%= pieces[:approved] %></abbr> / 10</span>
         </span>
 
-        <span class="upl-math"><%= svg_icon(:minus) %></span>
-        <span class="upl-element">
-          <abbr class="upl-pending" title="Pending or Flagged Posts, Pending Replacements"><%= pieces[:pending] %></abbr>
+        <span class="upl-group">
+          <span class="upl-math"><%= svg_icon(:minus) %></span>
+          <span class="upl-element">
+            <abbr class="upl-deleted" title="Deleted or Replaced Posts, Rejected Replacements&#013;<%= pieces[:deleted_ignore] %> of your Replaced Posts do not affect your upload limit">
+              <%= pieces[:deleted] %></abbr> / 4
+          </span>
         </span>
 
-        <span class="upl-math"><%= svg_icon(:equals) %></span>
-        <span class="upl-element">
-          <abbr class="upl-total" title="Remaining Upload Limit"><%= @user.upload_limit %></abbr>
+        <span class="upl-group">
+          <span class="upl-math"><%= svg_icon(:minus) %></span>
+          <span class="upl-element">
+            <abbr class="upl-pending" title="Pending or Flagged Posts, Pending Replacements"><%= pieces[:pending] %></abbr>
+          </span>
+        </span>
+
+        <span class="upl-group">
+          <span class="upl-math"><%= svg_icon(:equals) %></span>
+          <span class="upl-element">
+            <abbr class="upl-total" title="Remaining Upload Limit"><%= @user.upload_limit %></abbr>
+          </span>
         </span>
       </span>
 


### PR DESCRIPTION
This change fixes an issue with the upload limit explanation rendering on mobile devices.

Additionally, it now groups each section of the upload limit formula by operation, that way any wrapping will occur such that the mathematical operator is always at the beginning of the new line.

Prior to operation grouping, it would be possible for the formula to wrap as shown:
```
10 + (0 / 10) - (0 / 4) -
0 = 10
```
Note that the wrapped line starts with the number and not the mathematical operator.

With operation grouping, that same wrapping formula will now result in the operator leading the new line:
```
10 + (0 / 10) - (0 / 4)
- 0 = 10
```