### PR TITLE
[ExceptionLog] Fix an error if unable to record request IP

### DIFF
--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -32,7 +32,11 @@ class ExceptionLog < ApplicationRecord
     end
 
     create!(
-      ip_addr: request.remote_ip || "0.0.0.0",
+      ip_addr: begin
+        request.remote_ip
+      rescue StandardError
+        "0.0.0.0"
+      end,
       class_name: unwrapped_exception.class.name,
       message: unwrapped_exception.message,
       trace: unwrapped_exception.backtrace.join("\n"),

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -34,7 +34,7 @@ class ExceptionLog < ApplicationRecord
     create!(
       ip_addr: begin
         request.remote_ip
-      rescue StandardError
+      rescue ActionDispatch::RemoteIp::IpSpoofAttackError
         "0.0.0.0"
       end,
       class_name: unwrapped_exception.class.name,

--- a/spec/models/exception_log/class_methods_spec.rb
+++ b/spec/models/exception_log/class_methods_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe ExceptionLog do
       expect(log.ip_addr.to_s).to eq("10.0.0.1")
     end
 
+    it "handles ActionDispatch::RemoteIp::IpSpoofAttackError being raised" do
+      request = make_request
+      allow(request).to receive(:remote_ip).and_raise(ActionDispatch::RemoteIp::IpSpoofAttackError)
+      log = ExceptionLog.add(make_exception, CurrentUser.id, request)
+      expect(log.ip_addr.to_s).to eq("0.0.0.0")
+    end
+
     it "stores the user_id" do
       user = create(:user)
       log  = ExceptionLog.add(make_exception, user.id, make_request)


### PR DESCRIPTION
Happened recently when someone tried to spoof their IP.
https://us5.datadoghq.com/error-tracking/issue/ce68a086-07bd-11ef-82a5-da7ad0900000