### PR TITLE
[Misc] Return no results for malformed boolean searches

### DIFF
--- a/app/logical/elastic_query_builder.rb
+++ b/app/logical/elastic_query_builder.rb
@@ -162,7 +162,7 @@ class ElasticQueryBuilder
     elsif q[key].to_s.falsy?
       must.push({ term: { index_field => false } })
     else
-      raise ArgumentError, "value must be truthy or falsy"
+      @has_invalid_input = true
     end
   end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -54,7 +54,7 @@ class ApplicationRecord < ActiveRecord::Base
         elsif value.to_s.falsy?
           value = false
         else
-          raise ArgumentError, "value must be truthy or falsy"
+          return none
         end
 
         where(attribute => value)


### PR DESCRIPTION
Invalid Boolean Values in Search Parameters

**Attack Vector:** Boolean search parameters in forms across the site

**Method:** Submitting values that are neither truthy nor falsy to boolean attributes
- Targets both OpenSearch queries and ActiveRecord database queries
- SQL injection probe attempts with malformed strings

**Result:** `ArgumentError: value must be truthy or falsy` flooding server logs

**Impact:** Log pollution making legitimate errors harder to identify

**Mitigation:** Modified error handling to return empty result sets instead of exceptions:
1. `ElasticQueryBuilder#add_boolean_match`: Sets `@has_invalid_input` flag to trigger `match_none` query
2. `ApplicationRecord.boolean_attribute_matches`: Returns `none` relation for invalid values