### PR TITLE
[Comments] Optimize comment index to fix timeout issues

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,10 +9,10 @@ class CommentsController < ApplicationController
   skip_before_action :api_check
 
   def index
-    if params[:group_by] == "comment"
-      index_by_comment
-    else
+    if params[:group_by] == "post"
       index_by_post
+    else
+      index_by_comment
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -114,7 +114,7 @@ class CommentsController < ApplicationController
     narrowing_params = %i[body_matches post_id post_tags_match creator_name creator_id
                           post_note_updater_name post_note_updater_id poster_id poster_name ip_addr]
     has_narrowing_search = narrowing_params.any? { |param| params[:search]&.dig(param).present? }
-    has_narrowing_search ||= params[:search]&.dig(:is_hidden)&.to_s == "true"
+    has_narrowing_search ||= params[:search]&.dig(:is_hidden)&.to_s == "false"
     has_narrowing_search ||= params[:search]&.dig(:is_sticky)&.to_s == "true"
 
     search_params_for_count = has_narrowing_search ? params[:search] : nil

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -110,11 +110,14 @@ class CommentsController < ApplicationController
   end
 
   def index_by_comment
+    # Disable pagination calculation unless needed to avoid expensive COUNT queries
+    search_params_for_count = params[:search]&.except(:order).presence
+
     @comments = Comment
                 .visible(CurrentUser.user)
                 .includes(:creator, :updater)
                 .search(search_params)
-                .paginate(params[:page], limit: params[:limit], search_count: params[:search])
+                .paginate(params[:page], limit: params[:limit], search_count: search_params_for_count)
     @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
 
     if CurrentUser.is_staff?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -52,18 +52,15 @@ class Comment < ApplicationRecord
     end
 
     def visible(user)
-      q = where("comments.score >= ? or comments.is_sticky = true", user.comment_threshold)
-      unless user.is_moderator?
-        # Checking whether the post has comments disabled is expensive, especially in COUNT queries for pagination.
-        # Only 19 posts qualify as of Nov 2025. If that number grows significantly, we will need to rethink this approach.
-        q = q.where("comments.is_sticky = true or comments.creator_id = ? or comments.post_id NOT IN (SELECT id FROM posts WHERE is_comment_disabled = true)", user.id)
-        if user.is_janitor?
-          q = q.where("comments.is_sticky = true or comments.is_hidden = false or comments.creator_id = ?", user.id)
-        else
-          q = q.where("comments.is_hidden = false or comments.creator_id = ?", user.id)
-        end
-      end
-      q
+      return where("comments.score >= ? OR comments.is_sticky = true", user.comment_threshold) if user.is_moderator?
+
+      # Only 19 posts have comments disabled as of Nov 2025.
+      # If that number grows significantly, we will need to rethink this approach.
+      passes_checks = "(comments.score >= ?) AND comments.post_id NOT IN (SELECT id FROM posts WHERE is_comment_disabled = true)"
+      passes_checks += " AND comments.is_hidden = false" unless user.is_janitor?
+      sticky_or_own = "comments.is_sticky = true OR comments.creator_id = ?"
+
+      where("#{sticky_or_own} OR (#{passes_checks})", user.id, user.comment_threshold)
     end
 
     def post_tags_match(query)

--- a/app/views/comments/_secondary_links.html.erb
+++ b/app/views/comments/_secondary_links.html.erb
@@ -1,8 +1,16 @@
 <% content_for(:secondary_links) do %>
   <li><%= render "comments/quick_search" %></li>
-  <%= subnav_link_to "Listing", comments_path(group_by: "post") %>
+  <%= subnav_link_to "Listing", comments_path %>
   <%= subnav_link_to "Search", search_comments_path %>
   <%= subnav_link_to "Help", help_page_path(id: "comments") %>
+
+  <li class="divider"></li>
+  <% if params[:group_by] == "post" %>
+    <%= subnav_link_to "By Comment", comments_path(group_by: "comment") %>
+  <% else %>
+    <%= subnav_link_to "By Post", comments_path(group_by: "post") %>
+  <% end %>
+
   <% if @latest.present? %>
     <li class="divider"></li>
     <%= subnav_link_to "Latest", @latest %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -5,10 +5,10 @@
     <%= render "posts/partials/common/inline_blacklist" %>
 
     <%= render "search" %>
-    <% if params[:group_by] == "comment" %>
-      <%= render "index_by_comment" %>
-    <% else %>
+    <% if params[:group_by] == "post" %>
       <%= render "index_by_post" %>
+    <% else %>
+      <%= render "index_by_comment" %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/_main_links.html.erb
+++ b/app/views/layouts/_main_links.html.erb
@@ -9,5 +9,5 @@
 <%= decorated_nav_link_to("Sets", :group, post_sets_path) %>
 <%= decorated_nav_link_to("Tags", :tags, tags_path) %>
 <%= decorated_nav_link_to("Blips", :megaphone, blips_path) %>
-<%= decorated_nav_link_to("Comments", :message_square, comments_path(group_by: "post")) %>
+<%= decorated_nav_link_to("Comments", :message_square, comments_path) %>
 <%= decorated_nav_link_to("Forum", :lectern, forum_topics_path, class: (CurrentUser.has_forum_been_updated? ? "notification" : nil)) %>

--- a/db/migrate/20251101144234_add_index_posts_on_is_comment_disabled.rb
+++ b/db/migrate/20251101144234_add_index_posts_on_is_comment_disabled.rb
@@ -2,6 +2,10 @@
 
 class AddIndexPostsOnIsCommentDisabled < ActiveRecord::Migration[7.1]
   def change
-    add_index :posts, :id, where: "is_comment_disabled = true", name: "index_posts_on_is_comment_disabled"
+    Post.without_timeout do
+      add_index :posts, :id, where: "is_comment_disabled = true", name: "index_posts_on_is_comment_disabled"
+      add_index :comments, :id, where: "is_sticky = true", name: "index_comments_on_is_sticky"
+      add_index :comments, :id, where: "is_hidden = true", name: "index_comments_on_is_hidden"
+    end
   end
 end

--- a/db/migrate/20251101144234_add_index_posts_on_is_comment_disabled.rb
+++ b/db/migrate/20251101144234_add_index_posts_on_is_comment_disabled.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexPostsOnIsCommentDisabled < ActiveRecord::Migration[7.1]
+  def change
+    add_index :posts, :id, where: "is_comment_disabled = true", name: "index_posts_on_is_comment_disabled"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4276,6 +4276,13 @@ CREATE INDEX index_posts_on_created_at ON public.posts USING btree (created_at);
 
 
 --
+-- Name: index_posts_on_is_comment_disabled; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_is_comment_disabled ON public.posts USING btree (id) WHERE (is_comment_disabled = true);
+
+
+--
 -- Name: index_posts_on_is_flagged; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4845,6 +4852,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251101144234'),
 ('20251014151300'),
 ('20251010171207'),
 ('20251001213309'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3702,6 +3702,20 @@ CREATE INDEX index_comments_on_creator_ip_addr ON public.comments USING btree (c
 
 
 --
+-- Name: index_comments_on_is_hidden; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_comments_on_is_hidden ON public.comments USING btree (id) WHERE (is_hidden = true);
+
+
+--
+-- Name: index_comments_on_is_sticky; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_comments_on_is_sticky ON public.comments USING btree (id) WHERE (is_sticky = true);
+
+
+--
 -- Name: index_comments_on_lower_body_trgm; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
The comment index occasionally experiences timeouts because of the COUNT calculations required to perform pagination.
Several things were done to improve the situation:
1. Changed default grouping to "by comment", since "by post" has a severe N+1 query issue
  We might want to phase out the latter page eventually. It's not terribly useful to begin with.
3. Added a whitelist to only perform page count calculations if the search isn't likely to return 99% of the posts.
  This includes only re-ordering the comment list, searching for `is_sticky=false`, `is_hidden=false`, etc.
5. Reworked comment visibility query to avoid having to do JOINs on the `posts` table to determine whether the post has comments disabled.
  Since we only have 19 posts with disabled comments on the site, it's easier and more performant to just fetch them all in a subquery. If we start disabling a lot more comment sections (as in, thousands), we'll have to revisit this.
7. Added a few indexes, just in case.
  Indexes on the `post.is_comment_disabled = true`, `comment.is_sticky = true`, and `is_hidden = true`.