### PR TITLE
[Misc] Move overmind lockfile to temp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ RUN addgroup --gid ${HOST_GID} e621ng && \
 RUN git config --global --add safe.directory $(pwd)
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["overmind", "start"]
+CMD ["overmind", "start", "-s", "/tmp/.overmind.sock"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,6 @@
 set -e
 
 yarn install --frozen-lockfile
-rm -f .overmind.sock
 
 if [ -d "vendor/dtext" ] && [ "$LOCAL_DTEXT" = "true" ]; then
   echo "dtext: Recompiling..."


### PR DESCRIPTION
Moves the overmind lockfile into the tmp directory, which is inside the container, and therefore not mirrored back to the host, preventing weirdness when starting the container. 