### PR TITLE
[Notes] Prevent attempts to revert notes if post has notes locked

### DIFF
--- a/app/controllers/note_versions_controller.rb
+++ b/app/controllers/note_versions_controller.rb
@@ -4,7 +4,12 @@ class NoteVersionsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @note_versions = NoteVersion.search(search_params).paginate(params[:page], limit: params[:limit])
+    @revertable = params.dig(:search, :post_id).present? || params.dig(:search, :note_id).present?
+    @note_versions = NoteVersion
+                     .search(search_params)
+                     .paginate(params[:page], limit: params[:limit])
+    @note_versions = @note_versions.includes(:post) if @revertable
+
     respond_with(@note_versions) do |format|
       format.html { @note_versions = @note_versions.includes(:updater) }
     end

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -3,7 +3,10 @@
 class NoteVersion < ApplicationRecord
   user_status_counter :note_count, foreign_key: :updater_id
   belongs_to_updater
-  scope :for_user, ->(user_id) {where("updater_id = ?", user_id)}
+  belongs_to :note
+  belongs_to :post
+
+  scope :for_user, ->(user_id) { where("updater_id = ?", user_id) }
 
   def self.search(params)
     q = super

--- a/app/views/note_versions/_revert_listing.html.erb
+++ b/app/views/note_versions/_revert_listing.html.erb
@@ -52,7 +52,9 @@
           <td><%= compact_time note_version.updated_at %></td>
           <% if CurrentUser.is_member? %>
             <td>
-              <%= link_to "Revert to", revert_note_path(note_version.note_id, :version_id => note_version.id, format: :json), class: 'revert-item-link', 'data-noun': 'note' %>
+              <% unless note_version.post.is_note_locked? %>
+                <%= link_to "Revert to", revert_note_path(note_version.note_id, :version_id => note_version.id, format: :json), class: 'revert-item-link', 'data-noun': 'note' %>
+              <% end %>
             </td>
           <% end %>
         </tr>

--- a/app/views/note_versions/index.html.erb
+++ b/app/views/note_versions/index.html.erb
@@ -4,7 +4,7 @@
 
     <%= render "search" %>
 
-    <% if params.dig(:search, :post_id).present? || params.dig(:search, :note_id).present? %>
+    <% if @revertable %>
       <%= render "revert_listing" %>
     <% else %>
       <%= render "standard_listing" %>


### PR DESCRIPTION
Note reverting was already prevented internally, this PR just removes the button.