### PR TITLE
[Build] Set the default build target to ES2018

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -23,6 +23,8 @@ export default defineConfig({
   build: {
     // This would inline small assets, but ruins css variables.
     assetsInlineLimit: 0,
+    // Relatively modern browser support is required
+    target: "es2018",
   },
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
After upgrading to Vite 7.3.1, several users reported that JS no longer worked for them.

ES2018 is actually slightly more conservative than what we had before, but it should be fine.
Very minor bundle size increase.