### PR TITLE
[Posts] Ensure deterministic order of wildcard tag matches

### DIFF
--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1551,7 +1551,7 @@ class TagQuery
   def pull_wildcard_tags(tag)
     Tag.name_matches(tag)
        .limit(Danbooru.config.tag_query_limit) # .limit(tag_query_limit)
-       .order("post_count DESC")
+       .order("post_count DESC", "name ASC")
        .pluck(:name)
        .presence || ["~~not_found~~"]
   end


### PR DESCRIPTION
If two tags that match a wildcard have the same post count, they can get returned in any order.

This caused a test to fail very rarely.
No real impact in production.