### PR TITLE
[Docker] Disable TTY

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
         condition: service_started
       iqdb:
         condition: service_started
-    tty: true
 
   autocompleted:
     image: ghcr.io/e621ng/autocompleted:8807bc8658f594cd0de04de1c272c3a2f917fc48


### PR DESCRIPTION
Evidently, TTY interfered with tmux, causing overmind to only start the first process in procfile.