### PR TITLE
[Favorites] Optimize the page that lists users who favorited the post

### DIFF
--- a/app/controllers/post_favorites_controller.rb
+++ b/app/controllers/post_favorites_controller.rb
@@ -8,7 +8,7 @@ class PostFavoritesController < ApplicationController
 
     # Base query: users who favorited this post
     query = User.includes(:user_status)
-                .joins("INNER JOIN favorites ON favorites.user_id = users.id AND favorites.post_id = #{@post.id.to_i}")
+                .joins(favorites: {}).where(favorites: { post_id: @post.id })
 
     # Privacy filter for non-moderators
     unless CurrentUser.is_moderator?

--- a/app/controllers/post_favorites_controller.rb
+++ b/app/controllers/post_favorites_controller.rb
@@ -5,12 +5,23 @@ class PostFavoritesController < ApplicationController
 
   def index
     @post = Post.find(params[:post_id])
-    query = User.includes(:user_status).joins(:favorites)
+
+    # Base query: users who favorited this post
+    query = User.includes(:user_status)
+                .joins("INNER JOIN favorites ON favorites.user_id = users.id AND favorites.post_id = #{@post.id.to_i}")
+
+    # Privacy filter for non-moderators
     unless CurrentUser.is_moderator?
-      query = query.where("bit_prefs & :value != :value", { value: User.flag_value_for("enable_privacy_mode") }).or(query.where(favorites: { user_id: CurrentUser.id }))
+      privacy_flag = User.flag_value_for("enable_privacy_mode")
+      query = query.where("(users.bit_prefs & ?) = 0", privacy_flag)
     end
-    query = query.where(favorites: { post_id: @post.id })
+
     query = query.order("users.name asc")
-    @users = query.paginate(params[:page], limit: params[:limit])
+
+    paginate_options = {}
+    paginate_options[:limit] = params[:limit].to_i.clamp(1, 100) if params[:limit].present?
+    paginate_options[:total_count] = @post.fav_count if @post.fav_count > 1000
+
+    @users = query.paginate(params[:page], paginate_options)
   end
 end

--- a/app/views/post_favorites/index.html.erb
+++ b/app/views/post_favorites/index.html.erb
@@ -2,6 +2,24 @@
   <div id="a-index">
     <h1>Post Favorites</h1>
     <%= render(PostThumbnailComponent.new(post: @post)) %>
+
+    <div class="styled-dtext" style="margin: 1rem 0;">
+      <blockquote>
+        <p>
+          Some users may be excluded from this list due to their <a href="/users/settings?find=privacy">privacy settings</a>.
+          <% if CurrentUser.user.enable_privacy_mode? %>
+            <br /><b>This includes you.</b>
+          <% end %>
+        </p>
+        <% if @post.fav_count > 1000 %>
+          <p>
+            <b>Note:</b> This post has a large number of favorites.<br />
+            Page count may or may not be accurate.
+          </p>
+        <% end %>
+      </blockquote>
+    </div>
+
     <table class="striped">
       <thead>
         <tr>


### PR DESCRIPTION
It's a rarely-used page, but it's a heavy one.

Reworked the query building a bit.
It should be able to utilize the index better, since I got rid of a check that forced the list to include the current user.
Most people open that page to find _other_ people who like the same stuff as them, not to look at themselves.

Tweaked pagination to use the post's `fav_count` instead of calculating one for posts with over 1000 favorites.
The total page count may be a little off, but that is an acceptable alternative to performance issues.