### PR TITLE
Make it more obvious when reporting comment/blip/forum post

### DIFF
--- a/app/javascript/src/styles/common/_comment_container.scss
+++ b/app/javascript/src/styles/common/_comment_container.scss
@@ -32,7 +32,14 @@
     grid-row: 1;
     padding: $padding-025 $padding-050;
 
-    .content-menu { margin-top: 1rem; }
+    .content-menu {
+      margin-top: 1rem;
+      
+      .post-report {
+        font-size: 90%;
+        float: right;
+      }
+    }
   }
 }
 

--- a/app/javascript/src/styles/views/tickets/new/_new.scss
+++ b/app/javascript/src/styles/views/tickets/new/_new.scss
@@ -15,10 +15,10 @@
 
   .ticket-warning {
     display: block;
-    background: themed("color-section-lighten-5");
+    background: themed("color-danger-darken-10");
     @include st-radius;
     padding: 0.5rem;
-    margin-bottom: 1rem;
+    margin: .5rem 0;
   
     ul {
       list-style: disc;

--- a/app/javascript/src/styles/views/tickets/new/_new.scss
+++ b/app/javascript/src/styles/views/tickets/new/_new.scss
@@ -18,7 +18,7 @@
     background: themed("color-danger-darken-10");
     @include st-radius;
     padding: 0.5rem;
-    margin: .5rem 0;
+    margin-bottom: 1rem;
   
     ul {
       list-style: disc;

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -54,7 +54,7 @@
           <% end %>
 
           <% if CurrentUser.is_member? %>
-            <li><%= link_to "Report", new_ticket_path(disp_id: blip.id, qtype: 'blip') %></li>
+            <li class="post-report"><%= link_to "Report", new_ticket_path(disp_id: blip.id, qtype: 'blip') %></li>
           <% end %>
 
           <% if CurrentUser.is_moderator? %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -48,7 +48,7 @@
             <% end %>
             <% if CurrentUser.is_member? && !comment.is_sticky %>
               <li>|</li>
-              <li><%= link_to "Report", new_ticket_path(disp_id: comment.id, qtype: 'comment') %></li>
+              <li class="report"><%= link_to "Report", new_ticket_path(disp_id: comment.id, qtype: 'comment') %></li>
             <% end %>
             <% if CurrentUser.is_moderator? %>
               <li>|</li>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -48,7 +48,7 @@
             <% end %>
             <% if CurrentUser.is_member? && !comment.is_sticky %>
               <li>|</li>
-              <li class="report"><%= link_to "Report", new_ticket_path(disp_id: comment.id, qtype: 'comment') %></li>
+              <li class="post-report"><%= link_to "Report", new_ticket_path(disp_id: comment.id, qtype: 'comment') %></li>
             <% end %>
             <% if CurrentUser.is_moderator? %>
               <li>|</li>

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -59,7 +59,7 @@
             <li><%= link_to "Parent", forum_topic_path(forum_post.topic, :page => forum_post.forum_topic_page, :anchor => "forum_post_#{forum_post.id}") %></li>
           <% end %>
           <% if CurrentUser.is_member? %>
-            <li><%= link_to "Report", new_ticket_path(disp_id: forum_post.id, qtype: 'forum') %></li>
+            <li class="post-report"><%= link_to "Report", new_ticket_path(disp_id: forum_post.id, qtype: 'forum') %></li>
           <% end %>
           <% if CurrentUser.is_moderator? %>
             <li>|</li>


### PR DESCRIPTION
Float report button to the right, reduce its font size, change abuse warning background to red to make it more obvious to users that they're reporting and not replying