### PR TITLE
[Users] Gracefully handle empty names

### DIFF
--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -5,7 +5,10 @@ class UserNameValidator < ActiveModel::EachValidator
     name = value
 
     # Should be handled by presence validator instead
-    return if name.blank?
+    if name.blank?
+      rec.errors.add(attr, "can't be blank")
+      return
+    end
 
     # For User model, check against rec.id
     # For other models (like UserNameChangeRequest), check against the user_id option

--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -7,6 +7,9 @@ class UserNameValidator < ActiveModel::EachValidator
     # Blank names should never be saved. This check ensures that on user creation and name change requests,
     # an error is shown immediately instead of only requiring a name change on the next screen.
     # Check if the presence validator already added an error for blank name to avoid duplicate error messages.
+    #
+    # Note that this only works if the presence validator is defined before this custom validator.
+    # If the order ever changes, this will break.
     return if rec.errors.added?(attr, :blank)
     if name.blank? # If the presence validator is not used, we still want to add an error for blank name.
       rec.errors.add(attr, "can't be blank")

--- a/app/logical/user_name_validator.rb
+++ b/app/logical/user_name_validator.rb
@@ -4,8 +4,11 @@ class UserNameValidator < ActiveModel::EachValidator
   def validate_each(rec, attr, value)
     name = value
 
-    # Should be handled by presence validator instead
-    if name.blank?
+    # Blank names should never be saved. This check ensures that on user creation and name change requests,
+    # an error is shown immediately instead of only requiring a name change on the next screen.
+    # Check if the presence validator already added an error for blank name to avoid duplicate error messages.
+    return if rec.errors.added?(attr, :blank)
+    if name.blank? # If the presence validator is not used, we still want to add an error for blank name.
       rec.errors.add(attr, "can't be blank")
       return
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1065,10 +1065,10 @@ class User < ApplicationRecord
   # Copied from UserNameValidator. Check back later how effective this was.
   # Users with invalid names may be automatically renamed in the future.
   def name_error
-    if name.length > 20
+    if name.length > 20 || name.length < 2
       "must be 2 to 20 characters long"
     elsif name !~ /\A[a-zA-Z0-9\-_~']+\z/
-      "must contain only alphanumeric characters, hypens, apostrophes, tildes and underscores"
+      "must contain only alphanumeric characters, hyphens, apostrophes, tildes and underscores"
     elsif name =~ /\A[_\-~']/
       "must not begin with a special character"
     elsif name =~ /_{2}|-{2}|~{2}|'{2}/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,7 @@ class User < ApplicationRecord
   validate :validate_email_address_allowed, on: %i[create update], if: ->(rec) { (rec.new_record? && rec.email.present?) || (rec.email.present? && rec.email_changed?) }
 
   normalizes :profile_about, :profile_artinfo, with: ->(value) { value.gsub("\r\n", "\n") }
+  validates :name, presence: true
   validates :name, user_name: true, on: :create
   validates :default_image_size, inclusion: { in: %w[large fit fitv original] }
   validates :per_page, inclusion: { in: 1..320 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,7 +91,7 @@ class User < ApplicationRecord
   validate :validate_email_address_allowed, on: %i[create update], if: ->(rec) { (rec.new_record? && rec.email.present?) || (rec.email.present? && rec.email_changed?) }
 
   normalizes :profile_about, :profile_artinfo, with: ->(value) { value.gsub("\r\n", "\n") }
-  validates :name, presence: true
+  validates :name, presence: true # NOTE: validation order is important here. See UserNameValidator for details.
   validates :name, user_name: true, on: :create
   validates :default_image_size, inclusion: { in: %w[large fit fitv original] }
   validates :per_page, inclusion: { in: 1..320 }

--- a/app/views/layouts/navigation/_avatar_menu.html.erb
+++ b/app/views/layouts/navigation/_avatar_menu.html.erb
@@ -10,7 +10,7 @@
   data-has-mail="<%= has_mail %>"
 >
   <span class="avatar-name"><%= user.pretty_name %></span>
-  <span class="avatar-image" data-name="<%= user.name&.[](0)&.capitalize || "" %>"></span>
+  <span class="avatar-image" data-name="<%= user.name&.to_s&.first&.capitalize || "" %>"></span>
   <span class="avatar-more"><%= svg_icon(:chevron_down) %></span>
 </a>
 

--- a/app/views/layouts/navigation/_avatar_menu.html.erb
+++ b/app/views/layouts/navigation/_avatar_menu.html.erb
@@ -10,7 +10,7 @@
   data-has-mail="<%= has_mail %>"
 >
   <span class="avatar-name"><%= user.pretty_name %></span>
-  <span class="avatar-image" data-name="<%= user.name[0].capitalize %>"></span>
+  <span class="avatar-image" data-name="<%= user.name&.[](0)&.capitalize || "" %>"></span>
   <span class="avatar-more"><%= svg_icon(:chevron_down) %></span>
 </a>
 

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -176,6 +176,16 @@ class UserTest < ActiveSupport::TestCase
     end
 
     context "name" do
+      should "be present on create and update" do
+        user = build(:user, name: nil)
+        assert_not(user.valid?)
+        assert_includes(user.errors[:name], "can't be blank")
+
+        user = create(:user)
+        assert_not(user.update(name: nil))
+        assert_includes(user.errors[:name], "can't be blank")
+      end
+
       should "be #{Danbooru.config.default_guest_name} given an invalid user id" do
         assert_equal(Danbooru.config.default_guest_name, User.id_to_name(-1))
       end


### PR DESCRIPTION
Return an error to the user if they enter a blank name. 
Require username presence in user model. 
If the user somehow already has a blank name, they will be directed to the user name change page. The HTML patch allows that page to render if their name is blank.
Add tests to ensure that the validator does not accept `nil` names.

fixes e621ng/e621ng#1713