### PR TITLE
[ModActions] Fix errors caused by values unexpectedly containing nil values

### DIFF
--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -135,7 +135,7 @@ class ModActionDecorator < ApplicationDecorator
         "Changed #{user} level to #{vals['level']}"
       end
     when "user_flags_change"
-      "Changed #{user} flags. Added: [#{vals['added'].join(', ')}] Removed: [#{vals['removed'].join(', ')}]"
+      "Changed #{user} flags. Added: [#{vals['added']&.join(', ')}] Removed: [#{vals['removed']&.join(', ')}]"
     when "edited_user"
       "Edited #{user}"
     when "user_blacklist_changed"
@@ -154,7 +154,7 @@ class ModActionDecorator < ApplicationDecorator
       ### User Record ###
 
     when "user_feedback_create"
-      "Created #{vals['type'].capitalize} record ##{vals['record_id']} for #{user} with reason: #{vals['reason']}"
+      "Created #{vals['type']&.capitalize} record ##{vals['record_id']} for #{user} with reason: #{vals['reason']}"
     when "user_feedback_update"
       if vals["reason_was"].present? || vals["type_was"].present?
         text = "Edited record ##{vals['record_id']} for #{user}"

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -195,7 +195,7 @@ class ModAction < ApplicationRecord
 
   def values
     original_values = self[:values] || {}
-
+    return {} if original_values.nil?
     if CurrentUser.is_admin?
       original_values
     else

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -195,7 +195,8 @@ class ModAction < ApplicationRecord
 
   def values
     original_values = self[:values] || {}
-    return {} if original_values.nil?
+    return {} unless original_values.is_a?(Hash) && original_values.present?
+
     if CurrentUser.is_admin?
       original_values
     else

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -195,7 +195,7 @@ class ModAction < ApplicationRecord
 
   def values
     original_values = self[:values] || {}
-    return {} unless original_values.is_a?(Hash) && original_values.present?
+    return {} unless original_values.is_a?(Hash)
 
     if CurrentUser.is_admin?
       original_values


### PR DESCRIPTION
When a `mod_action`'s action is not in `known_actions`, the decorator logic does one of two things:
1. If the user is an admin, `"Unknown action #{object.action}: #{object.values.inspect}"`
2. Otherwise, `"Unknown action #{object.action}"`

However, `object.values` (from `ModAction.values` also does one of two things: 
1. If the user is an admin, it passed back the original values
2. Otherwise, it parses it to process what information needs to be sanitized to show the user (for example, removing ticket ids for non-moderators). 

If an unknown action exists and a non-admin attempts to view it, the `values` method attempts to process it's keys, resulting an an exception when it tries to `slice` (or `to_sym`) the nil value. 

To fix this, an early return for all of `values` is added when the original value is nil. Additionally, add safely operators to decorator cases that assume a kv pair exist.

----
Note: When we get tests for these, this should be a test.
