### PR TITLE
[Replacements] Add reporting for replacements

### DIFF
--- a/app/javascript/src/styles/specific/post_replacements.scss
+++ b/app/javascript/src/styles/specific/post_replacements.scss
@@ -56,6 +56,10 @@ div#c-post-replacements {
   #a-new {
     input[type="text"] { max-width: unset !important; }
   }
+
+  .replacement-embedded {
+    margin-bottom: 1rem;
+  }
 }
 
 // Lost both thumbs in an industrial accident.

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -450,6 +450,12 @@ class PostReplacement < ApplicationRecord
     status == "approved" && !is_current?
   end
 
+  def visible_to?(user)
+    return true unless is_rejected?
+    return false unless user.is_staff? # Only staff can see rejected replacements
+    true
+  end
+
   def promoted_id
     return nil unless is_promoted?
     if post.has_children?

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -39,6 +39,7 @@ class Ticket < ApplicationRecord
   # |    User    |         Any         | Moderator+ / Creator |
   # |  Wiki Page |         Any         |  Janitor+ / Creator  |
   # |    Other   |         None        | Moderator+ / Creator |
+  # |Replacement |         Any         |  Janitor+ / Creator  |
 
   module TicketTypes
     module Blip
@@ -171,6 +172,24 @@ class Ticket < ApplicationRecord
 
       def can_view?(user)
         user.is_staff? || user.is_admin? || (user.id == creator_id)
+      end
+    end
+
+    module Replacement
+      def model
+        ::PostReplacement
+      end
+
+      def can_view?(user)
+        user.is_janitor? || (user.id == creator_id)
+      end
+
+      def can_create_for?(user)
+        content&.visible_to?(user)
+      end
+
+      def subject
+        reason.split("\n")[0] || "Unknown Report Type"
       end
     end
   end

--- a/app/views/post_replacements/partials/show/_post_replacement.html.erb
+++ b/app/views/post_replacements/partials/show/_post_replacement.html.erb
@@ -112,5 +112,6 @@
     <% if CurrentUser.is_admin? %>
       <dd class="replacement-spaced-row"> <%= link_to "Destroy", "#destroy", class: "replacement-destroy-action", data: { replacement_id: post_replacement.id } %> </dd>
     <% end %>
+    <%= link_to("Report", new_ticket_path(disp_id: post_replacement.id, qtype: "replacement"), class: "replacement-report-action replacement-action-button") %>
   </td>
 </tr>

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -12,6 +12,7 @@
           To submit a ticket about a problematic set, click "Report" on the set page itself.<br/>
           To submit a ticket about a problematic user, click "Report" on the user's profile page.<br/>
           To submit a ticket about a problematic private message, click "Report PM" above the PM itself.<br/>
+          To submit a ticket about a problematic replacement, click "Report" on the replacement itself.<br/>
           To submit a username request, click "Request Username Change" on <a href='/user/home'>the user home page</a>.<br/>
         </div>
       <% else %>

--- a/app/views/tickets/new_types/_replacement.html.erb
+++ b/app/views/tickets/new_types/_replacement.html.erb
@@ -1,0 +1,6 @@
+<div id="c-post-replacements">
+You are reporting the following replacement: 
+  <div class: "replacement-embedded">
+    <%= render partial: "post_replacements/partials/show/post_replacement", locals: { post_replacement: @ticket.content } %>
+  </div>
+</div>

--- a/app/views/tickets/types/_replacement.erb
+++ b/app/views/tickets/types/_replacement.erb
@@ -1,0 +1,11 @@
+<div id="c-post-replacements">
+
+<% if @ticket.content %>
+  <div class: "replacement-embedded">
+    <%= render partial: "post_replacements/partials/show/post_replacement", locals: { post_replacement: @ticket.content } %>
+</div>
+
+<% else %>
+<% end %>
+
+</div>

--- a/app/views/tickets/types/_replacement.erb
+++ b/app/views/tickets/types/_replacement.erb
@@ -5,7 +5,6 @@
     <%= render partial: "post_replacements/partials/show/post_replacement", locals: { post_replacement: @ticket.content } %>
 </div>
 
-<% else %>
 <% end %>
 
 </div>


### PR DESCRIPTION
> [!IMPORTANT]
> This is PR is a subset of #1207. This PR should be merged _before_ it.
> Degradation info: 
> ✅ Functions: Tickets can be created and handled.
> ❌ UX: UI is degraded, since the mobile-replacement card partial is unavailable.


Adds a ticket process for replacements. 

<img width="286" height="394" alt="Replacements index" src="https://github.com/user-attachments/assets/89de59a4-921b-4de0-b729-3742ed0470d4" />

<img width="832" height="1069" alt="Report form" src="https://github.com/user-attachments/assets/eccc4113-27cf-4acd-b6db-93a4f815fc16" />

<img width="1410" height="723" alt="Ticket view" src="https://github.com/user-attachments/assets/9484e577-5c19-4045-b2b8-4b1c63270283" />
