### PR TITLE
[SearchTrends] Fix flaky controller tests

### DIFF
--- a/test/controllers/search_trends_controller_test.rb
+++ b/test/controllers/search_trends_controller_test.rb
@@ -30,13 +30,13 @@ class SearchTrendsControllerTest < ActionDispatch::IntegrationTest
     end
 
     should "index displays correct ranks without search filters" do
-      day = Date.current
+      day = Time.now.utc.to_date
       # Create SearchTrend records for consistent ranking tests
       SearchTrend.create!(tag: "alpha", day: day, count: 300)
       SearchTrend.create!(tag: "beta", day: day, count: 200)
       SearchTrend.create!(tag: "gamma", day: day, count: 100)
 
-      get "/search_trends"
+      get "/search_trends", params: { day: day.to_s }
       assert_response :success
 
       # Should use offset-based ranking (current behavior)
@@ -45,7 +45,7 @@ class SearchTrendsControllerTest < ActionDispatch::IntegrationTest
     end
 
     should "index preserves original ranks with search filters" do
-      day = Date.current
+      day = Time.now.utc.to_date
       # Create test data with clear ranking
       SearchTrend.create!(tag: "wolf", day: day, count: 300)    # rank 1
       SearchTrend.create!(tag: "fox", day: day, count: 200)     # rank 2
@@ -53,7 +53,7 @@ class SearchTrendsControllerTest < ActionDispatch::IntegrationTest
       SearchTrend.create!(tag: "dog", day: day, count: 50)      # rank 4
 
       # Search for tags containing 'o' (wolf, fox, dog)
-      get "/search_trends", params: { search: { name_matches: "*o*" } }
+      get "/search_trends", params: { day: day.to_s, search: { name_matches: "*o*" } }
       assert_response :success
 
       # Parse the response to check that original daily ranks are preserved

--- a/test/models/search_trend_blacklist_test.rb
+++ b/test/models/search_trend_blacklist_test.rb
@@ -136,7 +136,7 @@ class SearchTrendBlacklistTest < ActiveSupport::TestCase
         SearchTrendBlacklist.create!(tag: "wolf", reason: "")
       end
       assert_difference -> { SearchTrendHourly.count }, +1 do
-        SearchTrendHourly.bulk_increment!([{ tag: "fox", hour: 1.hour.ago }])
+        SearchTrendHourly.bulk_increment!([{ tag: "fox", hour: 1.hour.ago.utc }])
       end
     end
 
@@ -146,11 +146,11 @@ class SearchTrendBlacklistTest < ActiveSupport::TestCase
         SearchTrendBlacklist.create!(tag: "*_species", reason: "")
       end
       SearchTrendHourly.bulk_increment!([
-        { tag: "wolf", hour: 1.hour.ago },
-        { tag: "fox", hour: 1.hour.ago },
-        { tag: "canine_species", hour: 1.hour.ago },
+        { tag: "wolf", hour: 1.hour.ago.utc },
+        { tag: "fox", hour: 1.hour.ago.utc },
+        { tag: "canine_species", hour: 1.hour.ago.utc },
       ])
-      tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
+      tags = SearchTrendHourly.for_day(Time.now.utc.to_date).pluck(:tag)
       assert_includes tags, "fox"
       assert_not_includes tags, "wolf"
       assert_not_includes tags, "canine_species"
@@ -161,7 +161,7 @@ class SearchTrendBlacklistTest < ActiveSupport::TestCase
         SearchTrendBlacklist.create!(tag: "wolf", reason: "")
       end
       assert_no_difference -> { SearchTrendHourly.count } do
-        SearchTrendHourly.bulk_increment!([{ tag: "wolf", hour: 1.hour.ago }])
+        SearchTrendHourly.bulk_increment!([{ tag: "wolf", hour: 1.hour.ago.utc }])
       end
     end
   end

--- a/test/models/search_trend_hourly_test.rb
+++ b/test/models/search_trend_hourly_test.rb
@@ -6,7 +6,7 @@ class SearchTrendHourlyTest < ActiveSupport::TestCase
   context "search trend hourly" do
     setup do
       Setting.trends_enabled = true
-      @trend = SearchTrendHourly.create!(tag: "test", hour: 1.hour.ago.beginning_of_hour, count: 5)
+      @trend = SearchTrendHourly.create!(tag: "test", hour: 1.hour.ago.utc.beginning_of_hour, count: 5)
     end
 
     teardown do
@@ -27,13 +27,13 @@ class SearchTrendHourlyTest < ActiveSupport::TestCase
     end
 
     should "default processed to false" do
-      new_trend = SearchTrendHourly.create!(tag: "new", hour: 2.hours.ago.beginning_of_hour, count: 3)
+      new_trend = SearchTrendHourly.create!(tag: "new", hour: 2.hours.ago.utc.beginning_of_hour, count: 3)
       assert_equal false, new_trend.processed
     end
 
     context "#bulk_increment!" do
       should "create new record if it doesn't exist" do
-        hour = 3.hours.ago.beginning_of_hour
+        hour = 3.hours.ago.utc.beginning_of_hour
 
         assert_difference("SearchTrendHourly.count", 1) do
           SearchTrendHourly.bulk_increment!([{ tag: "newtag", hour: hour }])
@@ -45,7 +45,7 @@ class SearchTrendHourlyTest < ActiveSupport::TestCase
       end
 
       should "increment existing record" do
-        hour = 4.hours.ago.beginning_of_hour # Ensure we use beginning of hour
+        hour = 4.hours.ago.utc.beginning_of_hour # Ensure we use beginning of hour
         existing = SearchTrendHourly.create!(tag: "existing", hour: hour, count: 5)
 
         assert_no_difference("SearchTrendHourly.count") do
@@ -57,8 +57,8 @@ class SearchTrendHourlyTest < ActiveSupport::TestCase
       end
 
       should "handle multiple tag-hour pairs efficiently" do
-        hour1 = 1.hour.ago.beginning_of_hour
-        hour2 = 2.hours.ago.beginning_of_hour
+        hour1 = 1.hour.ago.utc.beginning_of_hour
+        hour2 = 2.hours.ago.utc.beginning_of_hour
 
         data = [
           { tag: "bulk1", hour: hour1 },
@@ -78,8 +78,8 @@ class SearchTrendHourlyTest < ActiveSupport::TestCase
 
     context "scopes" do
       setup do
-        @processed = SearchTrendHourly.create!(tag: "processed", hour: 5.hours.ago.beginning_of_hour, count: 3, processed: true)
-        @unprocessed = SearchTrendHourly.create!(tag: "unprocessed", hour: 6.hours.ago.beginning_of_hour, count: 2, processed: false)
+        @processed = SearchTrendHourly.create!(tag: "processed", hour: 5.hours.ago.utc.beginning_of_hour, count: 3, processed: true)
+        @unprocessed = SearchTrendHourly.create!(tag: "unprocessed", hour: 6.hours.ago.utc.beginning_of_hour, count: 2, processed: false)
       end
 
       context ".unprocessed" do
@@ -101,8 +101,8 @@ class SearchTrendHourlyTest < ActiveSupport::TestCase
 
     context "#prune!" do
       should "remove old processed records but keep recent and unprocessed ones" do
-        old_hour = 3.days.ago      # More than 48 hours ago
-        recent_hour = 1.hour.ago   # Less than 48 hours ago
+        old_hour = 3.days.ago.utc      # More than 48 hours ago
+        recent_hour = 1.hour.ago.utc   # Less than 48 hours ago
 
         # Old processed records (should be deleted)
         old_processed1 = SearchTrendHourly.create!(tag: "owl", hour: old_hour, count: 10, processed: true)
@@ -126,8 +126,8 @@ class SearchTrendHourlyTest < ActiveSupport::TestCase
       end
 
       should "only remove old processed hourly records" do
-        old_hour = 3.days.ago
-        recent_hour = 1.hour.ago
+        old_hour = 3.days.ago.utc
+        recent_hour = 1.hour.ago.utc
 
         # Create some processed and unprocessed hourly records
         old_processed = SearchTrendHourly.create!(tag: "old", hour: old_hour, count: 10, processed: true)

--- a/test/models/search_trend_test.rb
+++ b/test/models/search_trend_test.rb
@@ -12,7 +12,7 @@ class SearchTrendTest < ActiveSupport::TestCase
   end
 
   test "bulk_increment! creates an hourly record and increments it" do
-    hour = 1.hour.ago.beginning_of_hour
+    hour = 1.hour.ago.utc.beginning_of_hour
     assert_difference -> { SearchTrendHourly.count }, +1 do
       SearchTrendHourly.bulk_increment!([{ tag: "Test_Tag", hour: hour }])
     end
@@ -28,9 +28,9 @@ class SearchTrendTest < ActiveSupport::TestCase
   end
 
   test "bulk_increment! handles multiple tags and de-dupes" do
-    hour = 1.hour.ago.beginning_of_hour
+    hour = 1.hour.ago.utc.beginning_of_hour
     SearchTrendHourly.bulk_increment!([{ tag: "alpha", hour: hour }, { tag: "beta", hour: hour }, { tag: "alpha", hour: hour }]) # alpha counted twice
-    rows = SearchTrendHourly.for_day(Date.current).pluck(:tag, :count).to_h
+    rows = SearchTrendHourly.for_day(Time.now.utc.to_date).pluck(:tag, :count).to_h
     assert_equal({ "alpha" => 2, "beta" => 1 }, rows)
   end
 
@@ -88,7 +88,7 @@ class SearchTrendTest < ActiveSupport::TestCase
   end
 
   test "prune! only removes old low-count daily records" do
-    old_day = Date.current - 3
+    old_day = Time.now.utc.to_date - 3
 
     low_daily  = SearchTrend.create!(tag: "prune_me", day: old_day, count: 1)
     keep_daily = SearchTrend.create!(tag: "keep_me",  day: old_day, count: 999)
@@ -100,7 +100,7 @@ class SearchTrendTest < ActiveSupport::TestCase
   end
 
   test "for_day_ranked includes daily_rank column ordered by count DESC, tag ASC" do
-    day = Date.current
+    day = Time.now.utc.to_date
 
     # Create trends with different counts to test ranking
     SearchTrend.create!(tag: "zebra", day: day, count: 100)
@@ -159,29 +159,29 @@ class SearchTrendTest < ActiveSupport::TestCase
 
   test "record_query! records plain tags" do
     SearchTrendHourly.record_query!("cat dog")
-    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
+    tags = SearchTrendHourly.for_day(Time.now.utc.to_date).pluck(:tag)
     assert_includes tags, "cat"
     assert_includes tags, "dog"
   end
 
   test "record_query! strips the ~ prefix and records the tag" do
     SearchTrendHourly.record_query!("~wolf")
-    assert SearchTrendHourly.for_day(Date.current).where(tag: "wolf").exists?
+    assert SearchTrendHourly.for_day(Time.now.utc.to_date).where(tag: "wolf").exists?
   end
 
   test "record_query! excludes tags with the - prefix" do
     SearchTrendHourly.record_query!("-fox")
-    assert_not SearchTrendHourly.for_day(Date.current).where(tag: "fox").exists?
+    assert_not SearchTrendHourly.for_day(Time.now.utc.to_date).where(tag: "fox").exists?
   end
 
   test "record_query! excludes tags with a ~- compound prefix" do
     SearchTrendHourly.record_query!("~-cat")
-    assert_not SearchTrendHourly.for_day(Date.current).where(tag: "cat").exists?
+    assert_not SearchTrendHourly.for_day(Time.now.utc.to_date).where(tag: "cat").exists?
   end
 
   test "record_query! handles a mixed query correctly" do
     SearchTrendHourly.record_query!("cat ~dog -fox ~-bird")
-    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
+    tags = SearchTrendHourly.for_day(Time.now.utc.to_date).pluck(:tag)
     assert_includes     tags, "cat"
     assert_includes     tags, "dog"   # ~ stripped
     assert_not_includes tags, "fox"   # - excluded
@@ -190,26 +190,26 @@ class SearchTrendTest < ActiveSupport::TestCase
 
   test "record_query! excludes all tags inside a negated group" do
     SearchTrendHourly.record_query!("-( cat dog )")
-    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
+    tags = SearchTrendHourly.for_day(Time.now.utc.to_date).pluck(:tag)
     assert_not_includes tags, "cat"
     assert_not_includes tags, "dog"
   end
 
   test "record_query! records tags from a ~ group without prefix" do
     SearchTrendHourly.record_query!("~( cat dog )")
-    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
+    tags = SearchTrendHourly.for_day(Time.now.utc.to_date).pluck(:tag)
     assert_includes tags, "cat"
     assert_includes tags, "dog"
   end
 
   test "record_query! excludes tags inside a doubly-negated group" do
     SearchTrendHourly.record_query!("-( ~( cat ) )")
-    assert_not SearchTrendHourly.for_day(Date.current).where(tag: "cat").exists?
+    assert_not SearchTrendHourly.for_day(Time.now.utc.to_date).where(tag: "cat").exists?
   end
 
   test "record_query! skips metatags" do
     SearchTrendHourly.record_query!("cat rating:s score:>10")
-    tags = SearchTrendHourly.for_day(Date.current).pluck(:tag)
+    tags = SearchTrendHourly.for_day(Time.now.utc.to_date).pluck(:tag)
     assert_includes     tags, "cat"
     assert_not_includes tags, "rating:s"
     assert_not_includes tags, "score:>10"

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1544,16 +1544,16 @@ class PostTest < ActiveSupport::TestCase
 
     should "return posts for the age:<1minute tag when the user is in Pacific time zone" do
       post = create(:post)
-      Time.zone = "Pacific Time (US & Canada)"
-      assert_tag_match([post], "age:<1minute")
-      Time.zone = "Eastern Time (US & Canada)"
+      Time.use_zone("Pacific Time (US & Canada)") do
+        assert_tag_match([post], "age:<1minute")
+      end
     end
 
     should "return posts for the age:<1minute tag when the user is in Tokyo time zone" do
       post = create(:post)
-      Time.zone = "Asia/Tokyo"
-      assert_tag_match([post], "age:<1minute")
-      Time.zone = "Eastern Time (US & Canada)"
+      Time.use_zone("Asia/Tokyo") do
+        assert_tag_match([post], "age:<1minute")
+      end
     end
 
     should "return posts for the ' tag" do


### PR DESCRIPTION
## Problem

`SearchTrendsControllerTest` was intermittently failing in CI with "No trending data for this day yet." — indicating the test-inserted `SearchTrend` records were not found by the controller.

The failure was time-dependent: it only occurred between **00:00–05:00 UTC**, and only when certain post tests happened to run earlier in the same suite (test order is randomised by seed).

### Root cause: `Time.zone` leak in `post_test.rb`

Two tests in `test/unit/post_test.rb` were setting `Time.zone` globally to test timezone-sensitive behaviour, then restoring it to `"Eastern Time (US & Canada)"` instead of the original `"UTC"`:

```ruby
# Before fix
Time.zone = "Pacific Time (US & Canada)"
assert_tag_match([post], "age:<1minute")
Time.zone = "Eastern Time (US & Canada)"  # ← wrong, should restore to UTC
```

This left `Time.zone` stuck on Eastern Time for all subsequent tests in the run.

`Date.current` is timezone-aware — it returns `Time.zone.today`. With the zone leaked to Eastern Time, `Date.current` returned the Eastern date, which is one day behind UTC between midnight and 05:00 UTC. Meanwhile, the controller always uses `Time.now.utc.to_date`, so it queried a different date than the one the records were created for, finding nothing.

## Fix

### 1. Stop the `Time.zone` leak (`test/unit/post_test.rb`)

Replaced the manual set/reset pattern with `Time.use_zone`, which automatically restores the previous zone when the block exits:

```ruby
# After fix
Time.use_zone("Pacific Time (US & Canada)") do
  assert_tag_match([post], "age:<1minute")
end
```

### 2. Harden the search trends tests against future leaks (`test/controllers/search_trends_controller_test.rb`)

- Replaced `Date.current` with `Time.now.utc.to_date` to match the controller's own date logic exactly.
- Added an explicit `day:` parameter to the GET requests so the controller queries the same date the records were inserted for, regardless of when the test runs.
