### PR TITLE
[Users] Fix the "pending replacements" link

### DIFF
--- a/app/views/users/partials/show/_staff_info.html.erb
+++ b/app/views/users/partials/show/_staff_info.html.erb
@@ -31,7 +31,7 @@
     <h4>Pending</h4>
     <span>
       <%= link_to "Posts", posts_path(tags: "user:#{user.name} status:pending") %>
-      | <%= link_to "Replacements", post_replacements_path(search: { creator_name: user.name }) %>
+      | <%= link_to "Replacements", post_replacements_path(search: { creator_name: user.name, status: "pending" }) %>
     </span>
 
     <h4>Uploads</h4>


### PR DESCRIPTION
Add status filter for replacements link in staff info.
https://discord.com/channels/431908090883997698/1392682818890498059/1433624862341070979
To be tested