### PR TITLE
[AIBUR] Remove unused TagAliaseUndoJob reference

### DIFF
--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -15,7 +15,6 @@ class TagAlias < TagRelationship
         TagAliasJob.perform_later(id, update_topic)
       end
     end
-
   end
 
   module ForumMethods
@@ -244,8 +243,6 @@ class TagAlias < TagRelationship
     if TagAlias.active.exists?(antecedent_name: consequent_name)
       errors.add(:base, "A tag alias for #{consequent_name} already exists")
     end
-
-
   end
 
   def move_aliases_and_implications

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -16,11 +16,6 @@ class TagAlias < TagRelationship
       end
     end
 
-    def undo!(approver: CurrentUser.user)
-      CurrentUser.scoped(approver) do
-        TagAliaseUndoJob.perform_later(id, true)
-      end
-    end
   end
 
   module ForumMethods


### PR DESCRIPTION
Removes the dead `undo!` method from `TagAlias::ApprovalMethods`. It called `TagAliaseUndoJob` which doesn't exist as a class anywhere in the codebase. The method was leftover from an abandoned undo feature.

Grep confirms zero remaining references to `TagAliaseUndoJob` after this change.

Fixes #1759

This contribution was developed with AI assistance (Claude Code).