### PR TITLE
[Posts] Delete with reason DMails and deletion DMails titles

### DIFF
--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -66,15 +66,11 @@ module Moderator
           end
 
           if params[:dmail].present?
+            reason = params[:reason].to_s
             Dmail.create_automated({
               to_id: @post.uploader_id,
-              title: "Post ##{params[:id]} has been deleted",
-              body: params[:dmail]
-                .gsub("%POST_ID%", params[:id].to_s)
-                .gsub("%STAFF_NAME%", CurrentUser.name)
-                .gsub("%STAFF_ID%", CurrentUser.id.to_s)
-                .gsub("%UPLOADER_ID%", @post.uploader_id.to_s)
-                .gsub("%REASON%", params[:reason].to_s),
+              title: @post.substitute_deletion_dmail_template(params[:dmail_title], reason) || "Post ##{params[:id]} has been deleted",
+              body: @post.substitute_deletion_dmail_template(params[:dmail], reason),
             })
           end
         end

--- a/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
+++ b/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
@@ -13,24 +13,31 @@ PostDeletion.init = function () {
     dMailTemplate = document.querySelector("select#del-dmail-template"),
     /** @type {HTMLElement} */
     message = document.querySelector("label[for=send-dmail] ~ .dtext-formatter"),
+    /** @type {JQuery<HTMLInputElement>} */
+    dMailTitleInput = $(document.querySelector("#dmail-title")),
     /** @type {JQuery<HTMLTextAreaElement>} */
-    dMailTextArea = $(message).children("textarea.dtext-formatter-input");
+    dMailTextArea = $(document.querySelector("#dmail-message"));
   function updateDMailActivation () {
     if (cBox.checked) {
-      message.style.display = dMailTemplate.parentElement.style.display = "";
+      message.style.display = dMailTitleInput[0].style.display = dMailTemplate.parentElement.style.display = "";
+      dMailTitleInput.removeAttr("disabled");
       dMailTextArea.removeAttr("disabled");
     } else {
-      message.style.display = dMailTemplate.parentElement.style.display = "none";
+      message.style.display = dMailTitleInput[0].style.display = dMailTemplate.parentElement.style.display = "none";
+      dMailTitleInput.attr("disabled", "disabled");
       dMailTextArea.attr("disabled", "disabled");
     }
   }
   function updateReason () {
-    let newVal = input.val()?.toString();
-    dMailTextArea.val(
-      Utility.blank(newVal)
-        ? dMailTemplate.value
-        : dMailTemplate.value.replaceAll("%REASON%", newVal),
-    );
+    const newReason = input.val()?.toString();
+    let newTitle = dMailTemplate.selectedOptions[0].getAttribute("data-dmail-title");
+    let newMessage = dMailTemplate.value;
+    if (!Utility.blank(newReason)) {
+      newTitle = newTitle.replaceAll("%REASON%", newReason);
+      newMessage = newMessage.replaceAll("%REASON%", newReason);
+    }
+    dMailTitleInput.val(newTitle);
+    dMailTextArea.val(newMessage);
   }
   cBox.addEventListener("click", () => updateDMailActivation());
   dMailTemplate.addEventListener("change", () => updateReason());

--- a/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
+++ b/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
@@ -8,41 +8,45 @@ PostDeletion.init = function () {
 
   // #region DMail Notification
   /** @type {HTMLInputElement} */
-  const cBox = document.querySelector("input#send-dmail"),
+  const dMailCheckBox = document.querySelector("input#send-dmail"),
     /** @type {HTMLSelectElement} */
     dMailTemplate = document.querySelector("select#del-dmail-template"),
     /** @type {HTMLElement} */
-    message = document.querySelector("label[for=send-dmail] ~ .dtext-formatter"),
+    dMailMessage = document.querySelector("label[for=send-dmail] ~ .dtext-formatter"),
     /** @type {JQuery<HTMLInputElement>} */
     dMailTitleInput = $(document.querySelector("#dmail-title")),
     /** @type {JQuery<HTMLTextAreaElement>} */
     dMailTextArea = $(document.querySelector("#dmail-message"));
-  function updateDMailActivation () {
-    if (cBox.checked) {
-      message.style.display = dMailTitleInput[0].style.display = dMailTemplate.parentElement.style.display = "";
-      dMailTitleInput.removeAttr("disabled");
-      dMailTextArea.removeAttr("disabled");
-    } else {
-      message.style.display = dMailTitleInput[0].style.display = dMailTemplate.parentElement.style.display = "none";
-      dMailTitleInput.attr("disabled", "disabled");
-      dMailTextArea.attr("disabled", "disabled");
+  let updateDMailReason = null;
+  // Absent if no DMail template is configured
+  if (dMailCheckBox && dMailTemplate && dMailMessage && dMailTitleInput && dMailTextArea) {
+    function updateDMailActivation () {
+      if (dMailCheckBox.checked) {
+        dMailMessage.style.display = dMailTitleInput[0].style.display = dMailTemplate.parentElement.style.display = "";
+        dMailTitleInput.removeAttr("disabled");
+        dMailTextArea.removeAttr("disabled");
+      } else {
+        dMailMessage.style.display = dMailTitleInput[0].style.display = dMailTemplate.parentElement.style.display = "none";
+        dMailTitleInput.attr("disabled", "disabled");
+        dMailTextArea.attr("disabled", "disabled");
+      }
     }
+    updateDMailReason = function () {
+      const newReason = input.val()?.toString();
+      let newTitle = dMailTemplate.selectedOptions[0].getAttribute("data-dmail-title");
+      let newMessage = dMailTemplate.value;
+      if (!Utility.blank(newReason)) {
+        newTitle = newTitle.replaceAll("%REASON%", newReason);
+        newMessage = newMessage.replaceAll("%REASON%", newReason);
+      }
+      dMailTitleInput.val(newTitle);
+      dMailTextArea.val(newMessage);
+    };
+    dMailCheckBox.addEventListener("click", () => updateDMailActivation());
+    dMailTemplate.addEventListener("change", () => updateDMailReason());
+    updateDMailActivation();
+    updateDMailReason();
   }
-  function updateReason () {
-    const newReason = input.val()?.toString();
-    let newTitle = dMailTemplate.selectedOptions[0].getAttribute("data-dmail-title");
-    let newMessage = dMailTemplate.value;
-    if (!Utility.blank(newReason)) {
-      newTitle = newTitle.replaceAll("%REASON%", newReason);
-      newMessage = newMessage.replaceAll("%REASON%", newReason);
-    }
-    dMailTitleInput.val(newTitle);
-    dMailTextArea.val(newMessage);
-  }
-  cBox.addEventListener("click", () => updateDMailActivation());
-  dMailTemplate.addEventListener("change", () => updateReason());
-  updateDMailActivation();
-  updateReason();
   // #endregion DMail Notification
 
   // #region Delete Reason
@@ -86,7 +90,7 @@ PostDeletion.init = function () {
   input.on("input", () => {
     inputVal = input.val() + "";
     buttons.trigger("e621:refresh");
-    updateReason();
+    updateDMailReason?.();
   });
 
   $("#delreason-clear").on("click", () => {

--- a/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
+++ b/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
@@ -20,7 +20,7 @@ PostDeletion.init = function () {
   let updateDMailReason = null;
   // Absent if no DMail template is configured
   if (dMailCheckBox && dMailTemplate && dMailMessage && dMailTitleInput && dMailTextArea) {
-    function updateDMailActivation () {
+    const updateDMailActivation = function () {
       if (dMailCheckBox.checked) {
         dMailMessage.style.display = dMailTitleInput[0].style.display = dMailTemplate.parentElement.style.display = "";
         dMailTitleInput.removeAttr("disabled");
@@ -30,7 +30,7 @@ PostDeletion.init = function () {
         dMailTitleInput.attr("disabled", "disabled");
         dMailTextArea.attr("disabled", "disabled");
       }
-    }
+    };
     updateDMailReason = function () {
       const newReason = input.val()?.toString();
       let newTitle = dMailTemplate.selectedOptions[0].getAttribute("data-dmail-title");

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -741,7 +741,7 @@ Post.update = function (post_id, params) {
 };
 
 Post.delete_with_reason = function (post_id, reason, options = {}) {
-  const { reload_after_delete = false, from_flag = false, move_favorites = false } = options;
+  const { reload_after_delete = false, from_flag = false, move_favorites = false, dmail = null } = options;
 
   Post.notice_update("inc");
   let error = false;
@@ -750,7 +750,7 @@ Post.delete_with_reason = function (post_id, reason, options = {}) {
     $.ajax({
       type: "POST",
       url: `/moderator/post/posts/${post_id}/delete.json`,
-      data: {commit: "Delete", reason: reason, from_flag: from_flag, move_favorites: move_favorites},
+      data: {commit: "Delete", reason: reason, from_flag: from_flag, move_favorites: move_favorites, dmail: dmail},
     }).fail(function (data) {
       if (data.status === 409) {
         E621.Flash.notice("Post already deleted.");

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -741,7 +741,8 @@ Post.update = function (post_id, params) {
 };
 
 Post.delete_with_reason = function (post_id, reason, options = {}) {
-  const { reload_after_delete = false, from_flag = false, move_favorites = false, dmail = null } = options;
+  const { reload_after_delete = false, from_flag = false, move_favorites = false,
+    dmail = null, dmail_title = null } = options;
 
   Post.notice_update("inc");
   let error = false;
@@ -750,7 +751,8 @@ Post.delete_with_reason = function (post_id, reason, options = {}) {
     $.ajax({
       type: "POST",
       url: `/moderator/post/posts/${post_id}/delete.json`,
-      data: {commit: "Delete", reason: reason, from_flag: from_flag, move_favorites: move_favorites, dmail: dmail},
+      data: {commit: "Delete", reason: reason, from_flag: from_flag, move_favorites: move_favorites,
+        dmail: dmail, dmail_title: dmail_title},
     }).fail(function (data) {
       if (data.status === 409) {
         E621.Flash.notice("Post already deleted.");

--- a/app/javascript/src/js/pages/posts/show/mod_queue.js
+++ b/app/javascript/src/js/pages/posts/show/mod_queue.js
@@ -34,6 +34,52 @@ ModQueue.detailed_rejection_dialog = function () {
   return false;
 };
 
+let deletionDialog = null;
+ModQueue.delete_with_reason_dialog = function (event) {
+  const form = $("#delete-with-reason-dialog");
+  if (deletionDialog == null) {
+    deletionDialog = new Dialog("#delete-with-reason-dialog");
+    $("#delete-with-reason-dialog-cancel").on("click", () => deletionDialog.close());
+    $(document).on("keydown", (event) => {
+      // .isFocused would make more sense if it existed
+      if (event.key === "Enter" && deletionDialog.isOpen) {
+        event.preventDefault();
+        form.trigger("submit");
+      }
+    });
+  }
+
+  const data = event.currentTarget.dataset;
+  const hasReason = data.fromFlag !== "true";
+  const reason = data.reason;
+
+  const reasonInput = $("#delete-with-reason-dialog-input");
+  reasonInput.val(reason);
+  reasonInput[0].style.display = hasReason ? "" : "none";
+
+  form.off("submit").on("submit", (event) => {
+    event.preventDefault();
+    const dmailOption = $("#delete-with-reason-dialog-enable-dmail");
+    const sendDMail = dmailOption.prop("checked");
+    const dmailMessage = sendDMail ? dmailOption.attr("data-dmail-message") : null;
+    const finalReason = hasReason ? reasonInput.val() : reason;
+    Post.delete_with_reason(data.postId, finalReason, {
+      reload_after_delete: true,
+      from_flag: !hasReason,
+      move_favorites: data.moveFavs === "true",
+      dmail: dmailMessage,
+    });
+    return false;
+  });
+
+  deletionDialog.open();
+
+  // Scroll to end of reason so it's faster to append to it
+  reasonInput.scrollLeft(reasonInput[0].scrollWidth);
+
+  return false;
+};
+
 $(function () {
   if (!$("body").data("user-is-approver")) return;
 
@@ -57,18 +103,7 @@ $(function () {
 
   // Toolbar buttons
   $(document).on("click.danbooru", ".quick-mod .detailed-rejection-link", ModQueue.detailed_rejection_dialog);
-
-
-  $(".delete-with-reason-link").on("click", function (event) {
-    event.preventDefault();
-    const data = event.target.dataset;
-    if (!confirm(`Delete post for ${data.prompt}?`)) return;
-    Post.delete_with_reason(data.postId, data.reason, {
-      reload_after_delete: true,
-      from_flag: data.fromFlag === "true",
-      move_favorites: data.moveFavs === "true",
-    });
-  });
+  $(".delete-with-reason-link").on("click", ModQueue.delete_with_reason_dialog);
 });
 
 export default ModQueue;

--- a/app/javascript/src/js/pages/posts/show/mod_queue.js
+++ b/app/javascript/src/js/pages/posts/show/mod_queue.js
@@ -60,9 +60,10 @@ ModQueue.delete_with_reason_dialog = function (event) {
   form.off("submit").on("submit", (event) => {
     event.preventDefault();
     const dmailOption = $("#delete-with-reason-dialog-enable-dmail");
-    const sendDMail = dmailOption.prop("checked");
-    const dmailMessage = sendDMail ? dmailOption.attr("data-dmail-message") : null;
-    const dmailTitle = sendDMail ? dmailOption.attr("data-dmail-title") : null;
+    // Absent if no DMail template is configured
+    const sendDMail = dmailOption?.prop("checked");
+    const dmailMessage = sendDMail ? dmailOption?.attr("data-dmail-message") : null;
+    const dmailTitle = sendDMail ? dmailOption?.attr("data-dmail-title") : null;
     const finalReason = hasReason ? reasonInput.val() : reason;
     Post.delete_with_reason(data.postId, finalReason, {
       reload_after_delete: true,

--- a/app/javascript/src/js/pages/posts/show/mod_queue.js
+++ b/app/javascript/src/js/pages/posts/show/mod_queue.js
@@ -62,12 +62,14 @@ ModQueue.delete_with_reason_dialog = function (event) {
     const dmailOption = $("#delete-with-reason-dialog-enable-dmail");
     const sendDMail = dmailOption.prop("checked");
     const dmailMessage = sendDMail ? dmailOption.attr("data-dmail-message") : null;
+    const dmailTitle = sendDMail ? dmailOption.attr("data-dmail-title") : null;
     const finalReason = hasReason ? reasonInput.val() : reason;
     Post.delete_with_reason(data.postId, finalReason, {
       reload_after_delete: true,
       from_flag: !hasReason,
       move_favorites: data.moveFavs === "true",
       dmail: dmailMessage,
+      dmail_title: dmailTitle,
     });
     return false;
   });

--- a/app/javascript/src/styles/views/posts/show/_show.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.scss
@@ -18,6 +18,7 @@ body.c-posts.a-show-seq {
   }
 
   @import "partials/detailed_rejection";
+  @import "partials/delete_with_reason";
   @import "partials/add_to_pool";
   @import "partials/notes";
 }

--- a/app/javascript/src/styles/views/posts/show/partials/_delete_with_reason.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_delete_with_reason.scss
@@ -1,0 +1,19 @@
+#delete-with-reason-dialog {
+  display: flex;
+  flex-flow: column;
+  gap: 0.5rem;
+
+  & > .input { margin-bottom: 0; }
+  input[type="text"] {
+    width: 100%;
+    box-sizing: border-box;
+    resize: none;
+  }
+
+  div.delete-with-reason-dialog-submit {
+    display: flex;
+    gap: 0.5rem;
+
+    button { width: 25%; }
+  }
+}

--- a/app/javascript/src/styles/views/posts/show/partials/_delete_with_reason.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_delete_with_reason.scss
@@ -5,7 +5,9 @@
 
   & > .input { margin-bottom: 0; }
   input[type="text"] {
+    max-width: none;
     width: 100%;
+    margin: 0.25rem 0 0.25rem 0;
     box-sizing: border-box;
     resize: none;
   }

--- a/app/logical/post_pruner.rb
+++ b/app/logical/post_pruner.rb
@@ -11,18 +11,16 @@ class PostPruner
 
   def prune_pending!
     window = Danbooru.config.unapproved_post_deletion_window
-    dmail = Danbooru.config.post_pruned_dmail_template.presence
+    dmail = Danbooru.config.post_pruned_dmail_template
 
     CurrentUser.as_system do
       Post.where("is_deleted = ? and is_pending = ? and created_at < ?", false, true, window.ago).find_each do |post|
         post.delete!("Unapproved in #{window.inspect}")
-        if dmail.is_a?(Hash) && dmail[:body].presence
+        if dmail.is_a?(Hash) && dmail[:body].present?
           Dmail.create_automated({
             to_id: post.uploader.id,
-            title: dmail[:title].presence || "Post ##{post.id} has been deleted",
-            body: dmail[:body]
-              .gsub("%POST_ID%", post.id.to_s)
-              .gsub("%UPLOADER_ID%", post.uploader_id.to_s),
+            title: post.substitute_deletion_dmail_template(dmail[:title]) || "Post ##{post.id} has been deleted",
+            body: post.substitute_deletion_dmail_template(dmail[:body]),
           })
         end
       rescue PostFlag::Error

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1621,6 +1621,19 @@ class Post < ApplicationRecord
     def pending_flag
       flags.unresolved.order(id: :desc).first
     end
+
+    def substitute_deletion_dmail_template(text, reason = nil)
+      unless text.presence
+        return nil
+      end
+      if reason
+        text = text.gsub("%REASON%", reason)
+      end
+      text.gsub("%POST_ID%", id.to_s)
+          .gsub("%STAFF_NAME%", CurrentUser.name)
+          .gsub("%STAFF_ID%", CurrentUser.id.to_s)
+          .gsub("%UPLOADER_ID%", uploader_id.to_s)
+    end
   end
 
   module VersionMethods

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1623,9 +1623,7 @@ class Post < ApplicationRecord
     end
 
     def substitute_deletion_dmail_template(text, reason = nil)
-      unless text.presence
-        return nil
-      end
+      return nil if text.blank?
       if reason
         text = text.gsub("%REASON%", reason)
       end

--- a/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
+++ b/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
@@ -6,17 +6,8 @@
         <%= " checked" if Danbooru.config.enable_post_deletion_dmail %>
         <% message = Danbooru.config.post_deletion_dmail_templates.values.first %>
         <% if message.is_a?(Hash) %>
-          <% if message[:body].present? %>
-            data-dmail-message="<%= message[:body]
-              .gsub("%POST_ID%", @post.id.to_s)
-              .gsub("%STAFF_NAME%", CurrentUser.name)
-              .gsub("%STAFF_ID%", CurrentUser.id.to_s)
-              .gsub("%UPLOADER_ID%", @post.uploader_id.to_s)
-            %>"
-          <% else %>
-            data-dmail-message=""
-          <% end %>
-          data-dmail-title="<%= message[:title] || "" %>"
+          data-dmail-message="<%= @post.substitute_deletion_dmail_template(message[:body]) %>"
+          data-dmail-title="<%= @post.substitute_deletion_dmail_template(message[:title]) %>"
         <% end %>
         >
     </label>

--- a/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
+++ b/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
@@ -1,0 +1,29 @@
+<form class="simple_form" id="delete-with-reason-dialog" data-title="Delete Post" data-width="500" data-position="center">
+  <div class="input delete-with-reason-dialog-inputs">
+    <input type="text" id="delete-with-reason-dialog-input" placeholder="Enter reason here...">
+    <label for="delete-with-reason-dialog-enable-dmail">
+      Send DMail (default template)? <input type="checkbox" id="delete-with-reason-dialog-enable-dmail"
+        <%= " checked" if Danbooru.config.enable_post_deletion_dmail %>
+        <% message = Danbooru.config.post_deletion_dmail_templates.values.first %>
+        <% if message.is_a?(Hash) %>
+          <% if message[:body].present? %>
+            data-dmail-message="<%= message[:body]
+              .gsub("%POST_ID%", @post.id.to_s)
+              .gsub("%STAFF_NAME%", CurrentUser.name)
+              .gsub("%STAFF_ID%", CurrentUser.id.to_s)
+              .gsub("%UPLOADER_ID%", @post.uploader_id.to_s)
+            %>"
+          <% else %>
+            data-dmail-message=""
+          <% end %>
+          data-dmail-title="<%= message[:title] || "" %>"
+        <% end %>
+        >
+    </label>
+  </div>
+
+  <div class="input delete-with-reason-dialog-submit">
+    <button type="button" class="st-button" id="delete-with-reason-dialog-cancel">Cancel</button>
+    <button type="submit" class="st-button submit" id="delete-with-reason-dialog-ok">OK</button>
+  </div>
+</form>

--- a/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
+++ b/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
@@ -1,16 +1,19 @@
 <form class="simple_form" id="delete-with-reason-dialog" data-title="Delete Post" data-width="500" data-position="center">
   <div class="input delete-with-reason-dialog-inputs">
+    <label for=delete-with-reason-dialog-input>Reason</label>
     <input type="text" id="delete-with-reason-dialog-input" placeholder="Enter reason here...">
-    <label for="delete-with-reason-dialog-enable-dmail">
-      Send DMail (default template)? <input type="checkbox" id="delete-with-reason-dialog-enable-dmail"
-        <%= " checked" if Danbooru.config.enable_post_deletion_dmail %>
-        <% message = Danbooru.config.post_deletion_dmail_templates.values.first %>
-        <% if message.is_a?(Hash) %>
-          data-dmail-message="<%= @post.substitute_deletion_dmail_template(message[:body]) %>"
-          data-dmail-title="<%= @post.substitute_deletion_dmail_template(message[:title]) %>"
-        <% end %>
-        >
-    </label>
+    <% unless Danbooru.config.post_deletion_dmail_templates.blank? %>
+      <label for="delete-with-reason-dialog-enable-dmail">
+        Send DMail (default template)? <input type="checkbox" id="delete-with-reason-dialog-enable-dmail"
+          <%= " checked" if Danbooru.config.enable_post_deletion_dmail %>
+          <% message = Danbooru.config.post_deletion_dmail_templates.values.first %>
+          <% if message.is_a?(Hash) %>
+            data-dmail-message="<%= @post.substitute_deletion_dmail_template(message[:body]) %>"
+            data-dmail-title="<%= @post.substitute_deletion_dmail_template(message[:title]) %>"
+          <% end %>
+          >
+      </label>
+    <% end %>
   </div>
 
   <div class="input delete-with-reason-dialog-submit">

--- a/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
+++ b/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
@@ -1,6 +1,6 @@
 <form class="simple_form" id="delete-with-reason-dialog" data-title="Delete Post" data-width="500" data-position="center">
   <div class="input delete-with-reason-dialog-inputs">
-    <label for=delete-with-reason-dialog-input>Reason</label>
+    <label for="delete-with-reason-dialog-input">Reason</label>
     <input type="text" id="delete-with-reason-dialog-input" placeholder="Enter reason here...">
     <% unless Danbooru.config.post_deletion_dmail_templates.blank? %>
       <label for="delete-with-reason-dialog-enable-dmail">

--- a/app/views/moderator/post/posts/confirm_delete.html.erb
+++ b/app/views/moderator/post/posts/confirm_delete.html.erb
@@ -41,12 +41,9 @@
       <select id="del-dmail-template">
         <% Danbooru.config.post_deletion_dmail_templates.each_pair do |key, message| %>
           <% if message.is_a?(Hash) && message[:body].present? %>
-            <option class="button del-dmail-button" value="<%= message[:body]
-                .gsub("%POST_ID%", @post.id.to_s)
-                .gsub("%STAFF_NAME%", CurrentUser.name)
-                .gsub("%STAFF_ID%", CurrentUser.id.to_s)
-                .gsub("%UPLOADER_ID%", @post.uploader_id.to_s)
-              %>">
+            <option class="button del-dmail-button"
+              value="<%= @post.substitute_deletion_dmail_template(message[:body]) %>"
+              data-dmail-title="<%= @post.substitute_deletion_dmail_template(message[:title]) %>">
               <%= key.to_s.titleize %>
             </option>
           <% end %>
@@ -54,9 +51,10 @@
       </select>
     </label>
 
+    <input type="text" size="50" name="dmail_title" id="dmail-title">
     <%# TODO: Figure out using <%= f.input :dmail, as: :dtext, limit: Danbooru.config.dmail_max_size %>
     <div class="dtext-formatter pending" data-color="true" data-limit="<%= Danbooru.config.dmail_max_size %>">
-      <textarea class="dtext dtext-formatter-input dtext dtext-formatter-input" cols="80" rows="10" id="dmail_for_" name="dmail"></textarea>
+      <textarea class="dtext dtext-formatter-input dtext dtext-formatter-input" cols="80" rows="10" id="dmail-message" name="dmail"></textarea>
     </div>
 
     <%= submit_tag "Delete" %>

--- a/app/views/moderator/post/posts/confirm_delete.html.erb
+++ b/app/views/moderator/post/posts/confirm_delete.html.erb
@@ -32,30 +32,32 @@
       </div>
     <% end %>
 
-    <label for="send-dmail"  class="delete-send-dmail">
-      Send Dmail? <input type="checkbox" form="unused" name="send-dmail" id="send-dmail"<%= " checked" if Danbooru.config.enable_post_deletion_dmail %> />
-    </label>
+    <% unless Danbooru.config.post_deletion_dmail_templates.blank? %>
+      <label for="send-dmail"  class="delete-send-dmail">
+        Send DMail? <input type="checkbox" form="unused" name="send-dmail" id="send-dmail"<%= " checked" if Danbooru.config.enable_post_deletion_dmail %> />
+      </label>
 
-    <label for="del-dmail-template">
-      DMail Template
-      <select id="del-dmail-template">
-        <% Danbooru.config.post_deletion_dmail_templates.each_pair do |key, message| %>
-          <% if message.is_a?(Hash) && message[:body].present? %>
-            <option class="button del-dmail-button"
-              value="<%= @post.substitute_deletion_dmail_template(message[:body]) %>"
-              data-dmail-title="<%= @post.substitute_deletion_dmail_template(message[:title]) %>">
-              <%= key.to_s.titleize %>
-            </option>
+      <label for="del-dmail-template">
+        DMail Template
+        <select id="del-dmail-template">
+          <% Danbooru.config.post_deletion_dmail_templates.each_pair do |key, message| %>
+            <% if message.is_a?(Hash) && message[:body].present? %>
+              <option class="button del-dmail-button"
+                value="<%= @post.substitute_deletion_dmail_template(message[:body]) %>"
+                data-dmail-title="<%= @post.substitute_deletion_dmail_template(message[:title]) %>">
+                <%= key.to_s.titleize %>
+              </option>
+            <% end %>
           <% end %>
-        <% end %>
-      </select>
-    </label>
+        </select>
+      </label>
 
-    <input type="text" size="50" name="dmail_title" id="dmail-title">
-    <%# TODO: Figure out using <%= f.input :dmail, as: :dtext, limit: Danbooru.config.dmail_max_size %>
-    <div class="dtext-formatter pending" data-color="true" data-limit="<%= Danbooru.config.dmail_max_size %>">
-      <textarea class="dtext dtext-formatter-input dtext dtext-formatter-input" cols="80" rows="10" id="dmail-message" name="dmail"></textarea>
-    </div>
+      <input type="text" size="50" name="dmail_title" id="dmail-title">
+      <%# TODO: Figure out using <%= f.input :dmail, as: :dtext, limit: Danbooru.config.dmail_max_size %>
+      <div class="dtext-formatter pending" data-color="true" data-limit="<%= Danbooru.config.dmail_max_size %>">
+        <textarea class="dtext dtext-formatter-input dtext dtext-formatter-input" cols="80" rows="10" id="dmail-message" name="dmail"></textarea>
+      </div>
+    <% end %>
 
     <%= submit_tag "Delete" %>
     <%= submit_tag "Cancel" %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -178,6 +178,7 @@
 
       <% if CurrentUser.can_approve_posts? %>
         <%= render "post_disapprovals/detailed_rejection_dialog" %>
+        <%= render "moderator/post/posts/delete_with_reason_dialog" %>
       <% end %>
     </div>
 


### PR DESCRIPTION
- Replace the basic `window.confirm()` dialog with something more useful
  - Send deletion DMail checkbox (always uses the default template)
  - Prefilled reason text box so it can be modified (doesn't show when reason is `from-flag`)
  - Enter and escape key shortcuts still work as before
- Implement deletion DMail titles
  - New field in the deletion confirmation page so it can be edited 