### PR TITLE
[Users] Allow admins to rename users with blank names

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -34,6 +34,9 @@ module Admin
       @user.validate_email_format = true
       @user.is_admin_edit = true
       @user.update!(user_params(CurrentUser.user))
+      if @user.saved_change_to_name
+        ModAction.log(:user_name_change, { user_id: @user.id, old_name: @user.name_before_last_save, new_name: @user.name })
+      end
       if @user.saved_change_to_profile_about || @user.saved_change_to_profile_artinfo
         ModAction.log(:user_text_change, { user_id: @user.id })
       end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -126,7 +126,7 @@ module Admin
     private
 
     def user_params(user)
-      permitted_params = %i[profile_about profile_artinfo base_upload_limit enable_privacy_mode]
+      permitted_params = %i[name profile_about profile_artinfo base_upload_limit enable_privacy_mode]
       permitted_params << :email if user.is_bd_staff?
       params.require(:user).slice(*permitted_params).permit(permitted_params)
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -34,9 +34,6 @@ module Admin
       @user.validate_email_format = true
       @user.is_admin_edit = true
       @user.update!(user_params(CurrentUser.user))
-      if @user.saved_change_to_name
-        ModAction.log(:user_name_change, { user_id: @user.id, old_name: @user.name_before_last_save, new_name: @user.name })
-      end
       if @user.saved_change_to_profile_about || @user.saved_change_to_profile_artinfo
         ModAction.log(:user_text_change, { user_id: @user.id })
       end
@@ -129,7 +126,7 @@ module Admin
     private
 
     def user_params(user)
-      permitted_params = %i[name profile_about profile_artinfo base_upload_limit enable_privacy_mode]
+      permitted_params = %i[profile_about profile_artinfo base_upload_limit enable_privacy_mode]
       permitted_params << :email if user.is_bd_staff?
       params.require(:user).slice(*permitted_params).permit(permitted_params)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,7 +133,7 @@ module ApplicationHelper
     user_class += " user-post-uploader" if user.can_upload_free?
     user_class += " user-banned" if user.is_banned?
     user_class += " with-style" if CurrentUser.user.style_usernames?
-    html = link_to(user.pretty_name, user_path(user), class: user_class, rel: "nofollow")
+    html = link_to(user.pretty_name.presence || "<blank>", user_path(user), class: user_class, rel: "nofollow")
     html << " (Unactivated)" if include_activation && !user.is_verified?
     html
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,7 +91,7 @@ class User < ApplicationRecord
   validate :validate_email_address_allowed, on: %i[create update], if: ->(rec) { (rec.new_record? && rec.email.present?) || (rec.email.present? && rec.email_changed?) }
 
   normalizes :profile_about, :profile_artinfo, with: ->(value) { value.gsub("\r\n", "\n") }
-  validates :name, presence: true # NOTE: validation order is important here. See UserNameValidator for details.
+  validates :name, presence: true, if: -> { new_record? || name_changed? } # NOTE: validation order is important here. See UserNameValidator for details.
   validates :name, user_name: true, on: :create
   validates :default_image_size, inclusion: { in: %w[large fit fitv original] }
   validates :per_page, inclusion: { in: 1..Danbooru.config.max_per_page }

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -4,7 +4,7 @@ class UserNameChangeRequest < ApplicationRecord
   after_initialize :initialize_attributes, if: :new_record?
   after_create :apply!
 
-  validates :original_name, :desired_name, presence: true
+  validates :desired_name, presence: true
   validates :desired_name, user_name: { user_id: ->(rec) { rec.user_id } }, unless: :skip_user_name_validation
   validate :not_limited, on: :create
 

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -188,7 +188,7 @@ class UserPresenter
   end
 
   def previous_names(template)
-    user.user_name_change_requests.map { |req| template.link_to req.original_name, req }.join(" -> ").html_safe
+    user.user_name_change_requests.map { |req| template.link_to (req.original_name.presence || "<blank>"), req }.join(" -> ").html_safe
   end
 
   def favorite_tags_with_types

--- a/app/views/application/_profile_avatar.erb
+++ b/app/views/application/_profile_avatar.erb
@@ -3,11 +3,11 @@
 <div
   class="profile-avatar placeholder"
   data-id="<%= post_id %>"
-  data-name="<%= user.name %>"
-  data-initial="<%= user.name[0].capitalize%>"
+  data-name="<%= user.name.presence || "<blank>" %>"
+  data-initial="<%= (user.name.presence || "?")[0].capitalize %>"
 >
   <span
     class="avatar-image"
-    data-initial="<%= user.name[0].capitalize%>"
+    data-initial="<%= (user.name.presence || "?")[0].capitalize %>"
   ></span>
 </div>

--- a/app/views/layouts/navigation/_avatar_menu.html.erb
+++ b/app/views/layouts/navigation/_avatar_menu.html.erb
@@ -6,11 +6,11 @@
   class="simple-avatar placeholder nav-controls-profile collapse-2"
   data-user-id="<%= user.id %>"
   data-id="<%= avatar_id %>"
-  data-name="<%= user.name %>"
+  data-name="<%= user.name.presence || "<blank>" %>"
   data-has-mail="<%= has_mail %>"
 >
-  <span class="avatar-name"><%= user.pretty_name %></span>
-  <span class="avatar-image" data-name="<%= user.name&.to_s&.first&.capitalize || "" %>"></span>
+  <span class="avatar-name"><%= user.pretty_name.presence || "<blank>" %></span>
+  <span class="avatar-image" data-name="<%= (user.name.presence || "?")[0].capitalize %>"></span>
   <span class="avatar-more"><%= svg_icon(:chevron_down) %></span>
 </a>
 

--- a/app/views/user_name_change_requests/show.html.erb
+++ b/app/views/user_name_change_requests/show.html.erb
@@ -17,7 +17,7 @@
         </tr>
         <tr>
           <th>Old</th>
-          <td><%= @change_request.original_name %></td>
+          <td><%= @change_request.original_name.presence || "<blank>" %></td>
         </tr>
         <tr>
           <th>New</th>

--- a/spec/models/user_name_change_request/validations_spec.rb
+++ b/spec/models/user_name_change_request/validations_spec.rb
@@ -15,10 +15,9 @@ RSpec.describe UserNameChangeRequest do
   # Presence                                                            #
   # ------------------------------------------------------------------ #
   describe "presence validations" do
-    it "is invalid without original_name" do
+    it "is valid without original_name" do
       record = build_request(original_name: nil, skip_user_name_validation: true)
-      expect(record).not_to be_valid
-      expect(record.errors[:original_name]).to be_present
+      expect(record).to be_valid
     end
 
     it "is invalid without desired_name" do


### PR DESCRIPTION
The validation has been tightened to prevent users from making accounts with blank names.
But something needs to be done about existing accounts.