### PR TITLE
[Misc] Fix an error in `normalize_search` when the `search` param is a string

### DIFF
--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -12,7 +12,7 @@ class ForumTopicsController < ApplicationController
   skip_before_action :api_check
 
   def index
-    params[:search] ||= {}
+    params[:search] = {} unless params[:search].is_a?(Hash)
     params[:search][:order] ||= "sticky" if request.format == Mime::Type.lookup("text/html")
 
     @query = ForumTopic.visible(CurrentUser.user).search(search_params)
@@ -130,12 +130,12 @@ class ForumTopicsController < ApplicationController
 
   def normalize_search
     if params[:title_matches]
-      params[:search] ||= {}
+      params[:search] = {} unless params[:search].is_a?(Hash)
       params[:search][:title_matches] = params.delete(:title_matches)
     end
 
     if params[:title]
-      params[:search] ||= {}
+      params[:search] = {} unless params[:search].is_a?(Hash)
       params[:search][:title] = params.delete(:title)
     end
   end

--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -12,7 +12,7 @@ class ForumTopicsController < ApplicationController
   skip_before_action :api_check
 
   def index
-    params[:search] = {} unless params[:search].is_a?(Hash)
+    params[:search] = {} unless params[:search].is_a?(ActionController::Parameters)
     params[:search][:order] ||= "sticky" if request.format == Mime::Type.lookup("text/html")
 
     @query = ForumTopic.visible(CurrentUser.user).search(search_params)
@@ -129,13 +129,13 @@ class ForumTopicsController < ApplicationController
   end
 
   def normalize_search
-    if params[:title_matches]
-      params[:search] = {} unless params[:search].is_a?(Hash)
+    if params[:title_matches].is_a?(String)
+      params[:search] = {} unless params[:search].is_a?(ActionController::Parameters)
       params[:search][:title_matches] = params.delete(:title_matches)
     end
 
-    if params[:title]
-      params[:search] = {} unless params[:search].is_a?(Hash)
+    if params[:title].is_a?(String)
+      params[:search] = {} unless params[:search].is_a?(ActionController::Parameters)
       params[:search][:title] = params.delete(:title)
     end
   end

--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -5,7 +5,7 @@ class ForumTopicsController < ApplicationController
   before_action :member_only, except: %i[index show]
   before_action :moderator_only, only: [:unhide]
   before_action :admin_only, only: [:destroy]
-  before_action :normalize_search, only: :index
+  before_action :normalize_search_params, only: [:index]
   before_action :load_topic, only: %i[edit show update destroy hide unhide subscribe unsubscribe]
   before_action :check_min_level, only: %i[show edit update destroy hide unhide subscribe unsubscribe]
   before_action :ensure_lockdown_disabled, except: %i[index show]
@@ -128,14 +128,14 @@ class ForumTopicsController < ApplicationController
     params[:limit] || 40
   end
 
-  def normalize_search
+  def normalize_search_params
     if params[:title_matches].is_a?(String)
-      params[:search] = {} unless params[:search].is_a?(ActionController::Parameters)
+      params[:search] = ActionController::Parameters.new unless params[:search].is_a?(ActionController::Parameters)
       params[:search][:title_matches] = params.delete(:title_matches)
     end
 
     if params[:title].is_a?(String)
-      params[:search] = {} unless params[:search].is_a?(ActionController::Parameters)
+      params[:search] = ActionController::Parameters.new unless params[:search].is_a?(ActionController::Parameters)
       params[:search][:title] = params.delete(:title)
     end
   end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -117,7 +117,7 @@ class WikiPagesController < ApplicationController
 
   def normalize_search_params
     if params[:title].is_a?(String)
-      params[:search] = {} unless params[:search].is_a?(ActionController::Parameters)
+      params[:search] = ActionController::Parameters.new unless params[:search].is_a?(ActionController::Parameters)
       params[:search][:title] = params.delete(:title)
     end
   end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -2,38 +2,19 @@
 
 class WikiPagesController < ApplicationController
   respond_to :html, :json, :js
-  before_action :member_only, :except => [:index, :search, :show, :show_or_new]
-  before_action :admin_only, :only => [:destroy]
-  before_action :normalize_search_params, :only => [:index]
-
-  def new
-    @wiki_page = WikiPage.new(wiki_page_params(:create))
-    respond_with(@wiki_page)
-  end
-
-  def edit
-    if params[:id] =~ /\A\d+\z/
-      @wiki_page = WikiPage.find(params[:id])
-    else
-      @wiki_page = WikiPage.titled(params[:id])
-      if @wiki_page.nil? && request.format.symbol == :html
-        redirect_to show_or_new_wiki_pages_path(:title => params[:id])
-        return
-      end
-    end
-    ensure_can_edit(@wiki_page, CurrentUser.user)
-    respond_with(@wiki_page)
-  end
+  before_action :member_only, except: %i[index search show show_or_new]
+  before_action :admin_only, only: [:destroy]
+  before_action :normalize_search_params, only: [:index]
 
   def index
-    @wiki_pages = WikiPage.search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @wiki_pages = WikiPage.search(search_params).paginate(params[:page], limit: params[:limit], search_count: params[:search])
     respond_with(@wiki_pages) do |format|
       format.html do
         if params[:page].nil? || params[:page].to_i == 1
           if @wiki_pages.length == 1
             redirect_to(wiki_page_path(@wiki_pages.first))
-          elsif @wiki_pages.length == 0 && params[:search][:title].present? && params[:search][:title] !~ /\*/
-            redirect_to(wiki_pages_path(:search => {:title => "*#{params[:search][:title]}*"}))
+          elsif @wiki_pages.empty? && params[:search][:title].present? && params[:search][:title] !~ /\*/
+            redirect_to(wiki_pages_path(search: { title: "*#{params[:search][:title]}*" }))
           end
         end
       end
@@ -42,9 +23,6 @@ class WikiPagesController < ApplicationController
         expires_in params[:expiry].to_i.days if params[:expiry]
       end
     end
-  end
-
-  def search
   end
 
   def show
@@ -64,6 +42,28 @@ class WikiPagesController < ApplicationController
     else
       raise ActiveRecord::RecordNotFound
     end
+  end
+
+  def new
+    @wiki_page = WikiPage.new(wiki_page_params(:create))
+    respond_with(@wiki_page)
+  end
+
+  def edit
+    if params[:id] =~ /\A\d+\z/
+      @wiki_page = WikiPage.find(params[:id])
+    else
+      @wiki_page = WikiPage.titled(params[:id])
+      if @wiki_page.nil? && request.format.symbol == :html
+        redirect_to show_or_new_wiki_pages_path(title: params[:id])
+        return
+      end
+    end
+    ensure_can_edit(@wiki_page, CurrentUser.user)
+    respond_with(@wiki_page)
+  end
+
+  def search
   end
 
   def create
@@ -112,7 +112,7 @@ class WikiPagesController < ApplicationController
 
   def ensure_can_edit(page, user)
     return if user.is_janitor?
-    raise User::PrivilegeError.new("Wiki page is locked.") if page.is_locked
+    raise User::PrivilegeError, "Wiki page is locked." if page.is_locked
   end
 
   def normalize_search_params

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -117,7 +117,7 @@ class WikiPagesController < ApplicationController
 
   def normalize_search_params
     if params[:title]
-      params[:search] ||= {}
+      params[:search] = {} unless params[:search].is_a?(Hash)
       params[:search][:title] = params.delete(:title)
     end
   end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -116,8 +116,8 @@ class WikiPagesController < ApplicationController
   end
 
   def normalize_search_params
-    if params[:title]
-      params[:search] = {} unless params[:search].is_a?(Hash)
+    if params[:title].is_a?(String)
+      params[:search] = {} unless params[:search].is_a?(ActionController::Parameters)
       params[:search][:title] = params.delete(:title)
     end
   end


### PR DESCRIPTION
Fixes #1724