### PR TITLE
[Comments] Optimize body search

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,7 +58,7 @@ class PostsController < ApplicationController
     @has_samples = @post.is_image? || @post.video_sample_list[:has]
 
     if request.format.html? && @post.comment_count > 0
-      @comments = @post.comments.includes(:creator, :updater).visible(CurrentUser.user)
+      @comments = @post.comments.above_threshold.includes(:creator, :updater)
       @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
     else
       @comments = Comment.none

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -30,13 +30,58 @@ class Comment < ApplicationRecord
   user_status_counter :comment_count
   belongs_to :post, counter_cache: :comment_count
   belongs_to :warning_user, class_name: "User", optional: true
-  has_many :votes, :class_name => "CommentVote", :dependent => :destroy
+  has_many :votes, class_name: "CommentVote", dependent: :destroy
 
   scope :deleted, -> { where(is_hidden: true) }
   scope :undeleted, -> { where(is_hidden: false) }
   scope :stickied, -> { where(is_sticky: true) }
 
   module SearchMethods
+    # NOTE: Ensure that logic here matches that in AccessMethods
+
+    # ============================== #
+    # ===== Visibility Methods ===== #
+    # ============================== #
+
+    # Authorization check: comments that the user has permission to see.
+    def accessible(user = CurrentUser.user, bypass_user_settings: false)
+      conditions = []
+      arguments = []
+
+      # 1. Visibility: not hidden or created by the user themselves
+      if user.is_anonymous? || !(user.show_hidden_comments? || bypass_user_settings)
+        conditions << "comments.is_hidden = false"
+      elsif !user.is_staff?
+        conditions << "(comments.is_hidden = false OR comments.creator_id = ?)"
+        arguments << user.id
+      end
+
+      # 2. Disabled posts: non-staff cannot see any comments
+      # TODO: Rethink this approach if we reach 100+ posts with comments disabled
+      # As of November 2025, there are only 7 such posts.
+      unless user.is_staff?
+        disabled_post_ids = SearchMethods.comment_disabled_post_ids
+        unless disabled_post_ids.empty?
+          conditions << "comments.post_id NOT IN (?)"
+          arguments << disabled_post_ids
+        end
+      end
+
+      # If no conditions were added (staff with show_hidden_comments? enabled), return unfiltered relation.
+      return all if conditions.empty?
+      where(conditions.join(" AND "), *arguments)
+    end
+
+    # Score filtering: comments that meet the user's score threshold or are sticky.
+    def above_threshold(user = CurrentUser.user)
+      where("comments.is_sticky = true OR comments.score >= ?", user.comment_threshold)
+    end
+
+    # Score filtering: inverse of visible
+    def below_threshold(user = CurrentUser.user)
+      where("comments.is_sticky = false AND comments.score < ?", user.comment_threshold)
+    end
+
     def self.comment_disabled_post_ids
       Rails.cache.fetch("comment_disabled_post_ids", expires_in: 1.hour) do
         Post.where(is_comment_disabled: true).pluck(:id)
@@ -47,65 +92,14 @@ class Comment < ApplicationRecord
       Rails.cache.delete("comment_disabled_post_ids")
     end
 
-    def recent
-      reorder("comments.id desc").limit(RECENT_COUNT)
-    end
-
-    def hidden(user)
-      if user.is_moderator?
-        where("not(comments.score >= ? or comments.is_sticky = true)", user.comment_threshold)
-      elsif user.is_janitor?
-        where("not((comments.score >= ? or comments.is_sticky = true) and (comments.is_sticky = true or comments.is_hidden = false or comments.creator_id = ?))", user.comment_threshold, user.id)
-      else
-        where("not((comments.score >= ? or comments.is_sticky = true) and (comments.is_hidden = false or comments.creator_id = ?))", user.comment_threshold, user.id)
-      end
-    end
-
-    def visible(user)
-      return where("comments.score >= ? OR comments.is_sticky = true", user.comment_threshold) if user.is_moderator?
-
-      # Comment must meet any of the following:
-      # 1. Comment is sticky
-      # 2. Comment created by the user (if not anonymous)
-      # 3. All of the following are true:
-      #    a. Comment score meets threshold
-      #    b. Comment is not hidden (unless user is janitor)
-      #    c. Comment is not on a post with comments disabled (unless user is janitor)
-
-      arguments = []
-      sticky_or_own = "comments.is_sticky = true" # 1
-      unless user.is_anonymous?
-        sticky_or_own += " OR comments.creator_id = ?" # 2
-        arguments << user.id
-      end
-
-      passes_checks = ["comments.score >= ?"] # 3a
-      arguments << user.comment_threshold
-      unless user.is_janitor?
-        passes_checks << "comments.is_hidden = false" # 3b
-
-        # Comments disabled: only 19 posts as of Nov 2025.
-        disabled_post_ids = SearchMethods.comment_disabled_post_ids
-        unless disabled_post_ids.empty?
-          passes_checks << "comments.post_id NOT IN (?)" # 3c
-          arguments << disabled_post_ids
-        end
-      end
-      passes_checks = passes_checks.join(" AND ")
-
-      where("#{sticky_or_own} OR (#{passes_checks})", *arguments)
-    end
-
-    def post_tags_match(query)
-      where(post_id: Post.tag_match_sql(query).order(id: :desc).limit(300))
-    end
-
-    def for_creator(user_id)
-      user_id.present? ? where("creator_id = ?", user_id) : none
-    end
+    # ============================== #
+    # ======= Search Methods ======= #
+    # ============================== #
 
     def search(params)
       q = super.includes(:creator).includes(:updater).includes(:post)
+      q = q.accessible
+      creator_filter_applied = false
 
       # Body search subquery: prevent timeouts on broad searches
       if params[:body_matches].present? && params[:body_matches].exclude?("*")
@@ -117,6 +111,7 @@ class Comment < ApplicationRecord
         # Search by creator, if specified
         Comment.with_resolved_user_ids(:creator, params) do |user_ids|
           subquery = subquery.where(creator_id: user_ids)
+          creator_filter_applied = true if user_ids.present?
         end
 
         subquery = subquery.order(created_at: :desc).limit(10_000)
@@ -138,7 +133,7 @@ class Comment < ApplicationRecord
         q = q.where(post_id: NoteVersion.select(:post_id).where(updater_id: user_ids))
       end
 
-      q = q.where_user(:creator_id, :creator, params)
+      q = q.where_user(:creator_id, :creator, params) unless creator_filter_applied
 
       if params[:ip_addr].present?
         q = q.where("creator_ip_addr <<= ?", params[:ip_addr])
@@ -170,9 +165,74 @@ class Comment < ApplicationRecord
         condition.reorder("comments.created_at desc")
       end
     end
+
+    def post_tags_match(query)
+      where(post_id: Post.tag_match_sql(query).order(id: :desc).limit(300))
+    end
+
+    # ============================== #
+    # ======= Other Methods ======== #
+    # ============================== #
+
+    def for_creator(user_id)
+      user_id.present? ? where("creator_id = ?", user_id) : none
+    end
+
+    def recent
+      reorder("comments.id desc").limit(RECENT_COUNT)
+    end
+  end
+
+  module AccessMethods
+    # NOTE: Ensure that logic here matches that in SearchMethods
+
+    # Authorization check: user has permission to see this comment
+    def is_accessible?(user = CurrentUser.user, bypass_user_settings: false)
+      # 1. Visibility: not hidden or created by the user themselves
+      if user.is_anonymous? || !(user.show_hidden_comments? || bypass_user_settings)
+        return false if is_hidden?
+      elsif !user.is_staff?
+        return false if is_hidden? && creator_id != user.id
+      end
+
+      # 2. Disabled posts: non-staff cannot see any comments
+      return false if !user.is_staff? && SearchMethods.comment_disabled_post_ids.include?(post_id)
+
+      true
+    end
+
+    # Score filtering: comments that meet the user's score threshold or are sticky.
+    def is_above_threshold?(user = CurrentUser.user)
+      is_sticky? || score >= user.comment_threshold
+    end
+
+    # Score filtering: inverse of visible
+    def is_below_threshold?(user = CurrentUser.user)
+      !is_sticky? && score < user.comment_threshold
+    end
+
+    def can_reply?(user = CurrentUser.user)
+      return false if is_sticky?
+      return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
+      true
+    end
+
+    def can_edit?(user = CurrentUser.user)
+      return true if user.is_admin?
+      return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
+      return false if was_warned?
+      creator_id == user.id
+    end
+
+    def can_hide?(user = CurrentUser.user)
+      return true if user.is_moderator?
+      return false if was_warned? || post&.is_comment_disabled?
+      user.id == creator_id
+    end
   end
 
   extend SearchMethods
+  include AccessMethods
 
   def validate_post_exists
     errors.add(:post, "must exist") unless Post.exists?(post_id)
@@ -211,16 +271,16 @@ class Comment < ApplicationRecord
     return unless post
     other_comments = Comment.where("post_id = ? and id <> ?", post_id, id).order("id DESC")
     if other_comments.count == 0
-      post.update_columns(:last_commented_at => nil)
+      post.update_columns(last_commented_at: nil)
     else
-      post.update_columns(:last_commented_at => other_comments.first.created_at)
+      post.update_columns(last_commented_at: other_comments.first.created_at)
     end
 
     other_comments = other_comments.where("do_not_bump_post = FALSE")
     if other_comments.count == 0
-      post.update_columns(:last_comment_bumped_at => nil)
+      post.update_columns(last_comment_bumped_at: nil)
     else
-      post.update_columns(:last_comment_bumped_at => other_comments.first.created_at)
+      post.update_columns(last_comment_bumped_at: other_comments.first.created_at)
     end
     post.update_index
     true
@@ -230,39 +290,8 @@ class Comment < ApplicationRecord
     score < user.comment_threshold
   end
 
-  def can_reply?(user)
-    return false if is_sticky?
-    return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
-    true
-  end
-
-  def editable_by?(user)
-    return true if user.is_admin?
-    return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
-    return false if was_warned?
-    creator_id == user.id
-  end
-
-  def can_hide?(user)
-    return true if user.is_moderator?
-    return false if !visible_to?(user) || was_warned? || post&.is_comment_disabled?
-    user.id == creator_id
-  end
-
-  def visible_to?(user)
-    return true if user.is_staff?
-    return false if !is_sticky? && (post&.is_comment_disabled? && creator_id != user.id)
-    return true if is_hidden? == false
-    creator_id == user.id # Can always see your own comments, even if hidden.
-  end
-
-  def should_see?(user)
-    return user.show_hidden_comments? if creator_id == user.id && is_hidden?
-    visible_to?(user)
-  end
-
   def method_attributes
-    super + [:creator_name, :updater_name]
+    super + %i[creator_name updater_name]
   end
 
   def hide!

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -286,10 +286,6 @@ class Comment < ApplicationRecord
     true
   end
 
-  def below_threshold?(user = CurrentUser.user)
-    score < user.comment_threshold
-  end
-
   def method_attributes
     super + %i[creator_name updater_name]
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -53,7 +53,7 @@ class Post < ApplicationRecord
   has_many :flags, :class_name => "PostFlag", :dependent => :destroy
   has_many :votes, :class_name => "PostVote", :dependent => :destroy
   has_many :notes, :dependent => :destroy
-  has_many :comments, -> { order("comments.is_sticky DESC, comments.id") }, dependent: :destroy
+  has_many :comments, -> { accessible.order("comments.is_sticky DESC, comments.id") }, dependent: :destroy
   has_many :children, -> {order("posts.id")}, :class_name => "Post", :foreign_key => "parent_id"
   has_many :approvals, :class_name => "PostApproval", :dependent => :destroy
   has_many :disapprovals, :class_name => "PostDisapproval", :dependent => :destroy
@@ -2073,10 +2073,10 @@ class Post < ApplicationRecord
   end
 
   def visible_comment_count(user)
-    if user.is_moderator? || !is_comment_disabled?
-      comment_count
+    if is_comment_disabled? && !user.is_staff?
+      0
     else
-      comments.visible(user).count
+      comment_count
     end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1869,6 +1869,7 @@ class Post < ApplicationRecord
       if saved_change_to_is_comment_disabled?
         action = is_comment_disabled? ? :comment_disabled : :comment_enabled
         PostEvent.add(id, CurrentUser.user, action)
+        Comment::SearchMethods.clear_comment_disabled_cache
       end
       if saved_change_to_bg_color?
         PostEvent.add(id, CurrentUser.user, :changed_bg_color, { bg_color: bg_color })

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -54,11 +54,11 @@ class Ticket < ApplicationRecord
 
     module Comment
       def can_create_for?(user)
-        content&.is_visible?(user)
+        content&.is_accessible?(user, bypass_user_settings: true)
       end
 
       def can_view?(user)
-        (user.is_staff? && content&.is_visible?(user)) || user.is_admin? || (user.id == creator_id)
+        (user.is_staff? && content&.is_accessible?(user, bypass_user_settings: true)) || user.is_admin? || (user.id == creator_id)
       end
     end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -54,11 +54,11 @@ class Ticket < ApplicationRecord
 
     module Comment
       def can_create_for?(user)
-        content&.visible_to?(user)
+        content&.is_visible?(user)
       end
 
       def can_view?(user)
-        (user.is_staff? && content&.visible_to?(user)) || user.is_admin? || (user.id == creator_id)
+        (user.is_staff? && content&.is_visible?(user)) || user.is_admin? || (user.id == creator_id)
       end
     end
 

--- a/app/views/comments/_index_by_comment.html.erb
+++ b/app/views/comments/_index_by_comment.html.erb
@@ -1,6 +1,6 @@
 <div id="p-index-by-comment" class="comments-for-post">
     <% @comments.each do |comment| %>
-      <% if comment.post.present? && comment.should_see?(CurrentUser.user) %>
+      <% if comment.post.present? %>
       <div class="comment-post">
         <div class="post-container">
           <%= render(PostThumbnailComponent.new(post: comment.post, show_deleted: true)) %>

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% else %>
     <div class="row notices">
-      <% if post.comment_count > 0 && (post.comments.hidden(CurrentUser.user).count > 0 || (params[:controller] == "comments" && post.comments.count > Comment::RECENT_COUNT)) %>
+      <% if post.comment_count > 0 && (post.comments.below_threshold(CurrentUser.user).exists? || (params[:controller] == "comments" && post.comments.count > Comment::RECENT_COUNT)) %>
       <span id="threshold-comments-notice-for-<%= post.id %>">
         <%= link_to "Show all comments", comments_path(:post_id => post.id), 'data-pid': post.id, class: 'show-all-comments-for-post-link' %>
       </span>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -1,72 +1,69 @@
-<% if comment.should_see?(CurrentUser.user) || (params[:controller] == "comments" && params[:action] == "show" && CurrentUser.id == comment.creator_id) %>
-  <article class="comment comment-post-grid <%= "below-threshold" if comment.below_threshold? %>" data-post-id="<%= comment.post_id %>"
-           data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>"
-           data-creator="<%= comment.creator&.name.downcase %>" data-is-sticky="<%= comment.is_sticky %>" data-creator-id="<%= comment.creator_id %>"
-           data-is-deleted="<%= comment.is_hidden? %>" id="comment-<%= comment.id %>">
-    <div class="author-info">
-      <div class="name-rank">
-        <h4 class="author-name"><%= link_to_user comment.creator %></h4>
-        <%= comment.creator.level_string %>
-        <% if comment.is_hidden? %>
-          (hidden)
-        <% end %>
-      </div>
-      <div class="avatar">
-        <%= user_avatar(comment.creator) %>
-      </div>
-      <div class="post-time">
-        <%= link_to time_ago_in_words_tagged(comment.created_at), post_path(id: comment.post_id, anchor: "comment-#{comment.id}") %>
-      </div>
+<article class="comment comment-post-grid <%= "below-threshold" if comment.below_threshold? %>" data-post-id="<%= comment.post_id %>"
+         data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>"
+         data-creator="<%= comment.creator&.name.downcase %>" data-is-sticky="<%= comment.is_sticky %>" data-creator-id="<%= comment.creator_id %>"
+         data-is-deleted="<%= comment.is_hidden? %>" id="comment-<%= comment.id %>">
+  <div class="author-info">
+    <div class="name-rank">
+      <h4 class="author-name"><%= link_to_user comment.creator %></h4>
+      <%= comment.creator.level_string %>
+      <% if comment.is_hidden? %>
+        (hidden)
+      <% end %>
     </div>
-    <div class="content">
-      <div class="body dtext-container">
-        <%= format_text(comment.body, allow_color: comment.creator.is_privileged?) %>
-      </div>
-      <%= render "application/update_notice", record: comment %>
-      <%= render "application/warned_notice", record: comment if comment.was_warned? %>
-        <div class="content-menu">
-          <menu>
-            <% if post && comment.can_reply?(CurrentUser.user) %>
-              <li><%= tag.a "Reply", href: '#', class: "reply-link comment-reply-link" %></li>
-            <% end %>
-            <% if comment.editable_by?(CurrentUser.user) %>
-              <li><%= link_to "Edit", edit_comment_path(comment.id), :id => "edit_comment_link_#{comment.id}", :class => "edit_comment_link" %></li>
-            <% end %>
-            <% if !comment.is_hidden? && comment.can_hide?(CurrentUser.user) %>
-              <li><%= tag.a "Hide", href: '#', class: 'comment-hide-link' %></li>
-            <% elsif CurrentUser.is_moderator? %>
-              <li><%= tag.a "Unhide", href: '#', class: 'comment-unhide-link' %></li>
-            <% end %>
-
-            <% if CurrentUser.is_admin? %>
-              <li><%= tag.a "Delete", href: '#', class: 'comment-delete-link' %></li>
-            <% end %>
-            <li>|</li>
-            <%= comment_vote_block(comment, @comment_votes[comment.id]) %>
-            <% if CurrentUser.is_moderator? %>
-              <li><%= link_to "(List)", controller: 'comment_votes', search: { comment_id: comment.id } %></li>
-            <% end %>
-            <% if CurrentUser.is_member? && !comment.is_sticky %>
-              <li>|</li>
-              <li><%= link_to "Report", new_ticket_path(disp_id: comment.id, qtype: 'comment') %></li>
-            <% end %>
-            <% if CurrentUser.is_moderator? %>
-              <li>|</li>
-              <li><%= link_to "Show Edits", edit_history_path(id: comment.id, type: 'Comment') %></li>
-              <%= render "user_warnable/buttons", model: comment %>
-            <% end %>
-            <% if CurrentUser.is_admin? %>
-              <li>|</li>
-              <li>
-                <strong>IP</strong>
-                <span><%= link_to_ip comment.creator_ip_addr %></span>
-              </li>
-            <% end %>
-          </menu>
-          <% if comment.editable_by?(CurrentUser.user) %>
-            <%= render "comments/form", comment: comment, hidden: true %>
+    <div class="avatar">
+      <%= user_avatar(comment.creator) %>
+    </div>
+    <div class="post-time">
+      <%= link_to time_ago_in_words_tagged(comment.created_at), post_path(id: comment.post_id, anchor: "comment-#{comment.id}") %>
+    </div>
+  </div>
+  <div class="content">
+    <div class="body dtext-container">
+      <%= format_text(comment.body, allow_color: comment.creator.is_privileged?) %>
+    </div>
+    <%= render "application/update_notice", record: comment %>
+    <%= render "application/warned_notice", record: comment if comment.was_warned? %>
+      <div class="content-menu">
+        <menu>
+          <% if post && comment.can_reply? %>
+            <li><%= tag.a "Reply", href: '#', class: "reply-link comment-reply-link" %></li>
           <% end %>
-      </div>
+          <% if comment.can_edit? %>
+            <li><%= link_to "Edit", edit_comment_path(comment.id), :id => "edit_comment_link_#{comment.id}", :class => "edit_comment_link" %></li>
+          <% end %>
+          <% if !comment.is_hidden? && comment.can_hide? %>
+            <li><%= tag.a "Hide", href: '#', class: 'comment-hide-link' %></li>
+          <% elsif CurrentUser.is_moderator? %>
+            <li><%= tag.a "Unhide", href: '#', class: 'comment-unhide-link' %></li>
+          <% end %>
+          <% if CurrentUser.is_admin? %>
+            <li><%= tag.a "Delete", href: '#', class: 'comment-delete-link' %></li>
+          <% end %>
+          <li>|</li>
+          <%= comment_vote_block(comment, @comment_votes[comment.id]) %>
+          <% if CurrentUser.is_moderator? %>
+            <li><%= link_to "(List)", controller: 'comment_votes', search: { comment_id: comment.id } %></li>
+          <% end %>
+          <% if CurrentUser.is_member? && !comment.is_sticky %>
+            <li>|</li>
+            <li><%= link_to "Report", new_ticket_path(disp_id: comment.id, qtype: 'comment') %></li>
+          <% end %>
+          <% if CurrentUser.is_moderator? %>
+            <li>|</li>
+            <li><%= link_to "Show Edits", edit_history_path(id: comment.id, type: 'Comment') %></li>
+            <%= render "user_warnable/buttons", model: comment %>
+          <% end %>
+          <% if CurrentUser.is_admin? %>
+            <li>|</li>
+            <li>
+              <strong>IP</strong>
+              <span><%= link_to_ip comment.creator_ip_addr %></span>
+            </li>
+          <% end %>
+        </menu>
+        <% if comment.can_edit? %>
+          <%= render "comments/form", comment: comment, hidden: true %>
+        <% end %>
     </div>
-  </article>
-<% end %>
+  </div>
+</article>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -1,4 +1,4 @@
-<article class="comment comment-post-grid <%= "below-threshold" if comment.below_threshold? %>" data-post-id="<%= comment.post_id %>"
+<article class="comment comment-post-grid <%= "below-threshold" if comment.is_below_threshold? %>" data-post-id="<%= comment.post_id %>"
          data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>"
          data-creator="<%= comment.creator&.name.downcase %>" data-is-sticky="<%= comment.is_sticky %>" data-creator-id="<%= comment.creator_id %>"
          data-is-deleted="<%= comment.is_hidden? %>" id="comment-<%= comment.id %>">

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -152,7 +152,7 @@
 </tab-entry>
 
 <tab-entry tab="<%= tab_name %>" group="posts" class="inline" search="posts comments show hide display own hidden">
-  <tab-head><%= form.label :show_hidden_comments, "Show #{ CurrentUser.user.is_staff? ? "all" : "your"} hidden comments" %></tab-head>
+  <tab-head><%= form.label :show_hidden_comments, "Show #{CurrentUser.user.is_staff? ? 'all' : 'your'} hidden comments" %></tab-head>
   <tab-body>
     <%= form.input_field :show_hidden_comments, as: :boolean, class: "st-toggle" %>
     <%= form.label :show_hidden_comments, "!", class: "st-toggle", role: "switch" %>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -152,13 +152,13 @@
 </tab-entry>
 
 <tab-entry tab="<%= tab_name %>" group="posts" class="inline" search="posts comments show hide display own hidden">
-  <tab-head><%= form.label :show_hidden_comments, "Show own hidden comments" %></tab-head>
+  <tab-head><%= form.label :show_hidden_comments, "Show #{ CurrentUser.user.is_staff? ? "all" : "your"} hidden comments" %></tab-head>
   <tab-body>
     <%= form.input_field :show_hidden_comments, as: :boolean, class: "st-toggle" %>
     <%= form.label :show_hidden_comments, "!", class: "st-toggle", role: "switch" %>
   </tab-body>
   <tab-hint>
-    Show your hidden comments on comment pages.
+    Show <%= CurrentUser.user.is_staff? ? "all" : "your" %> hidden comments on comment pages.
   </tab-hint>
 </tab-entry>
 

--- a/db/migrate/20251127000001_add_index_comments_on_created_at.rb
+++ b/db/migrate/20251127000001_add_index_comments_on_created_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexCommentsOnCreatedAt < ActiveRecord::Migration[7.2]
+  def change
+    add_index :comments, %i[created_at id], order: { created_at: :desc, id: :desc }, name: :index_comments_on_created_at_desc
+  end
+end

--- a/db/migrate/20251127000001_add_index_comments_on_created_at.rb
+++ b/db/migrate/20251127000001_add_index_comments_on_created_at.rb
@@ -2,6 +2,8 @@
 
 class AddIndexCommentsOnCreatedAt < ActiveRecord::Migration[7.2]
   def change
-    add_index :comments, %i[created_at id], order: { created_at: :desc, id: :desc }, name: :index_comments_on_created_at_desc
+    Comment.without_timeout do
+      add_index :comments, %i[created_at id], order: { created_at: :desc, id: :desc }, name: :index_comments_on_created_at_desc
+    end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3695,6 +3695,13 @@ CREATE INDEX index_comment_votes_on_user_id_and_id ON public.comment_votes USING
 
 
 --
+-- Name: index_comments_on_created_at_desc; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_comments_on_created_at_desc ON public.comments USING btree (created_at DESC, id DESC);
+
+
+--
 -- Name: index_comments_on_creator_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4887,6 +4894,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251127000001'),
 ('20251114015027'),
 ('20251113060711'),
 ('20251106175207'),

--- a/test/functional/comments_controller_test.rb
+++ b/test/functional/comments_controller_test.rb
@@ -63,13 +63,13 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     context "update action" do
       context "when updating another user's comment" do
         should "succeed if updater is a moderator" do
-          put_auth comment_path(@comment.id), @user, params: {comment: {body: "abc"}}
+          put_auth comment_path(@comment.id), @user, params: { comment: { body: "abc" } }
           assert_equal("abc", @comment.reload.body)
           assert_redirected_to post_path(@comment.post)
         end
 
         should "fail if updater is not a moderator" do
-          put_auth comment_path(@mod_comment.id), @user, params: {comment: {body: "abc"}}
+          put_auth comment_path(@mod_comment.id), @user, params: { comment: { body: "abc" } }
           assert_not_equal("abc", @mod_comment.reload.body)
           assert_response 403
         end
@@ -78,25 +78,25 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
       context "when stickying a comment" do
         should "succeed if updater is a moderator" do
           @comment = create(:comment, creator: @mod)
-          put_auth comment_path(@comment.id), @mod, params: {comment: {is_sticky: true}}
+          put_auth comment_path(@comment.id), @mod, params: { comment: { is_sticky: true } }
           assert_equal(true, @comment.reload.is_sticky)
           assert_redirected_to @comment.post
         end
 
         should "fail if updater is not a moderator" do
-          put_auth comment_path(@comment.id), @user, params: {comment: {is_sticky: true}}
+          put_auth comment_path(@comment.id), @user, params: { comment: { is_sticky: true } }
           assert_equal(false, @comment.reload.is_sticky)
         end
       end
 
       should "update the body" do
-        put_auth comment_path(@comment.id), @user, params: {comment: {body: "abc"}}
+        put_auth comment_path(@comment.id), @user, params: { comment: { body: "abc" } }
         assert_equal("abc", @comment.reload.body)
         assert_redirected_to post_path(@comment.post)
       end
 
       should "not allow changing is_hidden" do
-        put_auth comment_path(@comment.id), @user, params: {comment: {body: "herp derp", is_hidden: true}}
+        put_auth comment_path(@comment.id), @user, params: { comment: { body: "herp derp", is_hidden: true } }
         assert_equal(false, @comment.is_hidden)
       end
 
@@ -104,7 +104,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
         as(@user) do
           @another_post = create(:post)
         end
-        put_auth comment_path(@comment.id), @comment.creator, params: {do_not_bump_post: true, post_id: @another_post.id}
+        put_auth comment_path(@comment.id), @comment.creator, params: { comment: { do_not_bump_post: true, post_id: @another_post.id } }
         assert_equal(false, @comment.reload.do_not_bump_post)
         assert_equal(@post.id, @comment.post_id)
       end
@@ -133,7 +133,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "create action"do
+    context "create action" do
       should "create a comment" do
         assert_difference("Comment.count", 1) do
           post_auth comments_path, @user, params: { comment: { body: "abc", post_id: @post.id } }

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -3,6 +3,383 @@
 require "test_helper"
 
 class CommentTest < ActiveSupport::TestCase
+  # =============================================================================
+  # VISIBILITY AND ACCESS CONTROL TESTS
+  # =============================================================================
+
+  context "Comment.accessible" do
+    setup do
+      @user = create(:user)
+      @other_user = create(:user)
+      @janitor = create(:janitor_user)
+      @moderator = create(:moderator_user)
+    end
+
+    context "with regular users" do
+      should "show non-hidden comments" do
+        comment = as(@user) { create(:comment, is_hidden: false) }
+        assert_includes(Comment.accessible(@user), comment)
+        assert(comment.is_accessible?(@user))
+      end
+
+      should "hide hidden comments when show_hidden_comments is false" do
+        @user.update!(show_hidden_comments: false)
+        comment = as(@user) { create(:comment, is_hidden: true) }
+        assert_not_includes(Comment.accessible(@user), comment)
+        assert_not(comment.is_accessible?(@user))
+      end
+
+      should "show own hidden comments when show_hidden_comments is true" do
+        @user.update!(show_hidden_comments: true)
+        comment = as(@user) { create(:comment, creator: @user, is_hidden: true) }
+        assert_includes(Comment.accessible(@user), comment)
+        assert(comment.is_accessible?(@user))
+      end
+
+      should "hide other users' hidden comments when show_hidden_comments is true" do
+        @user.update!(show_hidden_comments: true)
+        comment = as(@other_user) { create(:comment, creator: @other_user, is_hidden: true) }
+        assert_not_includes(Comment.accessible(@user), comment)
+        assert_not(comment.is_accessible?(@user))
+      end
+
+      should "hide comments on posts with disabled comments" do
+        post = as(@user) { create(:post, is_comment_disabled: true) }
+        comment = as(@moderator) { create(:comment, post: post) }
+        assert_not_includes(Comment.accessible(@user), comment)
+        assert_not(comment.is_accessible?(@user))
+      end
+
+      should "hide own comments on posts with disabled comments" do
+        post = as(@user) { create(:post, is_comment_disabled: true) }
+        comment = as(@moderator) { create(:comment, post: post, creator: @moderator) }
+        # Moderators CAN see comments on disabled posts (they are staff)
+        assert_includes(Comment.accessible(@moderator), comment)
+        assert(comment.is_accessible?(@moderator))
+      end
+    end
+
+    context "with anonymous users" do
+      setup do
+        @anon = User.anonymous
+      end
+
+      should "show non-hidden comments" do
+        comment = as(@user) { create(:comment, is_hidden: false) }
+        assert_includes(Comment.accessible(@anon), comment)
+        assert(comment.is_accessible?(@anon))
+      end
+
+      should "hide hidden comments" do
+        comment = as(@user) { create(:comment, is_hidden: true) }
+        assert_not_includes(Comment.accessible(@anon), comment)
+        assert_not(comment.is_accessible?(@anon))
+      end
+
+      should "hide comments on disabled posts" do
+        post = as(@user) { create(:post, is_comment_disabled: true) }
+        comment = as(@moderator) { create(:comment, post: post) }
+        assert_not_includes(Comment.accessible(@anon), comment)
+        assert_not(comment.is_accessible?(@anon))
+      end
+    end
+
+    context "with janitors" do
+      should "show non-hidden comments" do
+        comment = as(@janitor) { create(:comment, is_hidden: false) }
+        assert_includes(Comment.accessible(@janitor), comment)
+        assert(comment.is_accessible?(@janitor))
+      end
+
+      should "hide hidden comments when show_hidden_comments is false" do
+        @janitor.update!(show_hidden_comments: false)
+        comment = as(@janitor) { create(:comment, is_hidden: true) }
+        assert_not_includes(Comment.accessible(@janitor), comment)
+        assert_not(comment.is_accessible?(@janitor))
+      end
+
+      should "show all hidden comments when show_hidden_comments is true" do
+        @janitor.update!(show_hidden_comments: true)
+        comment1 = as(@user) { create(:comment, is_hidden: true) }
+        comment2 = as(@other_user) { create(:comment, is_hidden: true, creator: @other_user) }
+        assert_includes(Comment.accessible(@janitor), comment1)
+        assert_includes(Comment.accessible(@janitor), comment2)
+        assert(comment1.is_accessible?(@janitor))
+        assert(comment2.is_accessible?(@janitor))
+      end
+
+      should "show comments on disabled posts" do
+        post = as(@user) { create(:post, is_comment_disabled: true) }
+        comment = as(@moderator) { create(:comment, post: post) }
+        assert_includes(Comment.accessible(@janitor), comment)
+        assert(comment.is_accessible?(@janitor))
+      end
+    end
+
+    context "with moderators" do
+      should "show all hidden comments when show_hidden_comments is true" do
+        @moderator.update!(show_hidden_comments: true)
+        comment = as(@user) { create(:comment, is_hidden: true) }
+        assert_includes(Comment.accessible(@moderator), comment)
+        assert(comment.is_accessible?(@moderator))
+      end
+
+      should "show comments on disabled posts" do
+        post = as(@user) { create(:post, is_comment_disabled: true) }
+        comment = as(@moderator) { create(:comment, post: post) }
+        assert_includes(Comment.accessible(@moderator), comment)
+        assert(comment.is_accessible?(@moderator))
+      end
+    end
+
+    context "with bypass_user_settings flag" do
+      should "show hidden comments regardless of preference when true" do
+        @user.update!(show_hidden_comments: false)
+        comment = as(@user) { create(:comment, creator: @user, is_hidden: true) }
+        assert_not_includes(Comment.accessible(@user), comment)
+        assert_includes(Comment.accessible(@user, bypass_user_settings: true), comment)
+        assert_not(comment.is_accessible?(@user))
+        assert(comment.is_accessible?(@user, bypass_user_settings: true))
+      end
+
+      should "show all staff hidden comments when bypassing" do
+        @janitor.update!(show_hidden_comments: false)
+        comment = as(@user) { create(:comment, is_hidden: true) }
+        assert_not_includes(Comment.accessible(@janitor), comment)
+        assert_includes(Comment.accessible(@janitor, bypass_user_settings: true), comment)
+        assert_not(comment.is_accessible?(@janitor))
+        assert(comment.is_accessible?(@janitor, bypass_user_settings: true))
+      end
+    end
+  end
+
+  context "Comment.above_threshold" do
+    setup do
+      @user = create(:user, comment_threshold: 0)
+    end
+
+    should "show comments at or above threshold" do
+      comment_positive = as(@user) { create(:comment, score: 5) }
+      comment_zero = as(@user) { create(:comment, score: 0) }
+      comment_negative = as(@user) { create(:comment, score: -1) }
+
+      results = Comment.above_threshold(@user)
+      assert_includes(results, comment_positive)
+      assert_includes(results, comment_zero)
+      assert_not_includes(results, comment_negative)
+      assert(comment_positive.is_above_threshold?(@user))
+      assert(comment_zero.is_above_threshold?(@user))
+      assert_not(comment_negative.is_above_threshold?(@user))
+    end
+
+    should "show sticky comments regardless of score" do
+      sticky_low_score = as(@user) { create(:comment, score: -10, is_sticky: true) }
+      sticky_high_score = as(@user) { create(:comment, score: 10, is_sticky: true) }
+
+      results = Comment.above_threshold(@user)
+      assert_includes(results, sticky_low_score)
+      assert_includes(results, sticky_high_score)
+      assert(sticky_low_score.is_above_threshold?(@user))
+      assert(sticky_high_score.is_above_threshold?(@user))
+    end
+
+    should "respect different thresholds per user" do
+      user_high_threshold = create(:user, comment_threshold: 5)
+      user_low_threshold = create(:user, comment_threshold: -5)
+      comment_mid = as(@user) { create(:comment, score: 0) }
+
+      assert_not_includes(Comment.above_threshold(user_high_threshold), comment_mid)
+      assert_includes(Comment.above_threshold(user_low_threshold), comment_mid)
+      assert_not(comment_mid.is_above_threshold?(user_high_threshold))
+      assert(comment_mid.is_above_threshold?(user_low_threshold))
+    end
+
+    should "work with negative thresholds" do
+      user_negative = create(:user, comment_threshold: -10)
+      comment = as(@user) { create(:comment, score: -5) }
+      assert_includes(Comment.above_threshold(user_negative), comment)
+      assert(comment.is_above_threshold?(user_negative))
+    end
+  end
+
+  context "Comment.below_threshold" do
+    setup do
+      @user = create(:user, comment_threshold: 0)
+    end
+
+    should "show comments below threshold" do
+      comment_positive = as(@user) { create(:comment, score: 5) }
+      comment_negative = as(@user) { create(:comment, score: -1) }
+
+      results = Comment.below_threshold(@user)
+      assert_not_includes(results, comment_positive)
+      assert_includes(results, comment_negative)
+      assert_not(comment_positive.is_below_threshold?(@user))
+      assert(comment_negative.is_below_threshold?(@user))
+    end
+
+    should "exclude sticky comments regardless of score" do
+      sticky_low_score = as(@user) { create(:comment, score: -10, is_sticky: true) }
+      non_sticky_low_score = as(@user) { create(:comment, score: -10, is_sticky: false) }
+
+      results = Comment.below_threshold(@user)
+      assert_not_includes(results, sticky_low_score)
+      assert_includes(results, non_sticky_low_score)
+      assert_not(sticky_low_score.is_below_threshold?(@user))
+      assert(non_sticky_low_score.is_below_threshold?(@user))
+    end
+
+    should "respect different thresholds per user" do
+      user_high_threshold = create(:user, comment_threshold: 5)
+      user_low_threshold = create(:user, comment_threshold: -5)
+      comment_mid = as(@user) { create(:comment, score: 0) }
+
+      assert_includes(Comment.below_threshold(user_high_threshold), comment_mid)
+      assert_not_includes(Comment.below_threshold(user_low_threshold), comment_mid)
+      assert(comment_mid.is_below_threshold?(user_high_threshold))
+      assert_not(comment_mid.is_below_threshold?(user_low_threshold))
+    end
+  end
+
+  # =============================================================================
+  # SEARCH TESTS
+  # =============================================================================
+
+  context "Comment.search" do
+    setup do
+      @user = create(:user)
+      @other_user = create(:user)
+    end
+
+    context "with body_matches" do
+      should "find comments by text content" do
+        c1 = as(@user) { create(:comment, body: "aaa bbb ccc") }
+        c2 = as(@user) { create(:comment, body: "aaa ddd") }
+        as(@user) { create(:comment, body: "eee") }
+
+        CurrentUser.scoped(@user) do
+          matches = Comment.search(body_matches: "aaa")
+          assert_equal(2, matches.count)
+          assert_includes(matches, c1)
+          assert_includes(matches, c2)
+        end
+      end
+
+      should "use subquery for non-wildcard searches" do
+        as(@user) { create(:comment, body: "test content") }
+
+        CurrentUser.scoped(@user) do
+          query = Comment.search(body_matches: "test").to_sql
+          assert_match(/IN \(SELECT/, query)
+          assert_match(/LIMIT 10000/, query)
+        end
+      end
+
+      should "not use subquery for wildcard searches" do
+        as(@user) { create(:comment, body: "test content") }
+
+        CurrentUser.scoped(@user) do
+          query = Comment.search(body_matches: "test*").to_sql
+          assert_no_match(/IN \(SELECT/, query)
+          assert_match(/LIKE/i, query)
+        end
+      end
+    end
+
+    context "with creator filtering" do
+      should "filter by creator_id in main query when no body_matches" do
+        c1 = as(@user) { create(:comment, creator: @user) }
+        c2 = as(@other_user) { create(:comment) }
+
+        CurrentUser.scoped(@user) do
+          matches = Comment.search("creator_id" => @user.id.to_s)
+          assert_includes(matches, c1)
+          assert_not_includes(matches, c2)
+        end
+      end
+
+      should "filter by creator_id in subquery when body_matches is present" do
+        c1 = as(@user) { create(:comment, creator: @user, body: "test content") }
+        c2 = as(@other_user) { create(:comment, body: "test content") }
+
+        CurrentUser.scoped(@user) do
+          matches = Comment.search("body_matches" => "test", "creator_id" => @user.id.to_s)
+          assert_includes(matches, c1)
+          assert_not_includes(matches, c2)
+        end
+      end
+
+      should "not duplicate creator filter when used in subquery" do
+        as(@user) { create(:comment, creator: @user, body: "test") }
+
+        CurrentUser.scoped(@user) do
+          query = Comment.search("body_matches" => "test", "creator_id" => @user.id.to_s).to_sql
+          creator_filters = query.scan("creator_id").count
+          assert_equal(1, creator_filters, "Creator filter should appear exactly once")
+        end
+      end
+    end
+
+    context "with post_tags_match" do
+      should "find comments by post tags" do
+        p1 = as(@user) { create(:post, tag_string: "aaa bbb ccc") }
+        p2 = as(@user) { create(:post, tag_string: "aaa ddd") }
+        p3 = as(@user) { create(:post, tag_string: "eee") }
+        c1 = as(@user) { create(:comment, post: p1) }
+        c2 = as(@user) { create(:comment, post: p2) }
+        as(@user) { create(:comment, post: p3) }
+
+        CurrentUser.scoped(@user) do
+          matches = Comment.search(post_tags_match: "aaa")
+          assert_equal(2, matches.count)
+          assert_includes(matches, c1)
+          assert_includes(matches, c2)
+        end
+      end
+    end
+
+    context "with accessible scope applied by default" do
+      should "exclude hidden comments for regular users" do
+        @user.update!(show_hidden_comments: false)
+        CurrentUser.scoped(@user) do
+          visible_comment = create(:comment, is_hidden: false)
+          hidden_comment = create(:comment, is_hidden: true)
+
+          results = Comment.search({})
+          assert_includes(results, visible_comment)
+          assert_not_includes(results, hidden_comment)
+        end
+      end
+
+      should "exclude comments on disabled posts for regular users" do
+        CurrentUser.scoped(@user) do
+          normal_post = as(@user) { create(:post) }
+          disabled_post = as(@other_user) { create(:post, is_comment_disabled: true) }
+          normal_comment = as(@user) { create(:comment, post: normal_post) }
+          # Use moderator to create comment on disabled post
+          moderator = create(:moderator_user)
+          disabled_comment = as(moderator) { create(:comment, post: disabled_post) }
+
+          results = Comment.search({})
+          assert_includes(results, normal_comment)
+          assert_not_includes(results, disabled_comment)
+        end
+      end
+    end
+
+    should "default to id_desc order when no options specified" do
+      comms = as(@user) { create_list(:comment, 3) }
+      CurrentUser.scoped(@user) do
+        matches = Comment.search({})
+        assert_equal([comms[2].id, comms[1].id, comms[0].id], matches.map(&:id))
+      end
+    end
+  end
+
+  # =============================================================================
+  # VALIDATION AND CREATION TESTS
+  # =============================================================================
+
   context "A comment" do
     setup do
       @user = create(:user)
@@ -55,11 +432,11 @@ class CommentTest < ActiveSupport::TestCase
 
       should "not bump the parent post" do
         post = create(:post)
-        comment = create(:comment, do_not_bump_post: true, post: post)
+        create(:comment, do_not_bump_post: true, post: post)
         post.reload
         assert_nil(post.last_comment_bumped_at)
 
-        comment = create(:comment, post: post)
+        create(:comment, post: post)
         post.reload
         assert_not_nil(post.last_comment_bumped_at)
       end
@@ -69,52 +446,56 @@ class CommentTest < ActiveSupport::TestCase
         p = create(:post)
         c1 = create(:comment, post: p)
         travel_to(2.seconds.from_now) do
-          c2 = create(:comment, post: p)
+          create(:comment, post: p)
         end
         p.reload
         assert_equal(c1.created_at.to_s, p.last_comment_bumped_at.to_s)
       end
 
-      should "always record the last_commented_at properly" do
-        post = create(:post)
+      should "update last_commented_at on the post" do
+        post_creator = create(:user)
+        post = as(post_creator) { create(:post) }
         Danbooru.config.stubs(:comment_threshold).returns(1)
 
-        c1 = create(:comment, do_not_bump_post: true, post: post)
+        user = create(:user)
+        c1 = as(user) { create(:comment, do_not_bump_post: true, post: post) }
         post.reload
         assert_equal(c1.created_at.to_s, post.last_commented_at.to_s)
 
-        c2 = create(:comment, post: post)
+        c2 = as(user) { create(:comment, post: post) }
         post.reload
         assert_equal(c2.created_at.to_s, post.last_commented_at.to_s)
       end
 
       should "not record the user id of the voter" do
-        user = create(:user)
-        user2 = create(:user)
-        post = create(:post)
-        c1 = create(:comment, post: post)
+        comment_creator = create(:user)
+        voter = create(:user)
+        post_creator = create(:user)
+        post = as(post_creator) { create(:post) }
+        c1 = as(comment_creator) { create(:comment, post: post) }
 
-        as(user2) do
-          VoteManager.comment_vote!(user: user2, comment: c1, score: -1)
+        as(voter) do
+          VoteManager.comment_vote!(user: voter, comment: c1, score: -1)
           c1.reload
-          assert_not_equal(user2.id, c1.updater_id)
+          assert_not_equal(voter.id, c1.updater_id)
         end
       end
 
       should "not allow duplicate votes" do
-        user = create(:user)
-        user2 = create(:user)
-        post = create(:post)
-        c1 = create(:comment, post: post)
-        c2 = create(:comment, post: post)
+        comment_creator = create(:user)
+        voter = create(:user)
+        post_creator = create(:user)
+        post = as(post_creator) { create(:post) }
+        c1 = as(comment_creator) { create(:comment, post: post) }
+        c2 = as(comment_creator) { create(:comment, post: post) }
 
-        as(user2) do
-          assert_nothing_raised { VoteManager.comment_vote!(user: user2, comment: c1, score: -1) }
-          assert_equal(:need_unvote, VoteManager.comment_vote!(user: user2, comment: c1, score: -1))
+        as(voter) do
+          assert_nothing_raised { VoteManager.comment_vote!(user: voter, comment: c1, score: -1) }
+          assert_equal(:need_unvote, VoteManager.comment_vote!(user: voter, comment: c1, score: -1))
           assert_equal(1, CommentVote.count)
           assert_equal(-1, CommentVote.last.score)
 
-          assert_nothing_raised { VoteManager.comment_vote!(user: user2, comment: c2, score: -1) }
+          assert_nothing_raised { VoteManager.comment_vote!(user: voter, comment: c2, score: -1) }
           assert_equal(2, CommentVote.count)
         end
       end
@@ -139,33 +520,36 @@ class CommentTest < ActiveSupport::TestCase
 
       should "not allow votes on sticky comments" do
         user = create(:user)
-        post = create(:post)
-        c1 = create(:comment, post: post, is_sticky: true)
+        post_creator = create(:user)
+        post = as(post_creator) { create(:post) }
+        c1 = as(user) { create(:comment, post: post, is_sticky: true) }
 
         exception = assert_raises(ActiveRecord::RecordInvalid) { VoteManager.comment_vote!(user: user, comment: c1, score: -1) }
         assert_match(/You cannot vote on sticky comments/, exception.message)
       end
 
       should "allow undoing of votes" do
-        user = create(:user)
-        user2 = create(:user)
-        post = create(:post)
-        comment = create(:comment, post: post)
-        as(user2) do
-          VoteManager.comment_vote!(user: user2, comment: comment, score: 1)
+        comment_creator = create(:user)
+        voter = create(:user)
+        post_creator = create(:user)
+        post = as(post_creator) { create(:post) }
+        comment = as(comment_creator) { create(:comment, post: post) }
+        as(voter) do
+          VoteManager.comment_vote!(user: voter, comment: comment, score: 1)
           comment.reload
           assert_equal(1, comment.score)
-          VoteManager.comment_unvote!(user: user2, comment: comment)
+          VoteManager.comment_unvote!(user: voter, comment: comment)
           comment.reload
           assert_equal(0, comment.score)
-          assert_nothing_raised { VoteManager.comment_vote!(user: user2, comment: comment, score: -1) }
+          assert_nothing_raised { VoteManager.comment_vote!(user: voter, comment: comment, score: -1) }
         end
       end
 
-      should "be searchable by body" do
-        c1 = create(:comment, body: "aaa bbb ccc")
-        c2 = create(:comment, body: "aaa ddd")
-        c3 = create(:comment, body: "eee")
+      should "be searchable by body content" do
+        user = create(:user)
+        c1 = as(user) { create(:comment, body: "aaa bbb ccc") }
+        c2 = as(user) { create(:comment, body: "aaa ddd") }
+        as(user) { create(:comment, body: "eee") }
 
         matches = Comment.search(body_matches: "aaa")
         assert_equal(2, matches.count)
@@ -174,12 +558,13 @@ class CommentTest < ActiveSupport::TestCase
       end
 
       should "be searchable by post tags" do
-        p1 = create(:post, tag_string: "aaa bbb ccc")
-        p2 = create(:post, tag_string: "aaa ddd")
-        p3 = create(:post, tag_string: "eee")
-        c1 = create(:comment, post_id: p1.id, body: "comment body text")
-        c2 = create(:comment, post_id: p2.id, body: "comment body text")
-        c3 = create(:comment, post_id: p3.id, body: "comment body text") # rubocop:disable Lint/UselessAssignment, Lint/RedundantCopDisableDirective
+        user = create(:user)
+        p1 = as(user) { create(:post, tag_string: "aaa bbb ccc") }
+        p2 = as(user) { create(:post, tag_string: "aaa ddd") }
+        p3 = as(user) { create(:post, tag_string: "eee") }
+        c1 = as(user) { create(:comment, post_id: p1.id, body: "comment body text") }
+        c2 = as(user) { create(:comment, post_id: p2.id, body: "comment body text") }
+        as(user) { create(:comment, post_id: p3.id, body: "comment body text") }
 
         matches = Comment.search(post_tags_match: "aaa")
         assert_equal(2, matches.count)
@@ -189,12 +574,13 @@ class CommentTest < ActiveSupport::TestCase
       end
 
       should "be searchable by grouped post tags" do # rubocop:disable Style/MultilineIfModifier
-        p1 = create(:post, tag_string: "aaa bbb ccc")
-        p2 = create(:post, tag_string: "aaa ddd")
-        p3 = create(:post, tag_string: "eee")
-        c1 = create(:comment, post_id: p1.id, body: "comment body text")
-        c2 = create(:comment, post_id: p2.id, body: "comment body text")
-        c3 = create(:comment, post_id: p3.id, body: "comment body text") # rubocop:disable Lint/UselessAssignment, Lint/RedundantCopDisableDirective
+        user = create(:user)
+        p1 = as(user) { create(:post, tag_string: "aaa bbb ccc") }
+        p2 = as(user) { create(:post, tag_string: "aaa ddd") }
+        p3 = as(user) { create(:post, tag_string: "eee") }
+        c1 = as(user) { create(:comment, post_id: p1.id, body: "comment body text") }
+        c2 = as(user) { create(:comment, post_id: p2.id, body: "comment body text") }
+        as(user) { create(:comment, post_id: p3.id, body: "comment body text") }
 
         matches = Comment.search(post_tags_match: "~( aaa bbb ) ~( ddd -( ~ccc ~eee ) )")
         assert(matches.is_a?(ActiveRecord::Relation), "Return value isn't a ActiveRecord::Relation. #{matches}")


### PR DESCRIPTION
The full text body search has some crippling performance issues when encountering broad search terms.
This PR aims to fix that.

#### Reworked comment visibility, again
Separated the `accessible` method (can the user _ever_ see this comment?) from `above_threshold` (does the comment match the user's chosen score threshold?) to make extra sure that we don't leak hidden comments anywhere. Also, streamlined the corresponding comment-side methods to ensure that they follow the same logic.

Cached posts with disabled comments, no need to look them up every time.
Allowed janitors to see all hidden comments properly, including on posts with disabled comments.

#### Added an index
There wasn't an index on `comments.created_at`, which slowed down ordering

#### Moved body search into a subquery
This allows us to run an extremely quick lookup using an existing index, which then gets narrowed down with visibility and other search terms. As a downside, this does limit search to 10k results at most (before filtering), but that should be acceptable.

The subquery ensures that the comments belong to a specific user, if a the `creator_id` parameter is provided.