### PR TITLE
[Posts] Normalise `submissionview.php` Inkbunny sources to `/s/` sources

### DIFF
--- a/app/logical/sources/alternates/inkbunny.rb
+++ b/app/logical/sources/alternates/inkbunny.rb
@@ -46,7 +46,7 @@ module Sources
             return "#{id}-p#{page}" if page > 1
           end
 
-          id
+          return id
         end
 
         nil

--- a/app/logical/sources/alternates/inkbunny.rb
+++ b/app/logical/sources/alternates/inkbunny.rb
@@ -22,7 +22,34 @@ module Sources
           @parsed_url.path = @parsed_url.path.chomp("-")
         end
 
+        id = id_from_submission
+        return submission_url_from_id(id) if id
+
         @url = @parsed_url.to_s
+      end
+
+      private
+
+      def submission_url_from_id(id)
+        "https://inkbunny.net/s/#{id}"
+      end
+
+      def id_from_submission
+        return nil unless parsed_url&.host == "inkbunny.net"
+
+        if parsed_url.path == "/submissionview.php" && parsed_url.query_values.present? && parsed_url.query_values["id"].present?
+          id = parsed_url.query_values["id"].to_i
+          return nil if id <= 0
+
+          if parsed_url.query_values["page"].present?
+            page = parsed_url.query_values["page"].to_i
+            return "#{id}-p#{page}" if page > 1
+          end
+
+          id
+        end
+
+        nil
       end
     end
   end

--- a/test/unit/sources/alternates/inkbunny_test.rb
+++ b/test/unit/sources/alternates/inkbunny_test.rb
@@ -35,5 +35,37 @@ module Sources
         "https://inkbunny.net/s/237847384-p3",
       )
     end
+
+    context "A submissionview.php URL" do
+      alternate_should_work(
+        "https://inkbunny.net/submissionview.php?id=1382779",
+        Sources::Alternates::Inkbunny,
+        "https://inkbunny.net/s/1382779",
+      )
+    end
+
+    context "A submissionview.php URL with page number" do
+      alternate_should_work(
+        "https://inkbunny.net/submissionview.php?id=3123467&page=8",
+        Sources::Alternates::Inkbunny,
+        "https://inkbunny.net/s/3123467-p8",
+      )
+    end
+
+    context "A submissionview.php URL with page number 1" do
+      alternate_should_work(
+        "https://inkbunny.net/submissionview.php?id=3123467&page=1",
+        Sources::Alternates::Inkbunny,
+        "https://inkbunny.net/s/3123467",
+      )
+    end
+
+    context "A submissionview.php URL with an extra query part" do
+      alternate_should_work(
+        "https://inkbunny.net/submissionview.php?id=903232&latest",
+        Sources::Alternates::Inkbunny,
+        "https://inkbunny.net/s/903232",
+      )
+    end
   end
 end


### PR DESCRIPTION
Although the `submissionview.php` sources still work, Inkbunny generates the `/s/` sources in most places in its user interface, and the latter are much shorter.