### PR TITLE
[Misc] Ensure that search param values are scalars

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -263,7 +263,7 @@ class ApplicationController < ActionController::Base
     if params[:search].is_a?(ActionController::Parameters)
       nonblank_search_params = deep_reject_blank.call(params[:search])
       # Reject non-scalar values (e.g. {"$eq": "x"} hashes injected by probing tools).
-      nonblank_search_params = nonblank_search_params.select { |_, v| v.is_a?(String) || v.is_a?(Numeric) }
+      nonblank_search_params = nonblank_search_params.select { |_, v| v.is_a?(String) || v.is_a?(Numeric) || v.is_a?(TrueClass) || v.is_a?(FalseClass) }
     else
       nonblank_search_params = ActionController::Parameters.new
     end
@@ -280,6 +280,6 @@ class ApplicationController < ActionController::Base
 
   def permit_search_params(permitted_params)
     params.fetch(:search, {}).permit(%i[id created_at updated_at] + permitted_params)
-          .select { |_, v| v.is_a?(String) || v.is_a?(Numeric) }
+          .select { |_, v| v.is_a?(String) || v.is_a?(Numeric) || v.is_a?(TrueClass) || v.is_a?(FalseClass) }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -246,8 +246,14 @@ class ApplicationController < ActionController::Base
   def normalize_search
     return unless request.get? || request.head?
 
-    # Sanitize q parameter - must be a String or nil, not a nested hash
-    params[:q] = nil if params[:q].present? && !params[:q].is_a?(String)
+    # Coerce top-level params that must be scalars — reject hashes, unwrap single-element arrays.
+    %i[q page limit id].each do |key|
+      next unless params.key?(key)
+      params[key] = case params[key]
+                    when String then params[key]
+                    when Array  then params[key].first.is_a?(String) ? params[key].first : nil
+                    end
+    end
 
     params[:search] ||= ActionController::Parameters.new
 
@@ -256,6 +262,8 @@ class ApplicationController < ActionController::Base
     end
     if params[:search].is_a?(ActionController::Parameters)
       nonblank_search_params = deep_reject_blank.call(params[:search])
+      # Reject non-scalar values (e.g. {"$eq": "x"} hashes injected by probing tools).
+      nonblank_search_params = nonblank_search_params.select { |_, v| v.is_a?(String) || v.is_a?(Numeric) }
     else
       nonblank_search_params = ActionController::Parameters.new
     end
@@ -272,5 +280,6 @@ class ApplicationController < ActionController::Base
 
   def permit_search_params(permitted_params)
     params.fetch(:search, {}).permit(%i[id created_at updated_at] + permitted_params)
+          .select { |_, v| v.is_a?(String) || v.is_a?(Numeric) }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  class APIThrottled < Exception; end
+  class APIThrottled < StandardError; end
   class FeatureUnavailable < StandardError; end
 
   skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? || request.options? }
@@ -250,8 +250,8 @@ class ApplicationController < ActionController::Base
     %i[q page limit id].each do |key|
       next unless params.key?(key)
       params[key] = case params[key]
-                    when String then params[key]
-                    when Array  then params[key].first.is_a?(String) ? params[key].first : nil
+                    when String, Numeric then params[key]
+                    when Array           then params[key].first.is_a?(String) ? params[key].first : nil
                     end
     end
 

--- a/app/controllers/wiki_page_versions_controller.rb
+++ b/app/controllers/wiki_page_versions_controller.rb
@@ -14,16 +14,13 @@ class WikiPageVersionsController < ApplicationController
   end
 
   def diff
-    thispage = params[:thispage].is_a?(Array) ? params[:thispage].first : params[:thispage]
-    otherpage = params[:otherpage].is_a?(Array) ? params[:otherpage].first : params[:otherpage]
-
-    if thispage.blank? || otherpage.blank?
+    if params[:thispage].blank? || params[:otherpage].blank?
       redirect_back fallback_location: wiki_pages_path, notice: "You must select two versions to diff"
       return
     end
 
-    @thispage = WikiPageVersion.find(thispage)
-    @otherpage = WikiPageVersion.find(otherpage)
+    @thispage = WikiPageVersion.find(ParseValue.safe_id(params[:thispage].to_s))
+    @otherpage = WikiPageVersion.find(ParseValue.safe_id(params[:otherpage].to_s))
   end
 
   private

--- a/app/controllers/wiki_page_versions_controller.rb
+++ b/app/controllers/wiki_page_versions_controller.rb
@@ -14,13 +14,16 @@ class WikiPageVersionsController < ApplicationController
   end
 
   def diff
-    if params[:thispage].blank? || params[:otherpage].blank?
+    thispage = params[:thispage].is_a?(Array) ? params[:thispage].first : params[:thispage]
+    otherpage = params[:otherpage].is_a?(Array) ? params[:otherpage].first : params[:otherpage]
+
+    if thispage.blank? || otherpage.blank?
       redirect_back fallback_location: wiki_pages_path, notice: "You must select two versions to diff"
       return
     end
 
-    @thispage = WikiPageVersion.find(params[:thispage])
-    @otherpage = WikiPageVersion.find(params[:otherpage])
+    @thispage = WikiPageVersion.find(thispage)
+    @otherpage = WikiPageVersion.find(otherpage)
   end
 
   private

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -197,7 +197,7 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
       end
 
       should "coerce a hash injection in a search param to nil and redirect" do
-        get posts_path, params: { search: { status: { "$eq" => "active" } } }, as: :html
+        get posts_path, params: { search: { status: { "$eq" => "active" } } }
         assert_redirected_to posts_path
       end
 

--- a/test/functional/application_controller_test.rb
+++ b/test/functional/application_controller_test.rb
@@ -184,5 +184,27 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
         assert_response :success
       end
     end
+
+    context "scalar param coercion" do
+      should "coerce a hash injection in the page param to nil" do
+        get posts_path, params: { page: { "$eq" => "1" } }, as: :json
+        assert_response :success
+      end
+
+      should "coerce an array in the page param to its first element" do
+        get posts_path, params: { page: ["1"] }, as: :json
+        assert_response :success
+      end
+
+      should "coerce a hash injection in a search param to nil and redirect" do
+        get posts_path, params: { search: { status: { "$eq" => "active" } } }, as: :html
+        assert_redirected_to posts_path
+      end
+
+      should "pass boolean search params through unchanged" do
+        get posts_path, params: { search: { is_deleted: true } }, as: :json
+        assert_response :success
+      end
+    end
   end
 end

--- a/test/functional/wiki_page_versions_controller_test.rb
+++ b/test/functional/wiki_page_versions_controller_test.rb
@@ -37,6 +37,21 @@ class WikiPageVersionsControllerTest < ActionDispatch::IntegrationTest
         get diff_wiki_page_versions_path, params: { thispage: @wiki_page.versions.first.id, otherpage: @wiki_page.versions.last.id }
         assert_response :success
       end
+
+      should "return 404 when thispage is an array" do
+        get diff_wiki_page_versions_path, params: { thispage: [@wiki_page.versions.first.id.to_s], otherpage: @wiki_page.versions.last.id }
+        assert_response :not_found
+      end
+
+      should "return 404 when thispage is a hash injection" do
+        get diff_wiki_page_versions_path, params: { thispage: { "$eq" => @wiki_page.versions.first.id.to_s }, otherpage: @wiki_page.versions.last.id }
+        assert_response :not_found
+      end
+
+      should "return 404 when otherpage is a hash injection" do
+        get diff_wiki_page_versions_path, params: { thispage: @wiki_page.versions.first.id, otherpage: { "$eq" => @wiki_page.versions.last.id.to_s } }
+        assert_response :not_found
+      end
     end
   end
 end


### PR DESCRIPTION
## Problem

A malicious user has been intermittently running an automated vulnerability probe against the site. The tool sends nested hash payloads (e.g. `search[field]={"$eq":"value"}`) and arrays (e.g. `thispage[]=202877`) in place of expected scalar parameters. Several controllers crash when model code calls string methods like `.to_sym`, `.split`, or `.join` on an `ActionController::Parameters` or `Array` object instead of a plain string.

Previous fixes addressed individual controllers as they were discovered. The existing `permit_search_params` helper whitelists parameter names but not types, so the underlying cause remained.

## Fix

- **`ApplicationController#normalize_search`** — extends the existing scalar coercion (previously only applied to `q`) to also cover `page`, `limit`, and `id`. Additionally, after the blank-rejection pass on `params[:search]`, a type filter strips any remaining non-scalar values so that hash payloads in search subparams never reach model code. Runs as a `before_action` on all GET/HEAD requests.
- **`ApplicationController#permit_search_params`** — adds the same scalar type filter after `.permit(...)` as defense-in-depth for non-GET paths.
- **`WikiPageVersionsController#diff`** — coerces `thispage` and `otherpage` to scalars inline, since these are action-specific params outside the search namespace.
