### PR TITLE
[Users] Fix an error caused by an invalid bcrypt hash

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -236,6 +236,8 @@ class User < ApplicationRecord
 
     def bcrypt_password
       BCrypt::Password.new(bcrypt_password_hash)
+    rescue BCrypt::Errors::InvalidHash
+      nil
     end
 
     def encrypt_password_on_create


### PR DESCRIPTION
Still not quite sure how they ended up like this.
https://us5.datadoghq.com/error-tracking/issue/34cd2eb6-d534-11ef-a522-da7ad0900000