### PR TITLE
[Mailers] Stop raising errors in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,6 +58,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :mailgun
   config.action_mailer.mailgun_settings = {
     api_key: Danbooru.config.mailgun_api_key,


### PR DESCRIPTION
All errors raised so far come from malformed email addresses, which we can't do anything about.