### PR TITLE
[Session] Fix a crash caused by a non-scalar username / API key

### DIFF
--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -106,11 +106,14 @@ class SessionLoader
   end
 
   def authenticate_api_key(name, api_key)
-    if name && !name.dup.force_encoding("UTF-8").valid_encoding?
+    unless name.is_a?(String) && api_key.is_a?(String)
+      raise AuthenticationFailure
+    end
+    if !name.dup.force_encoding("UTF-8").valid_encoding?
       Rails.logger.warn("Invalid UTF-8 in login parameter from #{request.remote_ip}")
       raise AuthenticationFailure
     end
-    if api_key && !api_key.dup.force_encoding("UTF-8").valid_encoding?
+    if !api_key.dup.force_encoding("UTF-8").valid_encoding?
       Rails.logger.warn("Invalid UTF-8 in api_key parameter from #{request.remote_ip}")
       raise AuthenticationFailure
     end

--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -109,11 +109,11 @@ class SessionLoader
     unless name.is_a?(String) && api_key.is_a?(String)
       raise AuthenticationFailure
     end
-    if !name.dup.force_encoding("UTF-8").valid_encoding?
+    unless name.dup.force_encoding("UTF-8").valid_encoding?
       Rails.logger.warn("Invalid UTF-8 in login parameter from #{request.remote_ip}")
       raise AuthenticationFailure
     end
-    if !api_key.dup.force_encoding("UTF-8").valid_encoding?
+    unless api_key.dup.force_encoding("UTF-8").valid_encoding?
       Rails.logger.warn("Invalid UTF-8 in api_key parameter from #{request.remote_ip}")
       raise AuthenticationFailure
     end

--- a/test/unit/session_loader_test.rb
+++ b/test/unit/session_loader_test.rb
@@ -60,6 +60,24 @@ class SessionLoaderTest < ActiveSupport::TestCase
       end
     end
 
+    context "authentication with non-scalar login or api_key" do
+      should "reject login submitted as a hash" do
+        @request.stubs(:parameters).returns({ login: { "$eq" => "username" }, api_key: "test_key" })
+
+        assert_raises(SessionLoader::AuthenticationFailure) do
+          SessionLoader.new(@request).load
+        end
+      end
+
+      should "reject api_key submitted as a hash" do
+        @request.stubs(:parameters).returns({ login: "testuser", api_key: { "$eq" => "key" } })
+
+        assert_raises(SessionLoader::AuthenticationFailure) do
+          SessionLoader.new(@request).load
+        end
+      end
+    end
+
     context "authentication with invalid UTF-8" do
       should "reject Basic Auth with invalid UTF-8 bytes" do
         # Create invalid UTF-8 sequence and encode it


### PR DESCRIPTION
Fixes #1857 - both cases.