### PR TITLE
User preference for automatic upvote when favouriting

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -165,6 +165,7 @@ class UsersController < ApplicationController
       enable_auto_complete
       enable_safe_mode disable_responsive_mode
       forum_notification_dot
+      enable_combined_upvote_and_favorite
     ]
 
     permitted_params += [dmail_filter_attributes: %i[id words]]

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -24,7 +24,7 @@ class FavoriteManager
       raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
     end
 
-    VoteManager.vote!(post:, user:, score: 1) if user.enable_combined_upvote_and_favorite
+    VoteManager.vote!(post: post, user: user, score: 1) if user.enable_combined_upvote_and_favorite
   rescue ActiveRecord::RecordNotUnique
     return if force
     raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -23,6 +23,8 @@ class FavoriteManager
 
       raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
     end
+
+    VoteManager.vote!(post:, user:, score: 1) if user.enable_combined_upvote_and_favorite
   rescue ActiveRecord::RecordNotUnique
     return if force
     raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,7 @@ class User < ApplicationRecord
     replacements_beta
     is_bd_staff
     is_bd_auditor
+    enable_combined_upvote_and_favorite
   ].freeze
 
   include Danbooru::HasBitFlags

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -32,6 +32,7 @@
     <button
       class="st-button kinetic ptbr-favorite-button anim"
       favorited="<%= @post.is_favorited? %>"
+      increment-score="<%= CurrentUser.enable_combined_upvote_and_favorite %>"
       processing="false"
     >
       <%= svg_icon(:star) %>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -172,3 +172,15 @@
     Only show images rated safe.
   </tab-hint>
 </tab-entry>
+
+<tab-entry tab="<%= tab_name %>" group="posts" class="inline" search="posts like upvote favourite favourite save star">
+  <tab-head><%= form.label :enable_combined_upvote_and_favorite, "Combined Upvote and Favorite" %></tab-head>
+  <tab-body>
+    <%= form.input_field :enable_combined_upvote_and_favorite, as: :boolean, class: "st-toggle" %>
+    <%= form.label :enable_combined_upvote_and_favorite, "!", class: "st-toggle", role: "switch" %>
+  </tab-body>
+  <tab-hint>
+    Favoriting a post will also upvote it automatically.
+  </tab-hint>
+</tab-entry>
+


### PR DESCRIPTION
Closes #1795

Forum discussion from a while back: https://e621.net/forum_topics/59891

A few other booru-like boards automatically record an upvote when faving a post. That discussion points at it being useful for most folks, but for people who use favourites as a "see later" list it could be a bit annoying. Seems like a viable user preference with the default being the current behaviour?

It's implemented in the FavoriteManager service object in ruby, just because I assume API favourites + other ways of saving a favorite should also follow this preference. It could just as easily be implemented in the FE though, if you'd prefer!

### Preference in Settings > Basic > Posts
<img width="899" height="563" alt="Capture d’écran, le 2026-01-18 à 17 38 13" src="https://github.com/user-attachments/assets/e7ddb900-bb98-4b54-a8de-4dd5a78114a6" />

### And here it is when enabled
![2026-01-18 18 17 58](https://github.com/user-attachments/assets/7db83cca-6bad-41cf-9089-3dfe57d00a84)

> [!IMPORTANT]
> For the moment, there's no visual UI changes on the post page. Wanted everyone's thoughts on that before I give it a go. Discoverability is pretty low when it's a toggle at the bottom of settings.
> Thoughts on including a small dropdown menu on the fave button itself? Would be a similar popover implementation to the search settings.
> <img width="200" alt="exampleflow" src="https://github.com/user-attachments/assets/773682f6-28c5-4d44-8626-c5e54429bfa1" />

