### PR TITLE
[Users] Better page flow when trying to create an account while already logged in

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,10 @@ class UsersController < ApplicationController
   end
 
   def new
-    raise User::PrivilegeError, "Already signed in" unless CurrentUser.is_anonymous?
+    unless CurrentUser.is_anonymous?
+      redirect_back_or_to(posts_path, notice: "You are already signed in")
+      return
+    end
     return access_denied("Signups are disabled") unless Danbooru.config.enable_signups?
     @user = User.new
     respond_with(@user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,7 +35,11 @@ class UsersController < ApplicationController
 
   def new
     unless CurrentUser.is_anonymous?
-      redirect_back_or_to(posts_path, notice: "You are already signed in")
+      if request.format.html?
+        redirect_back_or_to(posts_path, notice: "You are already signed in")
+      else
+        access_denied("Already signed in")
+      end
       return
     end
     return access_denied("Signups are disabled") unless Danbooru.config.enable_signups?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,11 +35,8 @@ class UsersController < ApplicationController
 
   def new
     unless CurrentUser.is_anonymous?
-      if request.format.html?
-        redirect_back_or_to(posts_path, notice: "You are already signed in")
-      else
-        access_denied("Already signed in")
-      end
+      return access_denied("You are already signed in") unless request.format.html?
+      redirect_back_or_to(posts_path, notice: "You are already signed in")
       return
     end
     return access_denied("Signups are disabled") unless Danbooru.config.enable_signups?

--- a/app/views/auths/_login.html.erb
+++ b/app/views/auths/_login.html.erb
@@ -33,8 +33,10 @@
       <%= link_to("Reset Password", new_maintenance_user_password_reset_path, class: "hint-link") %>
     </div>
 
-    <hr />
+    <% if Danbooru.config.enable_signups? %>
+      <hr />
 
-    <%= link_to("Create an account", new_user_path, class: "st-button") %>
+      <%= link_to("Create an account", new_user_path, class: "st-button") %>
+    <% end %>
   <% end %>
 </div>

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -95,8 +95,14 @@ RSpec.describe UsersController do
     context "when already logged in" do
       before { sign_in_as create(:user) }
 
-      it "returns 403" do
+      it "redirects back with a notice for HTML requests" do
         get new_user_path
+        expect(response).to redirect_to(posts_path)
+        expect(flash[:notice]).to include("already signed in")
+      end
+
+      it "returns 403 for JSON requests" do
+        get new_user_path(format: :json)
         expect(response).to have_http_status(:forbidden)
       end
     end


### PR DESCRIPTION
Flow goes something like this:

1. Open two tabs of e621 while logged out
2. On one of them, log in using the auth overlay
3. In another, click on the "Create Account" button.
 
Not sure why this is happening to so many people, though.

https://us5.datadoghq.com/error-tracking/issue/992e8710-df61-11ef-88ed-da7ad0900000