### PR TITLE
[Posts] Fix an error when providing extremely large IDs

### DIFF
--- a/app/logical/parse_value.rb
+++ b/app/logical/parse_value.rb
@@ -117,6 +117,12 @@ module ParseValue
     range
   end
 
+  # Ensures that the value is a safe integer ID (0 to MAX_INT)
+  def safe_id(value)
+    int_val = value.to_i
+    int_val >= 0 && int_val <= MAX_INT ? int_val : -1
+  end
+
   private
 
   def cast(object, type)

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1307,7 +1307,7 @@ class TagQuery
       when "user", "-user", "~user" then add_to_query(type, :uploader_ids, user_id_or_invalid(g2))
 
       # NOTE: This doesn't match the behavior of `User.name_or_id_to_id`, as that ensures an integral, whereas this will convert leading digits of a non-numeric string.
-      when "user_id", "-user_id", "~user_id" then add_to_query(type, :uploader_ids, g2.to_i)
+      when "user_id", "-user_id", "~user_id" then add_to_query(type, :uploader_ids, ParseValue.safe_id(g2))
 
       when "approver", "-approver", "~approver"
         add_to_query(type, :approver_ids, g2, any_none_key: :approver) { user_id_or_invalid(g2) }
@@ -1398,11 +1398,11 @@ class TagQuery
       when /[-~]?(#{TagCategory::SHORT_NAME_REGEX})tags/
         add_to_query(type, :"#{TagCategory::SHORT_NAME_MAPPING[$1]}_tag_count", ParseValue.range(g2))
 
-      when "parent", "-parent", "~parent" then add_to_query(type, :parent_ids, g2, any_none_key: :parent) { g2.to_i }
+      when "parent", "-parent", "~parent" then add_to_query(type, :parent_ids, g2, any_none_key: :parent) { ParseValue.safe_id(g2) }
 
       when "child" then q[:child] = g2.downcase
 
-      when "randseed" then q[:random_seed] = g2.to_i
+      when "randseed" then q[:random_seed] = ParseValue.safe_id(g2)
 
       when "order", "-order" then q[:order] = TagQuery.normalize_order_value(g2.downcase, invert: type == :must_not)
 

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -147,7 +147,7 @@ class Pool < ApplicationRecord
 
   def self.name_to_id(name)
     if name =~ /\A\d+\z/
-      name.to_i
+      ParseValue.safe_id(name)
     else
       Pool.where("lower(name) = ?", name.downcase.tr(" ", "_")).pick(:id).to_i
     end
@@ -159,7 +159,7 @@ class Pool < ApplicationRecord
 
   def self.find_by_name(name)
     if name =~ /\A\d+\z/
-      where("pools.id = ?", name.to_i).first
+      where("pools.id = ?", ParseValue.safe_id(name)).first
     elsif name
       where("lower(pools.name) = ?", normalize_name(name).downcase).first
     else

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -941,7 +941,7 @@ class Post < ApplicationRecord
           end
 
         when /^set:(\d+)$/i
-          set = PostSet.find_by(id: $1.to_i)
+          set = PostSet.find_by(id: ParseValue.safe_id($1))
           if set&.can_edit_posts?(CurrentUser.user)
             set.add!(self)
             if set.errors.any?
@@ -950,7 +950,7 @@ class Post < ApplicationRecord
           end
 
         when /^-set:(\d+)$/i
-          set = PostSet.find_by(id: $1.to_i)
+          set = PostSet.find_by(id: ParseValue.safe_id($1))
           if set&.can_edit_posts?(CurrentUser.user)
             set.remove!(self)
             if set.errors.any?
@@ -1213,7 +1213,7 @@ class Post < ApplicationRecord
 
   module SetMethods
     def set_ids
-      pool_string.scan(/set\:(\d+)/).map {|set| set[0].to_i}
+      pool_string.scan(/set:(\d+)/).map { |set| ParseValue.safe_id(set[0]) }
     end
 
     def post_sets
@@ -1263,7 +1263,7 @@ class Post < ApplicationRecord
 
   module PoolMethods
     def pool_ids
-      pool_string.scan(/pool:(\d+)/).map { |pool| pool[0].to_i }
+      pool_string.scan(/pool:(\d+)/).map { |pool| ParseValue.safe_id(pool[0]) }
     end
 
     def pools

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -51,7 +51,7 @@ class PostSet < ApplicationRecord
 
   def self.name_to_id(name)
     if name =~ /\A\d+\z/
-      name.to_i
+      ParseValue.safe_id(name)
     else
       PostSet.where("lower(shortname) = ?", name.downcase.tr(" ", "_")).pick(:id).to_i
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,14 +169,14 @@ class User < ApplicationRecord
 
       def name_or_id_to_id(name)
         if name =~ /\A!\d+\z/
-          return name[1..-1].to_i
+          return ParseValue.safe_id(name[1..-1])
         end
         User.name_to_id(name)
       end
 
       def name_or_id_to_id_forced(name)
         if name =~ /\A\d+\z/
-          return name.to_i
+          return ParseValue.safe_id(name)
         end
         User.name_to_id(name)
       end


### PR DESCRIPTION
Integer Overflow in Search Parameters

**Attack Vector:** Integer ID parameters in tag search queries (`tags=`)

**Method:** Submitting extremely large integer values exceeding 32-bit signed integer range
- Example: `tags=user_id:112521631028384300`
- Example: `tags=parent:999999999999999`

**Result:** `OpenSearch::Transport::Transport::Errors::BadRequest: [400] failed to create query: Value [112521631028384300] is out of range for an integer`

**Impact:** 
- Application crash revealing internal query structure and OpenSearch usage
- Exposed that the application uses 32-bit integers for IDs
- Search queries fail instead of returning appropriate results

**Technical Details:**
Multiple metatags were directly converting user input to integers using `.to_i` without validation:
- `user_id:` metatag in `TagQuery#parse_query`
- `parent:` metatag in `TagQuery#parse_query`
- `randseed:` metatag in `TagQuery#parse_query`
- `User.name_or_id_to_id` and `User.name_or_id_to_id_forced` methods
- `Pool.name_to_id` and `Pool.find_by_name` methods
- `PostSet.name_to_id` method
- Post model's `set:ID` and `-set:ID` metatag handling
- Post model's `set_ids` and `pool_ids` methods

**Mitigation:** Created `ParseValue.safe_id(value)` helper method that validates integer range:
1. Returns the integer value if it's between 0 and `MAX_INT` (2,147,483,647)
2. Returns `-1` for out-of-range or negative values
3. Applied to all ID field parsing throughout the application

This approach ensures that:
- Valid IDs work normally
- Overflow IDs return `-1`, which won't match any real record (returns no results)
- No misleading results from clamped values (e.g., searching for user 112521631028384300 won't incorrectly return user 2147483647)
- Database queries remain within valid 32-bit integer range for OpenSearch/PostgreSQL compatibility