### PR TITLE
[Posts] Allow privileged users to lock post rating using a metatag

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1021,7 +1021,7 @@ class Post < ApplicationRecord
           self.is_note_locked = ($1 != "-") if CurrentUser.is_janitor?
 
         when /^(-?)locked:rating$/i
-          self.is_rating_locked = ($1 != "-") if CurrentUser.is_janitor?
+          self.is_rating_locked = ($1 != "-") if CurrentUser.is_privileged?
 
         when /^(-?)locked:status$/i
           self.is_status_locked = ($1 != "-") if CurrentUser.is_admin?

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -916,6 +916,7 @@ class PostTest < ActiveSupport::TestCase
         context "of" do
           setup do
             @janitor = create(:janitor_user)
+            @privileged = create(:privileged_user)
           end
 
           context "locked:notes" do
@@ -942,18 +943,18 @@ class PostTest < ActiveSupport::TestCase
           context "locked:rating" do
             context "by a member" do
               should "not lock the rating" do
-                @post.update(:tag_string => "locked:rating")
+                @post.update(tag_string: "locked:rating")
                 assert_equal(false, @post.is_rating_locked)
               end
             end
 
-            context "by a janitor" do
+            context "by a privileged user" do
               should "lock/unlock the rating" do
-                as(@janitor) do
-                  @post.update(:tag_string => "locked:rating")
+                as(@privileged) do
+                  @post.update(tag_string: "locked:rating")
                   assert_equal(true, @post.is_rating_locked)
 
-                  @post.update(:tag_string => "-locked:rating")
+                  @post.update(tag_string: "-locked:rating")
                   assert_equal(false, @post.is_rating_locked)
                 end
               end


### PR DESCRIPTION
As it says on the tin, allows privileged users to use the `locked:rating` to ratinglock posts with a tag only edit.
It would probably be useful to centralize all of the checks for rating locking into a named function so mismatches like this can't persist for years.