### PR TITLE
[Artists] Add search by linked user

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -12,7 +12,8 @@ class ArtistsController < ApplicationController
     # Only enable COUNT for searches that actually narrow results to avoid expensive queries
     search_params_for_count = search_count_params(
       narrowing: %i[id name group_name any_other_name_like any_name_matches
-                    any_name_or_url_matches url_matches creator_name creator_id],
+                    any_name_or_url_matches url_matches creator_name creator_id
+                    linked_user_id linked_user_name],
       falsy: %i[has_tag],
       truthy: %i[is_linked],
     )

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -478,6 +478,7 @@ class Artist < ApplicationRecord
       end
 
       q = q.where_user(:creator_id, :creator, params)
+      q = q.where_user(:linked_user_id, :linked_user, params)
 
       if params[:has_tag].to_s.truthy?
         q = q.joins(:tag).where("tags.post_count > 0")

--- a/app/views/artists/_search.html.erb
+++ b/app/views/artists/_search.html.erb
@@ -2,6 +2,7 @@
   <%= f.input :any_name_matches, label: "Name", hint: "Use * for wildcard", autocomplete: "artist" %>
   <%= f.input :url_matches, label: "URL", as: :string %>
   <%= f.user :creator %>
+  <%= f.user :linked_user, label: "Linked User" %>
   <%= f.input :has_tag, label: "Has tag?", collection: [["Yes", true], ["No", false]], include_blank: true %>
   <%= f.input :is_linked, label: "Linked?", collection: [["Yes", true], ["No", false]], include_blank: true %>
   <%= f.input :order, collection: [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]] %>


### PR DESCRIPTION
Allows searching artists by their linked user. This allows finding artist verifications for a given user in the API.