### PR TITLE
[Posts] Hide reason label when reason is from flag

### DIFF
--- a/app/javascript/src/js/pages/posts/show/mod_queue.js
+++ b/app/javascript/src/js/pages/posts/show/mod_queue.js
@@ -53,9 +53,13 @@ ModQueue.delete_with_reason_dialog = function (event) {
   const hasReason = data.fromFlag !== "true";
   const reason = data.reason;
 
+  const reasonInputAndLabel = $("#delete-with-reason-dialog-labeled-input");
+  reasonInputAndLabel[0].style.display = hasReason ? "" : "none";
+
   const reasonInput = $("#delete-with-reason-dialog-input");
-  reasonInput.val(reason);
-  reasonInput[0].style.display = hasReason ? "" : "none";
+  if (hasReason) {
+    reasonInput.val(reason);
+  }
 
   form.off("submit").on("submit", (event) => {
     event.preventDefault();

--- a/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
+++ b/app/views/moderator/post/posts/_delete_with_reason_dialog.html.erb
@@ -1,7 +1,9 @@
 <form class="simple_form" id="delete-with-reason-dialog" data-title="Delete Post" data-width="500" data-position="center">
-  <div class="input delete-with-reason-dialog-inputs">
-    <label for="delete-with-reason-dialog-input">Reason</label>
-    <input type="text" id="delete-with-reason-dialog-input" placeholder="Enter reason here...">
+  <div class="input">
+    <div id="delete-with-reason-dialog-labeled-input">
+      <label for="delete-with-reason-dialog-input">Reason</label>
+      <input type="text" id="delete-with-reason-dialog-input" placeholder="Enter reason here...">
+    </div>
     <% unless Danbooru.config.post_deletion_dmail_templates.blank? %>
       <label for="delete-with-reason-dialog-enable-dmail">
         Send DMail (default template)? <input type="checkbox" id="delete-with-reason-dialog-enable-dmail"


### PR DESCRIPTION
Forgot to hide that label too.

If you "delete with reason", then that sets `from_flag: true` for the delete `POST`, so you can't set the reason yourself, it's ignored (the flag reason is used). That's why the input box is hidden.