### PR TITLE
[ForumPosts] Fix an error caused by an orphaned post

### DIFF
--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -90,6 +90,7 @@ class ForumPostsController < ApplicationController
   def load_post
     @forum_post = ForumPost.includes(topic: [:category]).find(params[:id])
     @forum_topic = @forum_post.topic
+    raise ActiveRecord::RecordNotFound, "Forum post has no associated topic" if @forum_topic.nil?
   end
 
   def check_min_level


### PR DESCRIPTION
Some ancient posts ended up mangled – with no topic associated with them.