### PR TITLE
[Session] Prevent an error caused by malformed auth headers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -279,9 +279,14 @@ class User < ApplicationRecord
       end
 
       def authenticate_api_key(name, api_key)
-        key = ApiKey.where(:key => api_key).first
+        # Validate inputs: PostgreSQL expects UTF-8
+        return nil unless name.is_a?(String) && name.dup.force_encoding("UTF-8").valid_encoding?
+        return nil unless api_key.is_a?(String) && api_key.dup.force_encoding("UTF-8").valid_encoding?
+        return nil if name.blank? || api_key.blank?
+
+        key = ApiKey.where(key: api_key).first
         return nil if key.nil?
-        user = find_by_name(name)
+        user = find_by(name: name)
         return nil if user.nil?
         return user if key.user_id == user.id
         nil


### PR DESCRIPTION
Invalid UTF-8 in Authentication Headers

**Attack Vector:** HTTP Basic Authentication and API key authentication

**Method:** Submitting malformed Authorization headers with invalid UTF-8 byte sequences
- Example: Basic Auth header containing bytes `0xee 0xce 0x0d`
- User-Agent: `PostmanRuntime/7.37.3`

**Result:** `PG::CharacterNotInRepertoire: ERROR: invalid byte sequence for encoding "UTF8"` when credentials reach database query in `User.authenticate_api_key`

**Impact:** Exception logs revealed internal application structure (file paths, authentication flow, database type) useful for reconnaissance

**Mitigation:** Added three-layer defense:
1. UTF-8 validation in `SessionLoader#authenticate_basic_auth` and `#authenticate_api_key` before database operations
2. Secondary validation in `User.authenticate_api_key` model method
3. Exception handling for any remaining database encoding errors
4. Warning logs with attacker IP address for monitoring

Invalid authentication attempts now fail gracefully with 401/403 instead of exceptions 