### PR TITLE
[Home] Disable themes on the home page

### DIFF
--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -23,20 +23,6 @@ function initSearch () {
 }
 
 $(function () {
-  const isStaticHome = $("body").is(".c-static.a-home");
-  $("#theme-switcher").change(function () {
-    let theme = $(this).val();
-    LStorage.put("theme", theme);
-    if (!isStaticHome) $("body").attr("data-th-main", theme);
-  });
-
-  {
-    let theme = LStorage.get("theme") || "hexagon";
-    // Note: homepage overrides theme colors to `hexagon` manually in SCSS
-    if (!isStaticHome) $("body").attr("data-th-main", theme);
-    $("#theme-switcher").val(theme);
-  }
-
   // Account notices
   $(".dmail-notice-hide").on("click.danbooru", function (event) {
     event.preventDefault();

--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -1,6 +1,5 @@
 import Cookie from "./cookie";
 import Utility from "./utility";
-import LStorage from "./utility/storage";
 
 function initSearch () {
   const $searchForm = $("#searchform");

--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -23,16 +23,17 @@ function initSearch () {
 }
 
 $(function () {
+  const isStaticHome = $("body").is(".c-static.a-home");
   $("#theme-switcher").change(function () {
     let theme = $(this).val();
     LStorage.put("theme", theme);
-    $("body").attr("data-th-main", theme);
+    if (!isStaticHome) $("body").attr("data-th-main", theme);
   });
 
   {
     let theme = LStorage.get("theme") || "hexagon";
     // Note: homepage overrides theme colors to `hexagon` manually in SCSS
-    $("body").attr("data-th-main", theme);
+    if (!isStaticHome) $("body").attr("data-th-main", theme);
     $("#theme-switcher").val(theme);
   }
 

--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -31,6 +31,7 @@ $(function () {
 
   {
     let theme = LStorage.get("theme") || "hexagon";
+    // Note: homepage overrides theme colors to `hexagon` manually in SCSS
     $("body").attr("data-th-main", theme);
     $("#theme-switcher").val(theme);
   }

--- a/app/javascript/src/javascripts/themes.js
+++ b/app/javascript/src/javascripts/themes.js
@@ -17,6 +17,12 @@ for (const [label, settings] of Object.entries(Theme.Values)) {
         // This has the unintended side effect of setting
         // attribute values that don't exist on the body.
         LStorage[label][one] = value;
+        // If we're on the static homepage, don't apply the main or extra theme
+        // attributes; leave those unset so the default (hexagon) is used.
+        if ($("body").is(".c-static.a-home") && (one === "Main" || one === "Extra")) return;
+
+        // Homepage fallback to hexagon is handled elsewhere; just write the
+        // attribute normally for other pages/keys.
         $("body").attr("data-th-" + one.toLowerCase(), value);
       },
     });

--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -1,6 +1,12 @@
 body.c-static.a-home {
   background: #012e57; // I am certain this was needed for something
   background-color: themed("bg-color", #012e57);
+  /* Override themed() by setting the CSS variables they read */
+  --color-text: #ffffff;
+  --fg-color: rgba(255,255,255,0.08); 
+  --color-link: #b4c7d9;
+  --color-link-hover: #e9f2fa;
+  --color-link-active: #f3c400;
 
   #page {
     background: none;

--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -1,12 +1,6 @@
 body.c-static.a-home {
   background: #012e57; // I am certain this was needed for something
   background-color: themed("bg-color", #012e57);
-  /* Override themed() by setting the CSS variables they read */
-  --color-text: #ffffff;
-  --fg-color: rgba(255,255,255,0.08); 
-  --color-link: #b4c7d9;
-  --color-link-hover: #e9f2fa;
-  --color-link-active: #f3c400;
 
   #page {
     background: none;

--- a/app/views/layouts/_theme_include.html.erb
+++ b/app/views/layouts/_theme_include.html.erb
@@ -1,6 +1,9 @@
 <%= javascript_tag nonce: true do -%>
 (function() {
   try {
+    // Server-side flag: true when rendering the static homepage. Used to avoid
+    // applying main/extra theme attributes there so the page uses the default.
+    const isStaticHome = <%= (controller_name == 'static' && action_name == 'home') ? 'true' : 'false' %>;
     const values = {
       // Theme
       "th-main": localStorage.getItem("theme") || "hexagon",
@@ -23,6 +26,9 @@
 
     var b = document.body;
     for (const [name, value] of Object.entries(values)) {
+      // If we're on the static homepage, don't apply the main or extra theme
+      // attributes; leave those unset so the default (hexagon) is used.
+      if (isStaticHome && (name === 'th-main' || name === 'th-extra')) continue;
       b.setAttribute("data-" + name, value);
     }
   } catch(e) {}

--- a/app/views/layouts/_theme_include.html.erb
+++ b/app/views/layouts/_theme_include.html.erb
@@ -3,7 +3,7 @@
   try {
     // Server-side flag: true when rendering the static homepage. Used to avoid
     // applying main/extra theme attributes there so the page uses the default.
-    const isStaticHome = <%= (controller_name == 'static' && action_name == 'home') ? 'true' : 'false' %>;
+    const isStaticHome = <%= controller_name == "static" && action_name == "home" ? "true" : "false" %>;
     const values = {
       // Theme
       "th-main": localStorage.getItem("theme") || "hexagon",


### PR DESCRIPTION
Fixes an issue where homepage text uses the user-preferred `theme` color, despite the page itself forcing `hexagon` themed background. 

The problem: 
<img width="550" height="345" alt="image" src="https://github.com/user-attachments/assets/e3e648e3-5e4a-4267-9561-c4d34ef5d5d9" />
Fix:
<img width="492" height="230" alt="image" src="https://github.com/user-attachments/assets/1167245e-8bb0-42a7-b1d0-42f78b30beef" />
