### PR TITLE
[Stats] Add webp posts to stats

### DIFF
--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -32,6 +32,7 @@ class StatsUpdater
     stats[:explicit_posts] = Post.tag_match("rating:e", always_show_deleted: true).count_only
     stats[:jpg_posts] = Post.tag_match("type:jpg", always_show_deleted: true).count_only
     stats[:png_posts] = Post.tag_match("type:png", always_show_deleted: true).count_only
+    stats[:webp_posts] = Post.tag_match("type:webp", always_show_deleted: true).count_only
     stats[:gif_posts] = Post.tag_match("type:gif", always_show_deleted: true).count_only
     stats[:swf_posts] = Post.tag_match("type:swf", always_show_deleted: true).count_only
     stats[:webm_posts] = Post.tag_match("type:webm", always_show_deleted: true).count_only

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -38,6 +38,7 @@
           ["JPG posts", "jpg_posts", "existing_posts"],
           ["PNG posts", "png_posts", "existing_posts"],
           ["GIF posts", "gif_posts", "existing_posts"],
+          ["WEBP posts", "webp_posts", "existing_posts"],
           ["Flash posts", "swf_posts", "existing_posts"],
           ["WebM posts", "webm_posts", "existing_posts"],
           ["MP4 posts", "mp4_posts", "existing_posts"],


### PR DESCRIPTION
Fixes #1464

Before daily maintenance is run, the data's key will be shown instead. This is explicitly programmed in the `percentage_table` partial. 