### PR TITLE
[UserNameChangeRequests] Rework the name change process

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -891,7 +891,6 @@ Rails/DynamicFindBy:
     - 'app/logical/related_tag_query.rb'
     - 'app/logical/session_creator.rb'
     - 'app/logical/session_loader.rb'
-    - 'app/logical/user_name_validator.rb'
     - 'app/models/post.rb'
     - 'app/models/tag.rb'
     - 'app/models/user.rb'

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -55,6 +55,7 @@ module Admin
           user_id: @user.id,
           desired_name: desired_username,
           change_reason: "Administrative change",
+          skip_limited_validation: true,
         )
         ModAction.log(:user_name_change, { user_id: @user.id })
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -50,14 +50,12 @@ module Admin
       old_username = @user.name
       desired_username = params[:user][:name]
       if old_username != desired_username && desired_username.present?
-        change_request = UserNameChangeRequest.create!(
+        UserNameChangeRequest.create!(
           original_name: @user.name,
           user_id: @user.id,
           desired_name: desired_username,
           change_reason: "Administrative change",
-          skip_limited_validation: true,
         )
-        change_request.approve!
         ModAction.log(:user_name_change, { user_id: @user.id })
       end
       redirect_to user_path(@user), notice: "User updated"

--- a/app/controllers/user_name_change_requests_controller.rb
+++ b/app/controllers/user_name_change_requests_controller.rb
@@ -27,8 +27,7 @@ class UserNameChangeRequestsController < ApplicationController
     if @change_request.errors.any?
       render action: "new"
     else
-      @change_request.approve!
-      redirect_to user_name_change_request_path(@change_request), notice: "Your name has been changed"
+      redirect_to user_path(@change_request.user), notice: "Your name has been changed"
     end
   end
 

--- a/app/controllers/user_name_change_requests_controller.rb
+++ b/app/controllers/user_name_change_requests_controller.rb
@@ -27,7 +27,7 @@ class UserNameChangeRequestsController < ApplicationController
     if @change_request.errors.any?
       render action: "new"
     else
-      redirect_to user_path(@change_request.user), notice: "Your name has been changed"
+      redirect_to user_name_change_request_path(@change_request), notice: "Your name has been changed"
     end
   end
 

--- a/app/logical/user_deletion.rb
+++ b/app/logical/user_deletion.rb
@@ -30,7 +30,6 @@ class UserDeletion
       original_name: user.name,
       desired_name: "user_#{user.id}",
       change_reason: admin_deletion ? "Administrative deletion" : "User deletion",
-      status: "approved",
       skip_limited_validation: true,
     )
   end

--- a/app/logical/user_deletion.rb
+++ b/app/logical/user_deletion.rb
@@ -14,8 +14,15 @@ class UserDeletion
 
   def delete!
     validate
-    create_name_history
-    rename_user
+
+    original_name = user.name
+    final_name = calculate_final_name
+
+    # Create name change history if the name will actually change
+    if final_name != original_name
+      create_name_history(original_name, final_name)
+    end
+
     clear_user_settings
     reset_password
     create_mod_action
@@ -24,13 +31,14 @@ class UserDeletion
 
   private
 
-  def create_name_history
+  def create_name_history(original_name, final_name)
     UserNameChangeRequest.create!(
       user_id: user.id,
-      original_name: user.name,
-      desired_name: "user_#{user.id}",
+      original_name: original_name,
+      desired_name: final_name,
       change_reason: admin_deletion ? "Administrative deletion" : "User deletion",
       skip_limited_validation: true,
+      skip_user_name_validation: true,
     )
   end
 
@@ -58,22 +66,25 @@ class UserDeletion
     user.update_columns(password_hash: "", bcrypt_password_hash: "*LK*")
   end
 
-  def rename_user
+  def calculate_final_name
     base_name = "user_#{user.id}"
+
+    # If the user already has the target name, no change needed
+    return user.name if user.name == base_name
+
     name = base_name
     n = 0
 
-    while User.where(name: name).exists? && n < 10
+    while User.where(name: name).where.not(id: user.id).exists? && n < 1000
       n += 1
-      name = base_name + ("~" * n)
+      name = "#{base_name}_#{n}"
     end
 
-    if n >= 10
+    if n >= 1000
       raise ValidationError, "New name could not be found"
     end
 
-    user.update_column(:name, name)
-    user.update_cache
+    name
   end
 
   def validate

--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -4,6 +4,9 @@ class UserNameValidator < ActiveModel::EachValidator
   def validate_each(rec, attr, value)
     name = value
 
+    # Should be handled by presence validator instead
+    return if name.blank?
+
     # For User model, check against rec.id
     # For other models (like UserNameChangeRequest), check against the user_id option
     user_id = rec.is_a?(User) ? rec.id : options[:user_id]&.call(rec)

--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -4,13 +4,24 @@ class UserNameValidator < ActiveModel::EachValidator
   def validate_each(rec, attr, value)
     name = value
 
-    rec.errors.add(attr, "already exists") if User.find_by_name(name).present?
-    rec.errors.add(attr, "must be 2 to 20 characters long") if !name.length.between?(2, 20)
+    # For User model, check against rec.id
+    # For other models (like UserNameChangeRequest), check against the user_id option
+    user_id = rec.is_a?(User) ? rec.id : options[:user_id]&.call(rec)
+
+    lookup = User.find_by_name(name) # rubocop:disable Rails/DynamicFindBy
+    if lookup.present?
+      if lookup.id != user_id
+        rec.errors.add(attr, "already exists")
+      elsif lookup.name == name
+        rec.errors.add(attr, "is the same as your current name")
+      end
+    end
+    rec.errors.add(attr, "must be 2 to 20 characters long") unless name.length.between?(2, 20)
     rec.errors.add(attr, "must contain only alphanumeric characters, hypens, apostrophes, tildes and underscores") unless name =~ /\A[a-zA-Z0-9\-_~']+\z/
     rec.errors.add(attr, "must not begin with a special character") if name =~ /\A[_\-~']/
     rec.errors.add(attr, "must not contain consecutive special characters") if name =~ /_{2}|-{2}|~{2}|'{2}/
     rec.errors.add(attr, "cannot begin or end with an underscore") if name =~ /\A_|_\z/
     rec.errors.add(attr, "cannot consist of numbers only") if name =~ /\A[0-9]+\z/
-    rec.errors.add(attr, "cannot be the string 'me'") if name.downcase == 'me'
+    rec.errors.add(attr, "cannot be be one of the reserved words") if %w[me home settings admin].include?(name.downcase)
   end
 end

--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -22,6 +22,6 @@ class UserNameValidator < ActiveModel::EachValidator
     rec.errors.add(attr, "must not contain consecutive special characters") if name =~ /_{2}|-{2}|~{2}|'{2}/
     rec.errors.add(attr, "cannot begin or end with an underscore") if name =~ /\A_|_\z/
     rec.errors.add(attr, "cannot consist of numbers only") if name =~ /\A[0-9]+\z/
-    rec.errors.add(attr, "cannot be be one of the reserved words") if %w[me home settings].include?(name.downcase)
+    rec.errors.add(attr, "cannot be one of the reserved words") if %w[me home settings].include?(name.downcase)
   end
 end

--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -17,7 +17,7 @@ class UserNameValidator < ActiveModel::EachValidator
       end
     end
     rec.errors.add(attr, "must be 2 to 20 characters long") unless name.length.between?(2, 20)
-    rec.errors.add(attr, "must contain only alphanumeric characters, hypens, apostrophes, tildes and underscores") unless name =~ /\A[a-zA-Z0-9\-_~']+\z/
+    rec.errors.add(attr, "must contain only alphanumeric characters, hyphens, apostrophes, tildes and underscores") unless name =~ /\A[a-zA-Z0-9\-_~']+\z/
     rec.errors.add(attr, "must not begin with a special character") if name =~ /\A[_\-~']/
     rec.errors.add(attr, "must not contain consecutive special characters") if name =~ /_{2}|-{2}|~{2}|'{2}/
     rec.errors.add(attr, "cannot begin or end with an underscore") if name =~ /\A_|_\z/

--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -22,6 +22,6 @@ class UserNameValidator < ActiveModel::EachValidator
     rec.errors.add(attr, "must not contain consecutive special characters") if name =~ /_{2}|-{2}|~{2}|'{2}/
     rec.errors.add(attr, "cannot begin or end with an underscore") if name =~ /\A_|_\z/
     rec.errors.add(attr, "cannot consist of numbers only") if name =~ /\A[0-9]+\z/
-    rec.errors.add(attr, "cannot be be one of the reserved words") if %w[me home settings admin].include?(name.downcase)
+    rec.errors.add(attr, "cannot be be one of the reserved words") if %w[me home settings].include?(name.downcase)
   end
 end

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -10,6 +10,8 @@ class UserNameChangeRequest < ApplicationRecord
 
   belongs_to :user
 
+  attr_accessor :skip_limited_validation
+
   def initialize_attributes
     self.user_id ||= CurrentUser.user.id
     self.original_name ||= CurrentUser.user.name
@@ -36,6 +38,7 @@ class UserNameChangeRequest < ApplicationRecord
   end
 
   def not_limited
+    return true if skip_limited_validation == true
     if UserNameChangeRequest.where("user_id = ? and created_at >= ?", CurrentUser.user.id, 1.week.ago).exists?
       errors.add(:base, "You can only submit one name change request per week")
       false

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -5,12 +5,12 @@ class UserNameChangeRequest < ApplicationRecord
   after_create :apply!
 
   validates :original_name, :desired_name, presence: true
-  validates :desired_name, user_name: { user_id: ->(rec) { rec.user_id } }
+  validates :desired_name, user_name: { user_id: ->(rec) { rec.user_id } }, unless: :skip_user_name_validation
   validate :not_limited, on: :create
 
   belongs_to :user
 
-  attr_accessor :skip_limited_validation
+  attr_accessor :skip_limited_validation, :skip_user_name_validation
 
   def initialize_attributes
     self.user_id ||= CurrentUser.user.id
@@ -19,8 +19,6 @@ class UserNameChangeRequest < ApplicationRecord
 
   def self.search(params)
     q = super
-
-    q = q.where_user(:user_id, :current, params)
 
     if params[:original_name].present?
       q = q.where_ilike(:original_name, User.normalize_name(params[:original_name]))

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -36,12 +36,11 @@ class UserNameChangeRequest < ApplicationRecord
   end
 
   def not_limited
-    true
-    # if UserNameChangeRequest.where("user_id = ? and created_at >= ?", CurrentUser.user.id, 1.week.ago).exists?
-    #   errors.add(:base, "You can only submit one name change request per week")
-    #   false
-    # else
-    #   true
-    # end
+    if UserNameChangeRequest.where("user_id = ? and created_at >= ?", CurrentUser.user.id, 1.week.ago).exists?
+      errors.add(:base, "You can only submit one name change request per week")
+      false
+    else
+      true
+    end
   end
 end

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -2,25 +2,17 @@
 
 class UserNameChangeRequest < ApplicationRecord
   after_initialize :initialize_attributes, if: :new_record?
+  after_create :apply!
+
   validates :original_name, :desired_name, presence: true
-  validates :status, inclusion: { in: %w[pending approved rejected] }
-  belongs_to :user
-  belongs_to :approver, class_name: "User", optional: true
+  validates :desired_name, user_name: { user_id: ->(rec) { rec.user_id } }
   validate :not_limited, on: :create
-  validates :desired_name, user_name: true
-  attr_accessor :skip_limited_validation
+
+  belongs_to :user
 
   def initialize_attributes
     self.user_id ||= CurrentUser.user.id
     self.original_name ||= CurrentUser.user.name
-  end
-
-  def self.pending
-    where(status: "pending")
-  end
-
-  def self.approved
-    where(status: "approved")
   end
 
   def self.search(params)
@@ -39,40 +31,17 @@ class UserNameChangeRequest < ApplicationRecord
     q.apply_basic_order(params)
   end
 
-  def rejected?
-    status == "rejected"
-  end
-
-  def approved?
-    status == "approved"
-  end
-
-  def pending?
-    status == "pending"
-  end
-
-  def approve!
-    update(status: "approved", approver_id: CurrentUser.user.id)
+  def apply!
     user.update_attribute(:name, desired_name)
-    body = "Your name change request has been approved. Be sure to log in with your new user name."
-    Dmail.create_automated(title: "Name change request approved", body: body, to_id: user_id)
   end
 
   def not_limited
-    return true if skip_limited_validation == true
-    if UserNameChangeRequest.where("user_id = ? and created_at >= ?", CurrentUser.user.id, 1.week.ago).exists?
-      errors.add(:base, "You can only submit one name change request per week")
-      false
-    else
-      true
-    end
-  end
-
-  def hidden_attributes
-    if CurrentUser.is_admin? || user == CurrentUser.user
-      []
-    else
-      super + %i[change_reason rejection_reason]
-    end
+    true
+    # if UserNameChangeRequest.where("user_id = ? and created_at >= ?", CurrentUser.user.id, 1.week.ago).exists?
+    #   errors.add(:base, "You can only submit one name change request per week")
+    #   false
+    # else
+    #   true
+    # end
   end
 end

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -38,12 +38,9 @@ class UserNameChangeRequest < ApplicationRecord
   end
 
   def not_limited
-    return true if skip_limited_validation == true
+    return if skip_limited_validation == true
     if UserNameChangeRequest.where("user_id = ? and created_at >= ?", CurrentUser.user.id, 1.week.ago).exists?
       errors.add(:base, "You can only submit one name change request per week")
-      false
-    else
-      true
     end
   end
 end

--- a/app/views/user_name_change_requests/index.html.erb
+++ b/app/views/user_name_change_requests/index.html.erb
@@ -10,8 +10,6 @@
           <th>User</th>
           <th>Original Name</th>
           <th>Desired Name</th>
-          <th>Reason</th>
-          <th>Status</th>
           <th>Date</th>
           <th></th>
         </tr>
@@ -22,19 +20,6 @@
             <td><%= link_to_user change_request.user %></td>
             <td><%= change_request.original_name %></td>
             <td><%= change_request.desired_name %></td>
-            <td>
-              <% if CurrentUser.is_admin? || CurrentUser.user == change_request.user %>
-                <%= change_request.change_reason %>
-              <% end %>
-            </td>
-            <td>
-              <%= change_request.status %>
-              <% if change_request.approved? %>
-                by <%= link_to_user change_request.approver %>
-              <% elsif change_request.rejected? %>
-                for reason: <%= link_to change_request.rejection_reason %>
-              <% end %>
-            </td>
             <td><%= compact_time change_request.created_at %></td>
             <td><%= link_to "view", user_name_change_request_path(change_request) %></td>
           </tr>

--- a/app/views/user_name_change_requests/new.html.erb
+++ b/app/views/user_name_change_requests/new.html.erb
@@ -15,7 +15,6 @@
 
     <%= custom_form_for(@change_request) do |f| %>
       <%= f.input :desired_name %>
-      <%= f.input :change_reason %>
       <%= f.submit "Submit" %>
     <% end %>
   </div>

--- a/app/views/user_name_change_requests/show.html.erb
+++ b/app/views/user_name_change_requests/show.html.erb
@@ -2,7 +2,7 @@
   <div id="a-show">
     <h1>Name Change Request</h1>
 
-    <table class="aligned-vertical">
+    <table style="border-spacing: 0.5rem 0.25rem; border-collapse: unset;">
       <tbody>
         <tr>
           <th>Date</th>
@@ -16,26 +16,12 @@
           <td><%= link_to_user @change_request.user %></td>
         </tr>
         <tr>
-          <th>Request</th>
-          <td>
-            <strong><%= @change_request.original_name %></strong> ->
-            <strong><%= @change_request.desired_name %></strong>
-          </td>
+          <th>Old</th>
+          <td><%= @change_request.original_name %></td>
         </tr>
         <tr>
-          <th>Reason</th>
-          <td><%= @change_request.change_reason %></td>
-        </tr>
-        <tr>
-          <th>Status</th>
-          <td>
-            <%= @change_request.status %>
-            <% if @change_request.approved? %>
-              by <%= link_to_user @change_request.approver %>
-            <% elsif @change_request.rejected? %>
-              for reason: <%= link_to @change_request.rejection_reason %>
-            <% end %>
-          </td>
+          <th>New</th>
+          <td><%= @change_request.desired_name %></td>
         </tr>
       </tbody>
     </table>

--- a/test/functional/user_name_change_requests_controller_test.rb
+++ b/test/functional/user_name_change_requests_controller_test.rb
@@ -115,7 +115,7 @@ class UserNameChangeRequestsControllerTest < ActionDispatch::IntegrationTest
 
       should "require authentication" do
         get user_name_change_request_path(@change_request)
-        assert_redirected_to(/session\/new/)
+        assert_redirected_to(%r{session/new})
       end
     end
 
@@ -146,7 +146,7 @@ class UserNameChangeRequestsControllerTest < ActionDispatch::IntegrationTest
 
       should "require authentication" do
         get user_name_change_requests_path
-        assert_redirected_to(/session\/new/)
+        assert_redirected_to(%r{session/new})
       end
     end
 
@@ -186,7 +186,7 @@ class UserNameChangeRequestsControllerTest < ActionDispatch::IntegrationTest
         assert_no_difference(-> { UserNameChangeRequest.count }) do
           delete user_name_change_request_path(@change_request)
         end
-        assert_redirected_to(/session\/new/)
+        assert_redirected_to(%r{session/new})
       end
     end
   end

--- a/test/functional/user_name_change_requests_controller_test.rb
+++ b/test/functional/user_name_change_requests_controller_test.rb
@@ -6,11 +6,12 @@ class UserNameChangeRequestsControllerTest < ActionDispatch::IntegrationTest
   context "The user name change requests controller" do
     setup do
       @user = create(:privileged_user)
+      @original_name = @user.name
       @admin = create(:admin_user)
     end
 
     context "new action" do
-      should "render" do
+      should "render successfully for authenticated users" do
         get_auth new_user_name_change_request_path, @user
         assert_response :success
       end
@@ -20,91 +21,172 @@ class UserNameChangeRequestsControllerTest < ActionDispatch::IntegrationTest
         get_auth new_user_name_change_request_path, @user
         assert_response :success
       end
+
+      should "redirect anonymous users to login" do
+        get new_user_name_change_request_path
+        assert_redirected_to(%r{session/new})
+      end
     end
 
     context "create action" do
-      should "work" do
-        post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: "zun" } }
+      should "create request and immediately change user name" do
+        assert_difference(-> { UserNameChangeRequest.count }, 1) do
+          post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: "newname" } }
+        end
+
         change_request = UserNameChangeRequest.last
         assert_redirected_to user_name_change_request_path(change_request)
-        assert_equal("zun", @user.reload.name)
+        @user.reload
+        assert_equal("newname", @user.name)
+        assert_equal(@original_name, change_request.original_name)
+        assert_equal("newname", change_request.desired_name)
       end
 
-      should "work for a user with a currently invalid name" do
+      should "work for users with currently invalid names" do
         @user.update_columns(name: "12345")
-        post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: "zun" } }
+        post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: "validname" } }
+
         change_request = UserNameChangeRequest.last
         assert_redirected_to user_name_change_request_path(change_request)
-        assert_equal("zun", @user.reload.name)
+        assert_equal("validname", @user.reload.name)
+      end
+
+      should "allow changing capitalization" do
+        new_name = @user.name.capitalize
+        post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: new_name } }
+
+        assert_response :redirect
+        assert_equal(new_name, @user.reload.name)
+      end
+
+      should "handle validation errors" do
+        create(:user, name: "taken")
+
+        post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: "taken" } }
+
+        assert_response :success # Should render new template with errors
+        assert_equal(@original_name, @user.reload.name) # Name should not change
+        assert_select ".error-messages", text: /already exists/
+      end
+
+      should "enforce rate limiting" do
+        # First request should work
+        post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: "firstchange" } }
+        assert_response :redirect
+        assert_equal("firstchange", @user.reload.name)
+
+        # Second request within a week should fail
+        post_auth user_name_change_requests_path, @user, params: { user_name_change_request: { desired_name: "secondchange" } }
+        assert_response :success # Should render form with errors
+        assert_equal("firstchange", @user.reload.name) # Name should not change
+        assert_select ".error-messages", text: /one name change request per week/
+      end
+
+      should "require authentication" do
+        post user_name_change_requests_path, params: { user_name_change_request: { desired_name: "newname" } }
+        assert_redirected_to(%r{session/new})
       end
     end
 
     context "show action" do
       setup do
         as(@user) do
-          @change_request = UserNameChangeRequest.create!(
-            user_id: @user.id,
-            original_name: @user.name,
-            desired_name: "abc",
-            change_reason: "hello",
-          )
+          @change_request = UserNameChangeRequest.create(desired_name: "uniquename#{rand(10_000)}", skip_limited_validation: true)
+          @user.reload
         end
       end
 
-      should "render" do
+      should "render for the request owner" do
         get_auth user_name_change_request_path(@change_request), @user
+        assert_response :success
+        assert_select "h1", text: /Name Change Request/
+      end
+
+      should "render for admins" do
+        get_auth user_name_change_request_path(@change_request), @admin
         assert_response :success
       end
 
-      context "when the current user is not an admin and does not own the request" do
-        should "fail" do
-          @another_user = create(:user)
-          get_auth user_name_change_request_path(@change_request), @another_user
-          assert_response :forbidden
-        end
+      should "deny access to other users" do
+        other_user = create(:user)
+        get_auth user_name_change_request_path(@change_request), other_user
+        assert_response :forbidden
+      end
+
+      should "require authentication" do
+        get user_name_change_request_path(@change_request)
+        assert_redirected_to(/session\/new/)
       end
     end
 
-    context "for actions restricted to admins" do
-      context "index action" do
-        should "render" do
-          get_auth user_name_change_requests_path, @admin
-          assert_response :success
-        end
+    context "index action" do
+      setup do
+        as(@user) { @request1 = UserNameChangeRequest.create(desired_name: "name1", skip_limited_validation: true) }
+        other_user = create(:user)
+        as(other_user) { @request2 = UserNameChangeRequest.create(desired_name: "name2", skip_limited_validation: true) }
+      end
+
+      should "render for admins" do
+        get_auth user_name_change_requests_path, @admin
+        assert_response :success
+        assert_select "h1", text: /Name Change Requests/
+      end
+
+      should "deny access to regular users" do
+        regular_user = create(:user)
+        get_auth user_name_change_requests_path, regular_user
+        assert_response :forbidden
+      end
+
+      should "support search filtering" do
+        get_auth user_name_change_requests_path, @admin, params: { search: { original_name: @user.name } }
+        assert_response :success
+        assert_select "tr", count: 2 # Header + 1 matching result
+      end
+
+      should "require authentication" do
+        get user_name_change_requests_path
+        assert_redirected_to(/session\/new/)
       end
     end
 
     context "destroy action" do
       setup do
         as(@user) do
-          @change_request = UserNameChangeRequest.new(
-            user_id: @user.id,
-            original_name: @user.name,
-            desired_name: "new_name",
-            change_reason: "test reason",
-            status: "pending",
-          )
+          @change_request = UserNameChangeRequest.new(desired_name: "deleteme")
           @change_request.skip_limited_validation = true
           @change_request.save!
         end
       end
 
       should "allow admins to delete requests" do
-        delete_auth user_name_change_request_path(@change_request), @admin
+        assert_difference(-> { UserNameChangeRequest.count }, -1) do
+          delete_auth user_name_change_request_path(@change_request), @admin
+        end
         assert_redirected_to user_name_change_requests_path
-        assert_not UserNameChangeRequest.exists?(@change_request.id)
       end
 
-      should "not allow regular users to delete requests" do
-        delete_auth user_name_change_request_path(@change_request), @user
+      should "deny access to regular users" do
+        regular_user = create(:user)
+        assert_no_difference(-> { UserNameChangeRequest.count }) do
+          delete_auth user_name_change_request_path(@change_request), regular_user
+        end
         assert_response :forbidden
-        assert UserNameChangeRequest.exists?(@change_request.id)
       end
 
-      should "not allow anonymous users to delete requests" do
-        delete user_name_change_request_path(@change_request)
-        assert_redirected_to new_session_path
-        assert UserNameChangeRequest.exists?(@change_request.id)
+      should "deny access to other users" do
+        other_user = create(:user)
+        assert_no_difference(-> { UserNameChangeRequest.count }) do
+          delete_auth user_name_change_request_path(@change_request), other_user
+        end
+        assert_response :forbidden
+      end
+
+      should "require authentication" do
+        assert_no_difference(-> { UserNameChangeRequest.count }) do
+          delete user_name_change_request_path(@change_request)
+        end
+        assert_redirected_to(/session\/new/)
       end
     end
   end

--- a/test/unit/user_name_change_request_test.rb
+++ b/test/unit/user_name_change_request_test.rb
@@ -46,7 +46,7 @@ class UserNameChangeRequestTest < ActiveSupport::TestCase
       end
 
       should "reject desired names that already exist" do
-        existing_user = create(:user, name: "taken")
+        create(:user, name: "taken")
         request = UserNameChangeRequest.new(desired_name: "taken")
         assert_not request.valid?
         assert_includes request.errors[:desired_name], "already exists"
@@ -119,7 +119,7 @@ class UserNameChangeRequestTest < ActiveSupport::TestCase
         as(@u2) { UserNameChangeRequest.create(desired_name: "Alice", skip_limited_validation: true) }
         @u2.reload
 
-        # User 1 takes User 2's old name  
+        # User 1 takes User 2's old name
         as(@u1) { UserNameChangeRequest.create(desired_name: "Bob", skip_limited_validation: true) }
         @u1.reload
 

--- a/test/unit/user_name_change_request_test.rb
+++ b/test/unit/user_name_change_request_test.rb
@@ -3,89 +3,151 @@
 require "test_helper"
 
 class UserNameChangeRequestTest < ActiveSupport::TestCase
-  context "in all cases" do
+  context "UserNameChangeRequest" do
     setup do
-      @admin = create(:admin_user)
-      @requester = create(:user)
-      CurrentUser.user = @requester
+      @user = create(:user, name: "originalname")
+      CurrentUser.user = @user
     end
 
-    context "approving a request" do
-      setup do
-        @change_request = UserNameChangeRequest.create(
-          user_id: @requester.id,
-          original_name: @requester.name,
-          status: "pending",
-          desired_name: "abc",
-        )
-        CurrentUser.user = @admin
-      end
-
-      should "create a dmail" do
-        assert_difference(-> { Dmail.count }, 1) do
-          @change_request.approve!
+    context "on creation" do
+      should "automatically apply the name change" do
+        assert_difference(-> { UserNameChangeRequest.count }, 1) do
+          UserNameChangeRequest.create(desired_name: "newname")
         end
+
+        @user.reload
+        assert_equal("newname", @user.name)
       end
 
-      should "change the user's name" do
-        @change_request.approve!
-        @requester.reload
-        assert_equal("abc", @requester.name)
+      should "initialize attributes correctly" do
+        request = UserNameChangeRequest.new(desired_name: "testname")
+        assert_equal(@user.id, request.user_id)
+        assert_equal(@user.name, request.original_name)
+      end
+
+      should "record the original and desired names" do
+        request = UserNameChangeRequest.create(desired_name: "newname")
+        assert_equal("originalname", request.original_name)
+        assert_equal("newname", request.desired_name)
+        assert_equal(@user.id, request.user_id)
       end
 
       should "clear the user name cache" do
-        @change_request.approve!
-        assert_equal("abc", Cache.fetch("uin:#{@requester.id}"))
+        UserNameChangeRequest.create(desired_name: "newname")
+        assert_equal("newname", Cache.fetch("uin:#{@user.id}"))
       end
     end
 
-    context "creating a new request" do
-      should "not validate if the desired name already exists" do
-        assert_difference(-> { UserNameChangeRequest.count }, 0) do
-          req = UserNameChangeRequest.create(
-            user_id: @requester.id,
-            original_name: @requester.name,
-            status: "pending",
-            desired_name: @requester.name,
-          )
-          assert_equal(["Desired name already exists"], req.errors.full_messages)
-        end
+    context "validation" do
+      should "reject invalid desired names" do
+        request = UserNameChangeRequest.new(desired_name: "x")
+        assert_not request.valid?
+        assert_includes request.errors[:desired_name], "must be 2 to 20 characters long"
       end
 
-      should "not convert the desired name to lower case" do
-        uncr = create(:user_name_change_request, user: @requester, original_name: "provence.", desired_name: "Provence")
-        as(@admin) { uncr.approve! }
+      should "reject desired names that already exist" do
+        existing_user = create(:user, name: "taken")
+        request = UserNameChangeRequest.new(desired_name: "taken")
+        assert_not request.valid?
+        assert_includes request.errors[:desired_name], "already exists"
+      end
 
-        assert_equal("Provence", @requester.name)
+      should "allow changing capitalization of current name" do
+        @user.update!(name: "testuser")
+        CurrentUser.user = @user
+        request = UserNameChangeRequest.create(desired_name: "TestUser")
+        assert request.persisted?
+        @user.reload
+        assert_equal("TestUser", @user.name)
+      end
+
+      should "reject same exact name" do
+        request = UserNameChangeRequest.new(desired_name: @user.name)
+        assert_not request.valid?
+        assert_includes request.errors[:desired_name], "is the same as your current name"
+      end
+
+      should "require presence of desired_name" do
+        request = UserNameChangeRequest.new
+        assert_not request.valid?
+        assert_includes request.errors[:desired_name], "can't be blank"
+        # original_name is auto-populated by initialize_attributes
+        assert request.original_name.present?
       end
     end
-  end
 
-  context "when users switch names" do
-    setup do
-      # Uppercase usernames are relevant for the test because of normalization
-      @u1 = create(:user, name: "Aaa")
-      @u2 = create(:user, name: "Bbb")
+    context "rate limiting" do
+      should "prevent multiple requests within a week" do
+        UserNameChangeRequest.create(desired_name: "firstchange")
+        @user.reload
 
-      # Fill cache with currently correct data
-      User.name_to_id("aaa")
-      User.name_to_id("bbb")
+        second_request = UserNameChangeRequest.new(desired_name: "secondchange")
+        assert_not second_request.valid?
+        assert_includes second_request.errors[:base], "You can only submit one name change request per week"
+      end
 
-      as(@u1) { UserNameChangeRequest.create(desired_name: "temporary", skip_limited_validation: true).approve! }
-      @u1.reload
+      should "allow requests when skip_limited_validation is true" do
+        UserNameChangeRequest.create(desired_name: "firstchange")
+        @user.reload
 
-      as(@u2) { UserNameChangeRequest.create(desired_name: "Aaa", skip_limited_validation: true).approve! }
-      @u2.reload
+        second_request = UserNameChangeRequest.new(desired_name: "secondchange")
+        second_request.skip_limited_validation = true
+        assert second_request.valid?
 
-      as(@u1) { UserNameChangeRequest.create(desired_name: "Bbb", skip_limited_validation: true).approve! }
-      @u1.reload
+        second_request.save!
+        @user.reload
+        assert_equal("secondchange", @user.name)
+      end
     end
 
-    should "update the user cache correcly" do
-      assert_equal("Bbb", @u1.name)
-      assert_equal("Aaa", @u2.name)
-      assert_equal(@u1.id, User.name_to_id(@u1.name))
-      assert_equal(@u2.id, User.name_to_id(@u2.name))
+    context "when users switch names" do
+      setup do
+        @u1 = create(:user, name: "Alice")
+        @u2 = create(:user, name: "Bob")
+
+        # Fill cache with currently correct data
+        User.name_to_id("alice")
+        User.name_to_id("bob")
+      end
+
+      should "handle name swapping correctly" do
+        # User 1 changes to temporary name
+        as(@u1) { UserNameChangeRequest.create(desired_name: "temp", skip_limited_validation: true) }
+        @u1.reload
+
+        # User 2 takes User 1's old name
+        as(@u2) { UserNameChangeRequest.create(desired_name: "Alice", skip_limited_validation: true) }
+        @u2.reload
+
+        # User 1 takes User 2's old name  
+        as(@u1) { UserNameChangeRequest.create(desired_name: "Bob", skip_limited_validation: true) }
+        @u1.reload
+
+        assert_equal("Bob", @u1.name)
+        assert_equal("Alice", @u2.name)
+        assert_equal(@u1.id, User.name_to_id(@u1.name))
+        assert_equal(@u2.id, User.name_to_id(@u2.name))
+      end
+    end
+
+    context "search" do
+      setup do
+        @request1 = as(@user) { UserNameChangeRequest.create(desired_name: "newname1", skip_limited_validation: true) }
+        @other_user = create(:user, name: "otheruser")
+        @request2 = as(@other_user) { UserNameChangeRequest.create(desired_name: "newname2", skip_limited_validation: true) }
+      end
+
+      should "filter by original_name" do
+        results = UserNameChangeRequest.search(original_name: "originalname")
+        assert_includes results, @request1
+        assert_not_includes results, @request2
+      end
+
+      should "filter by desired_name" do
+        results = UserNameChangeRequest.search(desired_name: "newname1")
+        assert_includes results, @request1
+        assert_not_includes results, @request2
+      end
     end
   end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -184,13 +184,13 @@ class UserTest < ActiveSupport::TestCase
         # U+2007: https://en.wikipedia.org/wiki/Figure_space
         user = build(:user, name: "foo\u2007bar")
         user.save
-        assert_equal(["Name must contain only alphanumeric characters, hypens, apostrophes, tildes and underscores"], user.errors.full_messages)
+        assert_equal(["Name must contain only alphanumeric characters, hyphens, apostrophes, tildes and underscores"], user.errors.full_messages)
       end
 
       should "not contain a colon" do
         user = build(:user, name: "a:b")
         user.save
-        assert_equal(["Name must contain only alphanumeric characters, hypens, apostrophes, tildes and underscores"], user.errors.full_messages)
+        assert_equal(["Name must contain only alphanumeric characters, hyphens, apostrophes, tildes and underscores"], user.errors.full_messages)
       end
 
       should "not begin with an underscore" do

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -36,8 +36,8 @@ class UserTest < ActiveSupport::TestCase
     should "not validate if the originating ip address is banned" do
       assert_raises ActiveRecord::RecordInvalid do
         as(User.anonymous, "1.2.3.4") do
-          create(:ip_ban, ip_addr: '1.2.3.4')
-          create(:user, last_ip_addr: '1.2.3.4')
+          create(:ip_ban, ip_addr: "1.2.3.4")
+          create(:user, last_ip_addr: "1.2.3.4")
         end
       end
     end
@@ -110,8 +110,8 @@ class UserTest < ActiveSupport::TestCase
       assert(@user.is_verified?)
       @user = create(:user)
       @user.mark_unverified!
-      assert(!@user.is_verified?)
-      assert_nothing_raised {@user.mark_verified!}
+      assert_not(@user.is_verified?)
+      assert_nothing_raised { @user.mark_verified! }
       assert(@user.is_verified?)
     end
 
@@ -160,19 +160,19 @@ class UserTest < ActiveSupport::TestCase
       assert(user.is_privileged?)
 
       user = create(:user, level: User::Levels::MODERATOR)
-      assert(!user.is_admin?)
+      assert_not(user.is_admin?)
       assert(user.is_moderator?)
       assert(user.is_privileged?)
 
       user = create(:user, level: User::Levels::PRIVILEGED)
-      assert(!user.is_admin?)
-      assert(!user.is_moderator?)
+      assert_not(user.is_admin?)
+      assert_not(user.is_moderator?)
       assert(user.is_privileged?)
 
       user = create(:user)
-      assert(!user.is_admin?)
-      assert(!user.is_moderator?)
-      assert(!user.is_privileged?)
+      assert_not(user.is_admin?)
+      assert_not(user.is_moderator?)
+      assert_not(user.is_privileged?)
     end
 
     context "name" do
@@ -337,8 +337,8 @@ class UserTest < ActiveSupport::TestCase
         user3 = create(:user, name: "bar123baz")
 
         assert_equal([user2.id, user1.id], User.search(name_matches: "foo*").map(&:id))
-        assert_equal([user2.id], User.search(name_matches: "foo\*bar").map(&:id))
-        assert_equal([user3.id], User.search(name_matches: "bar\*baz").map(&:id))
+        assert_equal([user2.id], User.search(name_matches: "foo*bar").map(&:id))
+        assert_equal([user3.id], User.search(name_matches: "bar*baz").map(&:id))
       end
     end
 


### PR DESCRIPTION
The manual approval of name change requests was phased out years ago.
At this point, we might as well streamline the process a little.

As a little bonus, allowed users to change the capitalization in their names directly.