### PR TITLE
[DbExport] Add database export page and job

### DIFF
--- a/app/controllers/db_exports_controller.rb
+++ b/app/controllers/db_exports_controller.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+class DbExportsController < ApplicationController
+  before_action :validate_exports_enabled
+  before_action :member_only, only: [:favorites]
+
+  def index
+    @date = params[:date]
+    @exports = list_exports(@date)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @exports }
+    end
+  end
+
+  def show
+    name = params[:id]
+    config = DbExportJob::EXPORTS[name]
+    raise ActiveRecord::RecordNotFound unless config
+
+    min_level = config[:min_level] || 0
+    raise User::PrivilegeError if CurrentUser.user.level < min_level
+
+    file = find_export(name, params[:date])
+    raise ActiveRecord::RecordNotFound unless file
+
+    send_file file, type: "application/gzip", disposition: "attachment"
+  end
+
+  def favorites
+    user = CurrentUser.user
+    query = "SELECT id, post_id, created_at FROM favorites WHERE user_id = #{user.id} ORDER BY id DESC"
+
+    filename = "favorites-#{user.name}-#{Date.current}.csv"
+    headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format(disposition: "attachment", filename: filename)
+    headers["Content-Type"] = "text/csv"
+
+    conn = ActiveRecord::Base.connection.raw_connection
+    self.response_body = Enumerator.new do |yielder|
+      conn.copy_data("COPY (#{query}) TO STDOUT WITH CSV HEADER") do
+        while (row = conn.get_copy_data)
+          yielder << row
+        end
+      end
+    end
+  end
+
+  private
+
+  def list_exports(date = nil)
+    DbExportJob::EXPORTS.filter_map do |name, config|
+      min_level = config[:min_level] || 0
+      next if CurrentUser.user.level < min_level
+
+      export_metadata(name, date)
+    end
+  end
+
+  def export_metadata(name, date = nil)
+    cache_key = "db_export:#{name}:#{date || 'latest'}"
+    Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+      file = find_export(name, date)
+      next unless file
+
+      {
+        name: name,
+        file_name: File.basename(file),
+        file_size: File.size(file),
+        updated_at: File.mtime(file),
+      }
+    end
+  end
+
+  def find_export(name, date = nil)
+    raise ActiveRecord::RecordNotFound unless DbExportJob::EXPORTS.key?(name)
+
+    if date.present?
+      begin
+        Date.parse(date)
+      rescue Date::Error
+        raise ActiveRecord::RecordNotFound
+      end
+      path = DbExportJob::EXPORT_DIR.join("#{name}-#{date}.csv.gz")
+      path if File.exist?(path)
+    else
+      today = DbExportJob::EXPORT_DIR.join("#{name}-#{Date.current}.csv.gz")
+      return today if File.exist?(today)
+
+      yesterday = DbExportJob::EXPORT_DIR.join("#{name}-#{Date.yesterday}.csv.gz")
+      yesterday if File.exist?(yesterday)
+    end
+  end
+
+  def validate_exports_enabled
+    raise ActiveRecord::RecordNotFound unless Danbooru.config.db_export_enabled?
+  end
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -185,7 +185,7 @@ class StaticController < ApplicationController
     add_link[:staff, "Tickets", tickets_path]
 
     add_link[:tools, "Subscribestar", Danbooru.config.subscribestar_url] if Danbooru.config.subscribestar_url.present?
-    add_link[:tools, "DB Export", Danbooru.config.db_export_path] if Danbooru.config.db_export_path.present?
+    add_link[:tools, "DB Export", db_exports_path] if Danbooru.config.db_export_enabled?
     add_link[:tools, "Discord", discord_post_path] if CurrentUser.can_discord?
     add_link[:users, "Signup", new_user_path] if CurrentUser.is_anonymous?
 

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -66,6 +66,7 @@
 @import "specific/bans.scss";
 @import "specific/blips.scss";
 @import "specific/comments.scss";
+@import "specific/db_exports.scss";
 @import "specific/destroyed_posts.scss";
 @import "specific/dmails.scss";
 @import "specific/edit_history.scss";

--- a/app/javascript/src/styles/specific/db_exports.scss
+++ b/app/javascript/src/styles/specific/db_exports.scss
@@ -1,0 +1,115 @@
+body.c-db-exports.a-index {
+  .exports-description {
+    margin-bottom: 1.5rem;
+    max-width: 50rem;
+
+    p {
+      margin-bottom: 0.5em;
+    }
+  }
+
+  h2 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .exports-list {
+    display: grid;
+    grid-template-columns: 1fr 0.75fr 1fr auto;
+    margin-bottom: 1rem;
+
+    .header {
+      font-weight: bold;
+      padding: $padding-050 $padding-025;
+      background-color: var(--color-section-darken-5);
+      border-bottom: 1px solid var(--color-foreground);
+      color: var(--color-text-table-header);
+    }
+
+    .cell {
+      padding: $padding-050 $padding-025;
+      background-color: var(--color-section);
+      border-bottom: 1px solid var(--color-table-border);
+      display: flex;
+      align-items: center;
+    }
+
+    .row {
+      display: contents;
+
+      &:last-child .cell {
+        border-bottom: none;
+      }
+
+      @media (min-width: 801px) {
+        &:hover .cell {
+          background-color: var(--color-section-lighten-10);
+        }
+      }
+    }
+
+    @media (max-width: 800px) {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+
+      .header {
+        display: none;
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: 1fr;
+        background: var(--color-section);
+        border-radius: 4px;
+        overflow: hidden;
+
+        .cell {
+          padding: 0.75rem 1rem;
+          border-bottom: 1px solid var(--color-table-border);
+          display: flex;
+          justify-content: space-between;
+          align-items: start;
+          gap: 1rem;
+
+          &:first-child {
+            background-color: var(--color-section-darken-5);
+            font-size: 1.1rem;
+            justify-content: flex-start;
+
+            &::before {
+              display: none;
+            }
+          }
+
+          &:last-child {
+            border-bottom: none;
+          }
+
+          &::before {
+            content: attr(data-label);
+            font-weight: bold;
+            flex-shrink: 0;
+          }
+        }
+      }
+    }
+  }
+
+  .export-download-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    white-space: nowrap;
+  }
+
+  .exports-favorites-section {
+    background: var(--color-section);
+    padding: 1rem;
+    border-radius: 4px;
+    max-width: 30rem;
+
+    p {
+      margin-bottom: 0.75rem;
+    }
+  }
+}

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+class DbExportJob < ApplicationJob
+  queue_as :default
+
+  EXPORT_DIR = Rails.root.join("tmp/db_export")
+  MAX_EXPORT_AGE = 3.days
+
+  EXPORTS = {
+    "posts" => {
+      query: -> {
+        <<~SQL.squish
+          SELECT id, uploader_id, created_at, md5, source, rating, image_width, image_height,
+                 tag_string, locked_tags, fav_count, file_ext, parent_id, change_seq, approver_id,
+                 file_size, comment_count, description, duration, updated_at, is_deleted, is_pending,
+                 is_flagged, score, up_score, down_score, is_rating_locked, is_status_locked, is_note_locked
+          FROM posts ORDER BY id
+        SQL
+      },
+    },
+    # Hidden versions are filtered out because they contain changes
+    # that are not visible to regular users.
+    "post_versions" => {
+      query: -> {
+        <<~SQL.squish
+          SELECT id, post_id, version, tags, added_tags, removed_tags, locked_tags,
+                 added_locked_tags, removed_locked_tags, rating, rating_changed, parent_id,
+                 parent_changed, source, source_changed, description, description_changed,
+                 updater_id, updated_at, reason
+          FROM post_versions WHERE is_hidden = false ORDER BY id
+        SQL
+      },
+    },
+    # Exposes creator_id for flag events which is normally hidden to
+    # protect flagger anonymity.
+    "post_events" => {
+      min_level: Danbooru.config.levels["Janitor"],
+      query: -> { "SELECT id, creator_id, post_id, action, extra_data, created_at FROM post_events ORDER BY id" },
+    },
+    # Exposes creator_id (flagger identity) which is normally hidden from
+    # non-staff users and the post uploader.
+    "post_flags" => {
+      min_level: Danbooru.config.levels["Janitor"],
+      query: -> { "SELECT id, post_id, creator_id, reason, is_resolved, is_deletion, created_at, updated_at FROM post_flags ORDER BY id" },
+    },
+    # Includes rejected and pending replacements that are not
+    # visible to regular users.
+    "post_replacements" => {
+      min_level: Danbooru.config.levels["Janitor"],
+      query: -> {
+        <<~SQL.squish
+          SELECT id, post_id, creator_id, approver_id, file_ext, file_size, image_height, image_width,
+                 md5, source, file_name, status, reason, created_at, updated_at
+          FROM post_replacements2 ORDER BY id
+        SQL
+      },
+    },
+    "tags" => {
+      query: -> { "SELECT id, name, category, post_count FROM tags ORDER BY id" },
+    },
+    "tag_aliases" => {
+      query: -> { "SELECT id, antecedent_name, consequent_name, created_at, status FROM tag_aliases ORDER BY id" },
+    },
+    "tag_implications" => {
+      query: -> { "SELECT id, antecedent_name, consequent_name, created_at, status FROM tag_implications ORDER BY id" },
+    },
+    "bulk_update_requests" => {
+      query: -> { "SELECT id, user_id, forum_topic_id, forum_post_id, script, status, approver_id, title, created_at, updated_at FROM bulk_update_requests ORDER BY id" },
+    },
+    "artists" => {
+      query: -> {
+        <<~SQL.squish
+          SELECT a.id, a.name, a.other_names, a.group_name, a.linked_user_id,
+                 a.is_active, a.is_locked, a.creator_id, a.created_at, a.updated_at,
+                 array_to_string(array_agg(au.url ORDER BY au.id) FILTER (WHERE au.url IS NOT NULL), ' ') AS urls
+          FROM artists a
+          LEFT JOIN artist_urls au ON au.artist_id = a.id AND au.is_active = true
+          GROUP BY a.id ORDER BY a.id
+        SQL
+      },
+    },
+    "pools" => {
+      query: -> { "SELECT id, name, created_at, updated_at, creator_id, description, is_active, category, post_ids FROM pools ORDER BY id" },
+    },
+    "wiki_pages" => {
+      query: -> { "SELECT id, created_at, updated_at, title, body, creator_id, updater_id, is_locked FROM wiki_pages WHERE is_deleted = false ORDER BY id" },
+    },
+    # Includes hidden comments which are only visible to staff on the site.
+    "comments" => {
+      min_level: Danbooru.config.levels["Janitor"],
+      query: -> {
+        <<~SQL.squish
+          SELECT id, post_id, creator_id, body, score, do_not_bump_post, is_hidden, is_sticky,
+                 warning_type, created_at, updated_at
+          FROM comments ORDER BY id
+        SQL
+      },
+    },
+    # Includes hidden topics and topics from restricted forum categories.
+    "forum_topics" => {
+      min_level: Danbooru.config.levels["Janitor"],
+      query: -> {
+        <<~SQL.squish
+          SELECT id, creator_id, updater_id, title, response_count, is_sticky, is_locked, is_hidden,
+                 category_id, created_at, updated_at
+          FROM forum_topics ORDER BY id
+        SQL
+      },
+    },
+    # Includes hidden posts and posts from restricted forum categories.
+    "forum_posts" => {
+      min_level: Danbooru.config.levels["Janitor"],
+      query: -> {
+        <<~SQL.squish
+          SELECT id, topic_id, creator_id, updater_id, body, is_hidden, warning_type, created_at, updated_at
+          FROM forum_posts ORDER BY id
+        SQL
+      },
+    },
+    # Includes deleted feedback which is only visible to staff on the site.
+    "user_feedback" => {
+      min_level: Danbooru.config.levels["Janitor"],
+      query: -> { "SELECT id, user_id, creator_id, updater_id, category, body, is_deleted, created_at, updated_at FROM user_feedback ORDER BY id" },
+    },
+    # Contains user reports with reporter identity, report reasons,
+    # and staff responses. Visibility on the site varies by ticket
+    # type, but all are accessible to moderators.
+    "tickets" => {
+      min_level: Danbooru.config.levels["Moderator"],
+      query: -> {
+        <<~SQL.squish
+          SELECT id, creator_id, disp_id, qtype, status, reason, report_reason,
+                 response, handler_id, claimant_id, accused_id, created_at, updated_at
+          FROM tickets ORDER BY id
+        SQL
+      },
+    },
+    # Excludes protected actions and admin-only actions.
+    # The exclusion list is derived from ModAction::ProtectedActionKeys.
+    "mod_actions" => {
+      min_level: Danbooru.config.levels["Moderator"],
+      query: -> {
+        excluded = ModAction::ProtectedActionKeys + %w[admin_user_delete]
+        excluded_sql = excluded.map { |a| "'#{a}'" }.join(", ")
+
+        allowed_keys = ModAction::KnownActions.values.flat_map(&:keys).uniq - [:ip_addr]
+        allowed_sql = allowed_keys.map { |k| "'#{k}'" }.join(", ")
+
+        <<~SQL.squish
+          SELECT id, creator_id, action,
+                 (SELECT COALESCE(jsonb_object_agg(k, v), '{}'::jsonb)
+                  FROM jsonb_each(values::jsonb) AS x(k, v)
+                  WHERE k = ANY(ARRAY[#{allowed_sql}])) AS values,
+                 created_at
+          FROM mod_actions
+          WHERE action NOT IN (#{excluded_sql})
+          ORDER BY id
+        SQL
+      },
+    },
+  }.freeze
+
+  def perform
+    return unless Danbooru.config.db_export_enabled?
+
+    FileUtils.mkdir_p(EXPORT_DIR)
+    today = Date.current.to_s
+
+    EXPORTS.each_key do |name|
+      generate_export(name, EXPORTS[name], today)
+    end
+
+    cleanup_old_exports
+    clear_cache
+  end
+
+  private
+
+  def generate_export(name, config, date)
+    gz_path = EXPORT_DIR.join("#{name}-#{date}.csv.gz")
+
+    return if File.exist?(gz_path)
+
+    Rails.logger.info("DbExportJob: Generating #{name} export")
+
+    query = config[:query].call
+    conn = ActiveRecord::Base.connection.raw_connection
+    conn.exec("SET statement_timeout = 0")
+    File.open(gz_path, "wb") do |file|
+      gz = Zlib::GzipWriter.new(file)
+      begin
+        conn.copy_data("COPY (#{query}) TO STDOUT WITH CSV HEADER") do
+          while (row = conn.get_copy_data)
+            gz.write(row)
+          end
+        end
+      ensure
+        gz.close
+      end
+    end
+
+    Rails.logger.info("DbExportJob: Finished #{name} export (#{ActiveSupport::NumberHelper.number_to_human_size(File.size(gz_path))})")
+  rescue StandardError => e
+    Rails.logger.error("DbExportJob: Failed to generate #{name} export: #{e.message}")
+    FileUtils.rm_f(gz_path)
+    ActiveRecord::Base.connection.reconnect!
+  end
+
+  def cleanup_old_exports
+    cutoff = MAX_EXPORT_AGE.ago
+    Dir.glob(EXPORT_DIR.join("*.csv.gz")).each do |file|
+      File.delete(file) if File.mtime(file) < cutoff
+    end
+  end
+
+  def clear_cache
+    dates = (0..MAX_EXPORT_AGE.in_days.to_i).map { |d| d.days.ago.to_date.to_s }
+    EXPORTS.each_key do |name|
+      Rails.cache.delete("db_export:#{name}:latest")
+      dates.each { |date| Rails.cache.delete("db_export:#{name}:#{date}") }
+    end
+  end
+end

--- a/app/views/db_exports/index.html.erb
+++ b/app/views/db_exports/index.html.erb
@@ -1,0 +1,49 @@
+<div id="c-db-exports">
+  <div id="a-index">
+    <h1>Database Exports</h1>
+
+    <div class="exports-description">
+      <p>Database exports in gzipped CSV format, updated daily.</p>
+      <p>For programmatic access, use the <%= link_to "JSON endpoint", db_exports_path(format: :json) %>.</p>
+    </div>
+
+    <% if @exports.any? %>
+      <div class="exports-list">
+        <div class="header">Name</div>
+        <div class="header">Size</div>
+        <div class="header">Updated</div>
+        <div class="header"></div>
+
+        <% @exports.each do |export| %>
+          <div class="row">
+            <div class="cell" data-label="Name"><strong><%= export[:name] %></strong></div>
+            <div class="cell" data-label="Size"><%= number_to_human_size(export[:file_size]) %></div>
+            <div class="cell" data-label="Updated"><%= time_ago_in_words_tagged(export[:updated_at]) %></div>
+            <div class="cell" data-label="Actions">
+              <%= link_to db_export_path(export[:name], date: @date), class: "export-download-link" do %>
+                <%= svg_icon(:download, width: 16, height: 16) %> Download
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p>No exports are currently available.</p>
+    <% end %>
+
+    <% if CurrentUser.user.favorite_count > 0 %>
+      <h2>Favorites</h2>
+
+      <div class="exports-favorites-section">
+        <p>Export your <%= number_with_delimiter(CurrentUser.user.favorite_count) %> favorites as a CSV file.</p>
+        <%= link_to favorites_db_exports_path, class: "export-download-link" do %>
+          <%= svg_icon(:download, width: 16, height: 16) %> Download
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% content_for(:page_title) do %>
+  Database Exports
+<% end %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -65,9 +65,9 @@ module Danbooru
       "Anonymous"
     end
 
-    # The path of the daily DB exports. Hidden from the site map if `nil`.
-    def db_export_path
-      "/db_export/"
+    # Whether database exports are enabled.
+    def db_export_enabled?
+      true
     end
 
     def levels

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,6 +23,11 @@ Sidekiq.configure_server do |config|
       "class" => "SearchTrendAggregateJob",
       "description" => "Aggregate unprocessed hourly search trends into daily totals",
     },
+    "DbExportJob" => {
+      "cron" => "0 4 * * *", # Daily at 4:00 AM
+      "class" => "DbExportJob",
+      "description" => "Generate daily database exports",
+    },
   }
 
   Sidekiq::Cron::Job.load_from_hash schedule

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,11 @@ Rails.application.routes.draw do
     end
   end
   resource :dtext_preview, only: %i[create]
+  resources :db_exports, only: %i[index show] do
+    collection do
+      get :favorites
+    end
+  end
   resources :favorites, only: %i[index create destroy]
   resources :forum_posts do
     resource :votes, controller: "forum_post_votes"

--- a/test/controllers/db_exports_controller_test.rb
+++ b/test/controllers/db_exports_controller_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DbExportsControllerTest < ActionDispatch::IntegrationTest
+  context "The db exports controller" do
+    setup do
+      @user = create(:user)
+      @janitor = create(:janitor_user)
+      @moderator = create(:moderator_user)
+
+      FileUtils.mkdir_p(DbExportJob::EXPORT_DIR)
+      @today = Date.current.to_s
+
+      DbExportJob::EXPORTS.each_key do |name|
+        path = DbExportJob::EXPORT_DIR.join("#{name}-#{@today}.csv.gz")
+        File.open(path, "wb") do |f|
+          gz = Zlib::GzipWriter.new(f)
+          gz.write("id,test\n1,data\n")
+          gz.close
+        end
+      end
+    end
+
+    teardown do
+      FileUtils.rm_rf(DbExportJob::EXPORT_DIR)
+    end
+
+    context "index action" do
+      should "render for anonymous users" do
+        get db_exports_path
+        assert_response :success
+      end
+
+      should "show only public exports to anonymous users" do
+        get db_exports_path
+        DbExportJob::EXPORTS.each do |name, config|
+          if config[:min_level]
+            assert_not_includes(response.body, ">#{name}<")
+          else
+            assert_includes(response.body, name)
+          end
+        end
+      end
+
+      should "show restricted exports to janitors" do
+        get_auth db_exports_path, @janitor
+        assert_includes(response.body, "post_flags")
+        assert_includes(response.body, "comments")
+      end
+
+      should "show moderator exports to moderators" do
+        get_auth db_exports_path, @moderator
+        assert_includes(response.body, "mod_actions")
+        assert_includes(response.body, "tickets")
+      end
+
+      should "not show moderator exports to janitors" do
+        get_auth db_exports_path, @janitor
+        assert_not_includes(response.body, "mod_actions")
+        assert_not_includes(response.body, "tickets")
+      end
+
+      should "render JSON" do
+        get db_exports_path(format: :json)
+        assert_response :success
+        json = response.parsed_body
+        assert json["exports"].is_a?(Array)
+      end
+
+      should "filter by date" do
+        get db_exports_path(date: @today)
+        assert_response :success
+      end
+
+      should "handle invalid date" do
+        get db_exports_path(date: "not-a-date")
+        assert_response 404
+      end
+    end
+
+    context "show action" do
+      should "download a public export" do
+        get db_export_path("posts")
+        assert_response :success
+        assert_equal "application/gzip", response.content_type
+      end
+
+      should "download a restricted export as janitor" do
+        get_auth db_export_path("post_flags"), @janitor
+        assert_response :success
+      end
+
+      should "reject a restricted export for anonymous users" do
+        get db_export_path("post_flags")
+        assert_response 302
+      end
+
+      should "reject a moderator export for janitors" do
+        get_auth db_export_path("mod_actions"), @janitor
+        assert_response 403
+      end
+
+      should "allow a moderator export for moderators" do
+        get_auth db_export_path("mod_actions"), @moderator
+        assert_response :success
+      end
+
+      should "return 404 for unknown exports" do
+        get db_export_path("nonexistent")
+        assert_response 404
+      end
+
+      should "accept a date parameter" do
+        get db_export_path("posts", date: @today)
+        assert_response :success
+      end
+
+      should "return 404 for invalid date" do
+        get db_export_path("posts", date: "bad")
+        assert_response 404
+      end
+    end
+
+    context "favorites action" do
+      should "download favorites for a logged-in user" do
+        post = create(:post)
+        create(:favorite, user: @user, post: post)
+        get_auth favorites_db_exports_path, @user
+        assert_response :success
+        assert_equal "text/csv", response.content_type
+      end
+
+      should "reject anonymous users" do
+        get favorites_db_exports_path
+        assert_response 302
+      end
+    end
+  end
+end

--- a/test/jobs/db_export_job_test.rb
+++ b/test/jobs/db_export_job_test.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DbExportJobTest < ActiveJob::TestCase
+  setup do
+    FileUtils.mkdir_p(DbExportJob::EXPORT_DIR)
+    @user = create(:user)
+    @mod = create(:moderator_user)
+  end
+
+  teardown do
+    FileUtils.rm_rf(DbExportJob::EXPORT_DIR)
+  end
+
+  should "generate export files for all configured exports" do
+    DbExportJob.perform_now
+    today = Date.current.to_s
+
+    DbExportJob::EXPORTS.each_key do |name|
+      path = DbExportJob::EXPORT_DIR.join("#{name}-#{today}.csv.gz")
+      assert File.exist?(path), "Expected export file for #{name}"
+      assert File.size(path) > 0, "Expected non-empty export file for #{name}"
+    end
+  end
+
+  should "skip exports that already exist" do
+    today = Date.current.to_s
+    path = DbExportJob::EXPORT_DIR.join("posts-#{today}.csv.gz")
+    File.write(path, "existing")
+
+    DbExportJob.perform_now
+
+    assert_equal "existing", File.read(path)
+  end
+
+  should "clean up old exports" do
+    old_path = DbExportJob::EXPORT_DIR.join("posts-2020-01-01.csv.gz")
+    File.write(old_path, "old")
+    FileUtils.touch(old_path, mtime: 5.days.ago.to_time)
+
+    DbExportJob.perform_now
+
+    assert_not File.exist?(old_path)
+  end
+
+  should "not run when exports are disabled" do
+    Danbooru.config.stubs(:db_export_enabled?).returns(false)
+
+    DbExportJob.perform_now
+    today = Date.current.to_s
+
+    assert_empty Dir.glob(DbExportJob::EXPORT_DIR.join("*-#{today}.csv.gz"))
+  end
+
+  should "continue when an individual export fails" do
+    today = Date.current.to_s
+    first_export = DbExportJob::EXPORTS.keys.first
+    last_export = DbExportJob::EXPORTS.keys.last
+
+    bad_query = -> { "SELECT * FROM nonexistent_table_#{SecureRandom.hex(4)}" }
+    original_query = DbExportJob::EXPORTS[first_export][:query]
+    DbExportJob::EXPORTS[first_export][:query] = bad_query
+
+    DbExportJob.perform_now
+
+    assert_not File.exist?(DbExportJob::EXPORT_DIR.join("#{first_export}-#{today}.csv.gz"))
+    assert File.exist?(DbExportJob::EXPORT_DIR.join("#{last_export}-#{today}.csv.gz"))
+  ensure
+    DbExportJob::EXPORTS[first_export][:query] = original_query
+  end
+
+  should "export posts" do
+    post = create(:post)
+    csv = export_csv("posts")
+    assert_includes csv, post.md5
+  end
+
+  should "export tags" do
+    create(:tag, name: "test_export_tag")
+    csv = export_csv("tags")
+    assert_includes csv, "test_export_tag"
+  end
+
+  should "export tag aliases" do
+    as(@user) { create(:tag_alias, antecedent_name: "aaa_export", consequent_name: "bbb_export") }
+    csv = export_csv("tag_aliases")
+    assert_includes csv, "aaa_export"
+  end
+
+  should "export tag implications" do
+    as(@user) { create(:tag_implication, antecedent_name: "aaa_impl", consequent_name: "bbb_impl") }
+    csv = export_csv("tag_implications")
+    assert_includes csv, "aaa_impl"
+  end
+
+  should "export pools" do
+    as(@user) { create(:pool, name: "test_export_pool") }
+    csv = export_csv("pools")
+    assert_includes csv, "test_export_pool"
+  end
+
+  should "export wiki pages" do
+    as(@user) { create(:wiki_page, title: "test_export_wiki") }
+    csv = export_csv("wiki_pages")
+    assert_includes csv, "test_export_wiki"
+  end
+
+  should "export artists" do
+    as(@user) { create(:artist, name: "test_export_artist") }
+    csv = export_csv("artists")
+    assert_includes csv, "test_export_artist"
+  end
+
+  should "export bulk update requests" do
+    as(@user) { create(:bulk_update_request, title: "test_export_bur", skip_forum: true) }
+    csv = export_csv("bulk_update_requests")
+    assert_includes csv, "test_export_bur"
+  end
+
+  should "export post versions" do
+    post = create(:post)
+    as(@user) do
+      post.update!(tag_string: "new_tag")
+    end
+    csv = export_csv("post_versions")
+    assert_includes csv, "new_tag"
+  end
+
+  should "export post flags" do
+    flag = as(@user) { create(:post_flag) }
+    csv = export_csv("post_flags")
+    assert_includes csv, flag.id.to_s
+  end
+
+  should "export user feedback" do
+    as(@mod) { create(:user_feedback, user: create(:user)) }
+    csv = export_csv("user_feedback")
+    assert_includes csv, "positive"
+  end
+
+  should "export comments" do
+    as(@user) { create(:comment) }
+    csv = export_csv("comments")
+    assert_includes csv, "comment_body"
+  end
+
+  should "export forum topics" do
+    as(@user) { create(:forum_topic, title: "test_export_topic") }
+    csv = export_csv("forum_topics")
+    assert_includes csv, "test_export_topic"
+  end
+
+  should "export forum posts" do
+    topic = as(@user) { create(:forum_topic) }
+    as(@user) { create(:forum_post, topic: topic, body: "test_export_fpost") }
+    csv = export_csv("forum_posts")
+    assert_includes csv, "test_export_fpost"
+  end
+
+  should "export post events" do
+    post = create(:post)
+    PostEvent.add(post.id, @user, :approved)
+    csv = export_csv("post_events")
+    assert_includes csv, post.id.to_s
+  end
+
+  should "export mod actions and filter protected ones" do
+    as(@user) do
+      ModAction.log(:artist_page_lock, { artist_page: "test" })
+      ModAction.log(:staff_note_create, { id: 1, user_id: 1, body: "secret" })
+    end
+    csv = export_csv("mod_actions")
+    assert_includes csv, "artist_page_lock"
+    assert_not_includes csv, "staff_note_create"
+  end
+
+  should "export tickets" do
+    post = create(:post)
+    report_reason = PostReportReason.create!(reason: "test_reason", creator: @mod, description: "test")
+    as(@user) { create(:ticket, qtype: "post", content: post, reason: "test_export_ticket", report_reason: report_reason.id) }
+    csv = export_csv("tickets")
+    assert_includes csv, "test_export_ticket"
+  end
+
+  private
+
+  def export_csv(name)
+    DbExportJob.perform_now
+    today = Date.current.to_s
+    path = DbExportJob::EXPORT_DIR.join("#{name}-#{today}.csv.gz")
+    Zlib::GzipReader.open(path).read
+  end
+end


### PR DESCRIPTION
New Db Export Page.

Uses Sidekiq to run a job daily for the export.
There are additional exports available for staff.

### TODO

- [ ] Database Admin is OK with this PR
- [ ] Where do the files live? Multiple app machines exist. No DB Server access. CDN with acces key?
- [ ] Disk space considerations. Only keep latest?
- [ ] Should these have access restrictions or should all sensitive data be stripped, and only public entities exported?
- [ ] Risk of leaks? One stolen API key could dump all exports immediately. Permission scopes?

### All exports

| Model | Access | Content |
| ----- | ----- | ----- |
| posts | Public | |
| post_versions | Public | Excludes hidden versions |
| post_events | Janitor+ | Includes flagger creator_id |
| post_flags | Janitor+ | Includes flagger creator_id |
| post_replacements | Janitor+ | Includes rejected/pending |
| tags | Public | |
| tag_aliases | Public | |
| tag_implications | Public | |
| bulk_update_requests | Public | |
| artists | Public | |
| pools | Public | |
| wiki_pages | Public | Excludes deleted |
| comments | Janitor+ | Includes hidden comments |
| forum_topics | Janitor+ | Includes hidden & restricted categories |
| forum_posts | Janitor+ | Includes hidden & restricted categories |
| user_feedback | Janitor+ | Includes deleted feedback |
| tickets | Moderator+ | |
| mod_actions | Moderator+ | Excludes Admin only values |

### Security

CSVs live in `/tmp` to ensure users cant bypass the auth check with a direct link. This is a problem because its on the App machine, and those are sharded.

### Api Stuff

The page comes with a JSON API that returns an array of

```json
{"name":"posts","file_name":"posts-2026-04-06.csv.gz","file_size":36547,"updated_at":"2026-04-06T18:56:23.844+00:00"},
```

### Performance

Available export file names are memory cached for one hour. Job runs once a day, without timeout. Some of those tables are large, but the previous export also ate large tables.

### Availability

The past 3 previous days are available as export, but users must specify the `date` as query parameter. This isnt visible in the UI explained anywhere. Easter egg.
Most users (maybe even ALL of them) will probably never need the export of a previous day.

### Testing

We have tests that check exports work. Models are created and dumped into the CSV. Writing a test to check the exact fields felt overkill.

### Other nice things

This also includes an option for the user to directly export all their favorite post IDs! No more scraping! Wooooo! That one is generated on the fly. I didnt include any additional rate limiting for this, but I am banking on the usual rate limits being fine, and the favorite CSV is not that large, even for users with maximum amount of favorites, since its just the IDs and dates, not the full posts.

### Deployment

This entirely replaces the previously used bash scripts that manually exported the DB. 

### Why do I need this

With these new exports, I can boostrap 6oclock much much much faster, without hammering the API for 8 hours. Similarly, users can now more easily fetch DB exports. And the UI is nicer.

### Things that would have been nice but I didnt do

Incremental delta exports (only things that changed since yesterday) would have been very nice for bandwidth reduction. However, this poses the problem fo destroyed items, which we would need to introduce a special field or something? Additionally, we wouldnt know which items have been destroyed since the last export. It seemed finicky.

Exports more than once a day, maybe every 12 hours could be an idea, but it just didnt seem that necessary. For the last stretch of 24 hours, people who need fresh data are just gonna need to scrape live.

### Screenshots

**Desktop As Moderator**

<img width="1800" height="1123" alt="image" src="https://github.com/user-attachments/assets/9e8f681c-e5d3-416e-b0af-e98b569a1a3b" />


**Desktop As Anonymous**

<img width="1800" height="948" alt="image" src="https://github.com/user-attachments/assets/8bc69033-3009-419c-bf83-918462233aa5" />


**Mobile**

<img width="448" height="877" alt="image" src="https://github.com/user-attachments/assets/b5183f10-9074-4b7a-8276-90e256b3d471" />


