### PR TITLE
[Posts] Add `hasparent` and `haschild` metatags

### DIFF
--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -255,12 +255,14 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
       (q[:hasdescription] ? must : must_not).push({ exists: { field: :description } })
     end
 
-    if q.include?(:ischild)
-      (q[:ischild] ? must : must_not).push({ exists: { field: :parent } })
+    has_parent_key = %i[ischild hasparent].find { |k| q.include?(k) }
+    if has_parent_key
+      (q[has_parent_key] ? must : must_not).push({ exists: { field: :parent } })
     end
 
-    if q.include?(:isparent)
-      must.push({ term: { has_children: q[:isparent] } })
+    has_children_key = %i[isparent haschild haschildren].find { |k| q.include?(k) }
+    if has_children_key
+      must.push({ term: { has_children: q[has_children_key] } })
     end
 
     if q.include?(:inpool)

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -255,14 +255,12 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
       (q[:hasdescription] ? must : must_not).push({ exists: { field: :description } })
     end
 
-    has_parent_key = %i[ischild hasparent].find { |k| q.include?(k) }
-    if has_parent_key
-      (q[has_parent_key] ? must : must_not).push({ exists: { field: :parent } })
+    if q.include?(:ischild)
+      (q[:ischild] ? must : must_not).push({ exists: { field: :parent } })
     end
 
-    has_children_key = %i[isparent haschild haschildren].find { |k| q.include?(k) }
-    if has_children_key
-      must.push({ term: { has_children: q[has_children_key] } })
+    if q.include?(:isparent)
+      must.push({ term: { has_children: q[:isparent] } })
     end
 
     if q.include?(:inpool)

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -66,6 +66,12 @@ class TagQuery
     hassource hasdescription isparent ischild hasparent haschild haschildren inpool pending_replacements artverified
   ].freeze
 
+  BOOLEAN_METATAG_ALIASES = {
+    "hasparent"   => "ischild",
+    "haschild"    => "isparent",
+    "haschildren" => "isparent",
+  }.freeze
+
   CATEGORY_METATAG_MAP = TagCategory::SHORT_NAME_MAPPING.to_h { |k, v| [-"#{k}tags", -"tag_count_#{v}"] }.freeze
 
   NEGATABLE_METATAGS = %w[
@@ -1445,7 +1451,9 @@ class TagQuery
 
       when *COUNT_METATAGS then q[metatag_name.downcase.to_sym] = ParseValue.range(g2)
 
-      when *BOOLEAN_METATAGS then q[metatag_name.downcase.to_sym] = parse_boolean(g2)
+      when *BOOLEAN_METATAGS
+        canonical = BOOLEAN_METATAG_ALIASES.fetch(metatag_name.downcase, metatag_name.downcase)
+        q[canonical.to_sym] = parse_boolean(g2)
 
       else
         add_tag(token)

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -63,7 +63,7 @@ class TagQuery
 
   # Tags with parsed values of `true` or `false`. See `TagQuery#parse_boolean` for details.
   BOOLEAN_METATAGS = %w[
-    hassource hasdescription isparent ischild inpool pending_replacements artverified
+    hassource hasdescription isparent ischild hasparent haschild haschildren inpool pending_replacements artverified
   ].freeze
 
   CATEGORY_METATAG_MAP = TagCategory::SHORT_NAME_MAPPING.to_h { |k, v| [-"#{k}tags", -"tag_count_#{v}"] }.freeze

--- a/test/unit/tag_query_test.rb
+++ b/test/unit/tag_query_test.rb
@@ -846,6 +846,7 @@ class TagQueryTest < ActiveSupport::TestCase
       should "parse boolean metatags correctly" do
         TagQuery::BOOLEAN_METATAGS.each do |e|
           label = "Failed on #{e}".freeze
+          canonical = TagQuery::BOOLEAN_METATAG_ALIASES.fetch(e, e).downcase.to_sym
           # Doesn't accept prefixes
           bad_parse = TagQuery.new("-#{e}:true".freeze)
           assert_nil(bad_parse[e.downcase.to_sym], label)
@@ -857,12 +858,12 @@ class TagQueryTest < ActiveSupport::TestCase
           assert_equal("#{e}:false", bad_parse[:tags][:should][0], label)
 
           # true & false give true & false
-          assert_equal(true, TagQuery.new("#{e}:true")[e.downcase.to_sym], label)
-          assert_equal(false, TagQuery.new("#{e}:false")[e.downcase.to_sym], label)
+          assert_equal(true, TagQuery.new("#{e}:true")[canonical], label)
+          assert_equal(false, TagQuery.new("#{e}:false")[canonical], label)
 
           # Doesn't behave like `Danbooru::Extensions::String#truthy?`
-          assert_equal(false, TagQuery.new("#{e}:literally_anything_else")[e.downcase.to_sym], label)
-          assert_equal(false, TagQuery.new("#{e}:t")[e.downcase.to_sym], label)
+          assert_equal(false, TagQuery.new("#{e}:literally_anything_else")[canonical], label)
+          assert_equal(false, TagQuery.new("#{e}:t")[canonical], label)
         end
 
         # ratinglocked, statuslocked, & notelocked


### PR DESCRIPTION
These are inverted aliases of `ischild` and `isparent` respectively.
Purely because I keep forgetting how these metatags go.