### PR TITLE
[UI] Add bypasses for default fields in search forms

### DIFF
--- a/app/helpers/form_search_helper.rb
+++ b/app/helpers/form_search_helper.rb
@@ -34,7 +34,7 @@ module FormSearchHelper
   def filled_form_fields(search_params, exclude_default_fields: %i[], &)
     form_field_collector = FormFieldCollector.new
     capture { yield(form_field_collector) }
-    available_fields = DEFAULT_SEARCH_FIELDS - Array(exclude_default_fields).map(&:to_sym) + form_field_collector.fields
+    available_fields = DEFAULT_SEARCH_FIELDS - exclude_default_fields + form_field_collector.fields
     available_fields & search_params.keys.map(&:to_sym)
   end
 end

--- a/app/helpers/form_search_helper.rb
+++ b/app/helpers/form_search_helper.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 module FormSearchHelper
-  def form_search(path:, always_display: false, hideable: request.path.split("/")[2] != "search", method: :get, &)
-    # dedicated search routes like /comments/search should always show
+  DEFAULT_SEARCH_FIELDS = %i[id created_at updated_at].freeze # needed for filled_form_fields to know which fields to look for in the params
+
+  def form_search(path:, always_display: false, hideable: request.path.split("/")[2] != "search", method: :get, exclude_default_fields: %i[], &)
+    # NOTE: dedicated search routes like /comments/search should always show
+    exclude_default_fields = Array(exclude_default_fields).map(&:to_sym)
     search_params = params[:search] || {}
-    show_on_load = filled_form_fields(search_params, &).any? || always_display || !hideable
+
+    show_on_load = filled_form_fields(search_params, exclude_default_fields: exclude_default_fields, &).any? || always_display || !hideable
     form = simple_form_for(:search, {
       method: method,
       url: path,
@@ -13,10 +17,13 @@ module FormSearchHelper
       defaults: { required: false },
       html: { class: "inline-form" },
     }) do |f|
-      id_input = f.input(:id, label: "ID", hide_unless_value: true)
-      created_at_input = f.input(:created_at, hide_unless_value: true)
-      updated_at_input = f.input(:updated_at, hide_unless_value: true)
-      id_input + created_at_input + updated_at_input + capture { yield(f) } + f.submit("Search")
+      inputs = []
+      inputs << f.input(:id, label: "ID", hide_unless_value: true) unless exclude_default_fields.include?(:id)
+      inputs << f.input(:created_at, hide_unless_value: true) unless exclude_default_fields.include?(:created_at)
+      inputs << f.input(:updated_at, hide_unless_value: true) unless exclude_default_fields.include?(:updated_at)
+      inputs << capture { yield(f) }
+      inputs << f.submit("Search")
+      safe_join(inputs)
     end
     render "application/form_search", hideable: hideable, show_on_load: show_on_load, form: form
   end
@@ -24,10 +31,10 @@ module FormSearchHelper
   # When the simple_form has f.input :name and search[name]=test [:name] will be returned
   # Some search params aren't exposed in the ui, but have links. In that case it
   # isn't expected to have the form be open, since no values are set.
-  def filled_form_fields(search_params, &)
+  def filled_form_fields(search_params, exclude_default_fields: %i[], &)
     form_field_collector = FormFieldCollector.new
     capture { yield(form_field_collector) }
-    available_fields = %i[id created_at updated_at] + form_field_collector.fields
+    available_fields = DEFAULT_SEARCH_FIELDS - Array(exclude_default_fields).map(&:to_sym) + form_field_collector.fields
     available_fields & search_params.keys.map(&:to_sym)
   end
 end

--- a/app/helpers/form_search_helper.rb
+++ b/app/helpers/form_search_helper.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module FormSearchHelper
-  DEFAULT_SEARCH_FIELDS = %i[id created_at updated_at].freeze # needed for filled_form_fields to know which fields to look for in the params
+  # needed for filled_form_fields to know which fields to look for in the params
+  DEFAULT_SEARCH_FIELDS = %i[id created_at updated_at].freeze
 
   def form_search(path:, always_display: false, hideable: request.path.split("/")[2] != "search", method: :get, exclude_default_fields: %i[], &)
     # NOTE: dedicated search routes like /comments/search should always show
@@ -31,7 +32,7 @@ module FormSearchHelper
   # When the simple_form has f.input :name and search[name]=test [:name] will be returned
   # Some search params aren't exposed in the ui, but have links. In that case it
   # isn't expected to have the form be open, since no values are set.
-  def filled_form_fields(search_params, exclude_default_fields: %i[], &)
+  def filled_form_fields(search_params, exclude_default_fields: [], &)
     form_field_collector = FormFieldCollector.new
     capture { yield(form_field_collector) }
     available_fields = DEFAULT_SEARCH_FIELDS - exclude_default_fields + form_field_collector.fields

--- a/spec/helpers/form_search_helper_spec.rb
+++ b/spec/helpers/form_search_helper_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FormSearchHelper do
+  before do
+    allow(helper).to receive_messages(
+      params: ActionController::Parameters.new({}),
+      request: instance_double(ActionDispatch::Request, path: "/posts"),
+    )
+  end
+
+  describe "#filled_form_fields" do
+    def collect(search_params, exclude_default_fields: [], &block)
+      block ||= proc {}
+      helper.filled_form_fields(search_params, exclude_default_fields: exclude_default_fields, &block)
+    end
+
+    context "with empty search params" do
+      it { expect(collect({})).to eq([]) }
+    end
+
+    context "when search params contains a default field" do
+      it "returns :id when present" do
+        expect(collect({ id: "1" })).to include(:id)
+      end
+
+      it "returns :created_at when present" do
+        expect(collect({ created_at: "2024-01-01" })).to include(:created_at)
+      end
+
+      it "returns :updated_at when present" do
+        expect(collect({ updated_at: "2024-01-01" })).to include(:updated_at)
+      end
+    end
+
+    context "when :id is in exclude_default_fields" do
+      it "does not return :id even when present in search params" do
+        expect(collect({ id: "1" }, exclude_default_fields: [:id])).not_to include(:id)
+      end
+    end
+
+    context "when the block registers a field" do
+      it "returns the field when it is also in search params" do
+        expect(collect({ name: "foo" }) { |f| f.input(:name) }).to include(:name)
+      end
+
+      it "does not return the field when it is absent from search params" do
+        expect(collect({}) { |f| f.input(:name) }).not_to include(:name)
+      end
+    end
+
+    context "when search params contains a key not registered in the form" do
+      it "does not include that key" do
+        expect(collect({ ghost_field: "x" })).not_to include(:ghost_field)
+      end
+    end
+
+    context "when the block calls f.user with a symbol prefix" do
+      it "includes :creator_name when present in search params" do
+        expect(collect({ creator_name: "bob" }) { |f| f.user(:creator) }).to include(:creator_name)
+      end
+
+      it "includes :creator_id when present in search params" do
+        expect(collect({ creator_id: "1" }) { |f| f.user(:creator) }).to include(:creator_id)
+      end
+    end
+  end
+
+  describe "#form_search" do
+    include_context "as member"
+
+    def render_form(**opts, &block)
+      block ||= proc {}
+      Nokogiri::HTML.fragment(helper.form_search(path: "/posts", **opts, &block))
+    end
+
+    context "when hideable (default for a non-search path)" do
+      it "renders the show toggle link" do
+        expect(render_form.at_css("#search-form-show-link")).not_to be_nil
+      end
+
+      it "renders the hide toggle link" do
+        expect(render_form.at_css("#search-form-hide-link")).not_to be_nil
+      end
+    end
+
+    context "when hideable: false" do
+      it "omits the show toggle link" do
+        expect(render_form(hideable: false).at_css("#search-form-show-link")).to be_nil
+      end
+
+      it "renders #searchform without display:none" do
+        expect(render_form(hideable: false).at_css("#searchform")["style"].to_s).not_to include("display:none")
+      end
+    end
+
+    context "when the path is a dedicated search route" do
+      before do
+        allow(helper).to receive(:request).and_return(
+          instance_double(ActionDispatch::Request, path: "/comments/search"),
+        )
+      end
+
+      it "is not hideable (omits show toggle link)" do
+        expect(render_form.at_css("#search-form-show-link")).to be_nil
+      end
+    end
+
+    context "with no filled search params" do
+      it "renders #searchform with display:none" do
+        expect(render_form.at_css("#searchform")["style"]).to include("display:none")
+      end
+    end
+
+    context "when always_display: true" do
+      it "renders #searchform without display:none" do
+        expect(render_form(always_display: true).at_css("#searchform")["style"].to_s).not_to include("display:none")
+      end
+    end
+
+    context "when search params has a filled field" do
+      before do
+        allow(helper).to receive(:params).and_return(
+          ActionController::Parameters.new(search: { id: "1" }),
+        )
+      end
+
+      it "renders #searchform without display:none" do
+        expect(render_form.at_css("#searchform")["style"].to_s).not_to include("display:none")
+      end
+    end
+
+    context "default field rendering" do
+      include_context "as admin"
+
+      it "renders the ID input by default" do
+        expect(render_form.at_css("input[name='search[id]']")).not_to be_nil
+      end
+
+      it "renders the created_at input by default" do
+        expect(render_form.at_css("input[name='search[created_at]']")).not_to be_nil
+      end
+
+      it "omits the ID input when :id is in exclude_default_fields" do
+        expect(render_form(exclude_default_fields: [:id]).at_css("input[name='search[id]']")).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes e621ng/e621ng#1830

Allows calls to `search_form` to exclude a given default field (`id`, `created_at`, `updated_at`). This can be used to remove useless fields, such as where `created_at` in `post_versions` doing nothing.