### PR TITLE
[AIBUR] Wait for transaction to commit before queuing jobs

### DIFF
--- a/app/jobs/tag_alias_job.rb
+++ b/app/jobs/tag_alias_job.rb
@@ -3,6 +3,7 @@
 class TagAliasJob < ApplicationJob
   queue_as :tags
   sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+  self.enqueue_after_transaction_commit = true
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/tag_implication_job.rb
+++ b/app/jobs/tag_implication_job.rb
@@ -3,6 +3,7 @@
 class TagImplicationJob < ApplicationJob
   queue_as :tags
   sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+  self.enqueue_after_transaction_commit = true
 
   def self.lock_args(args)
     [args[0]]


### PR DESCRIPTION
When approving BURs, sidekiq jobs for aliases and implications would be schedules to run immediately.
If the transaction in the BUR fails for whatever reason, the alias/implication record gets deleted, but the job remains orphaned.