### PR TITLE
[PostFlags] Move grandfathered post cut-off date to config

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2107,7 +2107,7 @@ class Post < ApplicationRecord
   end
 
   def flaggable_for_guidelines?
-    !has_tag?("grandfathered_content") && created_at.after?("2015-01-01")
+    !has_tag?("grandfathered_content") && created_at.after?(Danbooru.config.grandfathered_post_cutoff)
   end
 
   def visible_comment_count(user)

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -560,7 +560,7 @@ module Danbooru
     end
 
     def grandfathered_post_cutoff
-      "2015-01-01"
+      Time.zone.local(2015, 1, 1)
     end
 
     def auto_flag_ai_posts?

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -559,6 +559,10 @@ module Danbooru
       ]
     end
 
+    def grandfathered_post_cutoff
+      "2015-01-01"
+    end
+
     def auto_flag_ai_posts?
       true
     end


### PR DESCRIPTION
Title.

This is so we can use this instead for e6ai:
```ruby
# config/danbooru_default_config.rb
def grandfathered_post_cutoff
  4.months.ago
end
```
Since we use a rolling date.

Changes are identical to the ones suggested by jmortiger on DIscord.