### PR TITLE
[Posts] Add edit reason on deletion merge items

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -541,6 +541,7 @@ class Post < ApplicationRecord
     def copy_sources_to_parent
       return unless parent_id.present?
       parent.source += "\n#{self.source}"
+      set_merge_edit_reason
     end
   end
 
@@ -1082,6 +1083,7 @@ class Post < ApplicationRecord
     def copy_tags_to_parent
       return unless parent_id.present?
       parent.tag_string += " #{tag_string}"
+      set_merge_edit_reason
     end
 
     ## DB!
@@ -1451,6 +1453,11 @@ class Post < ApplicationRecord
       if has_children?
         @children_ids ||= children.map {|p| p.id}.join(' ')
       end
+    end
+
+    def set_merge_edit_reason
+      return unless parent_id.present?
+      parent.edit_reason = "Merged from post ##{self.id}"
     end
   end
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -156,11 +156,13 @@ class PostTest < ActiveSupport::TestCase
       @post.copy_tags_to_parent
       @post.parent.save
       assert_equal(@parent.reload.tag_string, "a b c d e f")
+      assert_equal(@parent.versions.last.reason, "Merged from post ##{@post.id}")
     end
     should "Copy sources to parent" do
       @post.copy_sources_to_parent
       @post.parent.save
       assert_equal(@parent.reload.source, "a\nb\nc\nd")
+      assert_equal(@parent.versions.last.reason, "Merged from post ##{@post.id}")
     end
   end
 


### PR DESCRIPTION
When using the "Merge tags into parent" or "Merge sources into parent" options on the deletion page, give the resulting PostVersion an edit reason.