### PR TITLE
[AutoMod] Add username and profile text checks

### DIFF
--- a/app/controllers/admin/automod_rules_controller.rb
+++ b/app/controllers/admin/automod_rules_controller.rb
@@ -47,7 +47,7 @@ module Admin
     end
 
     def automod_rule_params
-      params.require(:automod_rule).permit(:name, :description, :regex, :enabled)
+      params.require(:automod_rule).permit(:name, :description, :regex, :enabled, :comments, :usernames, :profile_text)
     end
   end
 end

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -45,6 +45,7 @@
 @import "views/application/application";
 @import "views/artists/artists";
 @import "views/auths/auths";
+@import "views/automod_rules/automod_rules";
 @import "views/forum_posts/forum_posts";
 @import "views/help/help";
 @import "views/maintenance/maintenance";

--- a/app/javascript/src/styles/views/automod_rules/_automod_rules.scss
+++ b/app/javascript/src/styles/views/automod_rules/_automod_rules.scss
@@ -1,0 +1,28 @@
+.c-admin-automod-rules {
+
+  .automod-applies {
+    grid-template-columns: repeat(auto-fill, minmax(0, 15rem));
+    display: grid;
+    max-width: 46rem;
+    gap: 0.25rem;
+
+    & > h5 { grid-column: 1 / -1; }
+
+    &-toggle {
+      display: flex;
+      background: themed("color-section-lighten-5");
+      padding: 0.25rem 0.75rem;
+      gap: 0.5rem;
+      align-items: center;
+      @include st-radius;
+
+      label.st-toggle {
+        margin-left: auto;
+      }
+    }
+
+    &-hint {
+      margin: 1rem 0;
+    }
+  }
+}

--- a/app/jobs/automod_check_job.rb
+++ b/app/jobs/automod_check_job.rb
@@ -7,7 +7,7 @@ class AutomodCheckJob < ApplicationJob
     comment = Comment.find(comment_id)
     return if Ticket.active.where(qtype: "comment", disp_id: comment.id).exists?
 
-    rule = AutomodRule.enabled.find { |r| r.match?(comment.body) }
+    rule = AutomodRule.for_comments.find { |r| r.match?(comment.body) }
     return unless rule
 
     CurrentUser.as_system do

--- a/app/jobs/automod_user_check_job.rb
+++ b/app/jobs/automod_user_check_job.rb
@@ -11,7 +11,7 @@ class AutomodUserCheckJob < ApplicationJob
     needed_mask = 0
     needed_mask |= 2 if check_username
     needed_mask |= 4 if check_profile
-    return if needed_mask.zero?
+    return if needed_mask == 0
 
     rules = AutomodRule.enabled.where("(apply_to & ?) > 0", needed_mask).to_a
 
@@ -21,11 +21,9 @@ class AutomodUserCheckJob < ApplicationJob
       rule = rules.select(&:usernames?).find { |r| r.match?(user.name) }
     end
 
-    unless rule
-      if check_profile
-        texts = [user.profile_about, user.profile_artinfo].select(&:present?).join("\n")
-        rule = rules.select(&:profile_text?).find { |r| r.match?(texts) }
-      end
+    if !rule && check_profile
+      texts = [user.profile_about, user.profile_artinfo].select(&:present?).join("\n")
+      rule = rules.select(&:profile_text?).find { |r| r.match?(texts) }
     end
 
     return unless rule

--- a/app/jobs/automod_user_check_job.rb
+++ b/app/jobs/automod_user_check_job.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class AutomodUserCheckJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_id, check_username:, check_profile:)
+    user = User.find(user_id)
+    return if Ticket.active.where(qtype: "user", disp_id: user.id).exists?
+
+    # Build mask for relevant contexts and load matching rules in one DB round-trip
+    needed_mask = 0
+    needed_mask |= 2 if check_username
+    needed_mask |= 4 if check_profile
+    return if needed_mask.zero?
+
+    rules = AutomodRule.enabled.where("(apply_to & ?) > 0", needed_mask).to_a
+
+    rule = nil
+
+    if check_username
+      rule = rules.select(&:usernames?).find { |r| r.match?(user.name) }
+    end
+
+    unless rule
+      if check_profile
+        texts = [user.profile_about, user.profile_artinfo].select(&:present?).join("\n")
+        rule = rules.select(&:profile_text?).find { |r| r.match?(texts) }
+      end
+    end
+
+    return unless rule
+
+    CurrentUser.as_system do
+      Ticket.create!(
+        creator_id: User.system.id,
+        creator_ip_addr: "127.0.0.1",
+        disp_id: user.id,
+        status: "pending",
+        qtype: "user",
+        reason: "AutoMod: #{rule.name} \n#{rule.description}",
+      )
+    end
+  rescue ActiveRecord::RecordNotFound
+    # User deleted before job ran; nothing to do.
+  end
+end

--- a/app/jobs/automod_user_check_job.rb
+++ b/app/jobs/automod_user_check_job.rb
@@ -9,8 +9,8 @@ class AutomodUserCheckJob < ApplicationJob
 
     # Build mask for relevant contexts and load matching rules in one DB round-trip
     needed_mask = 0
-    needed_mask |= 2 if check_username
-    needed_mask |= 4 if check_profile
+    needed_mask |= AutomodRule.flag_value_for("usernames") if check_username
+    needed_mask |= AutomodRule.flag_value_for("profile_text") if check_profile
     return if needed_mask == 0
 
     rules = AutomodRule.enabled.where("(apply_to & ?) > 0", needed_mask).to_a

--- a/app/models/automod_rule.rb
+++ b/app/models/automod_rule.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
 class AutomodRule < ApplicationRecord
+  include Danbooru::HasBitFlags
+
+  APPLY_TO_ATTRIBUTES = %w[comments usernames profile_text].freeze
+  has_bit_flags APPLY_TO_ATTRIBUTES, field: "apply_to"
+
   belongs_to_creator
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :regex, presence: true
   validate :validate_regex
 
-  scope :enabled, -> { where(enabled: true) }
+  scope :enabled,       -> { where(enabled: true) }
+  scope :for_comments,      -> { enabled.where("(apply_to & 1) > 0") }
+  scope :for_usernames,     -> { enabled.where("(apply_to & 2) > 0") }
+  scope :for_profile_text,  -> { enabled.where("(apply_to & 4) > 0") }
 
   def match?(text)
     Regexp.new(regex, Regexp::IGNORECASE, timeout: 1.0).match?(text)

--- a/app/models/automod_rule.rb
+++ b/app/models/automod_rule.rb
@@ -12,7 +12,7 @@ class AutomodRule < ApplicationRecord
   validates :regex, presence: true
   validate :validate_regex
 
-  scope :enabled,       -> { where(enabled: true) }
+  scope :enabled,           -> { where(enabled: true) }
   scope :for_comments,      -> { enabled.where("(apply_to & 1) > 0") }
   scope :for_usernames,     -> { enabled.where("(apply_to & 2) > 0") }
   scope :for_profile_text,  -> { enabled.where("(apply_to & 4) > 0") }

--- a/app/models/automod_rule.rb
+++ b/app/models/automod_rule.rb
@@ -13,9 +13,9 @@ class AutomodRule < ApplicationRecord
   validate :validate_regex
 
   scope :enabled,           -> { where(enabled: true) }
-  scope :for_comments,      -> { enabled.where("(apply_to & 1) > 0") }
-  scope :for_usernames,     -> { enabled.where("(apply_to & 2) > 0") }
-  scope :for_profile_text,  -> { enabled.where("(apply_to & 4) > 0") }
+  scope :for_comments,      -> { enabled.where("(apply_to & ?) > 0", flag_value_for("comments")) }
+  scope :for_usernames,     -> { enabled.where("(apply_to & ?) > 0", flag_value_for("usernames")) }
+  scope :for_profile_text,  -> { enabled.where("(apply_to & ?) > 0", flag_value_for("profile_text")) }
 
   def match?(text)
     Regexp.new(regex, Regexp::IGNORECASE, timeout: 1.0).match?(text)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,7 @@ class User < ApplicationRecord
 
   after_create_commit :enqueue_automod_user_check
   after_update_commit :enqueue_automod_user_update_check,
-    if: -> { saved_change_to_name? || saved_change_to_profile_about? || saved_change_to_profile_artinfo? }
+                      if: -> { saved_change_to_name? || saved_change_to_profile_about? || saved_change_to_profile_artinfo? }
 
   has_many :api_keys, dependent: :destroy
   has_one :dmail_filter

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,6 +117,10 @@ class User < ApplicationRecord
   before_update :encrypt_password_on_update
   after_save :update_cache
 
+  after_create_commit :enqueue_automod_user_check
+  after_update_commit :enqueue_automod_user_update_check,
+    if: -> { saved_change_to_name? || saved_change_to_profile_about? || saved_change_to_profile_artinfo? }
+
   has_many :api_keys, dependent: :destroy
   has_one :dmail_filter
   has_one :user_status
@@ -1086,5 +1090,19 @@ class User < ApplicationRecord
     @feedback_pieces = nil
     @is_artist = nil
     self
+  end
+
+  private
+
+  def enqueue_automod_user_check
+    AutomodUserCheckJob.perform_later(id, check_username: true, check_profile: false)
+  end
+
+  def enqueue_automod_user_update_check
+    AutomodUserCheckJob.perform_later(
+      id,
+      check_username: saved_change_to_name?,
+      check_profile:  saved_change_to_profile_about? || saved_change_to_profile_artinfo?,
+    )
   end
 end

--- a/app/views/admin/automod_rules/_form.html.erb
+++ b/app/views/admin/automod_rules/_form.html.erb
@@ -7,17 +7,31 @@
     <%= select_tag("automod_rule[enabled]", options_for_select([["Yes", true], ["No", false]], @automod_rule.enabled?)) %>
   </div>
 
-  <div class="input">
-    <label class="block">Applies To</label>
-    <%= f.input :comments,     as: :boolean, label: "Comments" %>
-    <%= f.input :usernames,    as: :boolean, label: "Usernames" %>
-    <%= f.input :profile_text, as: :boolean, label: "Profile text (About Me / Artist Info)" %>
+  <div class="automod-applies">
+    <h5>Applies To</h5>
+
+    <div class="automod-applies-toggle">
+      <%= f.label :comments %>
+      <%= f.input_field :comments, as: :boolean, class: "st-toggle" %>
+      <%= f.label :comments, "!", class: "st-toggle", role: "switch" %>
+    </div>
+
+    <div class="automod-applies-toggle">
+      <%= f.label :usernames %>
+      <%= f.input_field :usernames, as: :boolean, class: "st-toggle" %>
+      <%= f.label :usernames, "!", class: "st-toggle", role: "switch" %>
+    </div>
+  
+    <div class="automod-applies-toggle">
+      <%= f.label :profile_text %>
+      <%= f.input_field :profile_text, as: :boolean, class: "st-toggle" %>
+      <%= f.label :profile_text, "!", class: "st-toggle", role: "switch" %>
+    </div>
   </div>
 
-  <div style="margin: 1rem;">
-    Automod rules are checked against new and edited comments, usernames, and profile text fields
-    according to the selections above. When a match is found, a ticket will be automatically created
-    for a moderator to review.
+  <div class="automod-applies-hint">
+    Automod rules are checked against new and edited records according to the selections above.<br />
+    When a match is found, a ticket will be automatically created for a moderator to review.
   </div>
 
   <%= f.submit class: "st-button submit" %>

--- a/app/views/admin/automod_rules/_form.html.erb
+++ b/app/views/admin/automod_rules/_form.html.erb
@@ -7,9 +7,17 @@
     <%= select_tag("automod_rule[enabled]", options_for_select([["Yes", true], ["No", false]], @automod_rule.enabled?)) %>
   </div>
 
+  <div class="input">
+    <label class="block">Applies To</label>
+    <%= f.input :comments,     as: :boolean, label: "Comments" %>
+    <%= f.input :usernames,    as: :boolean, label: "Usernames" %>
+    <%= f.input :profile_text, as: :boolean, label: "Profile text (About Me / Artist Info)" %>
+  </div>
+
   <div style="margin: 1rem;">
-    Automod rules are checked against new and edited comments in the order they are listed.<br />
-    If a comment matches a rule, a ticket will be automatically created for a moderator to review.
+    Automod rules are checked against new and edited comments, usernames, and profile text fields
+    according to the selections above. When a match is found, a ticket will be automatically created
+    for a moderator to review.
   </div>
 
   <%= f.submit class: "st-button submit" %>

--- a/app/views/admin/automod_rules/_form.html.erb
+++ b/app/views/admin/automod_rules/_form.html.erb
@@ -21,7 +21,7 @@
       <%= f.input_field :usernames, as: :boolean, class: "st-toggle" %>
       <%= f.label :usernames, "!", class: "st-toggle", role: "switch" %>
     </div>
-  
+
     <div class="automod-applies-toggle">
       <%= f.label :profile_text %>
       <%= f.input_field :profile_text, as: :boolean, class: "st-toggle" %>

--- a/app/views/admin/automod_rules/index.html.erb
+++ b/app/views/admin/automod_rules/index.html.erb
@@ -11,6 +11,7 @@
           <th>Regex</th>
           <th>Description</th>
           <th>Enabled</th>
+          <th>Applies To</th>
           <th>Created By</th>
           <th></th>
         </tr>
@@ -22,6 +23,13 @@
             <td><code><%= truncate(rule.regex, length: 60) %></code></td>
             <td><%= rule.description %></td>
             <td><%= rule.enabled? ? "Yes" : "No" %></td>
+            <td>
+              <%= [
+                ("Comments" if rule.comments?),
+                ("Usernames" if rule.usernames?),
+                ("Profile text" if rule.profile_text?),
+              ].compact.join(", ").presence || "None" %>
+            </td>
             <td><%= link_to_user(rule.creator) %></td>
             <td>
               <%= link_to "Edit", edit_admin_automod_rule_path(rule) %>
@@ -32,7 +40,7 @@
         <% end %>
         <% if @automod_rules.empty? %>
           <tr>
-            <td colspan="6">No automod rules defined.</td>
+            <td colspan="7">No automod rules defined.</td>
           </tr>
         <% end %>
       </tbody>

--- a/db/migrate/20260420170420_add_apply_to_automod_rules.rb
+++ b/db/migrate/20260420170420_add_apply_to_automod_rules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddApplyToAutomodRules < ActiveRecord::Migration[8.1]
+  def change
+    add_column :automod_rules, :apply_to, :integer, null: false, default: 0
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -238,7 +238,8 @@ CREATE TABLE public.automod_rules (
     enabled boolean DEFAULT true NOT NULL,
     creator_id bigint NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    apply_to integer DEFAULT 0 NOT NULL
 );
 
 
@@ -5318,6 +5319,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260420170420'),
 ('20260406172356'),
 ('20260329181337'),
 ('20260325154501'),

--- a/test/factories/automod_rule.rb
+++ b/test/factories/automod_rule.rb
@@ -5,6 +5,12 @@ FactoryBot.define do
     sequence(:name) { |n| "automod_rule_#{n}" }
     regex { "spam" }
     enabled { true }
+    apply_to { 0 }
     creator
+
+    trait(:for_comments)     { apply_to { 1 } }
+    trait(:for_usernames)    { apply_to { 2 } }
+    trait(:for_profile_text) { apply_to { 4 } }
+    trait(:for_all)          { apply_to { 7 } }
   end
 end

--- a/test/jobs/automod_user_check_job_test.rb
+++ b/test/jobs/automod_user_check_job_test.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AutomodUserCheckJobTest < ActiveJob::TestCase
+  context "AutomodUserCheckJob" do
+    setup do
+      @admin = create(:admin_user)
+      CurrentUser.user = @admin
+      @user = create(:user, name: "normaluser")
+    end
+
+    teardown do
+      CurrentUser.user = nil
+    end
+
+    context "username checks" do
+      should "create a ticket when the username matches a usernames rule" do
+        rule = create(:automod_rule, :for_usernames, regex: "badword")
+        @user.update_columns(name: "badworduser")
+        assert_difference("Ticket.count", 1) do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: true, check_profile: false)
+        end
+        ticket = Ticket.last
+        assert_equal("user", ticket.qtype)
+        assert_equal(@user.id, ticket.disp_id)
+        assert_match(rule.name, ticket.reason)
+      end
+
+      should "not create a ticket when the username does not match" do
+        create(:automod_rule, :for_usernames, regex: "badword")
+        assert_no_difference("Ticket.count") do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: true, check_profile: false)
+        end
+      end
+
+      should "not create a ticket when the matching rule is comments-only" do
+        create(:automod_rule, :for_comments, regex: "normaluser")
+        assert_no_difference("Ticket.count") do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: true, check_profile: false)
+        end
+      end
+    end
+
+    context "profile text checks" do
+      should "create a ticket when profile_about matches a profile_text rule" do
+        create(:automod_rule, :for_profile_text, regex: "badcontent")
+        @user.update_columns(profile_about: "this is badcontent")
+        assert_difference("Ticket.count", 1) do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: false, check_profile: true)
+        end
+        assert_equal("user", Ticket.last.qtype)
+      end
+
+      should "create a ticket when profile_artinfo matches a profile_text rule" do
+        create(:automod_rule, :for_profile_text, regex: "badcontent")
+        @user.update_columns(profile_artinfo: "this is badcontent")
+        assert_difference("Ticket.count", 1) do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: false, check_profile: true)
+        end
+      end
+
+      should "not create a ticket when the matching rule is comments-only" do
+        create(:automod_rule, :for_comments, regex: "normaluser")
+        @user.update_columns(profile_about: "normaluser profile")
+        assert_no_difference("Ticket.count") do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: false, check_profile: true)
+        end
+      end
+    end
+
+    context "stopping at first match" do
+      should "not check profile text when the username already matched" do
+        username_rule = create(:automod_rule, :for_usernames, regex: "badword")
+        create(:automod_rule, :for_profile_text, regex: "also_bad")
+        @user.update_columns(name: "badworduser", profile_about: "also_bad content")
+        assert_difference("Ticket.count", 1) do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: true, check_profile: true)
+        end
+        assert_match(username_rule.name, Ticket.last.reason)
+      end
+    end
+
+    context "duplicate ticket prevention" do
+      should "not create a ticket when an active user ticket already exists" do
+        create(:automod_rule, :for_usernames, regex: "badword")
+        @user.update_columns(name: "badworduser")
+        CurrentUser.as_system do
+          Ticket.create!(creator_id: User.system.id, creator_ip_addr: "127.0.0.1",
+                         disp_id: @user.id, status: "pending", qtype: "user", reason: "existing")
+        end
+        assert_no_difference("Ticket.count") do
+          AutomodUserCheckJob.perform_now(@user.id, check_username: true, check_profile: false)
+        end
+      end
+    end
+
+    context "error handling" do
+      should "handle a deleted user gracefully" do
+        user_id = @user.id
+        @user.destroy
+        assert_nothing_raised do
+          AutomodUserCheckJob.perform_now(user_id, check_username: true, check_profile: false)
+        end
+      end
+    end
+  end
+end

--- a/test/models/automod_rule_test.rb
+++ b/test/models/automod_rule_test.rb
@@ -76,5 +76,58 @@ class AutomodRuleTest < ActiveSupport::TestCase
         assert_not_includes(enabled_ids, disabled_rule.id)
       end
     end
+
+    context "apply_to bit flags" do
+      should "expose comments?, usernames?, and profile_text? readers" do
+        rule = build(:automod_rule, :for_all)
+        assert(rule.comments?)
+        assert(rule.usernames?)
+        assert(rule.profile_text?)
+      end
+
+      should "return false for unset bits" do
+        rule = build(:automod_rule, apply_to: 0)
+        assert_not(rule.comments?)
+        assert_not(rule.usernames?)
+        assert_not(rule.profile_text?)
+      end
+    end
+
+    context "context scopes" do
+      setup do
+        @comments_rule     = create(:automod_rule, :for_comments)
+        @usernames_rule    = create(:automod_rule, :for_usernames)
+        @profile_text_rule = create(:automod_rule, :for_profile_text)
+        @all_rule          = create(:automod_rule, :for_all)
+        @no_context_rule   = create(:automod_rule, apply_to: 0)
+        @disabled_rule     = create(:automod_rule, :for_all, enabled: false)
+      end
+
+      should "for_comments returns only enabled rules with the comments bit set" do
+        ids = AutomodRule.for_comments.pluck(:id)
+        assert_includes(ids, @comments_rule.id)
+        assert_includes(ids, @all_rule.id)
+        assert_not_includes(ids, @usernames_rule.id)
+        assert_not_includes(ids, @profile_text_rule.id)
+        assert_not_includes(ids, @no_context_rule.id)
+        assert_not_includes(ids, @disabled_rule.id)
+      end
+
+      should "for_usernames returns only enabled rules with the usernames bit set" do
+        ids = AutomodRule.for_usernames.pluck(:id)
+        assert_includes(ids, @usernames_rule.id)
+        assert_includes(ids, @all_rule.id)
+        assert_not_includes(ids, @comments_rule.id)
+        assert_not_includes(ids, @disabled_rule.id)
+      end
+
+      should "for_profile_text returns only enabled rules with the profile_text bit set" do
+        ids = AutomodRule.for_profile_text.pluck(:id)
+        assert_includes(ids, @profile_text_rule.id)
+        assert_includes(ids, @all_rule.id)
+        assert_not_includes(ids, @comments_rule.id)
+        assert_not_includes(ids, @disabled_rule.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request extends the automod rules system to support matching not only comments, but also usernames and user profile text. It introduces a new bit-flag field (`apply_to`) to specify which contexts each rule applies to, updates the UI for rule management, and adds a new background job to check users against relevant automod rules. Comprehensive tests are included for the new functionality.

**Automod rule context support:**

* Added an `apply_to` bit-flag field to `automod_rules`, allowing each rule to specify if it applies to comments, usernames, and/or profile text. This includes a migration, schema update, and model changes with helper methods and scopes (`for_comments`, `for_usernames`, `for_profile_text`).
* Updated the automod rule form and index UI to allow admins to select and display which contexts each rule applies to. This includes new SCSS for styling and changes to the form partial and index table.

**Automod user checking:**

* Added `AutomodUserCheckJob`, a background job that checks new and updated users against automod rules for usernames and profile text, creating a ticket if a match is found.
* Updated the `User` model to enqueue this job after user creation and after relevant profile updates.

**Comment automod changes:**

* Updated `AutomodCheckJob` (for comments) to only consider rules with the comments bit set, using the new `for_comments` scope.

**Parameter and test updates:**

* Allowed the new context fields in automod rule params for controller actions.
* Added thorough tests for the new user check job and for the `apply_to` logic and scopes in the `AutomodRule` model.