### PR TITLE
[Misc] Add docker-cli-compose to devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   ],
   "postAttachCommand": ["/bin/sh", "/app/.devcontainer/post-attach.sh", "bash"],
   "postCreateCommand": {
-    "bash-completion": "apk update && apk --no-cache add bash-completion docker-cli && echo 'source /etc/bash/bash_completion.sh' >> ~/.bash_profile"
+    "bash-completion": "apk update && apk --no-cache add bash-completion docker-cli docker-cli-compose && echo 'source /etc/bash/bash_completion.sh' >> ~/.bash_profile"
   },
   
   "customizations": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,7 @@
       "type": "shell",
       "command": "docker compose up -d",
       "detail": "Run the application",
-      "hide": true,
+      "hide": false,
       "group": {
         "kind": "build",
         "isDefault": true
@@ -51,7 +51,7 @@
       "label": "e621: stop",
       "type": "shell",
       "command": "docker compose down",
-      "hide": true,
+      "hide": false,
       "detail": "Stop the application",
       "group": "build"
     },
@@ -81,7 +81,7 @@
       "label": "e621: dev_erase",
       "type": "shell",
       "command": "docker compose down -v",
-      "hide": true,
+      "hide": false,
       "detail": "Stop and remove volumes",
       "group": "none"
     },


### PR DESCRIPTION
It didn't work before, but now it does. Now, you can use 'docker compose' or 'docker-compose' commands right in the devcontainer terminal! 'tasks.json' *could* be updated to use 'compose' commands again, but it is probably slightly better for them to run directly anyway.