### PR TITLE
[Recommender] Fix issues with either having too many artist tags or none

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -171,8 +171,8 @@ class PostsController < ApplicationController
       return
     end
 
-    post_ids = Cache.fetch("post_recommendations:#{@original_post.id}:#{params[:page]}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}", expires_in: 15.minutes) do
-      PostSets::Recommended.new(@original_post, params[:page], limit: params[:limit]).post_ids
+    post_ids = Cache.fetch("post_recommendations:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}", expires_in: 15.minutes) do
+      PostSets::Recommended.new(@original_post, limit: params[:limit]).post_ids
     end
     # Matches the format of the recommendation engine
     render json: {

--- a/app/javascript/src/javascripts/recommended.js
+++ b/app/javascript/src/javascripts/recommended.js
@@ -170,7 +170,7 @@ Recommended.loadState = async function (action = Recommended.action) {
     const entry = data.results[postId];
     if (!entry) continue;
     const post = posts[postId];
-    if (post.flags.deleted) continue;
+    if (!post || !post.flags || post.flags.deleted) continue;
     entry.post = post;
 
     // Prevent layout shifts by replacing placeholders

--- a/app/logical/post_sets/recommended.rb
+++ b/app/logical/post_sets/recommended.rb
@@ -2,15 +2,17 @@
 
 module PostSets
   class Recommended < PostSets::Base
-    attr_reader :tag_array, :page, :limit, :post_count
+    attr_reader :tag_array, :limit
 
-    def initialize(post, page = 1, limit: nil)
+    def initialize(post, limit: 6)
       super()
       @original_post = post
+      @limit = limit.to_i.clamp(1, 20)
 
-      tags = post.known_artist_tags.map { |t| "~#{t.name}" }.first(10)
+      tags = post.known_artist_tags.sort_by(&:name).first(10).map { |t| "~#{t.name}" }
       if tags.empty?
         @no_results = true
+        @tag_array = []
         return
       end
 
@@ -22,43 +24,14 @@ module PostSets
       tags << "randseed:#{post.id}"
 
       @tag_array = TagQuery.scan_search(tags.join(" "), error_on_depth_exceeded: true)
-      @page = [page.to_i, 1].max
-      @limit = limit
     end
 
     def tag_string
-      @tag_string ||= if @no_results
-                        ""
-                      else
-                        TagQuery.scan_recursive(
-                          tag_array.uniq.join(" "),
-                          strip_duplicates_at_level: true,
-                          delimit_groups: true,
-                          flatten: true,
-                          strip_prefixes: false,
-                          sort_at_level: false,
-                          normalize_at_level: false,
-                        ).join(" ")
-                      end
-    end
-
-    def humanized_tag_string
-      @no_results ? "" : tag_array.slice(0, 25).join(" ").tr("_", " ")
+      @tag_string ||= @tag_array.join(" ")
     end
 
     def post_ids
-      @post_ids ||= @no_results ? [] : ::Post.tag_match(tag_string).paginate_posts(page, limit: limit).pluck(:id)
-    end
-
-    def posts
-      @posts ||= if @no_results
-                   []
-                 else
-                   temp = ::Post.tag_match(tag_string).paginate_posts(page, limit: limit, includes: [:uploader])
-
-                   @post_count = temp.total_count
-                   temp
-                 end
+      @post_ids ||= @no_results ? [] : ::Post.tag_match(tag_string).limit(@limit).pluck(:id)
     end
   end
 end

--- a/app/logical/post_sets/recommended.rb
+++ b/app/logical/post_sets/recommended.rb
@@ -8,7 +8,12 @@ module PostSets
       super()
       @original_post = post
 
-      tags = post.known_artist_tags.map { |t| "~#{t.name}" }
+      tags = post.known_artist_tags.map { |t| "~#{t.name}" }.first(10)
+      if tags.empty?
+        @no_results = true
+        return
+      end
+
       tags << "-id:#{post.id}"
       tags << "-parent:#{post.id}"
       tags << "-child:#{post.id}"
@@ -22,32 +27,38 @@ module PostSets
     end
 
     def tag_string
-      @tag_string ||= TagQuery.scan_recursive(
-        tag_array.uniq.join(" "),
-        strip_duplicates_at_level: true,
-        delimit_groups: true,
-        flatten: true,
-        strip_prefixes: false,
-        sort_at_level: false,
-        normalize_at_level: false,
-      ).join(" ")
+      @tag_string ||= if @no_results
+                        ""
+                      else
+                        TagQuery.scan_recursive(
+                          tag_array.uniq.join(" "),
+                          strip_duplicates_at_level: true,
+                          delimit_groups: true,
+                          flatten: true,
+                          strip_prefixes: false,
+                          sort_at_level: false,
+                          normalize_at_level: false,
+                        ).join(" ")
+                      end
     end
 
     def humanized_tag_string
-      tag_array.slice(0, 25).join(" ").tr("_", " ")
+      @no_results ? "" : tag_array.slice(0, 25).join(" ").tr("_", " ")
     end
 
     def post_ids
-      @post_ids ||= ::Post.tag_match(tag_string).paginate_posts(page, limit: limit).pluck(:id)
+      @post_ids ||= @no_results ? [] : ::Post.tag_match(tag_string).paginate_posts(page, limit: limit).pluck(:id)
     end
 
     def posts
-      @posts ||= begin
-        temp = ::Post.tag_match(tag_string).paginate_posts(page, limit: limit, includes: [:uploader])
+      @posts ||= if @no_results
+                   []
+                 else
+                   temp = ::Post.tag_match(tag_string).paginate_posts(page, limit: limit, includes: [:uploader])
 
-        @post_count = temp.total_count
-        temp
-      end
+                   @post_count = temp.total_count
+                   temp
+                 end
     end
   end
 end


### PR DESCRIPTION
Heavily cut down the Recommender class, removing everything that was not being actively used.
At the end of the day, we really only need the `post_ids`, although technically we could make use of the `tag_string` later.

Clamped limit to a value between 1 and 20, matching the behavior from the [recommender](https://github.com/e621ng/recommender).
Removed pagination.