### PR TITLE
[UserFeedbacks] Add missing `base_url` param to feedback notice emails

### DIFF
--- a/app/views/maintenance/user/user_feedback_mailer/feedback_notice.html.erb
+++ b/app/views/maintenance/user/user_feedback_mailer/feedback_notice.html.erb
@@ -6,7 +6,7 @@
         A new <a href="<%= user_feedbacks_url(search: { user_id: @user.id }) %>"><%= @is_ban ? "ban" : "#{@feedback.category} record" %></a> was added to your account on <%= Danbooru.config.app_name %>.
       </p>
       <blockquote class="quote">
-        <%= format_text(@feedback.body) %>
+        <%= format_text(@feedback.body, base_url: root_url, max_thumbs: 0) %>
       </blockquote>
     </mj-text>
     


### PR DESCRIPTION
Noticed a bug in URL rendering in positive record emails. Copied pattern from other spots in code, i.e.

```
feedback_notice.html.erb forgot params that ARE present in
dmail_notice.html.erb
forum_notice.html.erb
```

<img width="2338" height="1136" alt="image" src="https://github.com/user-attachments/assets/657265c7-2966-4213-9712-1cf25e838e2a" />

This PR should fix.