### PR TITLE
[Misc] Better handling of the static Discord link

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -66,9 +66,9 @@ class StaticController < ApplicationController
   end
 
   def discord
-    raise User::PrivilegeError, "You must have an account for at least one week in order to join the Discord server." unless CurrentUser.can_discord?
-
     if request.post?
+      raise User::PrivilegeError, "You must have an account for at least one week in order to join the Discord server." unless CurrentUser.can_discord?
+
       time = (Time.now + 5.minutes).to_i
       secret = Danbooru.config.discord_secret
       # TODO: Proper HMAC

--- a/app/views/static/discord.html.erb
+++ b/app/views/static/discord.html.erb
@@ -3,9 +3,17 @@
   <div class="dtext-container">
     <%= format_text(@page.body, allow_color: true) %>
   </div>
-  <%= form_tag(discord_post_path) do %>
-    <%= submit_tag "Join the Server", class: "st-button submit" %>
+
+  <% if CurrentUser.can_discord? %>
+    <%= form_tag(discord_post_path) do %>
+      <%= submit_tag "Join the Server", class: "st-button submit" %>
+    <% end %>
+  <% else %>
+    <p class="background-red" style="padding: 1rem; margin: 1rem;">
+      You must have an account for at least one week in order to join the Discord server.
+    </p>
   <% end %>
+
 </div></div>
 
 <% content_for(:secondary_links) do %>

--- a/app/views/static/discord.html.erb
+++ b/app/views/static/discord.html.erb
@@ -9,7 +9,7 @@
       <%= submit_tag "Join the Server", class: "st-button submit" %>
     <% end %>
   <% else %>
-    <p class="background-red" style="padding: 1rem; margin: 1rem;">
+    <p class="background-red box-section">
       You must have an account for at least one week in order to join the Discord server.
     </p>
   <% end %>


### PR DESCRIPTION
Show a more user-friendly error message, rather than throw a PrivilegeError on GET requests.