### PR TITLE
[WikiPages] Fix a crash caused by non-scalar `title` param

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -90,6 +90,7 @@ class ArtistsController < ApplicationController
   end
 
   def show_or_new
+    params[:name] = params[:name].to_s
     @artist = Artist.named(params[:name])
     if @artist
       redirect_to artist_path(@artist)

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -99,6 +99,7 @@ class WikiPagesController < ApplicationController
   end
 
   def show_or_new
+    params[:title] = params[:title].to_s
     @wiki_page = WikiPage.titled(params[:title])
     if @wiki_page
       redirect_to wiki_page_path(@wiki_page)

--- a/test/functional/artists_controller_test.rb
+++ b/test/functional/artists_controller_test.rb
@@ -53,6 +53,11 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
         get_auth(show_or_new_artists_path(name: @masao.name), @user)
         assert_redirected_to(@masao)
       end
+
+      should("not crash when name is a hash") do
+        get_auth(show_or_new_artists_path, @user, params: { name: { "$eq" => "lillymoo" } })
+        assert_response(:success)
+      end
     end
 
     context("edit action") do

--- a/test/functional/wiki_pages_controller_test.rb
+++ b/test/functional/wiki_pages_controller_test.rb
@@ -85,6 +85,11 @@ class WikiPagesControllerTest < ActionDispatch::IntegrationTest
         get show_or_new_wiki_pages_path, params: { title: "what" }
         assert_response :success
       end
+
+      should "not crash when title is a hash" do
+        get show_or_new_wiki_pages_path, params: { title: { "$testing" => "1" } }
+        assert_response :success
+      end
     end
 
     context "new action" do


### PR DESCRIPTION
Fixes #1862, both issues.