### PR TITLE
[Tags] Add debug output to solve stuck aliases

### DIFF
--- a/app/controllers/tag_corrections_controller.rb
+++ b/app/controllers/tag_corrections_controller.rb
@@ -2,7 +2,12 @@
 
 class TagCorrectionsController < ApplicationController
   respond_to :html, :json
-  before_action :janitor_only, only: [:new, :create]
+  before_action :janitor_only, only: %i[new create]
+
+  def show
+    @correction = TagCorrection.new(params[:tag_id])
+    respond_with(@correction)
+  end
 
   def new
     @from_wiki = request.referer.try(:include?, "wiki_pages") || false
@@ -15,14 +20,17 @@ class TagCorrectionsController < ApplicationController
       @aliases = TagAlias.where("(antecedent_name = ? OR consequent_name = ?) AND NOT status = ?", @tag.name, @tag.name, "deleted").count
       @implications = TagImplication.where("(antecedent_name = ? OR consequent_name = ?) AND NOT status = ?", @tag.name, @tag.name, "deleted").count
 
+      # If a tag is aliased away but still has posts, it means one of two things:
+      # 1. Alias is still being processed, tag counts have not been updated yet
+      # 2. Alias is stuck, tag counts will never be updated
+      @is_aliased_away = TagAlias.where(antecedent_name: @correction.tag.name, status: %w[active processing queued]).exists?
+      if @is_aliased_away && @true_count != 0
+        @true_post_ids = @true_count > 20 ? "> 20" : Post.tag_match("#{@tag.name} status:any", resolve_aliases: false).pluck(:id).join(", ")
+      end
+
       @destroyable = @true_count == 0 && @aliases == 0 && @implications == 0
     end
 
-    respond_with(@correction)
-  end
-
-  def show
-    @correction = TagCorrection.new(params[:tag_id])
     respond_with(@correction)
   end
 

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -12,6 +12,15 @@
     </div>
 
     <% if CurrentUser.user.is_bd_staff? %>
+      <% if @true_post_ids.present? %>
+        <div style="margin-bottom: 1em;">
+          <b>Warning:</b> Stuck posts may be present.<br />
+          <pre>
+            <%= @true_post_ids %>
+          </pre>
+        </div>
+      <% end %>
+
       <div style="margin-bottom: 1em;">
         <ul>
           <li><strong>Real count:</strong> <%= link_to(@true_count, posts_path(tags: "#{@tag.name} status:any")) %>


### PR DESCRIPTION
There are a couple tags on e6 that are unresolvably stuck.
https://e621.net/tags/78224/correction/new
This should at least let us know which posts are causing the problem.