### PR TITLE
[Users] Implement better email validation

### DIFF
--- a/app/logical/email_address_validator.rb
+++ b/app/logical/email_address_validator.rb
@@ -17,8 +17,8 @@ class EmailAddressValidator < ActiveModel::EachValidator
     end
 
     # No display names, comments, etc.
-    # We are stripping these out earlier, so they should not be present here.
-    if address.nil? || email != address
+    # Check if normalization detected display names in original input
+    if address.nil? || rec.instance_variable_get(:@email_had_display_name)
       rec.errors.add(attr, "is invalid")
       return
     end

--- a/app/logical/email_address_validator.rb
+++ b/app/logical/email_address_validator.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "mail"
+
+class EmailAddressValidator < ActiveModel::EachValidator
+  def validate_each(rec, attr, value)
+    email = value.to_s.strip
+    return if email.blank?
+
+    # Parse with Mail::Address
+    begin
+      parsed = Mail::Address.new(email)
+      address = parsed.address
+    rescue Mail::Field::ParseError
+      rec.errors.add(attr, "is invalid")
+      return
+    end
+
+    # No display names, comments, etc.
+    # We are stripping these out earlier, so they should not be present here.
+    if address.nil? || email != address
+      rec.errors.add(attr, "is invalid")
+      return
+    end
+
+    local, domain = address.split("@", 2)
+    if local.nil? || domain.nil?
+      rec.errors.add(attr, "is invalid")
+      return
+    end
+
+    # ===== Validating Local Parts ===== #
+
+    # Local-part validations
+    if local.start_with?(".") || local.end_with?(".")
+      rec.errors.add(attr, "cannot have dots at the beginning or end of the local part")
+      return
+    end
+
+    if local.include?("..")
+      rec.errors.add(attr, "cannot have consecutive dots in the local part")
+      return
+    end
+
+    if local.length > 64
+      rec.errors.add(attr, "local part is too long (maximum 64 characters)")
+      return
+    end
+
+    # ===== Validating Domain Parts ===== #
+
+    if domain.length > 253
+      rec.errors.add(attr, "domain is too long (maximum 253 characters)")
+      return
+    end
+
+    # Reject IP literals and require at least one dot (standard domain format)
+    if domain.start_with?("[") || domain.exclude?(".")
+      rec.errors.add(attr, "must use a standard domain format")
+      return
+    end
+
+    # Check domain labels
+    labels = domain.split(".")
+    labels.each do |label|
+      if label.empty?
+        rec.errors.add(attr, "has an invalid domain structure")
+        break
+      end
+
+      if label.length > 63
+        rec.errors.add(attr, "has a domain label that is too long")
+        break
+      end
+
+      if label.start_with?("-") || label.end_with?("-")
+        rec.errors.add(attr, "has a domain label that starts or ends with a hyphen")
+        break
+      end
+
+      # Require labels to be alphanumeric + hyphens only (no underscores, etc.)
+      unless label =~ /\A[a-zA-Z0-9-]+\z/
+        rec.errors.add(attr, "has invalid characters in the domain")
+        break
+      end
+    end
+
+    # TLD should be at least 2 characters and all letters
+    tld = labels.last
+    if tld.nil? || tld.length < 2 || tld !~ /\A[a-zA-Z]+\z/
+      rec.errors.add(attr, "has an invalid top-level domain")
+    end
+  end
+end

--- a/app/models/forum_subscription.rb
+++ b/app/models/forum_subscription.rb
@@ -11,6 +11,7 @@ class ForumSubscription < ApplicationRecord
   def self.process_all!
     ForumSubscription.find_each do |subscription|
       forum_topic = subscription.forum_topic
+      next unless subscription.user.is_verified?
       if forum_topic.updated_at > subscription.last_read_at
         CurrentUser.scoped(subscription.user) do
           forum_posts = forum_topic.posts.where("created_at > ?", subscription.last_read_at).order("id desc")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -396,7 +396,7 @@ class User < ApplicationRecord
     end
 
     def mark_unverified!
-      update_attribute(:email_verification_key, '1')
+      update_attribute(:email_verification_key, "1")
     end
 
     def mark_verified!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -420,12 +420,15 @@ class User < ApplicationRecord
       address = email.to_s.strip
       return if address.blank?
 
+      @email_had_display_name = false # Used in validation later
       parsed = Mail::Address.new(address)
-      local, domain = parsed.split("@", 2)
-      return if local.nil? || domain.nil?
-      address = "#{local}@#{domain.downcase}"
+      return if parsed.address.nil?
+      @email_had_display_name = true if address != parsed.address
 
-      self.email = address
+      local, domain = parsed.address.split("@", 2)
+      return if local.nil? || domain.nil?
+
+      self.email = "#{local}@#{domain.downcase}"
     rescue Mail::Field::ParseError
       # Do nothing; validation will catch this later
     end

--- a/db/fixes/131_invalidate_malformed_emails.rb
+++ b/db/fixes/131_invalidate_malformed_emails.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+User.without_timeout do # rubocop:disable Metrics/BlockLength
+  fixed = 0
+  invalidated = 0
+
+  # Create validator instance once for efficiency
+  email_validator = EmailAddressValidator.new(attributes: [:email])
+
+  User.in_batches.each_with_index do |group, index|
+    group.each do |user|
+      next if user.email.blank? || user.email_verification_key.present?
+
+      original_email = user.email
+      user.normalize_email_address
+
+      # Run email validation directly without triggering full model validation
+      user.errors.clear
+      email_validator.validate_each(user, :email, user.email)
+
+      if user.errors[:email].empty?
+        if user.email == original_email
+          next
+        end
+        begin
+          user.save!
+          puts "  Fixed email to '#{user.email}'"
+          fixed += 1
+        rescue ActiveRecord::RecordInvalid
+          user.update_column(:email_verification_key, "1")
+          invalidated += 1
+        end
+      else
+        user.update_column(:email_verification_key, "1")
+        invalidated += 1
+      end
+    end
+
+    puts "Batch #{index}: fixed #{fixed}, invalidated #{invalidated}"
+  end
+
+  puts "Final totals: fixed #{fixed}, invalidated #{invalidated}"
+end


### PR DESCRIPTION
Previously, the only thing ensuring that a email was actually valid was a simple regex.
This PR adds proper validation using the `mail` gem, plus some extra checks.