### PR TITLE
[Users] Allow janitors to see users' ticket counts

### DIFF
--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -88,11 +88,11 @@
     </div>
   <% end %>
 
-  <% if CurrentUser.user.id == user.id || CurrentUser.is_moderator? %>
+  <% if CurrentUser.user.id == user.id || CurrentUser.is_janitor? %>
     <div class="profile-line">
       <h4><%= svg_icon(:ticket) %> Tickets</h4>
       <span class="profile-line-number"><%= presenter.ticket_count(self) %></span>
-      <% if CurrentUser.is_moderator? %>
+      <% if CurrentUser.is_janitor? %>
         <span class="profile-line-extra">
           [<%= link_to "pending", tickets_path(search: { creator_id: user.id, status: "pending" }) %>]
           [<%= link_to "accused", tickets_path(search: { accused_id: user.id }) %>]


### PR DESCRIPTION
Janitors can already see tickets, no reason not to let them access them easier.