### PR TITLE
[PostVotes] Rework and optimize the vote manager

### DIFF
--- a/app/logical/vote_manager.rb
+++ b/app/logical/vote_manager.rb
@@ -3,79 +3,97 @@
 class VoteManager
   ISOLATION = Rails.env.test? ? {} : { isolation: :repeatable_read }
 
+  # ============================== #
+  # ========= Post Votes ========= #
+  # ============================== #
+
   def self.vote!(user:, post:, score:)
     @vote = nil
-    retries = 5
     score = score.to_i
-    begin
-      raise UserVote::Error, "Invalid vote" unless [1, -1].include?(score)
-      raise UserVote::Error, "You do not have permission to vote" unless user.is_member?
-      PostVote.transaction(**ISOLATION) do
-        PostVote.uncached do
-          score_modifier = score
-          old_vote = PostVote.where(user_id: user.id, post_id: post.id).first
-          if old_vote
-            raise UserVote::Error, "Vote is locked" if old_vote.score == 0
-            if old_vote.score == score
-              return :need_unvote
-            else
-              score_modifier *= 2
-            end
-            old_vote.destroy
-          end
-          @vote = vote = PostVote.create!(user: user, score: score, post: post)
-          vote_cols = "score = score + #{score_modifier}"
-          if vote.score > 0
-            vote_cols += ", up_score = up_score + #{vote.score}"
-            vote_cols += ", down_score = down_score - #{old_vote.score}" if old_vote
-          else
-            vote_cols += ", down_score = down_score + #{vote.score}"
-            vote_cols += ", up_score = up_score - #{old_vote.score}" if old_vote
-          end
-          Post.where(id: post.id).update_all(vote_cols)
-          post.reload
-        end
+    raise UserVote::Error, "Invalid vote" unless [1, -1].include?(score)
+    raise UserVote::Error, "You do not have permission to vote" unless user.is_member?
+
+    result = PostVote.transaction do
+      post.lock!
+      post.reload
+
+      old_vote = PostVote.where(user_id: user.id, post_id: post.id).first
+
+      if old_vote
+        raise UserVote::Error, "Vote is locked" if old_vote.score == 0
+        next :need_unvote if old_vote.score == score
+        old_vote.destroy
       end
-    rescue ActiveRecord::SerializationFailure
-      retries -= 1
-      retry if retries > 0
-      raise UserVote::Error, "Failed to vote, please try again later"
-    rescue ActiveRecord::RecordNotUnique
-      raise UserVote::Error, "You have already voted for this post"
+
+      @vote = PostVote.create!(user: user, score: score, post: post)
+
+      # If replacing an opposite vote, the change is doubled
+      score_delta = old_vote ? score * 2 : score
+      vote_cols = ["score = score + #{score_delta}"]
+
+      if score > 0
+        vote_cols << "up_score = up_score + 1"
+        vote_cols << "down_score = down_score - 1" if old_vote
+      else
+        vote_cols << "down_score = down_score + 1"
+        vote_cols << "up_score = up_score - 1" if old_vote
+      end
+      Post.where(id: post.id).update_all(vote_cols.join(", "))
+
+      post.reload
+      @vote
     end
-    post.update_index
-    @vote
+
+    post.update_index if result != :need_unvote
+    result
+  rescue ActiveRecord::RecordNotUnique
+    raise UserVote::Error, "You have already voted for this post"
   end
 
   def self.unvote!(user:, post:, force: false)
-    retries = 5
-    begin
-      PostVote.transaction(**ISOLATION) do
-        PostVote.uncached do
-          vote = PostVote.where(user_id: user.id, post_id: post.id).first
-          return unless vote
-          raise UserVote::Error, "You can't remove locked votes" if vote.score == 0 && !force
-          post.votes.where(user: user).delete_all
-          subtract_vote(post, vote)
-          post.reload
-        end
+    did_unvote = PostVote.transaction do
+      post.lock!
+      post.reload
+
+      vote = PostVote.where(user_id: user.id, post_id: post.id).first # Query after acquiring lock to prevent deadlocks
+      next false unless vote
+      raise UserVote::Error, "You can't remove locked votes" if vote.score == 0 && !force
+
+      post.votes.where(user: user).delete_all # Delete after acquiring lock to prevent deadlocks
+
+      vote_cols = ["score = score - #{vote.score}"]
+      if vote.score > 0
+        vote_cols << "up_score = up_score - 1"
+      else
+        vote_cols << "down_score = down_score - 1"
       end
-    rescue ActiveRecord::SerializationFailure
-      retries -= 1
-      retry if retries > 0
-      raise UserVote::Error, "Failed to unvote, please try again later"
+      Post.where(id: post.id).update_all(vote_cols.join(", "))
+
+      post.reload
+      true
     end
-    post.update_index
+
+    post.update_index if did_unvote
   end
 
   def self.lock!(id)
-    post = nil
-    PostVote.transaction(**ISOLATION) do
+    post = PostVote.transaction do
       vote = PostVote.find_by(id: id)
-      return unless vote
+      next nil unless vote
       post = vote.post
-      subtract_vote(post, vote)
+      post.lock!
+      post.reload
+
+      vote_cols = ["score = score - #{vote.score}"]
+      if vote.score > 0
+        vote_cols << "up_score = up_score - 1"
+      else
+        vote_cols << "down_score = down_score - 1"
+      end
+      Post.where(id: post.id).update_all(vote_cols.join(", "))
+
       vote.update_column(:score, 0)
+      post
     end
     post&.update_index
   end
@@ -84,6 +102,10 @@ class VoteManager
     vote = PostVote.find_by(id: id)
     unvote!(post: vote.post, user: vote.user, force: true) if vote
   end
+
+  # ============================== #
+  # ======== Comment Votes ======= #
+  # ============================== #
 
   def self.comment_vote!(user:, comment:, score:)
     retries = 5
@@ -146,17 +168,5 @@ class VoteManager
   def self.admin_comment_unvote!(id)
     vote = CommentVote.find_by(id: id)
     comment_unvote!(comment: vote.comment, user: vote.user, force: true) if vote
-  end
-
-  private
-
-  def self.subtract_vote(post, vote)
-    vote_cols = "score = score - #{vote.score}"
-    if vote.score > 0
-      vote_cols += ", up_score = up_score - #{vote.score}"
-    else
-      vote_cols += ", down_score = down_score - #{vote.score}"
-    end
-    Post.where(id: post.id).update_all(vote_cols)
   end
 end

--- a/test/unit/post_vote_test.rb
+++ b/test/unit/post_vote_test.rb
@@ -10,41 +10,273 @@ class PostVoteTest < ActiveSupport::TestCase
     @post = create(:post)
   end
 
-  context "Voting for a post" do
-    should "interpret up as +1 score" do
+  context "Validating vote scores" do
+    should "accept upvote (+1)" do
       vote = VoteManager.vote!(user: @user, post: @post, score: 1)
       assert_equal(1, vote.score)
     end
 
-    should "interpret down as -1 score" do
+    should "accept downvote (-1)" do
       vote = VoteManager.vote!(user: @user, post: @post, score: -1)
       assert_equal(-1, vote.score)
     end
 
-    should "not accept any other scores" do
-      error = assert_raises(UserVote::Error) { VoteManager.vote!(user: @user, post: @post, score: 'xxx') }
+    should "reject invalid scores" do
+      error = assert_raises(UserVote::Error) { VoteManager.vote!(user: @user, post: @post, score: 0) }
+      assert_equal("Invalid vote", error.message)
+
+      error = assert_raises(UserVote::Error) { VoteManager.vote!(user: @user, post: @post, score: 2) }
+      assert_equal("Invalid vote", error.message)
+
+      error = assert_raises(UserVote::Error) { VoteManager.vote!(user: @user, post: @post, score: "xxx") }
       assert_equal("Invalid vote", error.message)
     end
 
-    should "increase the score of the post" do
-      VoteManager.vote!(user: @user, post: @post, score: 1)
-      @post.reload
+    should "require member-level permissions" do
+      @user.update_column(:level, User::Levels::MEMBER - 1)
+      error = assert_raises(UserVote::Error) { VoteManager.vote!(user: @user, post: @post, score: 1) }
+      assert_equal("You do not have permission to vote", error.message)
+    end
+  end
 
+  context "Creating vote" do
+    should "create upvote record and update post columns" do
+      vote = VoteManager.vote!(user: @user, post: @post, score: 1)
+
+      assert_equal(1, vote.score)
+      assert_equal(@user.id, vote.user_id)
+      assert_equal(@post.id, vote.post_id)
+
+      @post.reload
       assert_equal(1, @post.score)
       assert_equal(1, @post.up_score)
+      assert_equal(0, @post.down_score)
     end
 
-    should "decrease the score of the post when removed" do
+    should "create downvote record and update post columns" do
+      vote = VoteManager.vote!(user: @user, post: @post, score: -1)
+
+      assert_equal(-1, vote.score)
+      assert_equal(@user.id, vote.user_id)
+      assert_equal(@post.id, vote.post_id)
+
+      @post.reload
+      assert_equal(-1, @post.score)
+      assert_equal(0, @post.up_score)
+      assert_equal(1, @post.down_score)
+    end
+  end
+
+  context "Replacing a downvote with an upvote" do
+    setup do
+      VoteManager.vote!(user: @user, post: @post, score: -1)
+      @post.reload
+    end
+
+    should "replace vote record and update all post columns correctly" do
+      VoteManager.vote!(user: @user, post: @post, score: 1)
+
+      assert_equal(1, PostVote.where(user: @user, post: @post).count)
+      vote = PostVote.find_by(user: @user, post: @post)
+      assert_equal(1, vote.score)
+
+      @post.reload
+      assert_equal(1, @post.score) # was -1, now +1 (change of +2)
+      assert_equal(1, @post.up_score) # was 0, now 1
+      assert_equal(0, @post.down_score) # was 1, now 0
+    end
+  end
+
+  context "Replacing an upvote with a downvote" do
+    setup do
       VoteManager.vote!(user: @user, post: @post, score: 1)
       @post.reload
-      assert_equal(1, @post.score)
-      assert_equal(1, @post.up_score)
+    end
 
-      VoteManager.unvote!(user: @user, post: @post)
+    should "replace vote record and update all post columns correctly" do
+      VoteManager.vote!(user: @user, post: @post, score: -1)
+
+      assert_equal(1, PostVote.where(user: @user, post: @post).count)
+      vote = PostVote.find_by(user: @user, post: @post)
+      assert_equal(-1, vote.score)
+
+      @post.reload
+      assert_equal(-1, @post.score) # was +1, now -1 (change of -2)
+      assert_equal(0, @post.up_score) # was 1, now 0
+      assert_equal(1, @post.down_score) # was 0, now 1
+    end
+  end
+
+  context "Voting the same way twice" do
+    should "return :need_unvote and not upvote again" do
+      VoteManager.vote!(user: @user, post: @post, score: 1)
+      @post.reload
+      original_score = @post.score
+      original_up_score = @post.up_score
+      original_down_score = @post.down_score
+
+      result = VoteManager.vote!(user: @user, post: @post, score: 1)
+      assert_equal(:need_unvote, result)
       @post.reload
 
+      assert_equal(original_score, @post.score)
+      assert_equal(original_up_score, @post.up_score)
+      assert_equal(original_down_score, @post.down_score)
+    end
+
+    should "return :need_unvote and not downvote again" do
+      VoteManager.vote!(user: @user, post: @post, score: -1)
+      @post.reload
+      original_score = @post.score
+      original_up_score = @post.up_score
+      original_down_score = @post.down_score
+
+      result = VoteManager.vote!(user: @user, post: @post, score: -1)
+      assert_equal(:need_unvote, result)
+      @post.reload
+
+      assert_equal(original_score, @post.score)
+      assert_equal(original_up_score, @post.up_score)
+      assert_equal(original_down_score, @post.down_score)
+    end
+  end
+
+  context "Removing an upvote" do
+    setup do
+      VoteManager.vote!(user: @user, post: @post, score: 1)
+      @post.reload
+    end
+
+    should "delete vote record and update all post columns correctly" do
+      VoteManager.unvote!(user: @user, post: @post)
+      assert_equal(0, PostVote.where(user: @user, post: @post).count)
+
+      @post.reload
       assert_equal(0, @post.score)
       assert_equal(0, @post.up_score)
+      assert_equal(0, @post.down_score)
+    end
+  end
+
+  context "Removing a downvote" do
+    setup do
+      VoteManager.vote!(user: @user, post: @post, score: -1)
+      @post.reload
+    end
+
+    should "delete vote record and update all post columns correctly" do
+      VoteManager.unvote!(user: @user, post: @post)
+      assert_equal(0, PostVote.where(user: @user, post: @post).count)
+
+      @post.reload
+      assert_equal(0, @post.score)
+      assert_equal(0, @post.up_score)
+      assert_equal(0, @post.down_score)
+    end
+  end
+
+  context "Removing a vote that doesn't exist" do
+    should "not raise an error or change post scores" do
+      original_score = @post.score
+      original_up_score = @post.up_score
+      original_down_score = @post.down_score
+
+      assert_nothing_raised do
+        VoteManager.unvote!(user: @user, post: @post)
+      end
+
+      @post.reload
+      assert_equal(original_score, @post.score)
+      assert_equal(original_up_score, @post.up_score)
+      assert_equal(original_down_score, @post.down_score)
+    end
+  end
+
+  context "Locked votes" do
+    setup do
+      @vote = VoteManager.vote!(user: @user, post: @post, score: 1)
+      VoteManager.lock!(@vote.id)
+      @post.reload
+    end
+
+    should "prevent voting again" do
+      error = assert_raises(UserVote::Error) do
+        VoteManager.vote!(user: @user, post: @post, score: 1)
+      end
+      assert_equal("Vote is locked", error.message)
+    end
+
+    should "prevent unvoting" do
+      error = assert_raises(UserVote::Error) do
+        VoteManager.unvote!(user: @user, post: @post)
+      end
+      assert_equal("You can't remove locked votes", error.message)
+    end
+
+    should "allow unvoting with force flag" do
+      assert_nothing_raised do
+        VoteManager.unvote!(user: @user, post: @post, force: true)
+      end
+    end
+
+    should "set vote score to 0 when locked" do
+      @vote.reload
+      assert_equal(0, @vote.score)
+    end
+  end
+
+  context "Multiple users voting on the same post" do
+    setup do
+      @user2 = create(:user, created_at: 1.month.ago)
+      @user3 = create(:user, created_at: 1.month.ago)
+    end
+
+    should "correctly accumulate upvotes" do
+      VoteManager.vote!(user: @user, post: @post, score: 1)
+      VoteManager.vote!(user: @user2, post: @post, score: 1)
+      VoteManager.vote!(user: @user3, post: @post, score: 1)
+
+      @post.reload
+      assert_equal(3, @post.score)
+      assert_equal(3, @post.up_score)
+      assert_equal(0, @post.down_score)
+    end
+
+    should "correctly accumulate downvotes" do
+      VoteManager.vote!(user: @user, post: @post, score: -1)
+      VoteManager.vote!(user: @user2, post: @post, score: -1)
+      VoteManager.vote!(user: @user3, post: @post, score: -1)
+
+      @post.reload
+      assert_equal(-3, @post.score)
+      assert_equal(0, @post.up_score)
+      assert_equal(3, @post.down_score)
+    end
+
+    should "correctly handle mixed votes" do
+      VoteManager.vote!(user: @user, post: @post, score: 1)
+      VoteManager.vote!(user: @user2, post: @post, score: 1)
+      VoteManager.vote!(user: @user3, post: @post, score: -1)
+
+      @post.reload
+      assert_equal(1, @post.score)
+      assert_equal(2, @post.up_score)
+      assert_equal(1, @post.down_score)
+    end
+
+    should "correctly handle vote changes from multiple users" do
+      VoteManager.vote!(user: @user, post: @post, score: 1)
+      VoteManager.vote!(user: @user2, post: @post, score: -1)
+      @post.reload
+      assert_equal(0, @post.score)
+      assert_equal(1, @post.up_score)
+      assert_equal(1, @post.down_score)
+
+      VoteManager.vote!(user: @user, post: @post, score: -1) # Change from +1 to -1
+      @post.reload
+      assert_equal(-2, @post.score)
+      assert_equal(0, @post.up_score)
+      assert_equal(2, @post.down_score)
     end
   end
 end


### PR DESCRIPTION
The previous approach was to run transactions in isolation and re-attempt if they fail.
The new approach is to lock the post row and let requests sort themselves out in order.

Also added some extra tests.