### PR TITLE
[PostReplacements] Fix an error caused by `promoted_id` not being found

### DIFF
--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -458,11 +458,30 @@ class PostReplacement < ApplicationRecord
 
   def promoted_id
     return nil unless is_promoted?
-    if post.has_children?
-      id = post.children.where(md5: md5)&.first&.id
+
+    @promoted_id ||= begin
+      id = nil
+      if post.has_children?
+        id = post.children.where(md5: md5)&.first&.id
+      end
+
+      # Fallback 1: md5 lookup
+      if id.nil?
+        found_post = Post.find_by(md5: md5)
+        id = found_post&.id
+      end
+
+      # Fallback 2: PostEvent lookup
+      if id.nil?
+        event = PostEvent.where(action: :replacement_promoted)
+                         .where("extra_data->>'source_post_id' = ?", post_id.to_s)
+                         .order(created_at: :desc)
+                         .first
+        id = event&.post_id
+      end
+
+      id
     end
-    return id unless id.nil?
-    Post.find_by(md5: md5)&.id
   end
 
   include ApiMethods

--- a/app/views/post_replacements/partials/show/_post_replacement.html.erb
+++ b/app/views/post_replacements/partials/show/_post_replacement.html.erb
@@ -25,7 +25,8 @@
     <dd>
       <% if post_replacement.is_current? %> (current)
       <% elsif post_replacement.is_approved? %> (retired)
-      <% elsif post_replacement.is_promoted? %> (#<%= link_to(post_replacement.promoted_id.to_s, post_path(post_replacement.promoted_id)) %>)
+      <% elsif post_replacement.is_promoted? && post_replacement.promoted_id.present? %>
+        (#<%= link_to(post_replacement.promoted_id.to_s, post_path(post_replacement.promoted_id)) %>)
       <% end %>
     </dd>
     <% if !post_replacement.approver.nil? %>


### PR DESCRIPTION
I use the term "fix" loosely here.
The `promoted_id` method is still fragile, but at least it won't cause the entire page to error out anymore.