### PR TITLE
[Tags] Fix an error caused by orphaned tag versions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -929,7 +929,6 @@ Rails/DynamicFindBy:
     - 'app/logical/user_name_validator.rb'
     - 'app/models/post.rb'
     - 'app/models/tag.rb'
-    - 'app/models/tag_type_version.rb'
     - 'app/models/user.rb'
     - 'app/models/wiki_page.rb'
     - 'test/functional/artists_controller_test.rb'

--- a/app/models/tag_type_version.rb
+++ b/app/models/tag_type_version.rb
@@ -9,7 +9,7 @@ class TagTypeVersion < ApplicationRecord
       q = super.includes(:creator, :tag)
 
       if params[:tag].present?
-        tag = Tag.find_by_normalized_name(params[:tag])
+        tag = Tag.find_by_normalized_name(params[:tag]) # rubocop:disable Rails/DynamicFindBy
         q = q.where(tag: tag)
       end
 

--- a/app/views/tag_type_versions/index.html.erb
+++ b/app/views/tag_type_versions/index.html.erb
@@ -17,7 +17,13 @@
         <tbody>
         <% @tag_versions.each do |change| %>
           <tr id="r<%= change.id %>">
-            <td><%= link_to change.tag.name, edit_tag_path(change.tag) %></td>
+            <td>
+              <% if change.tag.present? %>
+                <%= link_to change.tag.name, edit_tag_path(change.tag) %>
+              <% else %>
+                <span class="inactive">[deleted tag #<%= change.tag_id %>]</span>
+              <% end %>
+            </td>
             <td><%= compact_time change.created_at %></td>
             <td><%= link_to_user change.creator %></td>
 


### PR DESCRIPTION
Some of the tags were destroyed over the years.
Some of those destroyed tags left orphaned tag type versions behind.

This is just a quick fix to make sure that the page does not error out when encountering versions like this.
We are still keeping those versions around for posterity.