### PR TITLE
[DText] Quoting blips/comments/forum posts links to the original message

### DIFF
--- a/app/javascript/src/javascripts/blips.js
+++ b/app/javascript/src/javascripts/blips.js
@@ -1,6 +1,7 @@
 /* eslint-disable quotes */
 import Utility from './utility.js';
 import TextUtils from './utility/text_util.js';
+import TextPost from './utility/text_post.js';
 
 let Blip = {};
 
@@ -15,10 +16,17 @@ Blip.atme = function (e) {
   $('#blip_response_to')[0].value = blipId;
 };
 
+/**
+ * Generates a DText-formatted quote of the given text post.
+ *
+ * @todo Pull into a static method on `TextPost`.
+ * @param {Event} e
+ */
 Blip.quote = function (e) {
   e.preventDefault();
-  const $parent = $(e.target).parents("article.blip");
-  const blipId = $parent.data("blip-id");
+  const parent = $(e.target).parents("article.blip");
+  const blipId = parent.data("blip-id");
+  const link = TextPost.retrieveOwnUrlSegment(parent);
 
   $.ajax({
     url: `/blips/${blipId}.json`,
@@ -27,7 +35,7 @@ Blip.quote = function (e) {
     accept: 'text/javascript',
   }).done(function (data) {
     const $textarea = $("#blip_body_for_");
-    TextUtils.processQuote($textarea, data.body, $parent.data("creator"), $parent.data("creator-id"));
+    TextUtils.processQuote($textarea, data.body, parent.data("creator"), parent.data("creator-id"), link);
     $textarea.selectEnd();
 
     $('#blip_response_to')[0].value = blipId;

--- a/app/javascript/src/javascripts/comments.js
+++ b/app/javascript/src/javascripts/comments.js
@@ -1,6 +1,7 @@
 import DTextFormatter from "./dtext_formatter";
 import Utility from "./utility";
 import TextUtils from "./utility/text_util";
+import TextPost from "./utility/text_post.js";
 
 let Comment = {};
 
@@ -109,11 +110,18 @@ Comment.delete = function (e) {
   });
 };
 
+/**
+ * Generates a DText-formatted quote of the given text post.
+ *
+ * @todo Pull into a static method on `TextPost`.
+ * @param {Event} e
+ */
 Comment.quote = function (e) {
   e.preventDefault();
   const parent = $(e.target).parents("article.comment");
   const pid = parent.data("post-id");
   const cid = parent.data("comment-id");
+  const link = TextPost.retrieveOwnUrlSegment(parent);
   $.ajax({
     url: `/comments/${cid}.json`,
     type: "GET",
@@ -121,10 +129,10 @@ Comment.quote = function (e) {
     accept: "text/javascript",
   }).done(function (data) {
     const $div = $(`div.comments-for-post[data-post-id="${pid}"] div.new-comment`);
-    $div.find(".expand-comment-response").click();
+    $div.find(".expand-comment-response").trigger("click");
 
     const $textarea = $div.find("textarea");
-    TextUtils.processQuote($textarea, data.body, parent.data("creator"), parent.data("creator-id"));
+    TextUtils.processQuote($textarea, data.body, parent.data("creator"), parent.data("creator-id"), link);
     $textarea.selectEnd();
   }).fail(function (data) {
     Utility.error(data.responseText);

--- a/app/javascript/src/javascripts/forum_posts.js
+++ b/app/javascript/src/javascripts/forum_posts.js
@@ -1,5 +1,6 @@
 import Utility from "./utility";
 import TextUtils from "./utility/text_util";
+import TextPost from "./utility/text_post.js";
 
 let ForumPost = {};
 
@@ -94,10 +95,17 @@ ForumPost.vote_remove = function (evt) {
   });
 };
 
+/**
+ * Generates a DText-formatted quote of the given text post.
+ *
+ * @todo Pull into a static method on `TextPost`.
+ * @param {Event} e
+ */
 ForumPost.quote = function (e) {
   e.preventDefault();
   const parent = $(e.target).parents("article.forum-post");
   const fpid = parent.data("forum-post-id");
+  const link = TextPost.retrieveOwnUrlSegment(parent);
   $.ajax({
     url: `/forum_posts/${fpid}.json`,
     type: "GET",
@@ -105,7 +113,7 @@ ForumPost.quote = function (e) {
     accept: "text/javascript",
   }).done(function (data) {
     const $textarea = $("#forum_post_body_for_");
-    TextUtils.processQuote($textarea, data.body, parent.data("creator"), parent.data("creator-id"));
+    TextUtils.processQuote($textarea, data.body, parent.data("creator"), parent.data("creator-id"), link);
     $textarea.selectEnd();
 
     $("#topic-response").show();

--- a/app/javascript/src/javascripts/utility/text_post.js
+++ b/app/javascript/src/javascripts/utility/text_post.js
@@ -1,0 +1,21 @@
+/** @module TextPost Contains utilities for handling text posts (e.g. comments, forum posts, blips). */
+
+/** Contains utilities for handling text posts (e.g. comments, forum posts, blips). */
+const TextPost = Object.freeze(
+  {
+    /**
+     * Pulls the raw URL to the post from the post's UI. Using this method preserves the behavior of
+     * forum posts linking to the post's anchor on its forum topic's page, comments linking to the
+     * comment's anchor on its post's page, & blips linking directly to the blip's page.
+     * @param {JQuery<HTMLElement> | HTMLElement} postElement The post to pull the URL from
+     * @returns {String} The raw URL as contained in the anchor (won't include the domain, will
+     * include path, query, & fragment).
+     */
+    retrieveOwnUrlSegment (postElement) {
+      if (postElement instanceof HTMLElement) { postElement = $(postElement); }
+      return postElement.find(".post-time a").attr("href");
+    },
+  },
+);
+
+export default TextPost;

--- a/app/javascript/src/javascripts/utility/text_util.js
+++ b/app/javascript/src/javascripts/utility/text_util.js
@@ -22,10 +22,11 @@ TextUtils.strip_quotes = function (string) {
  * @param {String} message The message to quote
  * @param {String} creatorName Username of the message creator
  * @param {Number} creatorId ID of the message creator
+ * @param {String} [messagePath=undefined] The URL path to the quoted message; should have domain removed to remove external link icon
  * @returns {String} The formatted quote
  */
-TextUtils.formatQuote = function (message, creatorName, creatorId) {
-  return `[quote]"${creatorName}":/users/${creatorId} said:\n${TextUtils.strip_quotes(message)}\n[/quote]\n\n`;
+TextUtils.formatQuote = function (message, creatorName, creatorId, messagePath = undefined) {
+  return `[quote]"${creatorName}":/users/${creatorId} ${messagePath ? `"said":[${messagePath.replaceAll("]", "%5D").replaceAll("[", "%5B")}]` : "said"}:\n${TextUtils.strip_quotes(message)}\n[/quote]\n\n`;
 };
 
 /**
@@ -34,9 +35,10 @@ TextUtils.formatQuote = function (message, creatorName, creatorId) {
  * @param {String} quotedText The message to quote
  * @param {String} creatorName Username of the message creator
  * @param {Number} creatorId ID of the message creator
+ * @param {String} [messagePath=undefined] The URL path to the quoted message; should have domain removed to remove external link icon
  */
-TextUtils.processQuote = function ($textarea, quotedText, creatorName, creatorId) {
-  let message = TextUtils.formatQuote(quotedText, creatorName, creatorId);
+TextUtils.processQuote = function ($textarea, quotedText, creatorName, creatorId, messagePath = undefined) {
+  let message = TextUtils.formatQuote(quotedText, creatorName, creatorId, messagePath);
 
   const existingInput = $textarea.val();
   if (existingInput.length > 0)

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -190,6 +190,7 @@ class Dmail < ApplicationRecord
     end
   end
 
+  # IDEA: If sections ever support links in titles, change to match comment, forum, & blip quotes.
   def quoted_body
     "[section=#{from.pretty_name} said:]\n#{body}\n[/section]\n\n"
   end


### PR DESCRIPTION
When "Reply"/"Respond"ing to a blip/comment/forum post, it actually adds a link to the message being responded to instead of the old method of just quoting it with no way to find to original message beyond searching for the text.

It currently uses the same link as the UI does; e.g.
* forum posts link to the post's anchor on its forum topic's page
* comments link to the comment's anchor on its post's page
* blips link directly to the blip's page