### PR TITLE
[Popular] Fix a N+1 query issue

### DIFF
--- a/app/logical/post_sets/popular.rb
+++ b/app/logical/post_sets/popular.rb
@@ -17,7 +17,10 @@ module PostSets
     end
 
     def posts
-      @posts ||= ::Post.where("created_at between ? and ?", min_date.beginning_of_day, max_date.end_of_day).order("score desc").paginate_posts(1)
+      @posts ||= ::Post.where("created_at between ? and ?", min_date.beginning_of_day, max_date.end_of_day)
+                       .includes(:uploader)
+                       .order("score desc")
+                       .paginate_posts(1)
     end
 
     def api_posts


### PR DESCRIPTION
The thumbnail component requires the uploader's name to be included, for blacklisting purposes.
Without this, rendering the index view of the popular controller results in dozens of pointless queries.