### PR TITLE
[TagImplications] Extra safeguard against circular relations

### DIFF
--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -72,10 +72,15 @@ class TagImplication < TagRelationship
       update_attribute(:descendant_names, descendant_names)
     end
 
-    def update_descendant_names_for_parents
+    def update_descendant_names_for_parents(visited = Set.new)
+      visited.add(id)
       parents.each do |parent|
+        if visited.include?(parent.id)
+          parent.update_columns(status: "error: circular implication detected")
+          next
+        end
         parent.update_descendant_names!
-        parent.update_descendant_names_for_parents
+        parent.update_descendant_names_for_parents(visited)
       end
     end
   end

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -69,7 +69,7 @@ class TagImplication < TagRelationship
     def update_descendant_names!
       flush_cache
       update_descendant_names
-      update_attribute(:descendant_names, descendant_names)
+      update_columns(descendant_names: descendant_names)
     end
 
     def update_descendant_names_for_parents(visited = Set.new)


### PR DESCRIPTION
Fixes #1846, kinda.

Existing safeguards should already prevent the creation of _new_ circular implications.
This PR deals with the potential circular implications that could have been created at some point within the last 20 years, before sufficient validations were in place.