### PR TITLE
[User] Add blips to profile stats card

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -825,6 +825,10 @@ class User < ApplicationRecord
       user_status&.comment_count || 0
     end
 
+    def blip_count
+      user_status&.blip_count || 0
+    end
+
     def flag_count
       user_status&.post_flag_count || 0
     end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -118,6 +118,10 @@ class UserPresenter
     template.link_to(user.comment_count, template.comments_path(search: { creator_id: user.id }, group_by: "comment"))
   end
 
+  def blip_count(template)
+    template.link_to(user.blip_count, template.blips_path(search: { creator_id: user.id }))
+  end
+
   def commented_posts_count(template)
     count = Post.fast_count("commenter:#{user.name}", enable_safe_mode: false)
     template.link_to(count, template.posts_path(tags: "commenter:#{user.name} order:comment_bumped"))

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -20,6 +20,16 @@
     </span>
   </div>
 
+  <div class="profile-line">
+    <h4><%= svg_icon(:megaphone) %> Blips</h4>
+    <span class="profile-line-number">
+      <%= presenter.blip_count(self) %>
+    </span>
+    <span class="profile-line-extra">
+      <%= link_to "[mentions]", blips_path(search: { body_matches: user.name }) %>
+    </span>
+  </div>
+
   <% if user.can_approve_posts? || Post.where(approver: user).exists? %>
     <div class="profile-line">
       <h4><%= svg_icon(:stamp) %> Approvals</h4>


### PR DESCRIPTION
Add a simple stat for blip count and mentions to the user profile. 

<img width="233" height="67" alt="image" src="https://github.com/user-attachments/assets/08941275-7c50-4539-8b3a-8eaba9660db0" />
