### PR TITLE
[Posts] Display exact result count, if available

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -20,14 +20,17 @@ module PaginationHelper
     else
       pages = records.total_pages
       schar = "~"
-      count = ((pages - 1) * records.records_per_page) + (rand(0.2..0.8) * records.records_per_page).to_i
+
+      # Persistent random count approximation
+      rng = Random.new(params.to_unsafe_h.except(:controller, :action, :id, :page).hash)
+      count = ((pages - 1) * records.records_per_page) + (rng.rand(0.2..0.8) * records.records_per_page).to_i
       title = "Approximately #{number_with_delimiter(count)} results found.\nActual result count may differ."
     end
 
     tag.span(class: "approximate-count", title: title, data: { count: count, pages: pages, per: records.max_numbered_pages }) do
       concat schar
       if should_round
-        concat number_to_human(count, precision: 0, format: "%n%u", units: { thousand: "k" })
+        concat number_to_human(count, precision: 2, format: "%n%u", units: { thousand: "k" })
       else
         concat number_with_delimiter(count)
       end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -4,21 +4,33 @@ module PaginationHelper
   def approximate_count(records)
     return "" if records.pagination_mode != :numbered
 
-    if records.total_pages > records.max_numbered_pages
+    should_round = true
+    if records.is_last_page?
+      records_on_current_page = records.size
+      count = ((records.current_page - 1) * records.records_per_page) + records_on_current_page
+      pages = records.current_page
+      schar = ""
+      title = "Exactly #{number_with_delimiter(count)} results found."
+      should_round = false
+    elsif records.total_pages > records.max_numbered_pages
       pages = records.max_numbered_pages
       schar = "over "
       count = pages * records.records_per_page
-      title = "Over #{count} results found.\nActual result count may be much larger."
+      title = "Over #{number_with_delimiter(count)} results found.\nActual result count may be much larger."
     else
       pages = records.total_pages
       schar = "~"
-      count = pages * records.records_per_page
-      title = "Approximately #{count} results found.\nActual result count may differ."
+      count = ((pages - 1) * records.records_per_page) + (rand(0.2..0.8) * records.records_per_page).to_i
+      title = "Approximately #{number_with_delimiter(count)} results found.\nActual result count may differ."
     end
 
     tag.span(class: "approximate-count", title: title, data: { count: count, pages: pages, per: records.max_numbered_pages }) do
       concat schar
-      concat number_to_human(count, precision: 2, format: "%n%u", units: { thousand: "k" })
+      if should_round
+        concat number_to_human(count, precision: 0, format: "%n%u", units: { thousand: "k" })
+      else
+        concat number_with_delimiter(count)
+      end
       concat " "
       concat "result".pluralize(count)
     end


### PR DESCRIPTION
Typically only available on the last page of the search.