### PR TITLE
[Posts] Begin transitioning to more consistent API output

### DIFF
--- a/app/controllers/concerns/json_response_helper.rb
+++ b/app/controllers/concerns/json_response_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module JsonResponseHelper
+  extend ActiveSupport::Concern
+
+  private
+
+  # Renders JSON data with optional unwrapping for API transition
+  #
+  # @param data [Hash, Array] The data to render
+  # @param wrapper_key [Symbol] The key to wrap the data in (e.g., :posts, :post)
+  # @param collection [Boolean] Whether this is a collection response (for auto-wrapper naming)
+  def render_json_with_wrapper(data, wrapper_key: nil, collection: false)
+    if params[:only].present?
+      render json: data
+    else
+      # Backward compatibility: wrap in object
+      wrapper_key ||= collection ? :posts : :post
+      render json: { wrapper_key => data }
+    end
+  end
+
+  def render_posts_json(posts_data, collection: false)
+    wrapper_key = collection ? :posts : :post
+    render_json_with_wrapper(posts_data, wrapper_key: wrapper_key)
+  end
+
+  def render_events_json(events_data)
+    render_json_with_wrapper(events_data, wrapper_key: :post_events)
+  end
+end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,7 +2,7 @@
 
 class FavoritesController < ApplicationController
   include JsonResponseHelper
-  
+
   before_action :member_only, except: [:index]
   before_action :ensure_lockdown_disabled, except: %i[index]
   respond_to :json

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FavoritesController < ApplicationController
+  include JsonResponseHelper
+  
   before_action :member_only, except: [:index]
   before_action :ensure_lockdown_disabled, except: %i[index]
   respond_to :json
@@ -23,7 +25,7 @@ class FavoritesController < ApplicationController
       @posts = @post_set.posts
       respond_with(@posts) do |fmt|
         fmt.json do
-          render json: { posts: PostBlueprint.render_as_hash(@post_set.api_posts) }
+          render_posts_json(PostBlueprint.render_as_hash(@post_set.api_posts), collection: true)
         end
       end
     end
@@ -58,6 +60,8 @@ class FavoritesController < ApplicationController
   rescue Favorite::Error => e
     render_expected_error(422, e.message)
   end
+
+  private
 
   def ensure_lockdown_disabled
     render_expected_error(403, "Favorites are disabled") if Security::Lockdown.favorites_disabled? && !CurrentUser.is_staff?

--- a/app/controllers/popular_controller.rb
+++ b/app/controllers/popular_controller.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
 class PopularController < ApplicationController
+  include JsonResponseHelper
+  
   respond_to :html, :json
 
   def index
     @post_set = PostSets::Popular.new(params[:date], params[:scale])
     @posts = @post_set.posts
-    respond_with(@posts)
+    respond_with(@posts) do |format|
+      format.json do
+        render_posts_json(PostBlueprint.render_as_hash(@post_set.api_posts), collection: true)
+      end
+    end
   rescue ArgumentError => e
     render_expected_error(422, e)
   end

--- a/app/controllers/popular_controller.rb
+++ b/app/controllers/popular_controller.rb
@@ -2,7 +2,7 @@
 
 class PopularController < ApplicationController
   include JsonResponseHelper
-  
+
   respond_to :html, :json
 
   def index

--- a/app/controllers/post_events_controller.rb
+++ b/app/controllers/post_events_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PostEventsController < ApplicationController
+  include JsonResponseHelper
+
   respond_to :html, :json
 
   def index
@@ -9,7 +11,7 @@ class PostEventsController < ApplicationController
     )
     respond_with(@events) do |format|
       format.json do
-        render json: { post_events: PostEventBlueprint.render_as_hash(Draper.undecorate(@events)) }
+        render_events_json(PostEventBlueprint.render_as_hash(Draper.undecorate(@events)))
       end
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@
 
 class PostsController < ApplicationController
   include JsonResponseHelper
-  
+
   before_action :member_only, except: %i[show show_seq index random]
   before_action :admin_only, only: [:update_iqdb]
   before_action :ensure_lockdown_disabled, except: %i[index show show_seq random]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PostsController < ApplicationController
+  include JsonResponseHelper
+  
   before_action :member_only, except: %i[show show_seq index random]
   before_action :admin_only, only: [:update_iqdb]
   before_action :ensure_lockdown_disabled, except: %i[index show show_seq random]
@@ -12,7 +14,7 @@ class PostsController < ApplicationController
       respond_with(@post) do |format|
         format.html { redirect_to post_path(@post) }
         format.json do
-          render json: { post: PostBlueprint.render_as_hash(@post) }
+          render_posts_json(PostBlueprint.render_as_hash(@post))
         end
       end
     else
@@ -39,7 +41,7 @@ class PostsController < ApplicationController
 
       respond_with(@posts) do |format|
         format.json do
-          render json: { posts: PostBlueprint.render_as_hash(@post_set.api_posts) }
+          render_posts_json(PostBlueprint.render_as_hash(@post_set.api_posts), collection: true)
         end
         format.atom
       end
@@ -67,7 +69,7 @@ class PostsController < ApplicationController
 
     respond_with(@post) do |format|
       format.json do
-        render json: { post: PostBlueprint.render_as_hash(@post) }
+        render_posts_json(PostBlueprint.render_as_hash(@post))
       end
     end
   end
@@ -94,7 +96,7 @@ class PostsController < ApplicationController
     respond_with(@post) do |format|
       format.html { render "posts/show" }
       format.json do
-        render json: { post: PostBlueprint.render_as_hash(@post) }
+        render_posts_json(PostBlueprint.render_as_hash(@post))
       end
     end
   end
@@ -200,7 +202,7 @@ class PostsController < ApplicationController
       end
 
       format.json do
-        render json: { post: PostBlueprint.render_as_hash(post) }
+        render_posts_json(PostBlueprint.render_as_hash(post))
       end
     end
   end

--- a/app/logical/post_sets/popular.rb
+++ b/app/logical/post_sets/popular.rb
@@ -20,6 +20,13 @@ module PostSets
       @posts ||= ::Post.where("created_at between ? and ?", min_date.beginning_of_day, max_date.end_of_day).order("score desc").paginate_posts(1)
     end
 
+    def api_posts
+      result = posts
+      fill_children(result)
+      fill_tag_types(result)
+      result
+    end
+
     def min_date
       case scale
       when "week"


### PR DESCRIPTION
For legacy reasons, the posts API endpoints return JSON wrapped in a `posts` object.
The same is true for post events, although that is not as impactful.

As a way to transition away from this design paradigm, this PR adds an `only` param that will cause the output to follow the more standard format. This will allow API consumers to gradually transition to the new format – without outright breaking any existing code.

As a side effect, this also fixes #1568.