### PR TITLE
[Takedowns] Fix an error when creating a takedown

### DIFF
--- a/app/views/takedowns/new.html.erb
+++ b/app/views/takedowns/new.html.erb
@@ -1,6 +1,6 @@
 <div id="c-takedowns">
   <div id="c-new">
-    <%= format_text(@wiki.body, allow_color: true) %>
+    <%= format_text(@wiki&.body, allow_color: true) %>
     <br />
 
     <%= custom_form_for(@takedown) do |f| %>


### PR DESCRIPTION
The problem showed up when the new takedown had errors.
The page it rendered then would cause _another_ error because it could not pull the wiki page.

Also cleaned up some rubocop warnings.