### PR TITLE
[UI] Fix a transparency issue in the avatar menu

### DIFF
--- a/app/javascript/src/styles/views/application/_avatar.scss
+++ b/app/javascript/src/styles/views/application/_avatar.scss
@@ -109,7 +109,7 @@ nav.navigation .simple-avatar {
   // Desktop
   @include window-larger-than(50rem) {
     .avatar-name {
-      background: none;
+      background: themed("color-background");
       color: inherit;
 
       height: 1.5rem;
@@ -130,7 +130,7 @@ nav.navigation .simple-avatar {
     }
 
     &:hover, &:active {
-      .avatar-name { background: none; }
+      .avatar-name { background: themed("color-background"); }
     }
 
     .avatar-more {


### PR DESCRIPTION
On smaller screens, the username would get overlaid on top of some of the navbar items.