### PR TITLE
[Posts] Minor tweaks to the posts#show page UI

### DIFF
--- a/app/javascript/src/js/pages/posts/show/MobileTabs.ts
+++ b/app/javascript/src/js/pages/posts/show/MobileTabs.ts
@@ -2,10 +2,11 @@ import LStorage from "@/utility/storage";
 
 function bootstrapTabs () {
   const container = $(".post-display");
+  if (!container.length || !container.data("comments-enabled")) return;
   const validActions = ["comments", "tags"];
 
   const savedState = (LStorage.Posts.MobileTab as any) + "";
-  if (savedState === "tags") container.attr("data-tab-state", "tags");
+  if (savedState === "comments") container.attr("data-tab-state", "comments");
 
   container.find(".post-mobile-tab").on("click", (event) => {
     const action = $(event.currentTarget).data("action");
@@ -14,7 +15,9 @@ function bootstrapTabs () {
 
     container.attr("data-tab-state", action);
   });
+}
 
+function bootstrapGoUpButton () {
   $(".go-up button").on("click", () => {
     const tabs = $("#mobile-tabs");
     if (tabs.length) {
@@ -28,4 +31,5 @@ function bootstrapTabs () {
 
 $(() => {
   bootstrapTabs();
+  bootstrapGoUpButton();
 });

--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -224,7 +224,7 @@ export default class PostsShowToolbar {
         });
     });
 
-    $(".ptbr-etc-pool, .ptbr-etc-set, .ptbr-share-button").on("click", () => {
+    $(".ptbr-etc-pool, .ptbr-etc-set, .ptbr-share-button, .ptbr-etc-edit").on("click", () => {
       offclickHandler.disabled = true;
       menu.addClass("hidden");
     });

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -2,6 +2,7 @@
 <section id="ptbr-wrapper">
 
 <% if CurrentUser.is_member? %>
+  <%# ===== VOTE ===== #%>
   <div
     class="ptbr-vote"
     data-score="<%= @post.score %>"
@@ -30,6 +31,7 @@
     ><%= svg_icon(:chevron_down) %></button>
   </div>
 
+  <%# ===== FAVORITE ===== #%>
   <div class="ptbr-favorite">
     <button
       class="st-button kinetic ptbr-favorite-button anim"
@@ -58,6 +60,7 @@
 <% end %>
 
 <% if @post.visible? %>
+  <%# ===== NOTES ===== #%>
   <div class="<%= @post.has_notes? ? "ptbr-notes" : "ptbr-notes hidden" %>">
     <button
       class="st-button kinetic ptbr-notes-button"
@@ -69,6 +72,7 @@
 <% end %>
 
 <% if !@post.force_original_size? %>
+  <%# ===== RESIZE ===== #%>
   <div class="ptbr-resize">
     <select id="image-resize-selector" class="st-button" aria-label="Select image size">
       <option value="original">Original</option>
@@ -86,6 +90,7 @@
 <% end %>
 
 <% if @post.visible? %>
+  <%# ===== FULLSCREEN ===== #%>
   <div class="ptbr-fullscreen">
     <a
       href="<%= @post.file_url %>"
@@ -98,6 +103,7 @@
   </div>
 <% end %>
 <% if CurrentUser.is_member? %>
+  <%# ===== EDIT ===== #%>
   <div class="ptbr-edit">
     <button
       type="button"
@@ -110,12 +116,15 @@
   </div>
 <% end %>
 <% if @post.visible? %>
+  <%# ===== OVERFLOW ===== #%>
   <div class="ptbr-etc">
     <button class="st-button kinetic ptbr-etc-toggle" title="More Options">
       <%= svg_icon(:ellipsis_v) %>
     </button>
     <div class="ptbr-etc-menu hidden">
-      <button type="button" id="menu-post-edit-link" class="st-button ptbr-etc-edit">Edit</button>
+      <% if CurrentUser.is_member? %>
+        <button type="button" id="menu-post-edit-link" class="st-button ptbr-etc-edit">Edit</button>
+      <% end %>
       <a href="<%= @post.file_url %>" class="st-button ptbr-etc-fullscreen">Fullscreen</a>
       <a
         href="<%= @post.file_url %>"
@@ -129,8 +138,10 @@
       </a>
       <button class="st-button ptbr-share-button" data-hotkey="share">Share</button>
       <button class="st-button ptbr-notes-button <%= @post.has_notes? ? "" : "hidden"%>" enabled="true"></button>
-      <button class="st-button ptbr-etc-pool add-to-pool" data-hotkey="add-to-pool">Add to Pool</button>
-      <button class="st-button ptbr-etc-set add-to-set" data-hotkey="add-to-set">Add to Set</button>
+      <% if CurrentUser.is_member? %>
+        <button class="st-button ptbr-etc-pool add-to-pool" data-hotkey="add-to-pool">Add to Pool</button>
+        <button class="st-button ptbr-etc-set add-to-set" data-hotkey="add-to-set">Add to Set</button>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,5 +1,5 @@
 <div id="c-posts"><div id="a-show">
-  <div class="post-display" data-tab-state="<%= CurrentUser.hide_comments? ? "tags" : "comments" %>">
+  <div class="post-display" data-tab-state="tags" data-comments-enabled="<%= !CurrentUser.hide_comments? %>">
 
     <div class="search">
       <%= render "posts/partials/common/search", title: "Posts", tags: params[:q] %>
@@ -103,6 +103,12 @@
         </div>
       <% end %>
 
+      <% if CurrentUser.is_member? %>
+        <section id="edit" style="display: none;">
+          <%= render "posts/partials/show/content/edit", :post => @post %>
+        </section>
+      <% end %>
+
       <div
         id="post-recommendations"
         data-visible="true"
@@ -168,19 +174,13 @@
           <% end %>
         <% end %>
       </section>
-
-      <% if CurrentUser.is_member? %>
-        <section id="edit" style="display: none;">
-          <%= render "posts/partials/show/content/edit", :post => @post %>
-        </section>
-      <% end %>
     </div>
 
     <div class="tabs" id="mobile-tabs">
+      <button type="button" class="post-mobile-tab" data-action="tags">Tags</button>
       <% unless CurrentUser.hide_comments? %>
         <button type="button" class="post-mobile-tab" data-action="comments">Comments</button>
       <% end %>
-      <button type="button" class="post-mobile-tab" data-action="tags">Tags</button>
     </div>
 
     <div class="comments">
@@ -189,7 +189,9 @@
           <%= render "comments/partials/index/list", :comments => @comments, :post => @post, :show_header => false %>
         </section>
 
-        <div class="go-up"><button type="button" class="st-button kinetic" title="Scroll to top" aria-label="Scroll to top"><%= svg_icon(:corner_right_up) %></button></div>
+        <% if @comments.any? %>
+          <div class="go-up"><button type="button" class="st-button kinetic" title="Scroll to top" aria-label="Scroll to top"><%= svg_icon(:corner_right_up) %></button></div>
+        <% end %>
       <% end %>
     </div>
 


### PR DESCRIPTION
* Tags are now the default tab
* Moved the tag editing UI higher up
* Fixed a bug causing the overflow menu to not close when editing tags
* Hidden the "Go Up" button if there are no comments
* Hide "Edit", "Add to Pool", and "Add to Set" options in the overflow menu from guests