### PR TITLE
[Tickets] Add search by disp_id for staff

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -104,7 +104,7 @@ class TicketsController < ApplicationController
     current_search_params = params.fetch(:search, {})
     permitted_params = %i[qtype status order]
     permitted_params += %i[creator_id] if CurrentUser.is_staff? || (current_search_params[:creator_id].present? && current_search_params[:creator_id].to_i == CurrentUser.id)
-    permitted_params += %i[creator_name accused_name accused_id claimant_id claimant_name reason] if CurrentUser.is_staff?
+    permitted_params += %i[disp_id creator_name accused_name accused_id claimant_id claimant_name reason] if CurrentUser.is_staff?
     permit_search_params permitted_params
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -272,6 +272,8 @@ class Ticket < ApplicationRecord
       q = q.where_user(:claimant_id, :claimant, params)
       q = q.where_user(:accused_id, :accused, params)
 
+      q = q.attribute_matches(:disp_id, params[:disp_id])
+
       if params[:qtype].present?
         q = q.where("qtype = ?", params[:qtype])
       end


### PR DESCRIPTION
Allows searching tickets by disp_id, which is the ID of the reported resource. This allows finding "duplicate" tickets in the API. 