### PR TITLE
[EditHistories] Add search parameters

### DIFF
--- a/app/controllers/edit_histories_controller.rb
+++ b/app/controllers/edit_histories_controller.rb
@@ -5,12 +5,20 @@ class EditHistoriesController < ApplicationController
   before_action :moderator_only
 
   def index
-    @edit_history = EditHistory.includes(:user).paginate(params[:page], limit: params[:limit])
+    @edit_history = EditHistory.includes(:user).search(search_params).paginate(params[:page], limit: params[:limit])
     respond_with(@edit_history)
   end
 
   def show
-    @edits = EditHistory.includes(:user).where('versionable_id = ? AND versionable_type = ?', params[:id], params[:type]).order(:id)
+    @edits = EditHistory.includes(:user).where("versionable_id = ? AND versionable_type = ?", params[:id], params[:type]).order(:id)
     respond_with(@edits)
+  end
+
+  private
+
+  def search_params
+    permitted_params = %i[body_matches subject_matches versionable_type versionable_id editor_name editor_id order]
+    permitted_params += %i[ip_addr] if CurrentUser.is_admin?
+    permit_search_params permitted_params
   end
 end

--- a/app/models/edit_history.rb
+++ b/app/models/edit_history.rb
@@ -1,13 +1,40 @@
 # frozen_string_literal: true
 
 class EditHistory < ApplicationRecord
-  self.table_name = 'edit_histories'
+  self.table_name = "edit_histories"
   belongs_to :versionable, polymorphic: true
   belongs_to :user
 
   TYPE_MAP = {
-      comment: 'Comment',
-      forum: 'ForumPost',
-      blip: 'Blip'
-  }
+    comment: "Comment",
+    forum: "ForumPost",
+    blip: "Blip",
+  }.freeze
+
+  module SearchMethods
+    def search(params)
+      q = super
+
+      q = q.attribute_matches(:body, params[:body_matches])
+      q = q.attribute_matches(:subject, params[:subject_matches])
+
+      if params[:versionable_type].present?
+        q = q.where(versionable_type: params[:versionable_type])
+      end
+
+      if params[:versionable_id].present?
+        q = q.where(versionable_id: params[:versionable_id])
+      end
+
+      q = q.where_user(:user_id, :editor, params)
+
+      if params[:ip_addr].present?
+        q = q.where("ip_addr <<= ?", params[:ip_addr])
+      end
+
+      q.apply_basic_order(params)
+    end
+  end
+
+  extend SearchMethods
 end

--- a/app/views/edit_histories/_search.html.erb
+++ b/app/views/edit_histories/_search.html.erb
@@ -2,5 +2,8 @@
   <%= f.user :editor, label: "Editor" %>
   <%= f.input :body_matches, label: "Body" %>
   <%= f.input :subject_matches, label: "Subject" %>
+  <% if CurrentUser.is_admin? %>
+    <%= f.input :ip_addr, label: "Editor IP" %>
+  <% end %>
   <%= f.input :versionable_type, label: "Type", collection: EditHistory::TYPE_MAP.values.map { |v| [v, v] }, include_blank: true %>
 <% end %>

--- a/app/views/edit_histories/_search.html.erb
+++ b/app/views/edit_histories/_search.html.erb
@@ -1,0 +1,6 @@
+<%= form_search(path: edit_histories_path) do |f| %>
+  <%= f.user :editor, label: "Editor" %>
+  <%= f.input :body_matches, label: "Body" %>
+  <%= f.input :subject_matches, label: "Subject" %>
+  <%= f.input :versionable_type, label: "Type", collection: EditHistory::TYPE_MAP.values.map { |v| [v, v] }, include_blank: true %>
+<% end %>

--- a/app/views/edit_histories/index.html.erb
+++ b/app/views/edit_histories/index.html.erb
@@ -1,6 +1,8 @@
 <div id="c-edit-history">
   <div id="a-index">
-    <h1>Recent Edits</h1>
+    <h1>Edit Histories</h1>
+
+    <%= render "search" %>
 
     <table class="striped">
       <thead>
@@ -22,13 +24,13 @@
         <tr id="edit-<%= edit.id %>">
           <td><%= link_to "Show", action: "show", id: edit.versionable_id, type: edit.versionable_type %></td>
           <td><%= edit.versionable_type %></td>
-          <td><%= compact_time edit.updated_at %></td>
+          <td><%= compact_time edit.created_at %></td>
           <% if CurrentUser.is_admin? %>
             <td><%= link_to_ip edit.ip_addr %></td>
           <% end %>
           <td><%= link_to_user edit.user %></td>
           <td><%= edit.body[0..30] %></td>
-          <td><%= edit.subject&[0..30] %></td>
+          <td><%= edit.subject&.[](0..30) %></td>
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
Turns the index screen for edit histories into a proper search page, and adds the usual search parameters.