### PR TITLE
[IQDB] Fix errors caused by malformed input

### DIFF
--- a/test/functional/iqdb_queries_controller_test.rb
+++ b/test/functional/iqdb_queries_controller_test.rb
@@ -45,6 +45,25 @@ class IqdbQueriesControllerTest < ActionDispatch::IntegrationTest
           assert_response :success
           # Should render page with no results
         end
+
+        should "reject non-numeric values" do
+          get iqdb_queries_path, params: { post_id: "invalid" }
+          assert_response 400
+        end
+      end
+
+      context "with a file parameter" do
+        should "reject non-file objects" do
+          get iqdb_queries_path, params: { file: { foo: "bar" } }
+          assert_response 400
+        end
+      end
+
+      context "with a hash parameter" do
+        should "reject non-hex hash values" do
+          get iqdb_queries_path, params: { hash: "not-a-valid-hex-hash" }
+          assert_response 400
+        end
       end
     end
   end


### PR DESCRIPTION
Type Confusion in IQDB Query Parameters

**Attack Vector:** IQDB reverse image search endpoint (`/iqdb_queries`)

**Method:** Submitting invalid parameter types to trigger application crashes and reveal internal structure
- Example: `file: "upload test content"` (string instead of uploaded file object)
- Example: `post_id: "lN5U2axF') OR 609=(SELECT 609 FROM PG_SLEEP(15))--"` (SQL injection probe, though not actually vulnerable)
- Example: `hash: "' OR 1=1--"` (SQL injection probe in hash parameter)
- Submitting nested parameters via `search[post_id]=...`, `search[file]=...`, etc.

**Result:** `NoMethodError: undefined method 'tempfile' for an instance of String` when string file parameter reaches `.tempfile` call

**Note:** The SQL injection attempts were never actually viable due to ActiveRecord's parameterized queries properly escaping values in `Post.find_by(id: ...)`. The real vulnerability was the type confusion causing crashes.

**Mitigation:** Added strict parameter type validation in `IqdbQueriesController#show`:
1. **File parameter**: Validates it responds to `.tempfile` (is an `ActionDispatch::Http::UploadedFile`)
2. **Post ID parameter**: Validates it's numeric only using regex `/\A\d+\z/`
3. **URL parameter**: Validates it's a `String` instance
4. **Hash parameter**: Validates it's a string with hexadecimal format `/\A[0-9a-fA-F]+\z/`

Invalid parameters now raise `ProcessingError` (400 Bad Request) instead of causing crashes.