### PR TITLE
[Misc] Fix crashes caused by non-schalar `user_id` and `expiry` values

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -247,7 +247,7 @@ class ApplicationController < ActionController::Base
     return unless request.get? || request.head?
 
     # Coerce top-level params that must be scalars — reject hashes, unwrap single-element arrays.
-    %i[q page limit id].each do |key|
+    %i[q page limit id user_id expiry].each do |key|
       next unless params.key?(key)
       params[key] = case params[key]
                     when String, Numeric then params[key]


### PR DESCRIPTION
Fixes #1863 and #1865