### PR TITLE
[EditHistories] Allow JSON API

### DIFF
--- a/app/controllers/edit_histories_controller.rb
+++ b/app/controllers/edit_histories_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EditHistoriesController < ApplicationController
-  respond_to :html
+  respond_to :html, :json
   before_action :moderator_only
 
   def index


### PR DESCRIPTION
Enables the JSON API for edit histories, so that comment, forum and other edits can be accessed in the API.