### PR TITLE
[Discord] Add more previous and oldest stats to janitor daily report

### DIFF
--- a/app/logical/discord_report/janitor_stats.rb
+++ b/app/logical/discord_report/janitor_stats.rb
@@ -8,9 +8,11 @@ module DiscordReport
 
     def report
       current_stats = stats
+
       previous_pending_posts = Cache.redis.get("janitor_reports:previous_pending_posts") || current_stats[:pending][:posts]
       previous_pending_replacements = Cache.redis.get("janitor_reports:previous_pending_replacements") || current_stats[:pending][:replacements]
       previous_pending_flags = Cache.redis.get("janitor_reports:previous_pending_flags") || current_stats[:pending][:flags]
+
       Cache.redis.set("janitor_reports:previous_pending_posts", current_stats[:pending][:posts])
       Cache.redis.set("janitor_reports:previous_pending_replacements", current_stats[:pending][:replacements])
       Cache.redis.set("janitor_reports:previous_pending_flags", current_stats[:pending][:flags])
@@ -18,12 +20,13 @@ module DiscordReport
       diff_posts = current_stats[:pending][:posts] - previous_pending_posts.to_i
       diff_replacements = current_stats[:pending][:replacements] - previous_pending_replacements.to_i
       diff_flags = current_stats[:pending][:flags] - previous_pending_flags.to_i
+
       <<~REPORT.chomp
         Janitor report for <t:#{Time.now.to_i}:D>
         Currently, there are:
-        #{formatted_number(current_stats[:pending][:posts])} pending posts. That is #{more_fewer(diff_posts)} than the day before.
-        #{formatted_number(current_stats[:pending][:flags])} pending flags. That is #{more_fewer(diff_flags)} than the day before.
-        #{formatted_number(current_stats[:pending][:replacements])} pending replacements. That is #{more_fewer(diff_replacements)} than the day before.
+        #{formatted_number(current_stats[:pending][:posts])} pending posts. That is #{more_fewer(diff_posts)} than the day before. The oldest pending post was created #{formatted_number(current_stats[:oldest][:posts])} days ago.
+        #{formatted_number(current_stats[:pending][:flags])} pending flags. That is #{more_fewer(diff_flags)} than the day before. The oldest pending flag was created #{formatted_number(current_stats[:oldest][:flags])} days ago.
+        #{formatted_number(current_stats[:pending][:replacements])} pending replacements. That is #{more_fewer(diff_replacements)} than the day before. The oldest pending replacement was created #{formatted_number(current_stats[:oldest][:replacements])} days ago.
 
         #{formatted_number(current_stats[:posts])} posts were uploaded yesterday.
 
@@ -35,6 +38,9 @@ module DiscordReport
 
     def stats
       deletions = PostFlag.where(is_deletion: true).where("created_at >= ?", 1.day.ago)
+      oldest_pending_post = Post.pending.order(id: :asc).first&.created_at || Time.now
+      oldest_pending_flag = Post.where(is_flagged: true).order(id: :asc).first&.created_at || Time.now
+      oldest_pending_replacement = PostReplacement.pending.order(id: :asc).first&.created_at || Time.now
       {
         pending: {
           posts: Post.pending.count,
@@ -45,6 +51,11 @@ module DiscordReport
           total: deletions.count,
           automod: deletions.where(creator_id: User.system.id).count,
           takedowns: deletions.where("reason LIKE ?", "takedown #%").count,
+        },
+        oldest: {
+          posts: (Time.now - oldest_pending_post).seconds.in_days.to_i,
+          flags: (Time.now - oldest_pending_flag).seconds.in_days.to_i,
+          replacements: (Time.now - oldest_pending_replacement).seconds.in_days.to_i,
         },
         approvals: PostApproval.where("created_at >= ?", 1.day.ago).count,
         posts: Post.where("created_at >= ? ", 1.day.ago).count,

--- a/app/logical/discord_report/janitor_stats.rb
+++ b/app/logical/discord_report/janitor_stats.rb
@@ -9,15 +9,21 @@ module DiscordReport
     def report
       current_stats = stats
       previous_pending_posts = Cache.redis.get("janitor_reports:previous_pending_posts") || current_stats[:pending][:posts]
+      previous_pending_replacements = Cache.redis.get("janitor_reports:previous_pending_replacements") || current_stats[:pending][:replacements]
+      previous_pending_flags = Cache.redis.get("janitor_reports:previous_pending_flags") || current_stats[:pending][:flags]
       Cache.redis.set("janitor_reports:previous_pending_posts", current_stats[:pending][:posts])
+      Cache.redis.set("janitor_reports:previous_pending_replacements", current_stats[:pending][:replacements])
+      Cache.redis.set("janitor_reports:previous_pending_flags", current_stats[:pending][:flags])
 
-      diff = current_stats[:pending][:posts] - previous_pending_posts.to_i
+      diff_posts = current_stats[:pending][:posts] - previous_pending_posts.to_i
+      diff_replacements = current_stats[:pending][:replacements] - previous_pending_replacements.to_i
+      diff_flags = current_stats[:pending][:flags] - previous_pending_flags.to_i
       <<~REPORT.chomp
         Janitor report for <t:#{Time.now.to_i}:D>
         Currently, there are:
-        #{formatted_number(current_stats[:pending][:posts])} pending posts. That is #{more_fewer(diff)} than the day before.
-        #{formatted_number(current_stats[:pending][:flags])} pending flags.
-        #{formatted_number(current_stats[:pending][:replacements])} pending replacements.
+        #{formatted_number(current_stats[:pending][:posts])} pending posts. That is #{more_fewer(diff_posts)} than the day before.
+        #{formatted_number(current_stats[:pending][:flags])} pending flags. That is #{more_fewer(diff_flags)} than the day before.
+        #{formatted_number(current_stats[:pending][:replacements])} pending replacements. That is #{more_fewer(diff_replacements)} than the day before.
 
         #{formatted_number(current_stats[:posts])} posts were uploaded yesterday.
 

--- a/app/logical/discord_report/janitor_stats.rb
+++ b/app/logical/discord_report/janitor_stats.rb
@@ -9,6 +9,8 @@ module DiscordReport
     def report
       current_stats = stats
 
+      # This could be optimized by using a single Redis hash instead of multiple keys.
+      # However, since this runs once per day and the number of keys is small, the performance impact is negligible.
       previous_pending_posts = Cache.redis.get("janitor_reports:previous_pending_posts") || current_stats[:pending][:posts]
       previous_pending_replacements = Cache.redis.get("janitor_reports:previous_pending_replacements") || current_stats[:pending][:replacements]
       previous_pending_flags = Cache.redis.get("janitor_reports:previous_pending_flags") || current_stats[:pending][:flags]
@@ -39,7 +41,7 @@ module DiscordReport
     def stats
       deletions = PostFlag.where(is_deletion: true).where("created_at >= ?", 1.day.ago)
       oldest_pending_post = Post.pending.order(id: :asc).first&.created_at || Time.now
-      oldest_pending_flag = Post.where(is_flagged: true).order(id: :asc).first&.created_at || Time.now
+      oldest_pending_flag = PostFlag.where(is_deletion: false, is_resolved: false).order(id: :asc).first&.created_at || Time.now
       oldest_pending_replacement = PostReplacement.pending.order(id: :asc).first&.created_at || Time.now
       {
         pending: {


### PR DESCRIPTION
Adds post replacements and post flags to the trend data. 
Adds "oldest" data for pending posts, post flags, post replacements.
