### PR TITLE
[Posts] Fix having to tap twice on tags to navigate on some mobile devices

### DIFF
--- a/app/javascript/src/styles/views/posts/common/_tag_list.desktop.scss
+++ b/app/javascript/src/styles/views/posts/common/_tag_list.desktop.scss
@@ -55,9 +55,15 @@ ul.tag-list {
   }
 
   .tag-list-quick-blacklist { visibility: hidden; }
-  li:hover, li.blacklisted {
-    .tag-list-quick-blacklist { visibility: visible; }
+
+  // Media query to prevent Webkit users on touch devices from
+  // having to double tap the tag to perform a navigation
+  @media (hover: hover) and (pointer: fine) {
+    li:hover, li.blacklisted {
+      .tag-list-quick-blacklist { visibility: visible; }
+    }
   }
+
   li.blacklisted {
     .tag-list-quick-blacklist svg {
       color: themed("color-text-muted");


### PR DESCRIPTION
This PR fixes #1004, in which iPad users needs to tap on a tag twice to navigate to the link it points to. 

iPads are a interesting case, becasue while e621 does have a more touch firendly version of the tags for mobile, on iPads it always shows the desktop version. So having to tap the kinda small links two times is less than ideal, I personally fail the second tap alot and end up colapsing the Artists or Copyrights sections instead.

I could not find a definitive source for the root cause, but Webkit seems to have heuristics arround handling touch events for interactive controls which also have hover styles. What I think its happening is that it sees that the hover style makes an interactive element visible (the "blacklist tag" button, which is only shown on hover for desktop), and so it decides to prioritize showing that by sticking the element on its hover state on tap, instead of just doing the link navigation, and so the user must then decide to either tap the link again or click on the now visible black list button.

The PR essentially removes the blacklist button appearing on hover for touch screens on the desktop layout, but on the mobile layout we already don't have that, so we are already not expecting mobile users to use that feature. Desktops should still keep working as intended. (Since they match both `hover: hover` and `pointer: fine` queries)

Tested on Android and iPad for touch and Chrome and Safari for desktop.