### PR TITLE
[Comments] Show comments hidden by settings if searching by ID

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -123,8 +123,9 @@ class CommentsController < ApplicationController
     @comments = Comment
                 .includes(:creator, :updater, post: :uploader)
                 .search(search_params)
-                .above_threshold
-                .paginate(params[:page], limit: params[:limit], search_count: search_params_for_count)
+    @comments = @comments.above_threshold unless search_params[:id]
+    @comments = @comments.paginate(params[:page], limit: params[:limit], search_count: search_params_for_count)
+
     @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
 
     if CurrentUser.is_staff?
@@ -148,7 +149,7 @@ class CommentsController < ApplicationController
   end
 
   def search_params
-    permitted_params = %i[body_matches post_id post_tags_match creator_name creator_id post_note_updater_name post_note_updater_id poster_id poster_name is_sticky do_not_bump_post order]
+    permitted_params = %i[body_matches post_id post_tags_match creator_name creator_id post_note_updater_name post_note_updater_id poster_id poster_name is_sticky do_not_bump_post order advanced_search]
     permitted_params += %i[is_hidden] if CurrentUser.is_moderator?
     permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -98,7 +98,7 @@ class Comment < ApplicationRecord
 
     def search(params)
       q = super.includes(:creator).includes(:updater).includes(:post)
-      q = q.accessible
+      q = q.accessible(CurrentUser.user, bypass_user_settings: params[:id].present?)
       creator_filter_applied = false
 
       # Body search subquery: prevent timeouts on broad searches


### PR DESCRIPTION
If someone searches comments by direct IDs, they probably want to see them even if their settings would normally prevent that.  
Especially useful for links in user records.