### PR TITLE
[PostReplacements] Prevent cases where replacements touch deleted posts

### DIFF
--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -58,6 +58,16 @@ class PostReplacementsController < ApplicationController
 
   def approve
     @post_replacement = PostReplacement.find(params[:id])
+    is_reset_to = params.key?(:penalize_current_uploader) && !ActiveModel::Type::Boolean.new.cast(params[:penalize_current_uploader])
+
+    if @post_replacement.post.is_deleted?
+      # Both Approve and Reset To submit to this endpoint; reset-to passes penalize_current_uploader=false.
+      action_name = is_reset_to ? "reset to" : "approve"
+      flash[:notice] = "Error: Cannot #{action_name} replacement for deleted target post"
+      render plain: flash[:notice], status: :unprocessable_entity
+      return
+    end
+
     @post_replacement.approve!(penalize_current_uploader: params[:penalize_current_uploader])
 
     if @post_replacement.errors.any?

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -63,7 +63,7 @@ class PostReplacementsController < ApplicationController
     if @post_replacement.post.is_deleted?
       # Both Approve and Reset To submit to this endpoint; reset-to passes penalize_current_uploader=false.
       action_name = is_reset_to ? "reset to" : "approve"
-      flash[:notice] = "Error: Cannot #{action_name} replacement for deleted target post"
+      flash.now[:notice] = "Error: Cannot #{action_name} replacement for deleted target post"
       render plain: flash[:notice], status: :unprocessable_entity
       return
     end

--- a/app/views/post_replacements/partials/show/_post_replacement.html.erb
+++ b/app/views/post_replacements/partials/show/_post_replacement.html.erb
@@ -101,14 +101,14 @@
     <% if CurrentUser.can_approve_posts? %>
       <div class="pending-links">
         <% if post_replacement.status == "pending" %>
-          <%= link_to "Approve", "#approve", class: "replacement-approve-action", data: { replacement_id: post_replacement.id, penalize: post_replacement.post.uploader != post_replacement.creator } %><br />
+          <% if !post_replacement.post.is_deleted? %> <%= link_to "Approve", "#approve", class: "replacement-approve-action", data: { replacement_id: post_replacement.id, penalize: post_replacement.post.uploader != post_replacement.creator } %> <% end %><br />
           <%= link_to "Compare", moderator_post_diff_path(post_a: post_replacement.post_id, post_b: post_replacement.md5) %><br /><br />
           <%= link_to "Reject", "#reject", class: "replacement-reject-action", data: { replacement_id: post_replacement.id } %><br />
         <% end %>
       </div>
       <% if !post_replacement.is_current? && !post_replacement.is_promoted? %>
         <% if !post_replacement.is_backup? %> <%= link_to "As New Post", "#promote", class: "replacement-promote-action", data: { replacement_id: post_replacement.id } %><br> <% end %>
-        <% if !post_replacement.is_pending? %> <%= link_to "Reset To", "#reset-to", class: "replacement-approve-action", data: { replacement_id: post_replacement.id, penalize: false } %><br> <% end %>
+        <% if !post_replacement.is_pending? && !post_replacement.post.is_deleted? %> <%= link_to "Reset To", "#reset-to", class: "replacement-approve-action", data: { replacement_id: post_replacement.id, penalize: false } %><br> <% end %>
       <% end %>
     <% end %>
     <% if CurrentUser.is_admin? %>

--- a/test/functional/post_replacements_controller_test.rb
+++ b/test/functional/post_replacements_controller_test.rb
@@ -126,6 +126,24 @@ class PostReplacementsControllerTest < ActionDispatch::IntegrationTest
         assert_equal @replacement.md5, @post.md5
         assert_equal @replacement.status, "approved"
       end
+
+      should "return flash error for approve when target post is deleted" do
+        @post.update_column(:is_deleted, true)
+
+        put_auth approve_post_replacement_path(@replacement, penalize_current_uploader: true), @user
+
+        assert_response 422
+        assert_equal "Error: Cannot approve replacement for deleted target post", flash[:notice]
+      end
+
+      should "return flash error for reset to when target post is deleted" do
+        @post.update_column(:is_deleted, true)
+
+        put_auth approve_post_replacement_path(@replacement, penalize_current_uploader: false), @user
+
+        assert_response 422
+        assert_equal "Error: Cannot reset to replacement for deleted target post", flash[:notice]
+      end
     end
 
     context "promote action" do


### PR DESCRIPTION
An HTML error is shown when an approver attempts to do any of the following on a replacement for a deleted post:
 - Approve
 - Reset to

To prevent this, several changes are made:
 - The controller checks if the post is deleted and returns a 'flash' error
 - The HTML no longer shows the invalid options to approvers
 - Tests now check that an error is returned properly from the controller
