### PR TITLE
[PostSearch] Clamp filesize search to [0, max_file_size]

### DIFF
--- a/app/logical/parse_value.rb
+++ b/app/logical/parse_value.rb
@@ -185,7 +185,7 @@ module ParseValue
         size.to_f.megabytes
       else
         size.to_f
-      end.to_i.clamp(0, Danbooru.config.max_file_size)
+      end.to_i.clamp(0, MAX_INT)
     end
   end
 

--- a/app/logical/parse_value.rb
+++ b/app/logical/parse_value.rb
@@ -185,7 +185,7 @@ module ParseValue
         size.to_f.megabytes
       else
         size.to_f
-      end.to_i
+      end.to_i.clamp(0, Danbooru.config.max_file_size)
     end
   end
 

--- a/test/unit/parse_value_test.rb
+++ b/test/unit/parse_value_test.rb
@@ -54,7 +54,7 @@ class ParseValueTest < ActiveSupport::TestCase
 
   should "clamp filesizes" do
     assert_equal(0, eq_value("-5mb", :filesize))
-    assert_equal(Danbooru.config.max_file_size, eq_value("999999mb", :filesize))
+    assert_equal(ParseValue::MAX_INT, eq_value("999999mb", :filesize))
   end
 
   should "invert ranges" do

--- a/test/unit/parse_value_test.rb
+++ b/test/unit/parse_value_test.rb
@@ -52,6 +52,11 @@ class ParseValueTest < ActiveSupport::TestCase
     assert_equal(1.5 * 1024 * 1024, eq_value("1.5mb", :filesize))
   end
 
+  should "clamp filesizes" do
+    assert_equal(0, eq_value("-5mb", :filesize))
+    assert_equal(Danbooru.config.max_file_size, eq_value("999999mb", :filesize))
+  end
+
   should "invert ranges" do
     assert_equal([:eq, 10], subject.invert_range(subject.range("10")))
     assert_equal([:gt, 10], subject.invert_range(subject.range("<10")))


### PR DESCRIPTION
Clamps filesize searches in the range [0, max_file_size] to prevent integer overflow in opensearch

Fixes #1737