### PR TITLE
[Pagination] Fix an error caused by large page numbers, again

### DIFF
--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -56,7 +56,9 @@ module Danbooru
 
       def validate_bigint(value)
         int_value = value.to_i
-        if int_value > 9_223_372_036_854_775_807 || int_value < 0
+        # NOTE: Despite the method name, many tables still use integer for IDs.
+        # Integer max is 2_147_483_647, while bigint max is 9_223_372_036_854_775_807.
+        if int_value > 2_147_483_647 || int_value < 0
           raise Danbooru::Paginator::PaginationError, "Page parameter is out of valid range."
         end
         int_value

--- a/test/unit/paginator_test.rb
+++ b/test/unit/paginator_test.rb
@@ -71,6 +71,10 @@ class PaginatorTest < ActiveSupport::TestCase
         assert_invalid_page_number(model, "a")
         assert_invalid_page_number(model, "751")
         assert_invalid_page_number(model, "c1")
+        # Sequential pagination IDs must be within integer range (most tables use integer, not bigint)
+        assert_invalid_page_number(model, "b2147483648") # Integer max + 1
+        assert_invalid_page_number(model, "a2147483648") # Integer max + 1
+        assert_invalid_page_number(model, "b9999999999999999999") # Way over integer max
       end
 
       should "apply the correct limit" do


### PR DESCRIPTION
The `ab` page format is based on the relevant table's ID column.
For some tables, that value is a bigint, which #1538 assumed.
But for others, it is unfortunately an integer.