### PR TITLE
[IQDB] Fix an error when looking up certain corrupt files

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -372,7 +372,11 @@ class Post < ApplicationRecord
 
     ### Preview ###
     def has_preview?
-      is_image? || is_video?
+      return false unless is_image? || is_video?
+
+      # Some legacy files are corrupt and cannot be processed.
+      # They report dimensions of 1x1, although the actual dimensions are larger.
+      image_width.to_i > 1 && image_height.to_i > 1
     end
 
     def preview_dimensions(max_px = Danbooru.config.small_image_width)

--- a/test/functional/iqdb_queries_controller_test.rb
+++ b/test/functional/iqdb_queries_controller_test.rb
@@ -36,6 +36,15 @@ class IqdbQueriesControllerTest < ActionDispatch::IntegrationTest
           assert_response :success
           assert_select("article.thumbnail[data-id='#{post.id}']")
         end
+
+        should "return empty results for posts with corrupt 1x1 dimensions" do
+          post = create(:post, image_width: 1, image_height: 1)
+          # No IQDB request should be made since has_preview? returns false
+
+          get iqdb_queries_path, params: { post_id: post.id }
+          assert_response :success
+          # Should render page with no results
+        end
       end
     end
   end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1020,6 +1020,30 @@ class PostTest < ActiveSupport::TestCase
         assert_equal(%w(tag1 tag2), post.tag_array_was)
       end
 
+      context "with corrupt 1x1 dimensions" do
+        setup do
+          @post.image_width = 1
+          @post.image_height = 1
+          @post.file_ext = "jpg"
+        end
+
+        should "not have a preview" do
+          assert_equal(false, @post.has_preview?, "Post with 1x1 dimensions should not have preview")
+        end
+      end
+
+      context "with valid dimensions" do
+        setup do
+          @post.image_width = 100
+          @post.image_height = 100
+          @post.file_ext = "jpg"
+        end
+
+        should "have a preview" do
+          assert_equal(true, @post.has_preview?, "Post with valid dimensions should have preview")
+        end
+      end
+
       context "with large dimensions" do
         setup do
           @post.image_width = 10_000


### PR DESCRIPTION
There are some legacy files (~10 years old at this point) that can't get thumbnails generated.
Among other things, this causes the IQDB to throw errors when searching for them.