### PR TITLE
[Users] Add "me" user route

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,10 +42,11 @@ class UsersController < ApplicationController
   end
 
   def me
-    respond_with(CurrentUser.user) do |format|
+    user = CurrentUser.user
+    respond_with(user, methods: user.full_attributes) do |format|
       format.html do
-        next render_404 if CurrentUser.user.is_anonymous?
-        redirect_to(user_path(CurrentUser.user))
+        next render_404 if user.is_anonymous?
+        redirect_to(user_path(user))
       end
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,6 +41,15 @@ class UsersController < ApplicationController
     respond_with(@user)
   end
 
+  def me
+    respond_with(CurrentUser.user) do |format|
+      format.html do
+        next render_404 if CurrentUser.user.is_anonymous?
+        redirect_to(user_path(CurrentUser.user))
+      end
+    end
+  end
+
   def home
     @user = CurrentUser.user
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -326,6 +326,7 @@ Rails.application.routes.draw do
       get :search
       get :custom_style
       get :settings
+      get :me
 
       get :avatar_menu
     end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -198,5 +198,29 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
         assert_equal("body { display:none !important; }", @response.body.strip)
       end
     end
+
+    context("me action") do
+      should("redirect for authenticated html") do
+        get_auth(me_users_path, @user)
+        assert_redirected_to(user_path(@user))
+      end
+
+      should("404 for unauthenticated html") do
+        get(me_users_path)
+        assert_response(:not_found)
+      end
+
+      should("return the correct id for authenticated json") do
+        get_auth(me_users_path(format: :json), @user)
+        assert_response(:success)
+        assert_equal(@user.id, @response.parsed_body["id"])
+      end
+
+      should("return nil id for unauthenticated json") do
+        get(me_users_path(format: :json))
+        assert_response(:success)
+        assert_nil(@response.parsed_body["id"])
+      end
+    end
   end
 end


### PR DESCRIPTION
As is currently, no consistent and official way exists to fetch who we're authenticated as without having to look up usernames or scrape html.
Previously, I personally used `/users/upload_limit.json`, but this route was changed in #970 to require a user id, which is actually used. Currently I use `/users/0/edit.json` because it doesn't actually validate the id provided, but I have no doubt this could change in the future to either validate the id or not return json at all.

This pr adds `/users/me` (I'm open to changing the name), which returns the standard user json. It returns the default user configuration if no user is authenticated, and will redirect if fetched as html (unless anonymous, anonymous html will 404).