### PR TITLE
[Favorites] Avoid serialization failures when synchronizing post data

### DIFF
--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class FavoriteManager
-  ISOLATION = Rails.env.test? ? {} : { isolation: :repeatable_read }
-
   # Add a favorite for the given user and post.
   # @param user [User] The user adding the favorite
   # @param post [Post] The post being favorited
@@ -10,39 +8,32 @@ class FavoriteManager
   # @raises [Favorite::Error] When user has reached favorite limit, already favorited, or post save fails
   # @raises [ActiveRecord::SerializationFailure] When transaction conflicts cannot be resolved
   def self.add!(user:, post:, force: false)
-    retries = 5
-    begin
-      Favorite.transaction(**ISOLATION) do
-        if !force && (user.favorite_count >= user.favorite_limit)
-          raise Favorite::Error, "You can only keep up to #{user.favorite_limit} favorites."
-        end
-
-        Favorite.create(user_id: user.id, post_id: post.id)
-        post.with_lock do # Avoid SerializationFailure on concurrent fav_string updates
-          post.append_user_to_fav_string(user.id)
-          post.do_not_version_changes = true
-          raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
-        end
+    Favorite.transaction do
+      if !force && (user.favorite_count >= user.favorite_limit)
+        raise Favorite::Error, "You can only keep up to #{user.favorite_limit} favorites."
       end
-    rescue ActiveRecord::SerializationFailure => e
-      retries -= 1
-      if retries > 0
-        post.reload # Re-attempt with fresh post data
-        retry
-      end
-      raise e
-    rescue ActiveRecord::RecordNotUnique
-      return if force
 
-      Favorite.transaction(**ISOLATION) do
-        raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)
+      Favorite.create(user_id: user.id, post_id: post.id)
 
-        post.with_lock do
-          post.append_user_to_fav_string(user.id)
-          post.do_not_version_changes = true
-          raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
-        end
-      end
+      post.lock!
+      post.reload
+      post.append_user_to_fav_string(user.id)
+      post.do_not_version_changes = true
+
+      raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
+    end
+  rescue ActiveRecord::RecordNotUnique
+    return if force
+    raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)
+
+    # Handle orphaned favorite record
+    Favorite.transaction do
+      post.lock!
+      post.reload
+      post.append_user_to_fav_string(user.id)
+      post.do_not_version_changes = true
+
+      raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
     end
   end
 
@@ -52,23 +43,15 @@ class FavoriteManager
   # @raises [Favorite::Error] When post save fails after favorite removal
   # @raises [ActiveRecord::SerializationFailure] When transaction conflicts cannot be resolved
   def self.remove!(user:, post:)
-    retries = 5
-    begin
-      Favorite.transaction(**ISOLATION) do
-        Favorite.for_user(user.id).where(post_id: post.id).destroy_all
-        post.with_lock do # Avoid SerializationFailure on concurrent fav_string updates
-          post.delete_user_from_fav_string(user.id)
-          post.do_not_version_changes = true
-          raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
-        end
-      end
-    rescue ActiveRecord::SerializationFailure => e
-      retries -= 1
-      if retries > 0
-        post.reload # Re-attempt with fresh post data
-        retry
-      end
-      raise e
+    Favorite.transaction do
+      Favorite.for_user(user.id).where(post_id: post.id).destroy_all
+
+      post.lock!
+      post.reload
+      post.delete_user_from_fav_string(user.id)
+      post.do_not_version_changes = true
+
+      raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
     end
   end
 end


### PR DESCRIPTION
Got rid of isolation and went with locking the post row instead.
The outcome is roughly the same, except that row lock postpones other transactions instead of raising an error.

This may cause latency issues if a post is extremely hot and is getting bombarded with favorites.
But the previous approach would just retry 5 times and give up, which is arguably worse.