### PR TITLE
[SearchTrends] Rework hourly data tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "marcel"
 # bookmarks for later, if they are needed
 # gem 'sidekiq-worker-killer'
 gem "sidekiq-unique-jobs"
+gem "sidekiq-cron"
 gem "redis"
 gem "request_store"
 gem "zxcvbn-ruby", require: "zxcvbn"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,9 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    cronex (0.15.0)
+      tzinfo
+      unicode (>= 0.4.4.5)
     dalli (3.2.8)
     datadog (2.12.1)
       datadog-ruby_core_source (~> 3.4)
@@ -135,6 +138,8 @@ GEM
     dry-cli (1.3.0)
     erb (5.1.3)
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -153,6 +158,9 @@ GEM
     faraday-retry (2.2.1)
       faraday (~> 2.0)
     ffi (1.16.3)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashdiff (1.1.0)
@@ -238,6 +246,7 @@ GEM
     public_suffix (5.0.5)
     puma (6.4.3)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.5)
     rack-proxy (0.7.7)
@@ -357,6 +366,11 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
+    sidekiq-cron (2.3.1)
+      cronex (>= 0.13.0)
+      fugit (~> 1.8, >= 1.11.1)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6.5.0)
     sidekiq-unique-jobs (8.0.10)
       concurrent-ruby (~> 1.0, >= 1.0.5)
       sidekiq (>= 7.0.0, < 8.0.0)
@@ -373,6 +387,7 @@ GEM
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode (0.4.4.5)
     unicode-display_width (2.5.0)
     uri (1.1.1)
     useragent (0.16.11)
@@ -447,6 +462,7 @@ DEPENDENCIES
   shoulda-context
   shoulda-matchers
   sidekiq (~> 7.0)
+  sidekiq-cron
   sidekiq-unique-jobs
   simple_form
   streamio-ffmpeg

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -23,7 +23,7 @@ class PostsController < ApplicationController
 
       # Record trending tags for page 1 queries to avoid double-counting pagination
       if tag_query.present? && (params[:page].blank? || params[:page].to_i <= 1)
-        SearchTrend.record_query!(tag_query, day: Time.now.utc.to_date, ip: request.remote_ip)
+        SearchTrendHourly.record_query!(tag_query, ip: request.remote_ip)
       end
 
       @query = tag_query.nil? ? [] : tag_query.strip.split(/ /, 2).compact_blank

--- a/app/controllers/search_trend_hourlies_controller.rb
+++ b/app/controllers/search_trend_hourlies_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class SearchTrendHourliesController < ApplicationController
+  respond_to :html, :json
+  before_action :admin_only
+
+  def index
+    @start_time = if params[:start_time].present?
+                    begin
+                      Time.parse(params[:start_time])
+                    rescue StandardError
+                      48.hours.ago
+                    end
+                  else
+                    48.hours.ago
+                  end
+
+    @end_time = if params[:end_time].present?
+                  begin
+                    Time.parse(params[:end_time])
+                  rescue StandardError
+                    Time.current
+                  end
+                else
+                  Time.current
+                end
+
+    @hourlies = SearchTrendHourly.where(hour: @start_time..@end_time)
+                                 .search(hourly_params)
+                                 .order(hour: :desc, count: :desc)
+                                 .paginate(params[:page], limit: params[:limit])
+
+    @count_offset = (@hourlies.current_page - 1) * @hourlies.records_per_page
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @hourlies.as_json(only: %i[tag count hour processed]) }
+    end
+  end
+
+  private
+
+  def hourly_params
+    permitted_params = %i[start_time end_time name_matches]
+    params.fetch(:search_trend_hourlies, {}).permit(permitted_params)
+  end
+end

--- a/app/controllers/search_trends_controller.rb
+++ b/app/controllers/search_trends_controller.rb
@@ -35,7 +35,7 @@ class SearchTrendsController < ApplicationController
   end
 
   def track
-    @tag = params[:tag]
+    @tag = params[:tag].to_s.downcase.strip
 
     @trends = SearchTrend.for_tag(@tag).limit(30).order(day: :desc)
 
@@ -48,7 +48,7 @@ class SearchTrendsController < ApplicationController
   end
 
   def purge
-    @tag = params[:tag]
+    @tag = params[:tag].to_s.downcase.strip
     deleted_daily = SearchTrend.for_tag(@tag).delete_all
     deleted_hourly = SearchTrendHourly.where(tag: @tag).delete_all
     respond_to do |format|

--- a/app/controllers/search_trends_controller.rb
+++ b/app/controllers/search_trends_controller.rb
@@ -9,12 +9,23 @@ class SearchTrendsController < ApplicationController
       @day = begin
         Date.parse(params[:day])
       rescue StandardError
-        Date.current
+        Time.now.utc.to_date
       end
     else
-      @day = Date.current
+      @day = Time.now.utc.to_date
     end
-    @trending = SearchTrend.for_day_totals(@day).paginate(params[:page], limit: params[:limit])
+
+    search_filters_present = search_params[:name_matches].present?
+
+    if search_filters_present
+      @trending = SearchTrend.for_day_ranked(@day).search(search_params).paginate(params[:page], limit: params[:limit])
+      @using_calculated_ranks = true
+    else
+      @trending = SearchTrend.for_day(@day).search(search_params).paginate(params[:page], limit: params[:limit])
+      @using_calculated_ranks = false
+    end
+
+    @has_tomorrow = @day < Time.now.utc.to_date
     @count_offset = (@trending.current_page - 1) * @trending.records_per_page
 
     respond_to do |format|
@@ -25,26 +36,31 @@ class SearchTrendsController < ApplicationController
 
   def track
     @tag = params[:tag]
-    @trends = SearchTrend.for_tag(@tag).limit(100).order(day: :desc, hour: :desc)
+
+    @trends = SearchTrend.for_tag(@tag).limit(30).order(day: :desc)
+
     respond_to do |format|
-      format.html
-      format.json { render json: @trends.as_json(only: %i[tag count day hour]) }
+      format.html do
+        @hourlies = SearchTrendHourly.where(tag: @tag).order(hour: :desc).limit(50)
+      end
+      format.json { render json: @trends.as_json(only: %i[tag count day]) }
     end
   end
 
   def purge
     @tag = params[:tag]
-    deleted = SearchTrend.for_tag(@tag).delete_all
+    deleted_daily = SearchTrend.for_tag(@tag).delete_all
+    deleted_hourly = SearchTrendHourly.where(tag: @tag).delete_all
     respond_to do |format|
-      format.html { redirect_to search_trends_path, notice: "Purged #{deleted} trend record(s) for \"#{@tag}\"" }
-      format.json { render json: { deleted_count: deleted } }
+      format.html { redirect_to search_trends_path, notice: "Purged #{deleted_daily} historic record(s) and #{deleted_hourly} hourly record(s) for \"#{@tag}\"" }
+      format.json { render json: { daily_count: deleted_daily, hourly_count: deleted_hourly } }
     end
   end
 
   def rising
     respond_to do |format|
       format.html
-      format.json { render json: SearchTrend.rising_tags_list.as_json(only: %i[tag]) }
+      format.json { render json: SearchTrendHourly.rising_tags_list.as_json(only: %i[tag]) }
     end
   end
 
@@ -52,7 +68,7 @@ class SearchTrendsController < ApplicationController
   end
 
   def update_settings
-    params = trends_params
+    params = trend_settings_params
 
     if params.key?(:trends_enabled)
       Setting.trends_enabled = ActiveModel::Type::Boolean.new.cast(params[:trends_enabled])
@@ -98,8 +114,13 @@ class SearchTrendsController < ApplicationController
     end
   end
 
-  def trends_params
+  def search_params
+    permitted_params = %i[name_matches]
+    permit_search_params permitted_params
+  end
+
+  def trend_settings_params
     permitted_params = %i[trends_enabled trends_displayed trends_min_today trends_min_delta trends_min_ratio trends_ip_limit trends_ip_window trends_tag_limit trends_tag_window]
-    params.fetch(:search_trends, {}).permit(permitted_params)
+    params.fetch(:search_trend_settings, {}).permit(permitted_params)
   end
 end

--- a/app/helpers/search_trends_helper.rb
+++ b/app/helpers/search_trends_helper.rb
@@ -2,7 +2,7 @@
 
 module SearchTrendsHelper
   def rising_tags
-    rising_tags = SearchTrend.rising_tags_list
+    rising_tags = SearchTrendHourly.rising_tags_list
 
     return "" if rising_tags.blank?
 

--- a/app/javascript/src/styles/views/search_trends/_search_trends.scss
+++ b/app/javascript/src/styles/views/search_trends/_search_trends.scss
@@ -75,9 +75,18 @@ body.c-search-trends.a-index {
     align-items: center;
     gap: 0.75rem;
 
-    a {
+    a, span {
       display: flex;
       align-items: center;
     }
+  }
+
+  #trends_search_form {
+    display: flex;
+    gap: 0.5rem;
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    background: themed("color-section");
+    width: min-content;
   }
 }

--- a/app/jobs/search_trend_aggregate_job.rb
+++ b/app/jobs/search_trend_aggregate_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class SearchTrendAggregateJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    aggregate_unprocessed_records!
+  end
+
+  private
+
+  # Aggregate all unprocessed hourly records into daily totals and mark them as processed
+  def aggregate_unprocessed_records!
+    return if SearchTrendHourly.unprocessed.empty?
+
+    # Find all unprocessed records and group by tag and day (extracted from hour datetime)
+    unprocessed_groups = SearchTrendHourly.unprocessed
+                                          .group(:tag, "DATE(hour)")
+                                          .sum(:count)
+
+    # For each group, update or create the corresponding daily record
+    unprocessed_groups.each do |(tag, day), total_count|
+      SearchTrend.transaction do
+        # Update or create the daily aggregate record
+        daily_record = SearchTrend.find_or_initialize_by(tag: tag, day: day)
+        daily_record.count = (daily_record.count || 0) + total_count
+        daily_record.save!
+
+        # Mark the hourly records as processed (filter by tag and day extracted from hour)
+        SearchTrendHourly.unprocessed
+                         .where(tag: tag)
+                         .where("DATE(hour) = ?", day)
+                         .update_all(processed: true, updated_at: Time.current)
+      end
+    end
+
+    Rails.logger.info("SearchTrendAggregateJob: Processed #{unprocessed_groups.size} tag/day combinations")
+  end
+end

--- a/app/jobs/search_trend_aggregate_job.rb
+++ b/app/jobs/search_trend_aggregate_job.rb
@@ -9,31 +9,71 @@ class SearchTrendAggregateJob < ApplicationJob
 
   private
 
-  # Aggregate all unprocessed hourly records into daily totals and mark them as processed
+  # Aggregate all unprocessed hourly records into daily totals and mark them as processed.
+  # Only processes records older than 1 hour to avoid race conditions with active search operations.
+  # Uses batched processing with proper locking to prevent concurrent modification issues.
   def aggregate_unprocessed_records!
-    return if SearchTrendHourly.unprocessed.empty?
+    # Establish cutoff time - only process records older than 1 hour (UTC)
+    cutoff_time = 1.hour.ago.utc.beginning_of_hour
 
-    # Find all unprocessed records and group by tag and day (extracted from hour datetime)
-    unprocessed_groups = SearchTrendHourly.unprocessed
-                                          .group(:tag, "DATE(hour)")
+    # Quick check if there are any candidates
+    return if SearchTrendHourly.unprocessed_before(cutoff_time).empty?
+
+    batch_size = 100
+    total_processed = 0
+    start_time = Time.current.utc
+
+    # Use repeatable read isolation to prevent phantom reads during processing
+    isolation_level = Rails.env.test? ? {} : { isolation: :repeatable_read }
+
+    # Find all unprocessed records within our time window and group by tag, day
+    # Use timezone('UTC', hour) to ensure date extraction is in UTC regardless of database timezone
+    unprocessed_groups = SearchTrendHourly.unprocessed_before(cutoff_time)
+                                          .group(:tag, "DATE(timezone('UTC', hour))")
                                           .sum(:count)
 
-    # For each group, update or create the corresponding daily record
-    unprocessed_groups.each do |(tag, day), total_count|
-      SearchTrend.transaction do
-        # Update or create the daily aggregate record
-        daily_record = SearchTrend.find_or_initialize_by(tag: tag, day: day)
-        daily_record.count = (daily_record.count || 0) + total_count
-        daily_record.save!
+    # Process groups in batches to minimize lock time
+    unprocessed_groups.each_slice(batch_size).with_index do |batch_groups, batch_index|
+      SearchTrend.transaction(**isolation_level) do
+        batch_processed = 0
 
-        # Mark the hourly records as processed (filter by tag and day extracted from hour)
-        SearchTrendHourly.unprocessed
-                         .where(tag: tag)
-                         .where("DATE(hour) = ?", day)
-                         .update_all(processed: true, updated_at: Time.current)
+        batch_groups.each do |(tag, day), total_count|
+          # Lock and aggregate the specific hourly records for this tag/day combination
+          hourly_records = SearchTrendHourly.unprocessed_before(cutoff_time)
+                                            .where(tag: tag)
+                                            .where("DATE(timezone('UTC', hour)) = ?", day)
+                                            .lock("FOR UPDATE")
+                                            .to_a
+
+          # Skip if no records found (may have been processed by concurrent job)
+          next if hourly_records.empty?
+
+          # Verify the locked records sum matches our expected total
+          actual_total = hourly_records.sum(&:count)
+          if actual_total != total_count
+            Rails.logger.warn("SearchTrendAggregateJob: Count mismatch for #{tag}/#{day}: expected #{total_count}, got #{actual_total}")
+            # Use the actual locked total to ensure accuracy
+            total_count = actual_total
+          end
+
+          # Update or create the daily aggregate record
+          daily_record = SearchTrend.find_or_initialize_by(tag: tag, day: day)
+          daily_record.count = (daily_record.count || 0) + total_count
+          daily_record.save!
+
+          # Mark only the locked hourly records as processed
+          SearchTrendHourly.where(id: hourly_records.map(&:id))
+                           .update_all(processed: true, updated_at: Time.current.utc)
+
+          batch_processed += 1
+        end
+
+        total_processed += batch_processed
+        Rails.logger.debug { "SearchTrendAggregateJob: Batch #{batch_index + 1} processed #{batch_processed} tag/day combinations" }
       end
     end
 
-    Rails.logger.info("SearchTrendAggregateJob: Processed #{unprocessed_groups.size} tag/day combinations")
+    elapsed_time = Time.current.utc - start_time
+    Rails.logger.info("SearchTrendAggregateJob: Processed #{total_processed} tag/day combinations in #{elapsed_time.round(2)}s (cutoff: #{cutoff_time})")
   end
 end

--- a/app/jobs/search_trend_prune_job.rb
+++ b/app/jobs/search_trend_prune_job.rb
@@ -4,7 +4,7 @@ class SearchTrendPruneJob < ApplicationJob
   queue_as :low_prio
 
   def perform
-    SearchTrend.coalesce_hourly!
+    SearchTrendHourly.prune!
     SearchTrend.prune!
   end
 end

--- a/app/models/search_trend.rb
+++ b/app/models/search_trend.rb
@@ -1,266 +1,46 @@
 # frozen_string_literal: true
 
 class SearchTrend < ApplicationRecord
-  WINDOW_HOURS = 12
-
   validates :tag, presence: true, tag_name: true, on: :create
   validates :tag, length: { in: 1..100 }
   validates :day, presence: true
-  validates :hour, numericality: { only_integer: true, in: 0..23 }, allow_nil: true
 
-  # Returns all records for a given day (both hourly and daily aggregate records).
-  scope :for_day, ->(day) { where(day: day.to_date) }
-
-  # Returns per-tag totals for a given day, aggregating hourly records where present.
-  # Ordered by count descending, then tag ascending.
-  # Uses a subquery so that the paginator's COUNT(*) targets the subquery alias rather
-  # than the raw table (avoids GROUP BY + aggregate SELECT + COUNT(*) conflicts).
-  scope :for_day_totals, ->(day) {
-    quoted = connection.quote(day.to_date)
-    subquery = <<~SQL.squish
-      SELECT tag, day, SUM(count)::integer AS count
-      FROM search_trends
-      WHERE day = #{quoted}
-      GROUP BY tag, day
-    SQL
-    from("(#{subquery}) AS search_trends").order(Arel.sql("count DESC, tag ASC"))
+  scope :for_day, ->(day) { where(day: day.to_date).order(count: :desc, tag: :asc) }
+  scope :for_day_ranked, ->(day) {
+    from(
+      <<~SQL.squish,
+        (SELECT *, ROW_NUMBER() OVER (PARTITION BY day ORDER BY count DESC, tag ASC) AS daily_rank
+         FROM "search_trends"
+         WHERE day = '#{day.to_date}') AS "search_trends"
+      SQL
+    ).order(count: :desc, tag: :asc)
   }
+  scope :for_tag, ->(tag) { where(tag: tag.to_s.downcase.strip).order(count: :desc, tag: :asc) }
 
-  scope :for_tag, ->(tag) { where(tag: tag.to_s.downcase.strip) }
-
-  # Increment the hourly count for a tag. Sanitizes tag to downcase.
-  def self.increment!(tag, day: Time.now.utc.to_date, ip: nil)
-    t = tag.to_s.downcase.strip
-    return if t.blank?
-    return unless Setting.trends_enabled
-    return unless valid_tag?(t)
-    return if SearchTrendBlacklist.blacklisted?(t)
-
-    # Rate limiting checks
-    if ip.present?
-      ip_key = "trends:ip:#{ip}"
-      return if RateLimiter.check_limit(ip_key, Setting.trends_ip_limit, Setting.trends_ip_window.seconds)
-    end
-
-    tag_key = "trends:tag:#{t}"
-    return if RateLimiter.check_limit(tag_key, Setting.trends_tag_limit, Setting.trends_tag_window.seconds)
-
-    now  = Time.now.utc
-    date = day.to_date
-    hour = now.hour
-    values_sql = "(#{connection.quote(t)}, #{connection.quote(date)}, #{hour}, 1, #{connection.quote(now)}, #{connection.quote(now)})"
-    sql = <<~SQL.squish
-      INSERT INTO search_trends (tag, day, hour, count, created_at, updated_at)
-      VALUES #{values_sql}
-      ON CONFLICT (tag, day, hour) WHERE hour IS NOT NULL
-      DO UPDATE SET count = search_trends.count + 1, updated_at = EXCLUDED.updated_at
-    SQL
-    connection.execute(sql)
-
-    # Increment rate limit counters after successful database operation
-    RateLimiter.hit(ip_key, Setting.trends_ip_window.seconds) if ip.present?
-    RateLimiter.hit(tag_key, Setting.trends_tag_window.seconds)
-  end
-
-  # Parse a raw tag query string, extract plain affirmative tags, and record them.
-  # Tags with a `-` prefix (negated) are excluded entirely; tags with only a `~` prefix
-  # have that prefix stripped before recording. Metatags (containing `:`) are ignored.
-  # Errors in query parsing are logged and swallowed so the caller is never disrupted.
-  def self.record_query!(query, day: Time.now.utc.to_date, ip: nil)
-    return if query.blank?
-
-    tokens = TagQuery.scan_recursive(
-      query,
-      flatten: true,
-      strip_prefixes: false,
-      delimit_groups: true,
-      sort_at_level: false,
-      normalize_at_level: true,
-      strip_duplicates_at_level: true,
-    )
-
-    negated_stack = []
-    tag_tokens = tokens.filter_map do |t|
-      next if t.blank?
-      if t.end_with?("(")
-        negated_stack.push(t[/\A[-~]*/].include?("-") || negated_stack.last == true)
-        next
-      end
-      if t == ")"
-        negated_stack.pop
-        next
-      end
-      next if t.include?(":") # skip metatags
-      prefix = t[/\A[-~]*/]
-      next if prefix.include?("-") || negated_stack.last == true
-      t[prefix.length..].presence
-    end
-
-    bulk_increment!(tag_tokens, day: day, ip: ip) if tag_tokens.present?
-  rescue StandardError => e
-    Rails.logger.warn("Failed to record search trends for query #{query.inspect}: #{e.class}: #{e.message}")
-  end
-
-  # Bulk increment hourly counts for an array of tags. Upsert w/ increment on conflict.
-  def self.bulk_increment!(tags, day: Time.now.utc.to_date, ip: nil)
-    ts = Array(tags).map { |tg| tg.to_s.downcase.strip }.select(&:present?).uniq
-    return if ts.empty?
-    return unless Setting.trends_enabled
-
-    ts.select! { |tg| valid_tag?(tg) }
-    return if ts.empty?
-
-    # Rate limiting checks
-    if ip.present?
-      ip_key = "trends:ip:#{ip}"
-      return if RateLimiter.check_limit(ip_key, Setting.trends_ip_limit, Setting.trends_ip_window.seconds)
-    end
-
-    # Fetch blacklist patterns once for the whole batch
-    blacklist_patterns = SearchTrendBlacklist.cached_patterns
-
-    # Filter out blacklisted tags and tags that would exceed tag-specific rate limits
-    allowed_tags = ts.reject do |tag|
-      next true if blacklist_patterns.any? { |pat| File.fnmatch(pat, tag, File::FNM_CASEFOLD) }
-
-      tag_key = "trends:tag:#{tag}"
-      RateLimiter.check_limit(tag_key, Setting.trends_tag_limit, Setting.trends_tag_window.seconds)
-    end
-
-    return if allowed_tags.empty?
-
-    now  = Time.now.utc
-    date = day.to_date
-    hour = now.hour
-    values_sql = allowed_tags.map { |tg| "(#{connection.quote(tg)}, #{connection.quote(date)}, #{hour}, 1, #{connection.quote(now)}, #{connection.quote(now)})" }.join(", ")
-    sql = <<~SQL.squish
-      INSERT INTO search_trends (tag, day, hour, count, created_at, updated_at)
-      VALUES #{values_sql}
-      ON CONFLICT (tag, day, hour) WHERE hour IS NOT NULL
-      DO UPDATE SET count = search_trends.count + 1, updated_at = EXCLUDED.updated_at
-    SQL
-    connection.execute(sql)
-
-    # Increment rate limit counters after successful database operation
-    RateLimiter.hit(ip_key, Setting.trends_ip_window.seconds) if ip.present?
-    allowed_tags.each do |tag|
-      tag_key = "trends:tag:#{tag}"
-      RateLimiter.hit(tag_key, Setting.trends_tag_window.seconds)
-    end
-  end
-
-  # Coalesce hourly records older than `before` into daily aggregate records, then delete
-  # the originals. Called during daily maintenance so the hourly buffer stays bounded.
-  def self.coalesce_hourly!(before: Time.now.utc - 48.hours)
-    cutoff      = before
-    cutoff_day  = cutoff.utc.to_date
-    cutoff_hour = cutoff.utc.hour
-    now         = Time.now.utc
-
-    # Step 1: merge hourly totals into daily records (upsert, adding to any existing count).
-    connection.execute(<<~SQL.squish)
-      INSERT INTO search_trends (tag, day, hour, count, created_at, updated_at)
-      SELECT   tag, day, NULL, SUM(count)::integer, #{connection.quote(now)}, #{connection.quote(now)}
-      FROM     search_trends
-      WHERE    hour IS NOT NULL
-        AND    (day < #{connection.quote(cutoff_day)}
-                OR (day = #{connection.quote(cutoff_day)} AND hour <= #{cutoff_hour}))
-      GROUP BY tag, day
-      ON CONFLICT (tag, day) WHERE hour IS NULL
-      DO UPDATE SET count      = search_trends.count + EXCLUDED.count,
-                    updated_at = EXCLUDED.updated_at
-    SQL
-
-    # Step 2: delete the coalesced hourly records.
-    where(
-      "hour IS NOT NULL AND (day < ? OR (day = ? AND hour <= ?))",
-      cutoff_day, cutoff_day, cutoff_hour
-    ).delete_all
-  end
-
-  # Delete daily aggregate records from before today that fall below the minimum count.
-  # Hourly records are managed exclusively by coalesce_hourly! and are never pruned here.
+  # Delete historic data that is below the minimum threshold.
+  # Runs daily through SearchTrendPruneJob.
   def self.prune!(min_count: Danbooru.config.search_trend_minimum_count)
-    where("hour IS NULL AND day < ? AND count < ?", Time.now.utc.to_date, min_count)
+    where("day < ? AND count < ?", Time.now.utc.to_date, min_count)
       .in_batches(load: false)
       .delete_all
   end
+
+  def self.search(params)
+    q = super
+
+    if params[:name_matches].present?
+      q = q.where_ilike(:tag, Tag.normalize_name(params[:name_matches]))
+    end
+
+    q
+  end
+
+  private
 
   private_class_method def self.valid_tag?(tag)
     return false unless tag.length.between?(1, 100)
     record = new(tag: tag, day: Time.now.utc.to_date)
     TagNameValidator.new(attributes: [:tag]).validate_each(record, :tag, tag)
     record.errors[:tag].empty?
-  end
-
-  # Top tags for a given day by total search count, aggregated across any hourly records.
-  def self.top_for_day(day: Time.now.utc.to_date, limit: 100)
-    for_day_totals(day).limit(limit)
-  end
-
-  # Rising tags: tags whose search volume in the last `WINDOW_HOURS` hours is meaningfully
-  # higher than the same window 24 hours prior. Uses hourly records only.
-  #
-  # Both sides of the comparison span the same number of hours, eliminating the partial-day
-  # bias inherent in a simple today-vs-yesterday daily comparison.
-  def self.rising(at: Time.now.utc, limit: 10, min_today: 10, min_delta: 10, min_ratio: 2.0)
-    h = at.hour
-    d = at.to_date
-
-    today_cond = hourly_window_sql(d, h, WINDOW_HOURS)
-    prev_cond  = hourly_window_sql(d - 1.day, h, WINDOW_HOURS)
-
-    min_today_v = min_today.to_i
-    min_delta_v = min_delta.to_i
-    min_ratio_v = min_ratio.to_f
-    limit_v     = limit.to_i
-
-    subquery = <<~SQL.squish
-      WITH today_totals AS (
-        SELECT tag, SUM(count) AS c
-        FROM   search_trends
-        WHERE  hour IS NOT NULL AND (#{today_cond})
-        GROUP  BY tag
-      ),
-      prev_totals AS (
-        SELECT tag, SUM(count) AS c
-        FROM   search_trends
-        WHERE  hour IS NOT NULL AND (#{prev_cond})
-        GROUP  BY tag
-      )
-      SELECT t.tag, t.c AS count
-      FROM   today_totals t
-      LEFT   JOIN prev_totals y ON y.tag = t.tag
-      WHERE  t.c >= #{min_today_v}
-        AND  (
-               t.c - COALESCE(y.c, 0) >= #{min_delta_v}
-               OR (COALESCE(y.c, 0) > 0 AND t.c::numeric / NULLIF(y.c, 0) >= #{min_ratio_v})
-             )
-      ORDER  BY count DESC, tag ASC
-      LIMIT  #{limit_v}
-    SQL
-
-    select("tag, count::integer").from("(#{subquery}) AS search_trends")
-  end
-
-  def self.rising_tags_list
-    Cache.fetch("rising_tags", expires_in: 15.minutes) do
-      tags = SearchTrend.rising(min_today: Setting.trends_min_today, min_delta: Setting.trends_min_delta, min_ratio: Setting.trends_min_ratio).pluck(:tag)
-      TagAlias.to_aliased(tags)
-    end
-  end
-
-  # Returns a SQL fragment that matches hourly records within a `window_hours`-wide window
-  # ending at (day, hour). The window may span midnight into the previous day.
-  private_class_method def self.hourly_window_sql(day, hour, window_hours)
-    start_hour = hour - window_hours + 1
-    if start_hour >= 0
-      "day = #{connection.quote(day)} AND hour BETWEEN #{start_hour} AND #{hour}"
-    else
-      prev_day        = day - 1.day
-      prev_start_hour = 24 + start_hour # start_hour is negative, so this is < 24
-      "(day = #{connection.quote(day)} AND hour <= #{hour}) " \
-        "OR (day = #{connection.quote(prev_day)} AND hour >= #{prev_start_hour})"
-    end
   end
 end

--- a/app/models/search_trend.rb
+++ b/app/models/search_trend.rb
@@ -8,11 +8,14 @@ class SearchTrend < ApplicationRecord
   scope :for_day, ->(day) { where(day: day.to_date).order(count: :desc, tag: :asc) }
   scope :for_day_ranked, ->(day) {
     from(
-      <<~SQL.squish,
-        (SELECT *, ROW_NUMBER() OVER (PARTITION BY day ORDER BY count DESC, tag ASC) AS daily_rank
-         FROM "search_trends"
-         WHERE day = '#{day.to_date}') AS "search_trends"
-      SQL
+      sanitize_sql([
+        <<~SQL.squish,
+          (SELECT *, ROW_NUMBER() OVER (PARTITION BY day ORDER BY count DESC, tag ASC) AS daily_rank
+           FROM "search_trends"
+           WHERE day = ?) AS "search_trends"
+        SQL
+        day.to_date,
+      ]),
     ).order(count: :desc, tag: :asc)
   }
   scope :for_tag, ->(tag) { where(tag: tag.to_s.downcase.strip).order(count: :desc, tag: :asc) }

--- a/app/models/search_trend_hourly.rb
+++ b/app/models/search_trend_hourly.rb
@@ -8,7 +8,7 @@ class SearchTrendHourly < ApplicationRecord
   validates :tag, presence: true, tag_name: true, on: :create
   validates :tag, length: { in: 1..100 }
   validates :hour, presence: true
-  validates :count, presence: true, numericality: { integer: true, greater_than_or_equal_to: 0 }
+  validates :count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   validates :hour, uniqueness: { scope: [:tag] }
 
@@ -20,6 +20,7 @@ class SearchTrendHourly < ApplicationRecord
 
   scope :unprocessed, -> { where(processed: false) }
   scope :processed, -> { where(processed: true) }
+  scope :unprocessed_before, ->(time) { unprocessed.where("hour < ?", time) }
 
   # Parse a raw tag query string, extract plain affirmative tags, and record them.
   # Tags with a `-` prefix (negated) are excluded entirely; tags with only a `~` prefix
@@ -174,7 +175,7 @@ class SearchTrendHourly < ApplicationRecord
       .delete_all
   end
 
-  def search(params)
+  def self.search(params)
     q = super
 
     if params[:name_matches].present?

--- a/app/models/search_trend_hourly.rb
+++ b/app/models/search_trend_hourly.rb
@@ -131,8 +131,8 @@ class SearchTrendHourly < ApplicationRecord
                      .group(:tag)
                      .sum(:count)
 
-    # Aggregate counts for previous window
-    previous_counts = where(hour: previous_start..previous_end)
+    # Aggregate counts for previous window (use exclusive end to avoid overlap)
+    previous_counts = where(hour: previous_start...previous_end)
                       .group(:tag)
                       .sum(:count)
 
@@ -160,7 +160,7 @@ class SearchTrendHourly < ApplicationRecord
 
   def self.rising_tags_list
     Cache.fetch("rising_tags", expires_in: 15.minutes) do
-      tags = SearchTrendHourly.rising(min_today: Setting.trends_min_today, min_delta: Setting.trends_min_delta, min_ratio: Setting.trends_min_ratio).pluck(:tag)
+      tags = SearchTrendHourly.rising(min_today: Setting.trends_min_today, min_delta: Setting.trends_min_delta, min_ratio: Setting.trends_min_ratio).map(&:tag)
       TagAlias.to_aliased(tags)
     end
   end

--- a/app/models/search_trend_hourly.rb
+++ b/app/models/search_trend_hourly.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+class SearchTrendHourly < ApplicationRecord
+  WINDOW_HOURS = 12.hours
+
+  TrendingTag = Struct.new(:tag, :search_count, :delta)
+
+  validates :tag, presence: true, tag_name: true, on: :create
+  validates :tag, length: { in: 1..100 }
+  validates :hour, presence: true
+  validates :count, presence: true, numericality: { integer: true, greater_than_or_equal_to: 0 }
+
+  validates :hour, uniqueness: { scope: [:tag] }
+
+  scope :for_day, ->(day) {
+    day_date = day.to_date
+    where(hour: day_date.all_day)
+  }
+  scope :for_tag, ->(tag) { where(tag: tag.to_s.downcase.strip) }
+
+  scope :unprocessed, -> { where(processed: false) }
+  scope :processed, -> { where(processed: true) }
+
+  # Parse a raw tag query string, extract plain affirmative tags, and record them.
+  # Tags with a `-` prefix (negated) are excluded entirely; tags with only a `~` prefix
+  # have that prefix stripped before recording. Metatags (containing `:`) are ignored.
+  # Errors in query parsing are logged and swallowed so the caller is never disrupted.
+  def self.record_query!(query, hour: Time.now.utc.beginning_of_hour, ip: nil)
+    return if query.blank?
+
+    tokens = TagQuery.scan_recursive(
+      query,
+      flatten: true,
+      strip_prefixes: false,
+      delimit_groups: true,
+      sort_at_level: false,
+      normalize_at_level: true,
+      strip_duplicates_at_level: true,
+    )
+
+    negated_stack = []
+    tag_tokens = tokens.filter_map do |t|
+      next if t.blank?
+      if t.end_with?("(")
+        negated_stack.push(t[/\A[-~]*/].include?("-") || negated_stack.last == true)
+        next
+      end
+      if t == ")"
+        negated_stack.pop
+        next
+      end
+      next if t.include?(":") # skip metatags
+      prefix = t[/\A[-~]*/]
+      next if prefix.include?("-") || negated_stack.last == true
+      t[prefix.length..].presence
+    end
+
+    bulk_increment!(tag_tokens.map { |tag| { tag: tag, hour: hour } }, ip: ip) if tag_tokens.present?
+  rescue StandardError => e
+    Rails.logger.warn("Failed to record search trends for query #{query.inspect}: #{e.class}: #{e.message}")
+  end
+
+  # Increment multiple tag-hour combinations efficiently in a single query
+  def self.bulk_increment!(data, ip: nil)
+    return if data.blank?
+    return unless Setting.trends_enabled
+
+    # Rate limiting check for IP (once per bulk operation)
+    if ip.present?
+      ip_key = "trends:ip:#{ip}"
+      return if RateLimiter.check_limit(ip_key, Setting.trends_ip_limit, Setting.trends_ip_window.seconds)
+    end
+
+    # Group by tag-hour pairs and sum counts
+    grouped = data.group_by { |item| [item[:tag].to_s.downcase.strip, item[:hour].utc.beginning_of_hour] }
+
+    values = []
+    now = Time.now.utc
+    processed_tags = []
+
+    grouped.each do |(tag, hour_time), items|
+      next if tag.blank?
+      next unless valid_tag?(tag)
+      next if SearchTrendBlacklist.blacklisted?(tag)
+
+      # Rate limiting check for tag
+      tag_key = "trends:tag:#{tag}"
+      next if RateLimiter.check_limit(tag_key, Setting.trends_tag_limit, Setting.trends_tag_window.seconds)
+
+      count = items.length
+      values << "(#{connection.quote(tag)}, #{connection.quote(hour_time)}, #{count}, false, #{connection.quote(now)}, #{connection.quote(now)})"
+      processed_tags << tag
+    end
+
+    return if values.empty?
+
+    values_sql = values.join(", ")
+    sql = <<~SQL.squish
+      INSERT INTO search_trend_hourlies (tag, hour, count, processed, created_at, updated_at)
+      VALUES #{values_sql}
+      ON CONFLICT (tag, hour)
+      DO UPDATE SET count = search_trend_hourlies.count + EXCLUDED.count, updated_at = EXCLUDED.updated_at
+    SQL
+    connection.execute(sql)
+
+    # Increment rate limit counters after successful database operation
+    if ip.present?
+      ip_key = "trends:ip:#{ip}"
+      RateLimiter.hit(ip_key, Setting.trends_ip_window.seconds)
+    end
+
+    processed_tags.each do |tag|
+      tag_key = "trends:tag:#{tag}"
+      RateLimiter.hit(tag_key, Setting.trends_tag_window.seconds)
+    end
+  end
+
+  # Find tags that are trending upward compared to the previous equivalent time window
+  def self.rising(at: Time.now.utc, limit: 10, min_today: 10, min_delta: 10, min_ratio: 2.0)
+    # Current time window: last WINDOW_HOURS hours up to 'at'
+    current_end = at.utc
+    current_start = current_end - WINDOW_HOURS
+
+    # Previous time window: same duration, ending WINDOW_HOURS before current window
+    previous_end = current_start
+    previous_start = previous_end - WINDOW_HOURS
+
+    # Aggregate counts for current window
+    current_counts = where(hour: current_start..current_end)
+                     .group(:tag)
+                     .sum(:count)
+
+    # Aggregate counts for previous window
+    previous_counts = where(hour: previous_start..previous_end)
+                      .group(:tag)
+                      .sum(:count)
+
+    trending = []
+    current_counts.each do |tag, current_count|
+      next if current_count < min_today
+
+      previous_count = previous_counts[tag] || 0
+      delta = current_count - previous_count
+      next if delta < min_delta
+
+      if previous_count > 0
+        ratio = current_count.to_f / previous_count
+        next if ratio < min_ratio
+      end
+
+      trending << { tag: tag, count: current_count, delta: delta }
+    end
+
+    # Sort by current count descending, then by tag name
+    trending.sort_by { |t| [-t[:count], t[:tag]] }
+            .first(limit)
+            .map { |t| TrendingTag.new(t[:tag], t[:count], t[:delta]) }
+  end
+
+  def self.rising_tags_list
+    Cache.fetch("rising_tags", expires_in: 15.minutes) do
+      tags = SearchTrendHourly.rising(min_today: Setting.trends_min_today, min_delta: Setting.trends_min_delta, min_ratio: Setting.trends_min_ratio).pluck(:tag)
+      TagAlias.to_aliased(tags)
+    end
+  end
+
+  # Delete old processed hourly records to prevent the table from growing unbounded.
+  # Called during daily maintenance so the hourly buffer stays bounded.
+  def self.prune!
+    cutoff = Time.now.utc - 48.hours
+    processed
+      .where("hour < ?", cutoff)
+      .in_batches(load: false)
+      .delete_all
+  end
+
+  def search(params)
+    q = super
+
+    if params[:name_matches].present?
+      name_cond = TagQueryBuilder.build_like_condition("tag", params[:name_matches])
+      q = q.where(name_cond) if name_cond
+    end
+
+    q
+  end
+
+  private
+
+  private_class_method def self.valid_tag?(tag)
+    return false unless tag.length.between?(1, 100)
+    record = new(tag: tag, hour: Time.now.utc)
+    TagNameValidator.new(attributes: [:tag]).validate_each(record, :tag, tag)
+    record.errors[:tag].empty?
+  end
+end

--- a/app/views/search_trend_hourlies/index.html.erb
+++ b/app/views/search_trend_hourlies/index.html.erb
@@ -1,0 +1,88 @@
+<% content_for(:page_title, "Hourly Search Trends") %>
+
+<div id="c-search-trend-hourlies">
+  <div class="box-section">
+    <h1>Hourly Search Trends</h1>
+    
+    <%= form_with model: false, url: search_trend_hourlies_path, method: :get do |form| %>
+      <div class="input">
+        <%= form.label :start_time, "Start Time" %>
+        <%= form.datetime_local_field :start_time, value: @start_time&.strftime("%Y-%m-%dT%H:%M") %>
+      </div>
+      
+      <div class="input">
+        <%= form.label :end_time, "End Time" %>
+        <%= form.datetime_local_field :end_time, value: @end_time&.strftime("%Y-%m-%dT%H:%M") %>
+      </div>
+      
+      <div class="input">
+        <%= form.label :name_matches, "Tag Name" %>
+        <%= form.text_field :name_matches, placeholder: "Search by tag name..." %>
+      </div>
+      
+      <%= form.submit "Search", class: "ui-button ui-widget ui-state-default ui-corner-all" %>
+    <% end %>
+  </div>
+
+  <div class="box-section">
+    <h2>
+      Hourly Records 
+      <span class="count">(<%= @start_time.strftime("%Y-%m-%d %H:%M") %> to <%= @end_time.strftime("%Y-%m-%d %H:%M") %>)</span>
+    </h2>
+
+    <% if @hourlies.any? %>
+      <table class="striped">
+        <thead>
+          <tr>
+            <th>Rank</th>
+            <th>Tag</th>
+            <th>Hour</th>
+            <th>Count</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @hourlies.each_with_index do |hourly, index| %>
+            <tr>
+              <td><%= @count_offset + index + 1 %></td>
+              <td>
+                <%= link_to hourly.tag, track_search_trends_path(tag: hourly.tag), class: "search-tag" %>
+              </td>
+              <td><%= time_tag hourly.hour, hourly.hour %></td>
+              <td><%= number_with_delimiter hourly.count %></td>
+              <td>
+                <% if hourly.processed? %>
+                  <span class="status-processed">Processed</span>
+                <% else %>
+                  <span class="status-unprocessed">Unprocessed</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%= render PaginatorComponent.new(records: @hourlies) %>
+    <% else %>
+      <p>No hourly trends found for the selected time period.</p>
+    <% end %>
+  </div>
+</div>
+
+<style>
+  .status-processed {
+    color: #0c5928;
+    font-weight: bold;
+  }
+  
+  .status-unprocessed {
+    color: #8b4513;
+    font-weight: bold;
+  }
+  
+  .count {
+    font-weight: normal;
+    font-size: 0.9em;
+    color: #666;
+  }
+</style>

--- a/app/views/search_trends/_search.html.erb
+++ b/app/views/search_trends/_search.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag(search_trends_path, method: :get, id: "trends_search_form") do %>
+  <%= text_field "search", "name_matches", placeholder: "Search Trends" %>
+  <%= submit_tag "Search" %>
+<% end %>

--- a/app/views/search_trends/index.html.erb
+++ b/app/views/search_trends/index.html.erb
@@ -11,10 +11,16 @@
     </div>
 
     <div class="search-trend-nav">
-      <a href="<%= url_for(day: @day - 1) %>"><%= svg_icon(:chevron_left) %> Previous</a>
+      <a href="<%= url_for(request.query_parameters.except('day').merge('day' => (@day - 1).to_s)) %>"><%= svg_icon(:chevron_left) %> Previous</a>
       <strong><%= @day.to_s %></strong>
-      <a href="<%= url_for(day: @day + 1) %>">Next <%= svg_icon(:chevron_right) %></a>
+      <% if @has_tomorrow %>
+        <a href="<%= url_for(request.query_parameters.except('day').merge('day' => (@day + 1).to_s)) %>">Next <%= svg_icon(:chevron_right) %></a>
+      <% else %>
+        <span class="disabled">Next <%= svg_icon(:chevron_right) %></span>
+      <% end %>
     </div>
+
+    <%= render "search" %>
 
     <% if @trending.blank? %>
       <p>No trending data for this day yet.</p>
@@ -30,7 +36,7 @@
         <tbody>
           <% @trending.each_with_index do |row, idx| %>
             <tr>
-              <td><%= @count_offset + idx + 1 %></td>
+              <td><%= @using_calculated_ranks ? row.daily_rank : @count_offset + idx + 1 %></td>
               <td><%= link_to row.tag, track_search_trends_path(tag: row.tag) %></td>
               <td><%= row.count %></td>
             </tr>

--- a/app/views/search_trends/index.html.erb
+++ b/app/views/search_trends/index.html.erb
@@ -11,10 +11,10 @@
     </div>
 
     <div class="search-trend-nav">
-      <a href="<%= url_for(request.query_parameters.except('day').merge('day' => (@day - 1).to_s)) %>"><%= svg_icon(:chevron_left) %> Previous</a>
+      <a href="<%= url_for(request.query_parameters.except("day").merge(day: (@day - 1).to_s)) %>"><%= svg_icon(:chevron_left) %> Previous</a>
       <strong><%= @day.to_s %></strong>
       <% if @has_tomorrow %>
-        <a href="<%= url_for(request.query_parameters.except('day').merge('day' => (@day + 1).to_s)) %>">Next <%= svg_icon(:chevron_right) %></a>
+        <a href="<%= url_for(request.query_parameters.except("day").merge(day: (@day + 1).to_s)) %>">Next <%= svg_icon(:chevron_right) %></a>
       <% else %>
         <span class="disabled">Next <%= svg_icon(:chevron_right) %></span>
       <% end %>

--- a/app/views/search_trends/settings.html.erb
+++ b/app/views/search_trends/settings.html.erb
@@ -2,7 +2,7 @@
   <div id="a-settings">
     <h1>Search trend settings</h1>
 
-    <%= custom_form_for(:search_trends, url: update_settings_search_trends_path, method: :post, local: true, class: "simple_form") do |f| %>
+    <%= custom_form_for(:search_trend_settings, url: update_settings_search_trends_path, method: :post, local: true, class: "simple_form") do |f| %>
       <div class="input">
         <%= f.label :trends_enabled, "Enable trends" %>
         <%= f.check_box :trends_enabled, { checked: Setting.trends_enabled? }, "true", "false" %>

--- a/app/views/search_trends/track.html.erb
+++ b/app/views/search_trends/track.html.erb
@@ -4,14 +4,33 @@
       Search Trends for <%= @tag %>
     </h1>
 
+    <% unless @hourlies.blank? %>
+      <table class="striped">
+        <thead>
+          <tr>
+            <th>Hour</th>
+            <th>Searches</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @hourlies.each do |row| %>
+            <tr>
+              <td><%= row.hour.to_s %></td>
+              <td><%= row.count %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <br />
+    <% end %>
+
     <% if @trends.blank? %>
-      <p>No data for this tag yet.</p>
+      <p>No historic data for this tag yet.</p>
     <% else %>
       <table class="striped">
         <thead>
           <tr>
             <th>Date</th>
-            <th>Hour</th>
             <th>Searches</th>
           </tr>
         </thead>
@@ -19,7 +38,6 @@
           <% @trends.each do |row| %>
             <tr>
               <td><%= row.day.to_s %></td>
-              <td><%= row.hour %></td>
               <td><%= row.count %></td>
             </tr>
           <% end %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "sidekiq-unique-jobs"
+require "sidekiq-cron"
 
 Sidekiq.configure_server do |config|
   config.redis = { url: Danbooru.config.redis_url }
@@ -14,6 +15,17 @@ Sidekiq.configure_server do |config|
   end
 
   SidekiqUniqueJobs::Server.configure(config)
+
+  # Schedule recurring jobs
+  schedule = {
+    "SearchTrendAggregateJob" => {
+      "cron" => "0 * * * *", # Every hour at minute 0
+      "class" => "SearchTrendAggregateJob",
+      "description" => "Aggregate unprocessed hourly search trends into daily totals",
+    },
+  }
+
+  Sidekiq::Cron::Job.load_from_hash schedule
 end
 
 Sidekiq.configure_client do |config|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
       delete :purge
     end
   end
+  resources :search_trend_hourlies, only: %i[index]
   namespace :maintenance do
     namespace :user do
       resource :count_fixes, only: %i[new create]

--- a/db/migrate/20260325154501_split_search_trends_into_hourly_and_daily.rb
+++ b/db/migrate/20260325154501_split_search_trends_into_hourly_and_daily.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class SplitSearchTrendsIntoHourlyAndDaily < ActiveRecord::Migration[8.1]
+  def up
+    SearchTrend.without_timeout do
+      # Create the new search_trend_hourlies table with final schema
+      create_table :search_trend_hourlies do |t|
+        t.string :tag, null: false
+        t.datetime :hour, null: false
+        t.integer :count, null: false, default: 0
+        t.boolean :processed, null: false, default: false
+
+        t.timestamps
+      end
+
+      # Add indexes for the hourly table
+      add_index :search_trend_hourlies, %i[tag hour], unique: true
+      add_index :search_trend_hourlies, :hour
+
+      # Performance indexes
+      add_index :search_trend_hourlies, :processed, name: "index_search_trend_hourlies_on_processed"
+      add_index :search_trend_hourlies, %i[processed hour], name: "index_search_trend_hourlies_on_processed_and_hour"
+      add_index :search_trend_hourlies, :hour, where: "processed = false", name: "index_search_trend_hourlies_on_hour_unprocessed"
+
+      add_index :search_trends, %i[tag day], unique: true, name: "index_search_trends_on_tag_and_day"
+      add_index :search_trends, :tag, using: :gin, opclass: { tag: :gin_trgm_ops }, name: "index_search_trends_on_tag_trigram"
+
+      # Clean up existing hourly records from search_trends (they'll be rebuilt by normal operation)
+      execute("DELETE FROM search_trends WHERE hour IS NOT NULL")
+
+      # Remove the partial indexes that differentiated hourly from daily records
+      remove_index :search_trends, name: "index_search_trends_on_tag_day_hour" if index_exists?(:search_trends, %i[tag day hour], name: "index_search_trends_on_tag_day_hour")
+      remove_index :search_trends, name: "index_search_trends_on_tag_and_day_daily" if index_exists?(:search_trends, %i[tag day], name: "index_search_trends_on_tag_and_day_daily")
+      remove_index :search_trends, name: "index_search_trends_on_all" if index_exists?(:search_trends, %i[tag day hour], name: "index_search_trends_on_all")
+
+      # Remove the hour column since SearchTrend is now daily-only
+      remove_column :search_trends, :hour
+    end
+  end
+
+  def down
+    SearchTrend.without_timeout do
+      # Add back the hour column
+      add_column :search_trends, :hour, :integer
+
+      # Remove the daily-only index
+      remove_index :search_trends, name: "index_search_trends_on_tag_and_day"
+      remove_index :search_trends, name: "index_search_trends_on_tag_trigram"
+
+      # Restore the partial indexes for mixed daily/hourly records
+      add_index :search_trends, %i[tag day hour],
+                unique: true,
+                where: "hour IS NOT NULL",
+                name: "index_search_trends_on_tag_day_hour"
+      add_index :search_trends, %i[tag day],
+                unique: true,
+                where: "hour IS NULL",
+                name: "index_search_trends_on_tag_and_day_daily"
+      add_index :search_trends, %i[tag day hour], name: "index_search_trends_on_all"
+
+      # Drop the hourly table
+      drop_table :search_trend_hourlies
+    end
+  end
+end

--- a/db/populate.rb
+++ b/db/populate.rb
@@ -18,6 +18,7 @@ presets = {
   furids: ENV.fetch("FURIDS", 0).to_i,
   dmails: ENV.fetch("DM", 0).to_i,
   trends: ENV.fetch("TRENDS", 0).to_i,
+  trends_hours: ENV.fetch("TRENDS_HOURS", 0).to_i,
 }
 if presets.values.sum == 0
   puts "DEFAULTS"
@@ -33,6 +34,7 @@ if presets.values.sum == 0
     furids: 0,
     dmails: 0,
     trends: 7,
+    trends_hours: 48,
   }
 end
 
@@ -47,6 +49,7 @@ POOLS     = presets[:pools]
 FURIDS    = presets[:furids]
 DMAILS    = presets[:dmails]
 TRENDS    = presets[:trends]
+TRENDS_HOURS = presets[:trends_hours]
 
 DISTRIBUTION = ENV.fetch("DISTRIBUTION", 10).to_i
 DEFAULT_PASSWORD = ENV.fetch("PASSWORD", "hexerade")
@@ -525,14 +528,10 @@ def populate_dmails(number)
   end
 end
 
-# Seed search trend data for testing: the same selection of `tags_count` tags across the
-# past `days` days, with a subset showing a substantial rise today vs yesterday.
-# Hourly records are written for the most recent 50 hours; older data is stored as daily
-# aggregate records. This allows testing both the rising calculation (which reads hourly
-# records) and the coalesce_hourly! job (which targets records older than 48 hours).
+# Creates SearchTrend daily aggregate records for testing.
 def populate_search_trends(days: 7, tags_count: 100, rising_ratio: 0.25)
   return unless days > 0 && tags_count > 0
-  puts "* Seeding search trends for past #{days} days (#{tags_count} tags)"
+  puts "* Creating SearchTrend daily records for past #{days} days (#{tags_count} tags)"
 
   # Prefer existing tags; if not enough exist, synthesize the remainder.
   existing = Tag.order("random()").limit(tags_count).pluck(:name)
@@ -548,21 +547,16 @@ def populate_search_trends(days: 7, tags_count: 100, rising_ratio: 0.25)
   tags ||= []
   return if tags.empty?
 
-  now               = Time.current
-  hourly_cutoff     = now - 50.hours # hourly records start here
-  hourly_cutoff_day = hourly_cutoff.to_date
-  hourly_cutoff_hour = hourly_cutoff.hour
-
   start_day = Date.current - (days - 1)
   rising_count = [(tags.size * rising_ratio).to_i, 1].max.clamp(1, tags.size)
   rising_tags = tags.sample(rising_count)
 
-  tags.each do |tag| # rubocop:disable Metrics/BlockLength
+  tags.each do |tag|
     # Establish a baseline that can be below today's min threshold on some days.
     base = rand(6..25)
     prev = nil
 
-    (start_day..Date.current).each do |day| # rubocop:disable Metrics/BlockLength
+    (start_day..Date.current).each do |day|
       if day == start_day
         prev = base + rand(0..5)
       else
@@ -583,36 +577,66 @@ def populate_search_trends(days: 7, tags_count: 100, rising_ratio: 0.25)
         end
       end
 
-      if day < hourly_cutoff_day
-        # Entirely old — write a single daily aggregate record.
-        st = SearchTrend.find_or_initialize_by(tag: tag, day: day, hour: nil)
-        st.count = prev
-        st.save!
-      else
-        # Within the 50-hour hourly window. Spread the day's implied total evenly across hours.
-        per_hour = [((prev.to_f / 24) + 0.5).to_i, 1].max
-
-        # On the cutoff day, hours before hourly_cutoff_hour are summarised in a daily record.
-        if day == hourly_cutoff_day && hourly_cutoff_hour > 0
-          st = SearchTrend.find_or_initialize_by(tag: tag, day: day, hour: nil)
-          st.count = [per_hour * hourly_cutoff_hour, 1].max
-          st.save!
-        end
-
-        # Write individual hourly records from the cutoff hour onward (or from 0 on later days).
-        first_hour = day == hourly_cutoff_day ? hourly_cutoff_hour : 0
-        last_hour  = day == Date.current      ? now.hour           : 23
-
-        (first_hour..last_hour).each do |h|
-          st = SearchTrend.find_or_initialize_by(tag: tag, day: day, hour: h)
-          st.count = per_hour
-          st.save!
-        end
-      end
+      st = SearchTrend.find_or_initialize_by(tag: tag, day: day)
+      st.count = prev
+      st.save!
     end
   end
 
-  puts "  Seeded #{tags.size} tags across #{days} days (#{rising_tags.size} rising today, hourly records for last 50 hours)."
+  daily_trends = SearchTrend.count
+  puts "  Created #{tags.size} tags across #{days} days:"
+  puts "    #{rising_tags.size} rising today"
+  puts "    #{daily_trends} daily aggregate records"
+end
+
+# Creates SearchTrendHourly records for testing. All records are marked as unprocessed.
+def populate_search_trend_dailies(hours: 48, tags_count: 50)
+  return unless hours > 0 && tags_count > 0
+  puts "* Creating SearchTrendHourly records for past #{hours} hours (#{tags_count} tags)"
+
+  # Prefer existing tags; if not enough exist, synthesize the remainder.
+  existing = Tag.order("random()").limit(tags_count).pluck(:name)
+  if existing.size < tags_count
+    missing = tags_count - existing.size
+    generated = (1..missing).map { |i| "hourly_tag_#{format('%03d', i)}" }
+    tags = existing + generated
+  else
+    tags = existing
+    tags << "alpha"
+    tags << "beta"
+  end
+
+  tags.map! { |t| t.to_s.downcase.strip }.uniq!
+  tags ||= []
+  return if tags.empty?
+
+  now = Time.current
+  start_hour = now.beginning_of_hour - (hours - 1).hours
+
+  tags.each do |tag|
+    base_per_hour = rand(1..10)
+
+    (0...hours).each do |i|
+      hour_time = start_hour + i.hours
+      next if hour_time > now # Don't create future records
+
+      # Add some variance to the hourly count
+      count = [base_per_hour + rand(-2..3), 1].max
+
+      st = SearchTrendHourly.find_or_initialize_by(tag: tag, hour: hour_time)
+      st.count = count
+      st.processed = false # All records should be unprocessed as requested
+      st.save!
+    end
+  end
+
+  total_hourly = SearchTrendHourly.count
+  unprocessed_hourly = SearchTrendHourly.unprocessed.count
+
+  puts "  Created #{tags.size} tags across #{hours} hours:"
+  puts "    #{total_hourly} total hourly records"
+  puts "    #{unprocessed_hourly} unprocessed hourly records"
+  puts "  Ready to test aggregation job functionality!"
 end
 
 puts "Populating the Database"
@@ -635,3 +659,4 @@ populate_dmails(DMAILS)
 
 # Seed search trends last
 populate_search_trends(days: TRENDS, tags_count: 100)
+populate_search_trend_dailies(hours: TRENDS_HOURS, tags_count: 50)

--- a/db/populate.rb
+++ b/db/populate.rb
@@ -590,7 +590,7 @@ def populate_search_trends(days: 7, tags_count: 100, rising_ratio: 0.25)
 end
 
 # Creates SearchTrendHourly records for testing. All records are marked as unprocessed.
-def populate_search_trend_dailies(hours: 48, tags_count: 50)
+def populate_search_trend_hourlies(hours: 48, tags_count: 50)
   return unless hours > 0 && tags_count > 0
   puts "* Creating SearchTrendHourly records for past #{hours} hours (#{tags_count} tags)"
 
@@ -659,4 +659,4 @@ populate_dmails(DMAILS)
 
 # Seed search trends last
 populate_search_trends(days: TRENDS, tags_count: 100)
-populate_search_trend_dailies(hours: TRENDS_HOURS, tags_count: 50)
+populate_search_trend_hourlies(hours: TRENDS_HOURS, tags_count: 50)

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1818,6 +1818,40 @@ ALTER SEQUENCE public.search_trend_blacklists_id_seq OWNED BY public.search_tren
 
 
 --
+-- Name: search_trend_hourlies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.search_trend_hourlies (
+    id bigint NOT NULL,
+    tag character varying NOT NULL,
+    hour timestamp(6) without time zone NOT NULL,
+    count integer DEFAULT 0 NOT NULL,
+    processed boolean DEFAULT false NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: search_trend_hourlies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.search_trend_hourlies_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: search_trend_hourlies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.search_trend_hourlies_id_seq OWNED BY public.search_trend_hourlies.id;
+
+
+--
 -- Name: search_trends; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1827,8 +1861,7 @@ CREATE TABLE public.search_trends (
     day date NOT NULL,
     count integer DEFAULT 0 NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    hour integer
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -2924,6 +2957,13 @@ ALTER TABLE ONLY public.search_trend_blacklists ALTER COLUMN id SET DEFAULT next
 
 
 --
+-- Name: search_trend_hourlies id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.search_trend_hourlies ALTER COLUMN id SET DEFAULT nextval('public.search_trend_hourlies_id_seq'::regclass);
+
+
+--
 -- Name: search_trends id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3447,6 +3487,14 @@ ALTER TABLE ONLY public.schema_migrations
 
 ALTER TABLE ONLY public.search_trend_blacklists
     ADD CONSTRAINT search_trend_blacklists_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: search_trend_hourlies search_trend_hourlies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.search_trend_hourlies
+    ADD CONSTRAINT search_trend_hourlies_pkey PRIMARY KEY (id);
 
 
 --
@@ -4577,10 +4625,38 @@ CREATE UNIQUE INDEX index_search_trend_blacklists_on_tag ON public.search_trend_
 
 
 --
--- Name: index_search_trends_on_all; Type: INDEX; Schema: public; Owner: -
+-- Name: index_search_trend_hourlies_on_hour; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_search_trends_on_all ON public.search_trends USING btree (tag, day, hour);
+CREATE INDEX index_search_trend_hourlies_on_hour ON public.search_trend_hourlies USING btree (hour);
+
+
+--
+-- Name: index_search_trend_hourlies_on_hour_unprocessed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_search_trend_hourlies_on_hour_unprocessed ON public.search_trend_hourlies USING btree (hour) WHERE (processed = false);
+
+
+--
+-- Name: index_search_trend_hourlies_on_processed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_search_trend_hourlies_on_processed ON public.search_trend_hourlies USING btree (processed);
+
+
+--
+-- Name: index_search_trend_hourlies_on_processed_and_hour; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_search_trend_hourlies_on_processed_and_hour ON public.search_trend_hourlies USING btree (processed, hour);
+
+
+--
+-- Name: index_search_trend_hourlies_on_tag_and_hour; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_search_trend_hourlies_on_tag_and_hour ON public.search_trend_hourlies USING btree (tag, hour);
 
 
 --
@@ -4591,17 +4667,17 @@ CREATE INDEX index_search_trends_on_day_and_count ON public.search_trends USING 
 
 
 --
--- Name: index_search_trends_on_tag_and_day_daily; Type: INDEX; Schema: public; Owner: -
+-- Name: index_search_trends_on_tag_and_day; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_search_trends_on_tag_and_day_daily ON public.search_trends USING btree (tag, day) WHERE (hour IS NULL);
+CREATE UNIQUE INDEX index_search_trends_on_tag_and_day ON public.search_trends USING btree (tag, day);
 
 
 --
--- Name: index_search_trends_on_tag_day_hour; Type: INDEX; Schema: public; Owner: -
+-- Name: index_search_trends_on_tag_trigram; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX index_search_trends_on_tag_day_hour ON public.search_trends USING btree (tag, day, hour) WHERE (hour IS NOT NULL);
+CREATE INDEX index_search_trends_on_tag_trigram ON public.search_trends USING gin (tag public.gin_trgm_ops);
 
 
 --
@@ -5140,6 +5216,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260325154501'),
 ('20260324195504'),
 ('20260324153600'),
 ('20260312140702'),

--- a/test/controllers/search_trends_controller_test.rb
+++ b/test/controllers/search_trends_controller_test.rb
@@ -13,19 +13,64 @@ class SearchTrendsControllerTest < ActionDispatch::IntegrationTest
     end
 
     should "index renders html" do
-      SearchTrend.increment!("wolf")
+      SearchTrendHourly.bulk_increment!([{ tag: "wolf", hour: 1.hour.ago }])
       get "/search_trends"
       assert_response :success
       assert_match(/Trending Tags/, response.body)
     end
 
     should "index returns json" do
-      SearchTrend.increment!("fox")
+      SearchTrendHourly.bulk_increment!([{ tag: "fox", hour: 2.hours.ago }])
+      SearchTrendAggregateJob.perform_now
       get "/search_trends.json"
       assert_response :success
       json = response.parsed_body
       assert(json.is_a?(Array))
       assert(json.any? { |row| row["tag"] == "fox" })
+    end
+
+    should "index displays correct ranks without search filters" do
+      day = Date.current
+      # Create SearchTrend records for consistent ranking tests
+      SearchTrend.create!(tag: "alpha", day: day, count: 300)
+      SearchTrend.create!(tag: "beta", day: day, count: 200)
+      SearchTrend.create!(tag: "gamma", day: day, count: 100)
+
+      get "/search_trends"
+      assert_response :success
+
+      # Should use offset-based ranking (current behavior)
+      assert_match(%r{td>.*1.*</td>}, response.body) # alpha should be rank 1
+      # Simple check that ranking appears to be sequential starting from 1
+    end
+
+    should "index preserves original ranks with search filters" do
+      day = Date.current
+      # Create test data with clear ranking
+      SearchTrend.create!(tag: "wolf", day: day, count: 300)    # rank 1
+      SearchTrend.create!(tag: "fox", day: day, count: 200)     # rank 2
+      SearchTrend.create!(tag: "cat", day: day, count: 100)     # rank 3
+      SearchTrend.create!(tag: "dog", day: day, count: 50)      # rank 4
+
+      # Search for tags containing 'o' (wolf, fox, dog)
+      get "/search_trends", params: { search: { name_matches: "*o*" } }
+      assert_response :success
+
+      # Parse the response to check that original daily ranks are preserved
+      # The response should show wolf=rank1, fox=rank2, dog=rank4 (not 1,2,3)
+      response_body = response.body
+
+      # Check that wolf appears with rank 1
+      assert_match(%r{wolf</a>}i, response_body)
+
+      # Check that fox appears with rank 2 (not rank 2 in filtered sequence)
+      assert_match(%r{fox</a>}i, response_body)
+
+      # Check that dog appears with rank 4 (not rank 3 in filtered sequence)
+      assert_match(%r{dog</a>}i, response_body)
+
+      # Verify cat (rank 3) is NOT in the filtered results
+      assert_no_match(%r{cat</a>}i, response_body)
     end
   end
 
@@ -54,7 +99,7 @@ class SearchTrendsControllerTest < ActionDispatch::IntegrationTest
 
     should "form submission updates settings" do
       post_auth update_settings_search_trends_path, @admin, params: {
-        search_trends: {
+        search_trend_settings: {
           trends_enabled: false,
           trends_min_today: 11,
           trends_min_delta: 12,

--- a/test/jobs/search_trend_aggregate_job_test.rb
+++ b/test/jobs/search_trend_aggregate_job_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchTrendAggregateJobTest < ActiveJob::TestCase
+  setup do
+    Setting.trends_enabled = true
+  end
+
+  teardown do
+    Setting.trends_enabled = false
+  end
+
+  should "process records older than 1 hour and ignore newer records" do
+    # Create hourly records - some old, some new
+    old_hour = 2.hours.ago.utc.beginning_of_hour
+    new_hour = 30.minutes.ago.utc.beginning_of_hour
+
+    old_record1 = SearchTrendHourly.create!(tag: "old_tag1", hour: old_hour, count: 5, processed: false)
+    old_record2 = SearchTrendHourly.create!(tag: "old_tag2", hour: old_hour, count: 3, processed: false)
+    new_record = SearchTrendHourly.create!(tag: "new_tag", hour: new_hour, count: 10, processed: false)
+
+    # Run the aggregation job
+    SearchTrendAggregateJob.perform_now
+
+    # Check that old records were processed
+    old_record1.reload
+    old_record2.reload
+    new_record.reload
+
+    assert old_record1.processed, "Old record should be marked as processed"
+    assert old_record2.processed, "Old record should be marked as processed"
+    assert_not new_record.processed, "New record should NOT be marked as processed"
+
+    # Check that daily aggregates were created for old records only
+    old_day = old_hour.to_date
+    new_day = new_hour.to_date
+
+    assert SearchTrend.where(tag: "old_tag1", day: old_day).exists?, "Daily aggregate should exist for old_tag1"
+    assert SearchTrend.where(tag: "old_tag2", day: old_day).exists?, "Daily aggregate should exist for old_tag2"
+    assert_not SearchTrend.where(tag: "new_tag", day: new_day).exists?, "Daily aggregate should NOT exist for new_tag"
+
+    # Verify the counts are correct
+    assert_equal 5, SearchTrend.find_by(tag: "old_tag1", day: old_day).count
+    assert_equal 3, SearchTrend.find_by(tag: "old_tag2", day: old_day).count
+  end
+end

--- a/test/models/search_trend_blacklist_test.rb
+++ b/test/models/search_trend_blacklist_test.rb
@@ -131,21 +131,12 @@ class SearchTrendBlacklistTest < ActiveSupport::TestCase
       Setting.trends_enabled = false
     end
 
-    should "increment! skips blacklisted tags" do
+    should "bulk_increment! does not skip non-blacklisted tags" do
       as @admin do
         SearchTrendBlacklist.create!(tag: "wolf", reason: "")
       end
-      assert_no_difference -> { SearchTrend.count } do
-        SearchTrend.increment!("wolf")
-      end
-    end
-
-    should "increment! does not skip non-blacklisted tags" do
-      as @admin do
-        SearchTrendBlacklist.create!(tag: "wolf", reason: "")
-      end
-      assert_difference -> { SearchTrend.count }, +1 do
-        SearchTrend.increment!("fox")
+      assert_difference -> { SearchTrendHourly.count }, +1 do
+        SearchTrendHourly.bulk_increment!([{ tag: "fox", hour: 1.hour.ago }])
       end
     end
 
@@ -154,8 +145,12 @@ class SearchTrendBlacklistTest < ActiveSupport::TestCase
         SearchTrendBlacklist.create!(tag: "wolf", reason: "")
         SearchTrendBlacklist.create!(tag: "*_species", reason: "")
       end
-      SearchTrend.bulk_increment!(%w[wolf fox canine_species])
-      tags = SearchTrend.for_day(Date.current).pluck(:tag)
+      SearchTrendHourly.bulk_increment!([
+        { tag: "wolf", hour: 1.hour.ago },
+        { tag: "fox", hour: 1.hour.ago },
+        { tag: "canine_species", hour: 1.hour.ago },
+      ])
+      tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
       assert_includes tags, "fox"
       assert_not_includes tags, "wolf"
       assert_not_includes tags, "canine_species"
@@ -165,8 +160,8 @@ class SearchTrendBlacklistTest < ActiveSupport::TestCase
       as @admin do
         SearchTrendBlacklist.create!(tag: "wolf", reason: "")
       end
-      assert_no_difference -> { SearchTrend.count } do
-        SearchTrend.bulk_increment!(%w[wolf])
+      assert_no_difference -> { SearchTrendHourly.count } do
+        SearchTrendHourly.bulk_increment!([{ tag: "wolf", hour: 1.hour.ago }])
       end
     end
   end

--- a/test/models/search_trend_hourly_test.rb
+++ b/test/models/search_trend_hourly_test.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchTrendHourlyTest < ActiveSupport::TestCase
+  context "search trend hourly" do
+    setup do
+      Setting.trends_enabled = true # Enable trends for testing
+      @trend = SearchTrendHourly.create!(tag: "test", hour: 1.hour.ago.beginning_of_hour, count: 5)
+    end
+
+    should "validate required fields" do
+      trend = SearchTrendHourly.new
+      assert_not trend.valid?
+      assert_includes trend.errors[:tag], "can't be blank"
+      assert_includes trend.errors[:hour], "can't be blank"
+    end
+
+    should "validate uniqueness of tag and hour" do
+      duplicate_trend = SearchTrendHourly.new(tag: @trend.tag, hour: @trend.hour)
+      assert_not duplicate_trend.valid?
+      assert_includes duplicate_trend.errors[:hour], "has already been taken"
+    end
+
+    should "default processed to false" do
+      new_trend = SearchTrendHourly.create!(tag: "new", hour: 2.hours.ago.beginning_of_hour, count: 3)
+      assert_equal false, new_trend.processed
+    end
+
+    context "#bulk_increment!" do
+      should "create new record if it doesn't exist" do
+        hour = 3.hours.ago.beginning_of_hour
+
+        assert_difference("SearchTrendHourly.count", 1) do
+          SearchTrendHourly.bulk_increment!([{ tag: "newtag", hour: hour }])
+        end
+
+        trend = SearchTrendHourly.find_by(tag: "newtag", hour: hour)
+        assert_equal 1, trend.count
+        assert_equal false, trend.processed
+      end
+
+      should "increment existing record" do
+        hour = 4.hours.ago.beginning_of_hour # Ensure we use beginning of hour
+        existing = SearchTrendHourly.create!(tag: "existing", hour: hour, count: 5)
+
+        assert_no_difference("SearchTrendHourly.count") do
+          SearchTrendHourly.bulk_increment!([{ tag: "existing", hour: hour }])
+        end
+
+        existing.reload
+        assert_equal 6, existing.count
+      end
+
+      should "handle multiple tag-hour pairs efficiently" do
+        hour1 = 1.hour.ago.beginning_of_hour
+        hour2 = 2.hours.ago.beginning_of_hour
+
+        data = [
+          { tag: "bulk1", hour: hour1 },
+          { tag: "bulk2", hour: hour1 },
+          { tag: "bulk1", hour: hour2 },
+        ]
+
+        assert_difference("SearchTrendHourly.count", 3) do
+          SearchTrendHourly.bulk_increment!(data)
+        end
+
+        assert_equal 1, SearchTrendHourly.find_by(tag: "bulk1", hour: hour1).count
+        assert_equal 1, SearchTrendHourly.find_by(tag: "bulk2", hour: hour1).count
+        assert_equal 1, SearchTrendHourly.find_by(tag: "bulk1", hour: hour2).count
+      end
+    end
+
+    context "scopes" do
+      setup do
+        @processed = SearchTrendHourly.create!(tag: "processed", hour: 5.hours.ago.beginning_of_hour, count: 3, processed: true)
+        @unprocessed = SearchTrendHourly.create!(tag: "unprocessed", hour: 6.hours.ago.beginning_of_hour, count: 2, processed: false)
+      end
+
+      context ".unprocessed" do
+        should "return only unprocessed trends" do
+          results = SearchTrendHourly.unprocessed
+          assert_includes results, @unprocessed
+          assert_not_includes results, @processed
+        end
+      end
+
+      context ".processed" do
+        should "return only processed trends" do
+          results = SearchTrendHourly.processed
+          assert_includes results, @processed
+          assert_not_includes results, @unprocessed
+        end
+      end
+    end
+
+    context "#prune!" do
+      should "remove old processed records but keep recent and unprocessed ones" do
+        old_hour = 3.days.ago      # More than 48 hours ago
+        recent_hour = 1.hour.ago   # Less than 48 hours ago
+
+        # Old processed records (should be deleted)
+        old_processed1 = SearchTrendHourly.create!(tag: "owl", hour: old_hour, count: 10, processed: true)
+        old_processed2 = SearchTrendHourly.create!(tag: "owl", hour: old_hour + 1.hour, count: 15, processed: true)
+
+        # Old unprocessed records (should be kept)
+        old_unprocessed = SearchTrendHourly.create!(tag: "rabbit", hour: old_hour, count: 5, processed: false)
+
+        # Recent processed records (should be kept)
+        recent_processed = SearchTrendHourly.create!(tag: "cat", hour: recent_hour, count: 3, processed: true)
+
+        SearchTrendHourly.prune!
+
+        # Old processed records should be deleted
+        assert_not SearchTrendHourly.exists?(old_processed1.id)
+        assert_not SearchTrendHourly.exists?(old_processed2.id)
+
+        # Old unprocessed and recent records should remain
+        assert SearchTrendHourly.exists?(old_unprocessed.id)
+        assert SearchTrendHourly.exists?(recent_processed.id)
+      end
+
+      should "only remove old processed hourly records" do
+        old_hour = 3.days.ago
+        recent_hour = 1.hour.ago
+
+        # Create some processed and unprocessed hourly records
+        old_processed = SearchTrendHourly.create!(tag: "old", hour: old_hour, count: 10, processed: true)
+        old_unprocessed = SearchTrendHourly.create!(tag: "oldunproc", hour: old_hour, count: 5, processed: false)
+        recent_processed = SearchTrendHourly.create!(tag: "recent", hour: recent_hour, count: 20, processed: true)
+        recent_unprocessed = SearchTrendHourly.create!(tag: "recentunproc", hour: recent_hour, count: 15, processed: false)
+
+        SearchTrendHourly.prune!
+
+        # Only old processed records should be deleted
+        assert_not SearchTrendHourly.exists?(old_processed.id)
+        assert SearchTrendHourly.exists?(old_unprocessed.id) # Keep unprocessed
+        assert SearchTrendHourly.exists?(recent_processed.id) # Keep recent
+        assert SearchTrendHourly.exists?(recent_unprocessed.id) # Keep recent
+      end
+    end
+  end
+end

--- a/test/models/search_trend_hourly_test.rb
+++ b/test/models/search_trend_hourly_test.rb
@@ -5,8 +5,12 @@ require "test_helper"
 class SearchTrendHourlyTest < ActiveSupport::TestCase
   context "search trend hourly" do
     setup do
-      Setting.trends_enabled = true # Enable trends for testing
+      Setting.trends_enabled = true
       @trend = SearchTrendHourly.create!(tag: "test", hour: 1.hour.ago.beginning_of_hour, count: 5)
+    end
+
+    teardown do
+      Setting.trends_enabled = false
     end
 
     should "validate required fields" do

--- a/test/models/search_trend_test.rb
+++ b/test/models/search_trend_test.rb
@@ -11,26 +11,27 @@ class SearchTrendTest < ActiveSupport::TestCase
     Setting.trends_enabled = false
   end
 
-  test "increment! creates an hourly record and increments it" do
-    hour = Time.now.utc.hour
-    assert_difference -> { SearchTrend.count }, +1 do
-      SearchTrend.increment!("Test_Tag")
+  test "bulk_increment! creates an hourly record and increments it" do
+    hour = 1.hour.ago.beginning_of_hour
+    assert_difference -> { SearchTrendHourly.count }, +1 do
+      SearchTrendHourly.bulk_increment!([{ tag: "Test_Tag", hour: hour }])
     end
-    rec = SearchTrend.find_by(tag: "test_tag", day: Time.now.utc.to_date, hour: hour)
+    rec = SearchTrendHourly.find_by(tag: "test_tag", hour: hour)
     assert_not_nil rec
     assert_equal 1, rec.count
 
-    assert_no_difference -> { SearchTrend.count } do
-      SearchTrend.increment!("test_tag")
+    assert_no_difference -> { SearchTrendHourly.count } do
+      SearchTrendHourly.bulk_increment!([{ tag: "test_tag", hour: hour }])
     end
     rec.reload
     assert_equal 2, rec.count
   end
 
   test "bulk_increment! handles multiple tags and de-dupes" do
-    SearchTrend.bulk_increment!(%w[alpha beta alpha]) # alpha counted once
-    rows = SearchTrend.for_day(Date.current).pluck(:tag, :count).to_h
-    assert_equal({ "alpha" => 1, "beta" => 1 }, rows)
+    hour = 1.hour.ago.beginning_of_hour
+    SearchTrendHourly.bulk_increment!([{ tag: "alpha", hour: hour }, { tag: "beta", hour: hour }, { tag: "alpha", hour: hour }]) # alpha counted twice
+    rows = SearchTrendHourly.for_day(Date.current).pluck(:tag, :count).to_h
+    assert_equal({ "alpha" => 2, "beta" => 1 }, rows)
   end
 
   test "rising returns tags with substantial same-window increase, ordered by today count" do
@@ -40,25 +41,29 @@ class SearchTrendTest < ActiveSupport::TestCase
     today   = at.to_date
     yesterday = today - 1
 
-    # Records at hour 10 — inside both today's and yesterday's 4..15 window
-    SearchTrend.create!(tag: "low",   day: today,     hour: 10, count: 5) # below min_today
+    # Current window: 3 AM today → 3 PM today (12 hours)
+    # Previous window: 3 PM yesterday → 3 AM today (12 hours)
+    # Create records at times that fall within both windows
+
+    # Records at hour 10 today (current window) and hour 22 yesterday (previous window)
+    SearchTrendHourly.create!(tag: "low", hour: today.beginning_of_day + 10.hours, count: 5) # below min_today
 
     # Delta-based inclusion (30 - 10 = 20 >= min_delta 10)
-    SearchTrend.create!(tag: "foo",   day: yesterday, hour: 10, count: 10)
-    SearchTrend.create!(tag: "foo",   day: today,     hour: 10, count: 30)
+    SearchTrendHourly.create!(tag: "foo", hour: yesterday.beginning_of_day + 22.hours, count: 10)
+    SearchTrendHourly.create!(tag: "foo", hour: today.beginning_of_day + 10.hours, count: 30)
 
-    # Ratio-based inclusion (12/5 = 2.4 >= min_ratio 2.0, delta 7 < 10)
-    SearchTrend.create!(tag: "ratio", day: yesterday, hour: 10, count: 5)
-    SearchTrend.create!(tag: "ratio", day: today,     hour: 10, count: 12)
+    # Ratio-based inclusion (15/2 = 7.5 >= min_ratio 2.0, delta 13 >= 10)
+    SearchTrendHourly.create!(tag: "ratio", hour: yesterday.beginning_of_day + 22.hours, count: 2)
+    SearchTrendHourly.create!(tag: "ratio", hour: today.beginning_of_day + 10.hours, count: 15)
 
     # Delta-based inclusion (no yesterday record, 15 >= 10)
-    SearchTrend.create!(tag: "baz",   day: today,     hour: 10, count: 15)
+    SearchTrendHourly.create!(tag: "baz", hour: today.beginning_of_day + 10.hours, count: 15)
 
     # Not included (delta 5 < 10, ratio 1.25 < 2.0)
-    SearchTrend.create!(tag: "bar",   day: yesterday, hour: 10, count: 20)
-    SearchTrend.create!(tag: "bar",   day: today,     hour: 10, count: 25)
+    SearchTrendHourly.create!(tag: "bar", hour: yesterday.beginning_of_day + 22.hours, count: 20)
+    SearchTrendHourly.create!(tag: "bar", hour: today.beginning_of_day + 10.hours, count: 25)
 
-    rising = SearchTrend.rising(at: at, limit: 10)
+    rising = SearchTrendHourly.rising(at: at, limit: 10)
     assert_equal %w[foo baz ratio], rising.pluck(:tag)
   end
 
@@ -70,95 +75,113 @@ class SearchTrendTest < ActiveSupport::TestCase
     day_before = yesterday - 1
 
     # Today hours 0..3 (inside window)
-    SearchTrend.create!(tag: "cross", day: today,     hour: 2,  count: 20)
+    SearchTrendHourly.create!(tag: "cross", hour: today.beginning_of_day + 2.hours, count: 20)
     # Yesterday hours 16..23 (inside window)
-    SearchTrend.create!(tag: "cross", day: yesterday, hour: 20, count: 5)
+    SearchTrendHourly.create!(tag: "cross", hour: yesterday.beginning_of_day + 20.hours, count: 5)
     # "Yesterday's window" for the comparison = yesterday(0..3) + day_before(16..23)
-    SearchTrend.create!(tag: "cross", day: yesterday, hour: 2,  count: 2)
-    SearchTrend.create!(tag: "cross", day: day_before, hour: 20, count: 1)
+    SearchTrendHourly.create!(tag: "cross", hour: yesterday.beginning_of_day + 2.hours, count: 2)
+    SearchTrendHourly.create!(tag: "cross", hour: day_before.beginning_of_day + 20.hours, count: 1)
 
     # tag "cross" today_sum = 20+5 = 25, prev_sum = 2+1 = 3; delta 22 >= 10, ratio 8.3 >= 2.0
-    rising = SearchTrend.rising(at: at, limit: 10)
+    rising = SearchTrendHourly.rising(at: at, limit: 10)
     assert_includes rising.pluck(:tag), "cross"
   end
 
-  test "coalesce_hourly! merges old hourly records into daily aggregates" do
-    today      = Date.current
-    old_day    = today - 3
-    recent_day = today - 1
-
-    # Old hourly records (> 48 h ago) — should be coalesced
-    SearchTrend.create!(tag: "owl", day: old_day, hour: 5,  count: 10)
-    SearchTrend.create!(tag: "owl", day: old_day, hour: 10, count: 15)
-
-    # Recent hourly record (< 48 h ago) — should be left alone
-    SearchTrend.create!(tag: "owl", day: recent_day, hour: 22, count: 3)
-
-    SearchTrend.coalesce_hourly!
-
-    # Old day: daily record created, hourly records deleted
-    daily = SearchTrend.find_by!(tag: "owl", day: old_day, hour: nil)
-    assert_equal 25, daily.count
-    assert_equal 0, SearchTrend.where(tag: "owl", day: old_day).where.not(hour: nil).count
-
-    # Recent record: untouched
-    assert SearchTrend.where(tag: "owl", day: recent_day, hour: 22).exists?
-  end
-
-  test "coalesce_hourly! adds to existing daily record when one already exists" do
+  test "prune! only removes old low-count daily records" do
     old_day = Date.current - 3
 
-    SearchTrend.create!(tag: "cat", day: old_day, hour: nil, count: 50)
-    SearchTrend.create!(tag: "cat", day: old_day, hour: 4,   count: 30)
-
-    SearchTrend.coalesce_hourly!
-
-    daily = SearchTrend.find_by!(tag: "cat", day: old_day, hour: nil)
-    assert_equal 80, daily.count
-    assert_equal 0, SearchTrend.where(tag: "cat", day: old_day).where.not(hour: nil).count
-  end
-
-  test "prune! only removes old low-count daily records, not hourly records" do
-    old_day = Date.current - 3
-
-    low_daily  = SearchTrend.create!(tag: "prune_me",  day: old_day, hour: nil, count: 1)
-    keep_daily = SearchTrend.create!(tag: "keep_me",   day: old_day, hour: nil, count: 999)
-    hourly     = SearchTrend.create!(tag: "prune_me",  day: old_day, hour: 5,   count: 1)
+    low_daily  = SearchTrend.create!(tag: "prune_me", day: old_day, count: 1)
+    keep_daily = SearchTrend.create!(tag: "keep_me",  day: old_day, count: 999)
 
     SearchTrend.prune!(min_count: 10)
 
     assert_not SearchTrend.exists?(low_daily.id),  "low-count daily should be pruned"
     assert     SearchTrend.exists?(keep_daily.id), "high-count daily should be kept"
-    assert     SearchTrend.exists?(hourly.id),     "hourly record should never be pruned"
+  end
+
+  test "for_day_ranked includes daily_rank column ordered by count DESC, tag ASC" do
+    day = Date.current
+
+    # Create trends with different counts to test ranking
+    SearchTrend.create!(tag: "zebra", day: day, count: 100)
+    SearchTrend.create!(tag: "alpha", day: day, count: 200)
+    SearchTrend.create!(tag: "beta", day: day, count: 200) # same count as alpha, should rank by tag name
+    SearchTrend.create!(tag: "gamma", day: day, count: 50)
+
+    ranked_results = SearchTrend.for_day_ranked(day)
+
+    assert_equal 4, ranked_results.count
+
+    # Verify ranking: count DESC, tag ASC
+    expected_order = [
+      ["alpha", 200, 1],  # count 200, alphabetically first
+      ["beta", 200, 2],   # count 200, alphabetically second
+      ["zebra", 100, 3],  # count 100
+      ["gamma", 50, 4],   # count 50
+    ]
+
+    ranked_results.each_with_index do |trend, i|
+      expected_tag, expected_count, expected_rank = expected_order[i]
+      assert_equal expected_tag, trend.tag
+      assert_equal expected_count, trend.count
+      assert_equal expected_rank, trend.daily_rank
+    end
+  end
+
+  test "for_day_ranked preserves ranks when combined with search" do
+    day = Time.now.utc.to_date - 3
+
+    # Create test data
+    SearchTrend.create!(tag: "wolf", day: day, count: 100)     # rank 1
+    SearchTrend.create!(tag: "fox", day: day, count: 80)       # rank 2
+    SearchTrend.create!(tag: "cat", day: day, count: 60)       # rank 3
+    SearchTrend.create!(tag: "dog", day: day, count: 40)       # rank 4
+
+    # Search for tags containing 'o' (wolf, fox, dog) - should preserve original ranks
+    filtered_results = SearchTrend.for_day_ranked(day).where_ilike(:tag, "*o*")
+
+    assert_equal 3, filtered_results.count
+
+    # Verify original ranks are preserved even though results are filtered
+    filtered_results.each do |trend|
+      case trend.tag
+      when "wolf"
+        assert_equal 1, trend.daily_rank
+      when "fox"
+        assert_equal 2, trend.daily_rank
+      when "dog"
+        assert_equal 4, trend.daily_rank
+      end
+    end
   end
 
   # --- record_query! ---
 
   test "record_query! records plain tags" do
-    SearchTrend.record_query!("cat dog")
-    tags = SearchTrend.for_day(Date.current).pluck(:tag)
+    SearchTrendHourly.record_query!("cat dog")
+    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
     assert_includes tags, "cat"
     assert_includes tags, "dog"
   end
 
   test "record_query! strips the ~ prefix and records the tag" do
-    SearchTrend.record_query!("~wolf")
-    assert SearchTrend.for_day(Date.current).where(tag: "wolf").exists?
+    SearchTrendHourly.record_query!("~wolf")
+    assert SearchTrendHourly.for_day(Date.current).where(tag: "wolf").exists?
   end
 
   test "record_query! excludes tags with the - prefix" do
-    SearchTrend.record_query!("-fox")
-    assert_not SearchTrend.for_day(Date.current).where(tag: "fox").exists?
+    SearchTrendHourly.record_query!("-fox")
+    assert_not SearchTrendHourly.for_day(Date.current).where(tag: "fox").exists?
   end
 
   test "record_query! excludes tags with a ~- compound prefix" do
-    SearchTrend.record_query!("~-cat")
-    assert_not SearchTrend.for_day(Date.current).where(tag: "cat").exists?
+    SearchTrendHourly.record_query!("~-cat")
+    assert_not SearchTrendHourly.for_day(Date.current).where(tag: "cat").exists?
   end
 
   test "record_query! handles a mixed query correctly" do
-    SearchTrend.record_query!("cat ~dog -fox ~-bird")
-    tags = SearchTrend.for_day(Date.current).pluck(:tag)
+    SearchTrendHourly.record_query!("cat ~dog -fox ~-bird")
+    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
     assert_includes     tags, "cat"
     assert_includes     tags, "dog"   # ~ stripped
     assert_not_includes tags, "fox"   # - excluded
@@ -166,37 +189,37 @@ class SearchTrendTest < ActiveSupport::TestCase
   end
 
   test "record_query! excludes all tags inside a negated group" do
-    SearchTrend.record_query!("-( cat dog )")
-    tags = SearchTrend.for_day(Date.current).pluck(:tag)
+    SearchTrendHourly.record_query!("-( cat dog )")
+    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
     assert_not_includes tags, "cat"
     assert_not_includes tags, "dog"
   end
 
   test "record_query! records tags from a ~ group without prefix" do
-    SearchTrend.record_query!("~( cat dog )")
-    tags = SearchTrend.for_day(Date.current).pluck(:tag)
+    SearchTrendHourly.record_query!("~( cat dog )")
+    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
     assert_includes tags, "cat"
     assert_includes tags, "dog"
   end
 
   test "record_query! excludes tags inside a doubly-negated group" do
-    SearchTrend.record_query!("-( ~( cat ) )")
-    assert_not SearchTrend.for_day(Date.current).where(tag: "cat").exists?
+    SearchTrendHourly.record_query!("-( ~( cat ) )")
+    assert_not SearchTrendHourly.for_day(Date.current).where(tag: "cat").exists?
   end
 
   test "record_query! skips metatags" do
-    SearchTrend.record_query!("cat rating:s score:>10")
-    tags = SearchTrend.for_day(Date.current).pluck(:tag)
+    SearchTrendHourly.record_query!("cat rating:s score:>10")
+    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
     assert_includes     tags, "cat"
     assert_not_includes tags, "rating:s"
     assert_not_includes tags, "score:>10"
   end
 
   test "record_query! does nothing for a blank query" do
-    assert_no_difference -> { SearchTrend.count } do
-      SearchTrend.record_query!(nil)
-      SearchTrend.record_query!("")
-      SearchTrend.record_query!("   ")
+    assert_no_difference -> { SearchTrendHourly.count } do
+      SearchTrendHourly.record_query!(nil)
+      SearchTrendHourly.record_query!("")
+      SearchTrendHourly.record_query!("   ")
     end
   end
 
@@ -204,6 +227,6 @@ class SearchTrendTest < ActiveSupport::TestCase
     # Pass an object whose #blank? returns false but causes scan_recursive to blow up.
     bad_query = Object.new
     def bad_query.blank? = false
-    assert_nothing_raised { SearchTrend.record_query!(bad_query) }
+    assert_nothing_raised { SearchTrendHourly.record_query!(bad_query) }
   end
 end

--- a/test/models/search_trend_test.rb
+++ b/test/models/search_trend_test.rb
@@ -64,7 +64,7 @@ class SearchTrendTest < ActiveSupport::TestCase
     SearchTrendHourly.create!(tag: "bar", hour: today.beginning_of_day + 10.hours, count: 25)
 
     rising = SearchTrendHourly.rising(at: at, limit: 10)
-    assert_equal %w[foo baz ratio], rising.pluck(:tag)
+    assert_equal %w[foo baz ratio], rising.map(&:tag)
   end
 
   test "rising spans midnight correctly when window crosses into the previous day" do
@@ -84,7 +84,7 @@ class SearchTrendTest < ActiveSupport::TestCase
 
     # tag "cross" today_sum = 20+5 = 25, prev_sum = 2+1 = 3; delta 22 >= 10, ratio 8.3 >= 2.0
     rising = SearchTrendHourly.rising(at: at, limit: 10)
-    assert_includes rising.pluck(:tag), "cross"
+    assert_includes rising.map(&:tag), "cross"
   end
 
   test "prune! only removes old low-count daily records" do


### PR DESCRIPTION
Previous implementation was just unfortunate.
Replaced a hybrid daily/hourly system with separate tables for each.
Added better calculation of rising tags, search, and persistent ranking.