### PR TITLE
[Notes] Better guard against duplicated notes

### DIFF
--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -869,6 +869,8 @@ class NoteEditor {
         return false;
       }
 
+      if (this.saving) return false;
+
       this.saveNote();
       return false;
     });
@@ -908,6 +910,14 @@ class NoteEditor {
     if (!this._currentNote || this._currentNote.id !== this.id)
       this._currentNote = Note.getByID(this.id);
     return this._currentNote;
+  }
+
+  _saving = false;
+  get saving () { return this._saving; }
+  set saving (value) {
+    this._saving = value;
+    this.form.find("button[type='submit']").prop("disabled", value);
+    this.form.find("button[name='note-delete']").prop("disabled", value || this.currentNote?.isTemporary);
   }
 
   getCurrentNote () {
@@ -965,6 +975,8 @@ class NoteEditor {
     const note = this.currentNote;
     if (!note) return;
 
+    this.saving = true;
+
     const url = note.isTemporary ? "/notes.json" : `/notes/${this.id}.json`;
     const method = note.isTemporary ? "POST" : "PUT";
 
@@ -990,6 +1002,7 @@ class NoteEditor {
       type: method,
       data: { note: noteData },
       error: (xhr) => {
+        this.saving = false;
         const errorMessage = xhr.responseJSON?.reasons?.join("; ") || xhr.responseJSON?.reason || "Unknown error";
         Utility.error("Error saving note: " + errorMessage);
       },
@@ -1031,6 +1044,7 @@ class NoteEditor {
           $(window).trigger("e621:add_deferred_posts", data.posts);
         }
 
+        this.saving = false;
         this.close();
       },
     });
@@ -1087,6 +1101,7 @@ class NoteEditor {
     $(".note-box.focused").removeClass("focused");
 
     // Clean up editor state
+    this.saving = false;
     this.dialog.setTitle("");
     this.input.val("");
     this.form.removeClass("temporary");

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -891,6 +891,8 @@ class NoteEditor {
       if (!confirm(`Are you sure you want to delete note #${this.id}? This action cannot be undone.`))
         return;
 
+      if (this.saving) return false;
+
       this.deleteNote();
     });
 
@@ -993,6 +995,7 @@ class NoteEditor {
       const postId = $("#image-container").data("id");
       if (!postId) {
         Utility.error("Error: Could not determine post ID.");
+        this.saving = false;
         return;
       }
       noteData.post_id = postId;
@@ -1009,6 +1012,7 @@ class NoteEditor {
       success: (data) => {
         if (!data || !data.note || !data.dtext) {
           Utility.error("Error: Invalid response from server.");
+          this.saving = false;
           return;
         }
 
@@ -1055,11 +1059,19 @@ class NoteEditor {
     const note = this.currentNote;
     if (!note) return;
 
+    this.saving = true;
+
     $.ajax("/notes/" + this.id + ".json", {
       type: "DELETE",
       success: () => {
         note.destroy();
+        this.saving = false;
         this.close();
+      },
+      error: (xhr) => {
+        this.saving = false;
+        const errorMessage = xhr.responseJSON?.reasons?.join("; ") || xhr.responseJSON?.reason || "Unknown error";
+        Utility.error("Error deleting note: " + errorMessage);
       },
     });
   }
@@ -1082,6 +1094,7 @@ class NoteEditor {
     this.form.toggleClass("temporary", isTemporary);
     this.input.val(note.content || "");
 
+    this.saving = false;
     this.dialog.open();
   }
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -16,7 +16,6 @@ class Note < ApplicationRecord
   after_save :update_post
   after_save :create_version
   validate :post_must_not_be_note_locked
-  validate :note_not_duplicate
 
   module SearchMethods
     def active
@@ -93,11 +92,6 @@ class Note < ApplicationRecord
       self.errors.add(:note, "must be inside the image")
       return false
     end
-  end
-
-  def note_not_duplicate
-    duplicate = Note.active.where(post_id: post_id, x: x, y: y, width: width, height: height).where.not(id: id).exists?
-    errors.add(:note, "already exists with the same position and size") if duplicate
   end
 
   def is_locked?

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -16,6 +16,7 @@ class Note < ApplicationRecord
   after_save :update_post
   after_save :create_version
   validate :post_must_not_be_note_locked
+  validate :note_not_duplicate
 
   module SearchMethods
     def active
@@ -92,6 +93,11 @@ class Note < ApplicationRecord
       self.errors.add(:note, "must be inside the image")
       return false
     end
+  end
+
+  def note_not_duplicate
+    duplicate = Note.active.where(post_id: post_id, x: x, y: y, width: width, height: height).where.not(id: id).exists?
+    errors.add(:note, "already exists with the same position and size") if duplicate
   end
 
   def is_locked?


### PR DESCRIPTION
The notes form did not disable the submit and delete buttons while the form is being processed.
I also added an extra check to make sure that a note with the exact same coordinates and dimensions does not already exist, just in case.