### PR TITLE
[Artists] Optimize artist search to avoid timeouts

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -482,9 +482,9 @@ class Artist < ApplicationRecord
       end
 
       if params[:is_linked].to_s.truthy?
-        q = q.where("linked_user_id IS NOT NULL")
+        q = q.where.not(linked_user_id: nil)
       elsif params[:is_linked].to_s.falsy?
-        q = q.where("linked_user_id IS NULL")
+        q = q.where(linked_user_id: nil)
       end
 
       case params[:order]

--- a/db/migrate/20251113060711_add_index_artists_on_linked_user_id.rb
+++ b/db/migrate/20251113060711_add_index_artists_on_linked_user_id.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexArtistsOnLinkedUserId < ActiveRecord::Migration[7.2]
+  def change
+    Artist.without_timeout do
+      add_index :artists, :linked_user_id
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3548,6 +3548,13 @@ CREATE INDEX index_artists_on_group_name_trgm ON public.artists USING gin (group
 
 
 --
+-- Name: index_artists_on_linked_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_artists_on_linked_user_id ON public.artists USING btree (linked_user_id);
+
+
+--
 -- Name: index_artists_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4866,6 +4873,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251113060711'),
 ('20251101144234'),
 ('20251014151300'),
 ('20251010171207'),


### PR DESCRIPTION
The artist search fairly reliably times out for specific search queries.
https://e621.net/artists?search[is_linked]=true&search[order]=post_count
Just like with comments before, the root cause is the pagination.

I've added a whitelist that would cause the paginator to skip counting if the search params are not expected to significantly narrow down the results. Plus an index on the linked user ID for faster searched.