### PR TITLE
[CI] Skip checks in the master branch

### DIFF
--- a/.github/workflows/1-check.yml
+++ b/.github/workflows/1-check.yml
@@ -3,7 +3,6 @@ name: 1. Check
 on:
   push:
     branches:
-      - master
       - build-*
   pull_request:
     branches:
@@ -14,66 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  docker-build:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build
-        uses: docker/build-push-action@v7
-        with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: e621
-
-  rubocop:
-    runs-on: ubuntu-22.04
-    needs: docker-build
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/prepare-docker-image
-
-      - name: Run Rubocop
-        run: $DOCKER_RUN rubocop --format github
-
-  eslint:
-    runs-on: ubuntu-22.04
-    needs: docker-build
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/prepare-docker-image
-
-      - name: Run ESLint
-        run: $DOCKER_RUN linter
-
-  tests:
-    runs-on: ubuntu-22.04
-    needs:
-      - docker-build
-      - rubocop
-      - eslint
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: ./.github/prepare-docker-image
-
-      - name: Create DB
-        run: $DOCKER_RUN --entrypoint bin/rails tests db:create
-
-      - name: Load DB Schema
-        run: $DOCKER_RUN --entrypoint bin/rails tests db:schema:load
-
-      - name: Run Tests
-        run: $DOCKER_RUN tests --fail-fast
-
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: test-results
-          path: log/test.log
+  run-checks:
+    uses: ./.github/workflows/run-checks.yml
+    with:
+      run_tests: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}

--- a/.github/workflows/2-release.yml
+++ b/.github/workflows/2-release.yml
@@ -11,7 +11,13 @@ permissions:
   contents: write
 
 jobs:
+  checks:
+    uses: ./.github/workflows/run-checks.yml
+    with:
+      run_tests: true
+
   release:
+    needs: checks
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -1,0 +1,75 @@
+name: Run Checks
+
+on:
+  workflow_call:
+    inputs:
+      run_tests:
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: e621
+
+  rubocop:
+    runs-on: ubuntu-22.04
+    needs: docker-build
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/prepare-docker-image
+
+      - name: Run Rubocop
+        run: $DOCKER_RUN rubocop --format github
+
+  eslint:
+    runs-on: ubuntu-22.04
+    needs: docker-build
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/prepare-docker-image
+
+      - name: Run ESLint
+        run: $DOCKER_RUN linter
+
+  tests:
+    runs-on: ubuntu-22.04
+    needs:
+      - rubocop
+      - eslint
+    if: inputs.run_tests
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/prepare-docker-image
+
+      - name: Create DB
+        run: $DOCKER_RUN --entrypoint bin/rails tests db:create
+
+      - name: Load DB Schema
+        run: $DOCKER_RUN --entrypoint bin/rails tests db:schema:load
+
+      - name: Run Tests
+        run: $DOCKER_RUN tests --fail-fast
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: log/test.log


### PR DESCRIPTION
Branch protection rules already mandate that only PRs that pass checks can be merged into master.
We can still run checks before creating a release, but that should be sufficient.