### PR TITLE
[Analytics] Rework analytics to track specific events

### DIFF
--- a/app/controllers/security/lockdown_controller.rb
+++ b/app/controllers/security/lockdown_controller.rb
@@ -77,14 +77,14 @@ module Security
     end
 
     def analytics
-      params = analytics_params
+      analytics = analytics_params
 
-      if params[:collect_recommendation_events].present?
-        Setting.collect_recommendation_events = params[:collect_recommendation_events] == "1"
+      if analytics[:collect_recommendation_events].present?
+        Setting.collect_recommendation_events = analytics[:collect_recommendation_events] == "1"
       end
 
-      if params[:collect_search_trend_events].present?
-        Setting.collect_search_trend_events = params[:collect_search_trend_events] == "1"
+      if analytics[:collect_search_trend_events].present?
+        Setting.collect_search_trend_events = analytics[:collect_search_trend_events] == "1"
       end
 
       redirect_to security_root_path

--- a/app/controllers/security/lockdown_controller.rb
+++ b/app/controllers/security/lockdown_controller.rb
@@ -77,14 +77,14 @@ module Security
     end
 
     def analytics
-      analytics = analytics_params
+      settings = analytics_params
 
-      if analytics[:collect_recommendation_events].present?
-        Setting.collect_recommendation_events = analytics[:collect_recommendation_events] == "1"
+      if settings[:collect_recommendation_events].present?
+        Setting.collect_recommendation_events = settings[:collect_recommendation_events] == "1"
       end
 
-      if analytics[:collect_search_trend_events].present?
-        Setting.collect_search_trend_events = analytics[:collect_search_trend_events] == "1"
+      if settings[:collect_search_trend_events].present?
+        Setting.collect_search_trend_events = settings[:collect_search_trend_events] == "1"
       end
 
       redirect_to security_root_path

--- a/app/controllers/security/lockdown_controller.rb
+++ b/app/controllers/security/lockdown_controller.rb
@@ -76,6 +76,20 @@ module Security
       redirect_to security_root_path
     end
 
+    def analytics
+      params = analytics_params
+
+      if params[:collect_recommendation_events].present?
+        Setting.collect_recommendation_events = params[:collect_recommendation_events] == "1"
+      end
+
+      if params[:collect_search_trend_events].present?
+        Setting.collect_search_trend_events = params[:collect_search_trend_events] == "1"
+      end
+
+      redirect_to security_root_path
+    end
+
     def lockdown_params
       permitted_params = %i[uploads pools post_sets comments forums blips aiburs favorites votes takedowns]
       params.fetch(:lockdown, {}).permit(permitted_params)
@@ -84,6 +98,11 @@ module Security
     def maintenance_params
       permitted_params = %i[disable_exception_prune]
       params.fetch(:maintenance, {}).permit(permitted_params)
+    end
+
+    def analytics_params
+      permitted_params = %i[collect_recommendation_events collect_search_trend_events]
+      params.fetch(:analytics, {}).permit(permitted_params)
     end
   end
 end

--- a/app/helpers/site_settings_helper.rb
+++ b/app/helpers/site_settings_helper.rb
@@ -1,21 +1,24 @@
 # frozen_string_literal: true
 
 module SiteSettingsHelper
-  def site_settings_json
-    json_escape(site_settings_data.to_json).html_safe
+  # Base64-encoded JSON blob containing site settings for use in JavaScript.
+  def site_settings_base64
+    Base64.strict_encode64(site_settings_data.to_json)
   end
 
   private
 
   def site_settings_data
+    analytics_enabled = Danbooru.config.enable_visitor_metrics? && Danbooru.config.analytics_client_id.present?
+
     {
       analytics: {
-        enabled: Danbooru.config.enable_visitor_metrics? && Danbooru.config.analytics_client_id.present?,
-        client_id: Danbooru.config.analytics_client_id,
+        enabled: analytics_enabled,
+        client_id: analytics_enabled ? Danbooru.config.analytics_client_id : nil,
 
         events: {
-          recommendation: Setting.collect_recommendation_events?,
-          search_trend: Setting.collect_search_trend_events?,
+          recommendation: Setting.collect_recommendation_events? || false,
+          search_trend: Setting.collect_search_trend_events? || false,
         },
       },
     }

--- a/app/helpers/site_settings_helper.rb
+++ b/app/helpers/site_settings_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module SiteSettingsHelper
+  def site_settings_json
+    json_escape(site_settings_data.to_json).html_safe
+  end
+
+  private
+
+  def site_settings_data
+    {
+      analytics: {
+        enabled: Danbooru.config.enable_visitor_metrics? && Danbooru.config.analytics_client_id.present?,
+        client_id: Danbooru.config.analytics_client_id,
+
+        events: {
+          recommendation: Setting.collect_recommendation_events?,
+          search_trend: Setting.collect_search_trend_events?,
+        },
+      },
+    }
+  end
+end

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -84,4 +84,6 @@ window.E621 = {
   error: inError,
   notice: inNotice,
 };
+
+// We will eventually want to remove the Danbooru object, and use E621 instead.
 window.Danbooru = window.E621;

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -14,6 +14,7 @@ import.meta.glob("../src/javascripts/**/*.js", { eager: true });
 // TODO: Remove this global Danbooru object and migrate all code to use ES6 imports instead.
 // This mimics the old webpacker output.library behavior for backward compatibility.
 import LStorage from "../src/javascripts/utility/storage.js";
+import Settings from "../src/javascripts/utility/settings.js";
 import TaskQueue from "../src/javascripts/utility/task_queue.js";
 import Hotkeys from "../src/javascripts/hotkeys.js";
 import Dialog from "../src/javascripts/utility/dialog.js";
@@ -50,8 +51,9 @@ function inNotice (msg) {
   $(window).trigger("danbooru:notice", msg);
 }
 
-window.Danbooru = {
+window.E621 = {
   LStorage,
+  Settings,
   TaskQueue,
   Hotkeys,
   Dialog,
@@ -82,3 +84,4 @@ window.Danbooru = {
   error: inError,
   notice: inNotice,
 };
+window.Danbooru = window.E621;

--- a/app/javascript/src/javascripts/analytics.js
+++ b/app/javascript/src/javascripts/analytics.js
@@ -25,14 +25,16 @@ export default class Analytics {
 
   track (event, attributes = {}) {
     if (!this.enabledEvents[event]) return;
-    console.log(`Tracking event: ${event}`, attributes);
     this._op.track(event, attributes);
   }
 
   bootstrapSearchTrendClicks () {
     if (!Page.matches("static", "home")) return;
     if (!Settings.Analytics.events.search_trend) return;
+
     $(".rising-list").one("click", "a", (event) => {
+      // Only track the first click to prevent multiple events from being fired if the user clicks
+      // multiple times. The links navigate away from the page regardless, so this is acceptable.
       const data = event.currentTarget.dataset;
       if (!data.tag || !data.category) return;
       this.track(Analytics.Event.SearchTrend, {

--- a/app/javascript/src/javascripts/analytics.js
+++ b/app/javascript/src/javascripts/analytics.js
@@ -38,8 +38,8 @@ export default class Analytics {
       const data = event.currentTarget.dataset;
       if (!data.tag || !data.category) return;
       this.track(Analytics.Event.SearchTrend, {
-        tag: data.tag || null,
-        category: data.category || null,
+        tag: data.tag,
+        category: data.category,
       });
     });
   }

--- a/app/javascript/src/javascripts/analytics.js
+++ b/app/javascript/src/javascripts/analytics.js
@@ -1,9 +1,11 @@
 import { OpenPanel } from "@openpanel/web";
 import Page from "./utility/page";
+import Settings from "./utility/settings";
 
 export default class Analytics {
 
   constructor (clientID) {
+    if (Analytics._instance) throw new Error("Analytics has already been initialized");
     if (!clientID) throw new Error("clientID is required");
 
     this._op = new OpenPanel({
@@ -14,35 +16,69 @@ export default class Analytics {
       trackAttributes: true,
     });
 
-    // Disabled for performance reasons, for now.
-    // this.bootstrapSearchData();
+    this.enabledEvents = Settings.Analytics.events || {};
+
+    // Event listeners should be set up in their own modules.
+    // Only bootstrap them here if the module does not exist.
+    this.bootstrapSearchTrendClicks();
   }
 
-  bootstrapSearchData () {
-    if (!Page.matches("posts", "index")) return;
-    const query = $("#tags").val() || "";
-    let resultsCount = $(".approximate-count").data("count") || 0;
-    this._op.track("search", {
-      query: query,
-      queryLength: query.split(" ").length,
-      resultsCount: resultsCount,
-      hasResults: resultsCount > 0,
+  track (event, attributes = {}) {
+    if (!this.enabledEvents[event]) return;
+    console.log(`Tracking event: ${event}`, attributes);
+    this._op.track(event, attributes);
+  }
+
+  bootstrapSearchTrendClicks () {
+    if (!Page.matches("static", "home")) return;
+    if (!Settings.Analytics.events.search_trend) return;
+    $(".rising-list").one("click", "a", (event) => {
+      const data = event.currentTarget.dataset;
+      if (!data.tag || !data.category) return;
+      this.track(Analytics.Event.SearchTrend, {
+        tag: data.tag || null,
+        category: data.category || null,
+      });
     });
   }
 
   static _instance = null;
   static _init () {
-    this._instance = new Analytics(window.op_client_id);
+    this._instance = new Analytics(Settings.Analytics.client_id);
   }
 
-  static trigger (event, attributes = {}) {
+  /**
+   * Record an analytics event with the given name and attributes.  
+   * The event will only be recorded if analytics are enabled.
+   * @param {string} event - The name of the event to track.
+   * @param {Object} attributes - A key-value map of attributes to associate with the event.
+   * @returns {void}
+   */
+  static track (event, attributes = {}) {
     if (!this._instance) return;
     this._instance.track(event, attributes);
   }
 
+  /**
+   * @returns {boolean} Whether analytics tracking is enabled or not.
+   */
+  static get enabled () {
+    return !!Settings.Analytics.enabled;
+  }
+
+  /**
+   * Enum of supported analytics events. Only events listed here will be tracked.  
+   * Should be kept in sync with Settings.Analytics.events in the back-end.
+   * @readonly
+   * @enum {string}
+   */
+  static Event = {
+    Recommendation: "recommendation",
+    SearchTrend: "search_trend",
+  };
 }
 
 $(() => {
-  if (!window.op_client_id) return;
+  if (!Settings.Analytics.enabled) return;
   Analytics._init();
 });

--- a/app/javascript/src/javascripts/recommended.js
+++ b/app/javascript/src/javascripts/recommended.js
@@ -273,7 +273,7 @@ Recommended.waitUntilReady = function () {
   });
 };
 
-Recommended.render = function (data, currentPostId = Recommended.postId) {
+Recommended.render = function (data) {
   // Login-blocked, Safe-blocked, or just missing preview = can't render thumbnail
   if (!data || !data.post || !data.post.preview || !data.post.preview.url) return null;
 
@@ -320,7 +320,6 @@ Recommended.render = function (data, currentPostId = Recommended.postId) {
     .attr({
       "href": `/posts/${data.post.id}`,
       "data-target": data.post.id,
-      "data-current": currentPostId,
     })
     .appendTo(article);
 

--- a/app/javascript/src/javascripts/recommended.js
+++ b/app/javascript/src/javascripts/recommended.js
@@ -25,6 +25,8 @@ Recommended.init = function () {
   // Bootstrap analytics
   if (Analytics.enabled)
     Recommended.$wrapper.one("click", "a", (event) => {
+      // Only track the first click to prevent multiple events from being fired if the user clicks
+      // multiple times. The links navigate away from the page regardless, so this is acceptable.
       const data = event.currentTarget.dataset;
       if (!data.target) return;
       Analytics.track(Analytics.Event.Recommendation, {

--- a/app/javascript/src/javascripts/recommended.js
+++ b/app/javascript/src/javascripts/recommended.js
@@ -2,6 +2,7 @@ import Page from "./utility/page";
 import SVGIcon from "./utility/svg_icon";
 import LStorage from "./utility/storage";
 import Blacklist from "./blacklists";
+import Analytics from "./analytics";
 
 const Recommended = {};
 
@@ -20,6 +21,17 @@ Recommended.init = function () {
     Recommended.$wrapper.remove();
     return;
   }
+
+  // Bootstrap analytics
+  if (Analytics.enabled)
+    Recommended.$wrapper.one("click", "a", (event) => {
+      const data = event.currentTarget.dataset;
+      if (!data.target) return;
+      Analytics.track(Analytics.Event.Recommendation, {
+        target: "/posts/" + data.target,
+        action: Recommended.action,
+      });
+    });
 
   Recommended.SHOW_ENGINE_RESULTS = Recommended.$wrapper.attr("data-remote") === "true";
   if (Recommended.SHOW_ENGINE_RESULTS)
@@ -259,7 +271,7 @@ Recommended.waitUntilReady = function () {
   });
 };
 
-Recommended.render = function (data) {
+Recommended.render = function (data, currentPostId = Recommended.postId) {
   // Login-blocked, Safe-blocked, or just missing preview = can't render thumbnail
   if (!data || !data.post || !data.post.preview || !data.post.preview.url) return null;
 
@@ -303,7 +315,11 @@ Recommended.render = function (data) {
   // Core
   const link = $("<a>")
     .addClass("thm-link")
-    .attr("href", `/posts/${data.post.id}`)
+    .attr({
+      "href": `/posts/${data.post.id}`,
+      "data-target": data.post.id,
+      "data-current": currentPostId,
+    })
     .appendTo(article);
 
   $("<img>")

--- a/app/javascript/src/javascripts/utility/settings.js
+++ b/app/javascript/src/javascripts/utility/settings.js
@@ -1,9 +1,18 @@
 let _data = {}, loaded = false;
 const _get = function () {
   if (loaded) return _data;
-  _data = JSON.parse(document.getElementById("site-settings").textContent);
-  loaded = true;
-  return _data;
+  try {
+    const base64 = document.getElementById("site-settings").textContent;
+    const json = atob(base64);
+    _data = JSON.parse(json);
+    loaded = true;
+    return _data;
+  } catch (e) {
+    _data = {};
+    loaded = true;
+    console.error("Failed to load site settings:", e);
+    return {};
+  }
 };
 
 /*

--- a/app/javascript/src/javascripts/utility/settings.js
+++ b/app/javascript/src/javascripts/utility/settings.js
@@ -1,0 +1,32 @@
+let _data = {}, loaded = false;
+const _get = function () {
+  if (loaded) return _data;
+  _data = JSON.parse(document.getElementById("site-settings").textContent);
+  loaded = true;
+  return _data;
+};
+
+/*
+  Settings values passed from the back-end.
+  These are accessed via getters that replace themselves with the actual value on first access.
+  This allows us to avoid parsing JSON until it is needed, and also gives control over the structure
+  and contents of the Settings object exposed to the rest of the codebase.
+*/
+
+const Settings = {
+  get Analytics () {
+    const obj = _get().analytics || {};
+    delete Settings.Analytics;
+    Settings.Analytics = {
+      enabled: obj.enabled || false,
+      client_id: obj.client_id || null,
+      events: { // Synchronize with Analytics.Event enum
+        recommendation: obj.events?.recommendation || false,
+        search_trend: obj.events?.search_trend || false,
+      },
+    };
+    return Settings.Analytics;
+  },
+};
+
+export default Settings;

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -42,7 +42,7 @@ class Setting < RailsSettings::Base
   end
 
   scope :analytics do
-    field :collect_recommendation_events, type: :boolean, default: true
-    field :collect_search_trend_events, type: :boolean, default: true
+    field :collect_recommendation_events, type: :boolean, default: false
+    field :collect_search_trend_events, type: :boolean, default: false
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -40,4 +40,9 @@ class Setting < RailsSettings::Base
     field :trends_tag_limit, type: :integer, default: 100, validates: { presence: true, numericality: { only_integer: true, greater_than: 0 } }
     field :trends_tag_window, type: :integer, default: 600, validates: { presence: true, numericality: { only_integer: true, greater_than: 0 } }
   end
+
+  scope :analytics do
+    field :collect_recommendation_events, type: :boolean, default: true
+    field :collect_search_trend_events, type: :boolean, default: true
+  end
 end

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -61,7 +61,7 @@
 </script>
 
 <%# Site configuration for JavaScript %>
-<script type="application/json" id="site-settings"><%= site_settings_json %></script>
+<script type="application/json" id="site-settings"><%= site_settings_base64 %></script>
 
 <style id="blacklisted-hider">
   .thumbnail, #image-container, #c-comments .post, .post-thumbnail {

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -60,6 +60,9 @@
 }
 </script>
 
+<%# Site configuration for JavaScript %>
+<script type="application/json" id="site-settings"><%= site_settings_json %></script>
+
 <style id="blacklisted-hider">
   .thumbnail, #image-container, #c-comments .post, .post-thumbnail {
     visibility: hidden !important;

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -61,7 +61,7 @@
 </script>
 
 <%# Site configuration for JavaScript %>
-<script type="application/json" id="site-settings"><%= site_settings_base64 %></script>
+<script type="text/plain" id="site-settings" data-encoding="base64"><%= site_settings_base64 %></script>
 
 <style id="blacklisted-hider">
   .thumbnail, #image-container, #c-comments .post, .post-thumbnail {

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -37,12 +37,6 @@
   <% end %>
 
   <%= render "static/footer" %>
-  <% if Danbooru.config.enable_visitor_metrics? && Danbooru.config.analytics_client_id.present? %>
-    <script nonce="<%= content_security_policy_nonce %>">
-      window.op_client_id = "<%= Danbooru.config.analytics_client_id %>";
-    </script>
-  <% end %>
-
   <%= render "ads/revive" %>
   <% if Danbooru.config.fsc_modal_enabled? %>
     <script src="https://assets.freespeechcoalition.com/code/avActionModal.min.js"></script>

--- a/app/views/search_trends/_rising_inline.html.erb
+++ b/app/views/search_trends/_rising_inline.html.erb
@@ -6,7 +6,13 @@
     <div class="rising-left">
       <% left_tags.each do |row| %>
         <div class="rising-item">
-          <a href="<%= posts_path(tags: row[:name]) %>" class="tag-type-<%= row[:category] %>" data-place="<%= row[:place] %>">
+          <a
+            href="<%= posts_path(tags: row[:name]) %>"
+            class="tag-type-<%= row[:category] %>"
+            data-place="<%= row[:place] %>"
+            data-tag="<%= row[:name] %>"
+            data-category="<%= row[:category] %>"
+          >
             <span class="rising-rank">#<%= index %></span>
             <span class="rising-link"><%= row[:pretty_name] %></span>
           </a>
@@ -20,7 +26,13 @@
     <div class="rising-right">
       <% right_tags.each do |row| %>
         <div class="rising-item">
-          <a href="<%= posts_path(tags: row[:name]) %>" class="tag-type-<%= row[:category] %>" data-place="<%= row[:place] %>">
+          <a
+            href="<%= posts_path(tags: row[:name]) %>"
+            class="tag-type-<%= row[:category] %>"
+            data-place="<%= row[:place] %>"
+            data-tag="<%= row[:name] %>"
+            data-category="<%= row[:category] %>"
+          >
             <span class="rising-rank">#<%= index %></span>
             <span class="rising-link"><%= row[:pretty_name] %></span>
           </a>

--- a/app/views/security/dashboard/index.html.erb
+++ b/app/views/security/dashboard/index.html.erb
@@ -51,8 +51,8 @@
     <section class="settings-section">
       <h2>Analytics</h2>
       <%= custom_form_for(:analytics, url: analytics_security_lockdown_index_path, method: :put) do |f| %>
-        <%= f.input :collect_recommendation_events, as: :boolean, label: "Recommendation events", input_html: { checked: Setting.collect_recommendation_events? ? "checked" : "" } %>
-        <%= f.input :collect_search_trend_events, as: :boolean, label: "Search Trend events", input_html: { checked: Setting.collect_search_trend_events? ? "checked" : "" } %>
+        <%= f.input :collect_recommendation_events, as: :boolean, label: "Recommendation events", input_html: { checked: Setting.collect_recommendation_events? } %>
+        <%= f.input :collect_search_trend_events, as: :boolean, label: "Search Trend events", input_html: { checked: Setting.collect_search_trend_events? } %>
         <%= f.button :submit, value: "Submit" %>
       <% end %>
     </section>

--- a/app/views/security/dashboard/index.html.erb
+++ b/app/views/security/dashboard/index.html.erb
@@ -49,6 +49,15 @@
     </section>
 
     <section class="settings-section">
+      <h2>Analytics</h2>
+      <%= custom_form_for(:analytics, url: analytics_security_lockdown_index_path, method: :put) do |f| %>
+        <%= f.input :collect_recommendation_events, as: :boolean, label: "Recommendation events", input_html: { checked: Setting.collect_recommendation_events? ? "checked" : "" } %>
+        <%= f.input :collect_search_trend_events, as: :boolean, label: "Search Trend events", input_html: { checked: Setting.collect_search_trend_events? ? "checked" : "" } %>
+        <%= f.button :submit, value: "Submit" %>
+      <% end %>
+    </section>
+
+    <section class="settings-section">
       <h2>Exception Log Pruning</h2>
       Exception logs older than <b>1 year</b> are pruned during daily maintenance.
       <%= custom_form_for(:maintenance, url: maintenance_security_lockdown_index_path, method: :put) do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
         put :uploads_min_level
         put :uploads_hide_pending
         put :maintenance
+        put :analytics
       end
     end
   end

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,7 @@ export default [
       "no-multi-spaces": ["warn", { ignoreEOLComments: false }],
       "no-multiple-empty-lines": "warn",
       "no-tabs": "warn",
-      "no-trailing-spaces": "warn",
+      "no-trailing-spaces": ["warn", { ignoreComments: true, }],
       "no-whitespace-before-property": "warn",
       "nonblock-statement-body-position": "off",
       "object-curly-newline": ["warn", { consistent: true }],


### PR DESCRIPTION
Start tracking the actual usage of the new features – search trends and recommendations.
Added toggles to turn both off, if they start causing problems.

Also included a better way to pass settings variables between rails back-end and JS scripts.