### PR TITLE
[Comments] Artist checkmark in post comments

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1128,6 +1128,14 @@ class Post < ApplicationRecord
     end
 
     ## DB!
+    # Fetches ALL linked users for the post's artist tags and returns the user IDs.
+    # Sends a db request to look up the artist data.
+    def linked_users
+      tags = artist_tags.filter_map(&:artist).select(&:linked_user_id?)
+      @linked_users ||= tags.map(&:linked_user_id)
+    end
+
+    ## DB!
     # Fetches the avoid posting data for the post's artist tags.
     # Sends a db request to lookup avoid posting data.
     def avoid_posting_artists

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1123,16 +1123,20 @@ class Post < ApplicationRecord
     # Fetches the data for the artist tags to find any that have the linked artists matching the uploader
     # Sends a db request to look up the artist data.
     def uploader_linked_artists
-      tags = artist_tags.filter_map(&:artist).select { |artist| artist.linked_user_id == uploader_id }
-      @uploader_linked_artists ||= tags.map(&:name)
+      @uploader_linked_artists ||= begin
+        tags = artist_tags.filter_map(&:artist).select { |artist| artist.linked_user_id == uploader_id }
+        tags.map(&:name)
+      end
     end
 
     ## DB!
     # Fetches ALL linked users for the post's artist tags and returns the user IDs.
     # Sends a db request to look up the artist data.
     def linked_users
-      tags = artist_tags.filter_map(&:artist).select(&:linked_user_id?)
-      @linked_users ||= tags.map(&:linked_user_id)
+      @linked_users ||= begin
+        tags = artist_tags.filter_map(&:artist).select(&:linked_user_id?)
+        tags.map(&:linked_user_id)
+      end
     end
 
     ## DB!

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -4,7 +4,12 @@
          data-is-deleted="<%= comment.is_hidden? %>" id="comment-<%= comment.id %>">
   <div class="author-info">
     <div class="name-rank">
-      <h4 class="author-name"><%= link_to_user comment.creator %></h4>
+      <h4 class="author-name">
+        <%= link_to_user comment.creator %> 
+        <% if !post.nil? %>
+          <%= svg_icon(:chexagon, class: "chexagon", title: "Comment by an artist on this post") if comment.post.linked_users.include?(comment.creator_id) %>
+        <% end %>
+      </h4>
       <%= comment.creator.level_string %>
       <% if comment.is_hidden? %>
         (hidden)

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -7,7 +7,7 @@
       <h4 class="author-name">
         <%= link_to_user comment.creator %> 
         <% if !post.nil? %>
-          <%= svg_icon(:chexagon, class: "chexagon", title: "Comment by an artist on this post") if comment.post.linked_users.include?(comment.creator_id) %>
+          <%= svg_icon(:chexagon, class: "chexagon", title: "Comment by an artist on this post") if post.linked_users.include?(comment.creator_id) %>
         <% end %>
       </h4>
       <%= comment.creator.level_string %>


### PR DESCRIPTION
On the post page, show the `chexagon` icon next to usernames linked to the post's artist tags. Does not show on the comments index, to avoid excessive db requests.