### PR TITLE
[ModActions] Normalize legacy mod actions

### DIFF
--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -22,7 +22,11 @@ class ModActionDecorator < ApplicationDecorator
       ### Pool ###
 
     when "pool_delete"
-      "Deleted pool ##{vals['pool_id']} (named #{vals['pool_name']}) by #{user}"
+      if vals["pool_name"]
+        "Deleted pool ##{vals['pool_id']} (named #{vals['pool_name']}) by #{user}"
+      else
+        "Deleted pool ##{vals['pool_id']}" # Legacy format, missing pool_name and user_id
+      end
 
       ### Takedown ###
 
@@ -217,11 +221,23 @@ class ModActionDecorator < ApplicationDecorator
     when "forum_post_delete"
       "Deleted forum ##{vals['forum_post_id']} in topic ##{vals['forum_topic_id']} by #{user}"
     when "forum_post_update"
-      "Edited forum ##{vals['forum_post_id']} in topic ##{vals['forum_topic_id']} by #{user}"
+      if vals["forum_topic_id"]
+        "Edited forum ##{vals['forum_post_id']} in topic ##{vals['forum_topic_id']} by #{user}"
+      else
+        "Edited forum ##{vals['forum_post_id']} by #{user}" # Legacy format, missing forum_topic_id
+      end
     when "forum_post_hide"
-      "Hid forum ##{vals['forum_post_id']} in topic ##{vals['forum_topic_id']} by #{user}"
+      if vals["forum_topic_id"]
+        "Hid forum ##{vals['forum_post_id']} in topic ##{vals['forum_topic_id']} by #{user}"
+      else
+        "Hid forum ##{vals['forum_post_id']} by #{user}" # Legacy format, missing forum_topic_id
+      end
     when "forum_post_unhide"
-      "Unhid forum ##{vals['forum_post_id']} in topic ##{vals['forum_topic_id']} by #{user}"
+      if vals["forum_topic_id"]
+        "Unhid forum ##{vals['forum_post_id']} in topic ##{vals['forum_topic_id']} by #{user}"
+      else
+        "Unhid forum ##{vals['forum_post_id']} by #{user}" # Legacy format, missing forum_topic_id
+      end
     when "forum_topic_hide"
       "Hid topic ##{vals['forum_topic_id']} (with title #{vals['forum_topic_title']}) by #{user}"
     when "forum_topic_unhide"

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -11,24 +11,28 @@ class ModActionDecorator < ApplicationDecorator
     vals = object.values
     return "" if vals.nil?
 
-    if vals['user_id']
+    if vals["user_id"]
       user = "\"#{User.id_to_name(vals['user_id'])}\":/users/#{vals['user_id']}"
-    elsif vals['username']
+    elsif vals["username"]
       user = "\"#{vals['username']}\":/users/?name=#{vals['username']}"
     end
 
     case object.action
-      ### Pools ###
+
+      ### Pool ###
+
     when "pool_delete"
       "Deleted pool ##{vals['pool_id']} (named #{vals['pool_name']}) by #{user}"
 
-      ### Takedowns ###
+      ### Takedown ###
+
     when "takedown_process"
       "Completed takedown ##{vals['takedown_id']}"
     when "takedown_delete"
       "Deleted takedown ##{vals['takedown_id']}"
 
       ### IP Ban ###
+
     when "ip_ban_create"
       msg = "Created ip ban"
       if CurrentUser.is_admin?
@@ -44,6 +48,7 @@ class ModActionDecorator < ApplicationDecorator
       msg
 
       ### Ticket ###
+
     when "ticket_update"
       text = "Modified ticket ##{vals['ticket_id']}"
 
@@ -66,6 +71,7 @@ class ModActionDecorator < ApplicationDecorator
       "Unclaimed ticket ##{vals['ticket_id']}"
 
       ### Artist ###
+
     when "artist_delete"
       "Deleted artist ##{vals['artist_id']} (#{vals['artist_name']})"
     when "artist_page_rename"
@@ -80,6 +86,7 @@ class ModActionDecorator < ApplicationDecorator
       "Unlinked #{user} from artist ##{vals['artist_page']}"
 
       ### Avoid Posting ###
+
     when "avoid_posting_create"
       "Created \"avoid posting ##{vals['id']}\":/avoid_postings/#{vals['id']} for [[#{vals['artist_name']}]]"
     when "avoid_posting_update"
@@ -92,6 +99,7 @@ class ModActionDecorator < ApplicationDecorator
       "Undeleted \"avoid posting ##{vals['id']}\":/avoid_postings/#{vals['id']} for [[#{vals['artist_name']}]]"
 
       ### Staff Note ###
+
     when "staff_note_create"
       "Created \"staff note ##{vals['id']}\":/staff_notes/#{vals['id']} for #{user}\n#{vals['body']}"
     when "staff_note_update"
@@ -174,7 +182,9 @@ class ModActionDecorator < ApplicationDecorator
       "Undeleted #{vals['type']} record ##{vals['record_id']} for #{user} with reason: #{vals['reason']}"
     when "user_feedback_destroy"
       "Destroyed #{vals['type']} record ##{vals['record_id']} for #{user} with reason: #{vals['reason']}"
+
       ### Legacy User Record ###
+
     when "created_positive_record"
       "Created positive record ##{vals['record_id']} for #{user} with reason: #{vals['reason']}"
     when "created_neutral_record"
@@ -295,7 +305,7 @@ class ModActionDecorator < ApplicationDecorator
       if vals[:tag1]
         "Approved tag implication ({{#{vals[:tag1]}}} → {{#{vals[:tag2]}}})"
       end
-    when "tag_implicaton_delete"
+    when "tag_implication_delete"
       if vals[:tag1]
         "Deleted tag implication ({{#{vals[:tag1]}}} → {{#{vals[:tag2]}}})"
       end
@@ -306,7 +316,7 @@ class ModActionDecorator < ApplicationDecorator
         "Updated tag implication #{vals['implication_desc']}\n#{vals['change_desc']}"
       end
 
-      ### BURs ###
+      ### BUR ###
 
     when "mass_update"
       "Mass updated [[#{vals['antecedent']}]] → [[#{vals['consequent']}]]"
@@ -322,7 +332,7 @@ class ModActionDecorator < ApplicationDecorator
     when "deleted_flag_reason"
       "Deleted flag reason ##{vals['flag_reason_id']} (#{vals['flag_reason']})"
 
-      ### Post Report Reasons ###
+      ### Post Report Reason ###
 
     when "report_reason_create"
       "Created post report reason #{vals['reason']}"
@@ -338,7 +348,7 @@ class ModActionDecorator < ApplicationDecorator
     when "report_reason_delete"
       "Deleted post report reason #{vals['reason']} by #{user}"
 
-      ### Whitelist ###
+      ### Upload Whitelist ###
 
     when "upload_whitelist_create"
       if CurrentUser.is_admin?
@@ -388,7 +398,8 @@ class ModActionDecorator < ApplicationDecorator
     when "help_delete"
       "Deleted help entry \"#{vals['name']}\":/help/#{vals['name']} ([[#{vals['wiki_page']}]])"
 
-      ### Wiki ###
+      ### Wiki Page ###
+
     when "wiki_page_delete"
       "Deleted wiki page [[#{vals['wiki_page']}]]"
     when "wiki_page_lock"
@@ -398,7 +409,8 @@ class ModActionDecorator < ApplicationDecorator
     when "wiki_page_rename"
       "Renamed wiki page ([[#{vals['old_title']}]] → [[#{vals['new_title']}]])"
 
-      ### Mascots ###
+      ### Mascot ###
+
     when "mascot_create"
       "Created mascot ##{vals['id']}"
     when "mascot_update"
@@ -409,13 +421,26 @@ class ModActionDecorator < ApplicationDecorator
     when "bulk_revert"
       "Processed bulk revert for #{vals['constraints']} by #{user}"
 
-      ### Post Versions
+      ### Search Trend Blacklist ###
+
+    when "search_trend_blacklist_create"
+      "Created search trend blacklist entry for tag pattern \"#{vals['tag']}\" with reason: #{vals['reason']}"
+    when "search_trend_blacklist_update"
+      "Updated search trend blacklist entry for tag pattern \"#{vals['tag']}\" with reason: #{vals['reason']}"
+    when "search_trend_blacklist_delete"
+      "Deleted search trend blacklist entry for tag pattern \"#{vals['tag']}\" with reason: #{vals['reason']}"
+    when "search_trend_blacklist_purge"
+      "Purged #{vals['deleted_count']} search trends matching tag pattern \"#{vals['tag']}\" with reason: #{vals['reason']}"
+
+      ### Post Versions ###
+
     when "post_version_hide"
       "Hidden post version \"#{vals['version']}\":/post_versions?search[post_id]=#{vals['post_id']} on post ##{vals['post_id']}"
     when "post_version_unhide"
       "Restored post version \"#{vals['version']}\":/post_versions?search[post_id]=#{vals['post_id']} on post ##{vals['post_id']}"
 
       ### Legacy Post Events ###
+
     when "post_move_favorites"
       "Moves favorites from post ##{vals['post_id']} to post ##{vals['parent_id']}"
     when "post_delete"
@@ -435,6 +460,13 @@ class ModActionDecorator < ApplicationDecorator
       "Post replacement for post ##{vals['post_id']} was rejected"
     when "post_replacement_delete"
       "Post replacement for post ##{vals['post_id']} was deleted"
+
+      ### Other Legacy Events ###
+
+    when "invited_user" # Existed briefly in 2011
+      "Invited user ##{vals['username']}"
+    when "post_owner_reassign" # Actual data is lost forever
+      "Reassigned post owner (no data available)"
 
     else
       CurrentUser.is_admin? ? "Unknown action #{object.action}: #{object.values.inspect}" : "Unknown action #{object.action}"

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -3,9 +3,8 @@
 class ModAction < ApplicationRecord
   belongs_to :creator, class_name: "User"
   before_validation :initialize_creator, on: :create
-  validates :creator_id, presence: true
 
-  KnownActions = {
+  KNOWN_ACTIONS = {
     admin_user_delete: { user_id: :integer },
     artist_page_rename: { old_name: :string, new_name: :string },
     artist_page_lock: { artist_page: :string },
@@ -103,14 +102,19 @@ class ModAction < ApplicationRecord
     post_version_unhide: { version: :integer, post_id: :integer },
   }.freeze
 
-  ProtectedActionKeys = %w[staff_note_create staff_note_update staff_note_delete staff_note_undelete ip_ban_create ip_ban_delete post_version_hide post_version_unhide].freeze
+  PROTECTED_ACTION_KEYS = %w[
+    staff_note_create staff_note_update staff_note_delete staff_note_undelete
+    ip_ban_create ip_ban_delete
+    post_version_hide post_version_unhide
+    search_trend_blacklist_create search_trend_blacklist_update search_trend_blacklist_delete search_trend_blacklist_purge
+  ].freeze
 
-  KnownActionKeys = KnownActions.keys.freeze
+  KNOWN_ACTION_KEYS = KNOWN_ACTIONS.keys.freeze
 
   def self.available_action_keys(user = CurrentUser)
-    return KnownActionKeys if user.is_staff?
+    return KNOWN_ACTION_KEYS if user.is_staff?
 
-    KnownActionKeys - ProtectedActionKeys.map(&:to_sym)
+    KNOWN_ACTION_KEYS - PROTECTED_ACTION_KEYS.map(&:to_sym)
   end
 
   module SearchMethods
@@ -118,7 +122,7 @@ class ModAction < ApplicationRecord
       if user.is_staff?
         all
       else
-        where.not(action: ProtectedActionKeys)
+        where.not(action: PROTECTED_ACTION_KEYS)
       end
     end
 
@@ -159,8 +163,8 @@ class ModAction < ApplicationRecord
       q = q.where_user(:creator_id, :creator, params)
       q = q.where(action: params[:action]) if params[:action].present?
 
-      if params[:action].present? && KnownActions.key?(params[:action].to_sym)
-        field_types = KnownActions[params[:action].to_sym]
+      if params[:action].present? && KNOWN_ACTIONS.key?(params[:action].to_sym)
+        field_types = KNOWN_ACTIONS[params[:action].to_sym]
         valid_params = params.slice(*field_types.keys.map(&:to_s))
 
         field_types.each do |key, type|
@@ -189,7 +193,7 @@ class ModAction < ApplicationRecord
     if user.is_staff?
       true
     else
-      ProtectedActionKeys.exclude?(action)
+      PROTECTED_ACTION_KEYS.exclude?(action)
     end
   end
 
@@ -200,7 +204,7 @@ class ModAction < ApplicationRecord
     if CurrentUser.is_admin?
       original_values
     else
-      valid_keys = KnownActions[action.to_sym]&.keys&.map(&:to_s) || []
+      valid_keys = KNOWN_ACTIONS[action.to_sym]&.keys&.map(&:to_s) || []
       sanitized_values = original_values.slice(*valid_keys)
 
       if %i[ip_ban_create ip_ban_delete].include?(action.to_sym)

--- a/app/views/mod_actions/_search.html.erb
+++ b/app/views/mod_actions/_search.html.erb
@@ -6,7 +6,7 @@
           [
             key.to_s.capitalize.tr("_", " "),
             key.to_s,
-            { data: { fields: ModAction::KnownActions[key].keys.join(",") } }
+            { data: { fields: ModAction::KNOWN_ACTIONS[key].keys.join(",") } }
           ]
         end
       ),

--- a/db/fixes/133_rename_legacy_mod_actions.rb
+++ b/db/fixes/133_rename_legacy_mod_actions.rb
@@ -19,10 +19,13 @@ renames = {
   "edited_forum_post" => "forum_post_update",
   "hid_forum_post" => "forum_post_hide",
   "unhid_forum_post" => "forum_post_unhide",
-  "locked_forum_post" => "forum_topic_lock",
-  "unlocked_forum_post" => "forum_topic_unlock",
-  "stickied_forum_post" => "forum_topic_stick",
-  "unstickied_forum_post" => "forum_topic_unstick",
+
+  # Forum actions, unprocessable
+  # These store forum post IDs, but the new format expects topic IDs
+  # "locked_forum_post" => "forum_topic_lock",
+  # "unlocked_forum_post" => "forum_topic_unlock",
+  # "stickied_forum_post" => "forum_topic_stick",
+  # "unstickied_forum_post" => "forum_topic_unstick",
 
   # Tag alias actions
   "created_alias" => "tag_alias_create",
@@ -45,9 +48,10 @@ renames = {
   # Set actions
   "made_set_private" => "set_change_visibility",
 
-  # Report reason actions
-  "created_report_reason" => "report_reason_create",
-  "edited_report_reason" => "report_reason_update",
+  # Report reason actions, unprocessable
+  # These store report reason IDs, but the new format expects reason text
+  # "created_report_reason" => "report_reason_create",
+  # "edited_report_reason" => "report_reason_update",
 
   # Typo fixes
   "post_desroy" => "post_destroy",

--- a/db/fixes/133_rename_legacy_mod_actions.rb
+++ b/db/fixes/133_rename_legacy_mod_actions.rb
@@ -1,0 +1,67 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+renames = {
+  # User actions
+  "banned_user" => "user_ban",
+  "unbanned_user" => "user_unban",
+
+  # Comment actions
+  "deleted_comment" => "comment_delete",
+  "unhid_comment" => "comment_unhide",
+
+  # Pool actions
+  "deleted_pool" => "pool_delete",
+
+  # Forum actions
+  "edited_forum_post" => "forum_post_update",
+  "hid_forum_post" => "forum_post_hide",
+  "unhid_forum_post" => "forum_post_unhide",
+  "locked_forum_post" => "forum_topic_lock",
+  "unlocked_forum_post" => "forum_topic_unlock",
+  "stickied_forum_post" => "forum_topic_stick",
+  "unstickied_forum_post" => "forum_topic_unstick",
+
+  # Tag alias actions
+  "created_alias" => "tag_alias_create",
+  "deleted_alias" => "tag_alias_delete",
+  "approved_alias" => "tag_alias_approve",
+  "edited_alias" => "tag_alias_update",
+
+  # Tag implication actions
+  "created_implication" => "tag_implication_create",
+  "deleted_implication" => "tag_implication_delete",
+  "approved_implication" => "tag_implication_approve",
+  "edited_implication" => "tag_implication_update",
+
+  # Wiki page actions
+  "deleted_wiki_page" => "wiki_page_delete",
+  "renamed_wiki_page" => "wiki_page_rename",
+  "locked_wiki_page" => "wiki_page_lock",
+  "unlocked_wiki_page" => "wiki_page_unlock",
+
+  # Set actions
+  "made_set_private" => "set_change_visibility",
+
+  # Report reason actions
+  "created_report_reason" => "report_reason_create",
+  "edited_report_reason" => "report_reason_update",
+
+  # Typo fixes
+  "post_desroy" => "post_destroy",
+  "edited_uplupload_whitelist_updateoad_whitelist" => "upload_whitelist_update",
+}
+
+renames.each do |old_action, new_action|
+  count = ModAction.where(action: old_action).count
+  next if count == 0
+
+  ModAction.without_timeout do
+    ModAction.where(action: old_action).update_all(action: new_action)
+  end
+  puts "Renamed #{count} '#{old_action}' -> '#{new_action}'"
+end
+
+puts "Done."


### PR DESCRIPTION
Converts a bunch of pre-2021 mod action records to a modern format.
Required some tweaks to the mod action decorator to account for differences in value format.

The following actions were not converted:
* `locked_forum_post`, `unlocked_forum_post`, `stickied_forum_post`, `unstickied_forum_post`
  These store `forum_post_id` rather than `forum_topic_id`.
* `created_report_reason`, `edited_report_reason`
  These store `reason_id` rather than a strong `reason`

Also fixed some Rubocop alerts.