### PR TITLE
[Analytics] Stub out rrweb

### DIFF
--- a/app/javascript/src/js/core/analytics.js
+++ b/app/javascript/src/js/core/analytics.js
@@ -14,6 +14,9 @@ export default class Analytics {
       trackScreenViews: true,
       trackOutgoingLinks: true,
       trackAttributes: true,
+      sessionReplay: {
+        enabled: false,
+      },
     });
 
     this.enabledEvents = Settings.Analytics.events || {};

--- a/app/javascript/src/js/stubs/rrweb.js
+++ b/app/javascript/src/js/stubs/rrweb.js
@@ -1,0 +1,4 @@
+// Stub for rrweb. The @openpanel/web package statically imports `record` from
+// rrweb even when session replay is disabled. This stub replaces the module so
+// that rrweb is not included in the bundle. See: https://github.com/Openpanel-dev/openpanel/issues/336
+export function record () { return () => {}; }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./app/javascript/src/js', import.meta.url)),
+      'rrweb': fileURLToPath(new URL('./app/javascript/src/js/stubs/rrweb.js', import.meta.url)),
     },
   },
   plugins: [


### PR DESCRIPTION
Temporary fix for Openpanel-dev/openpanel#336.

`@openpanel/web` bundles `rrweb`, even if session replays are disabled.
The [documentation](https://openpanel.dev/docs/session-replay#npm-package) claims that this is not supposed to happen, and yet here we are.

Until/if that is fixed, we can avoid bundling that package by stubbing out the file.