### PR TITLE
[Posts] Rework the toolbar and post editing on mobile

### DIFF
--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -30,12 +30,16 @@ Post.initialize_all = function () {
 
   this.initialize_collapse();
 
-  $(document).on("danbooru:open-post-edit-tab", () => Hotkeys.enabled = false);
-  $(document).on("danbooru:open-post-edit-tab", () => $("#post_tag_string").trigger("focus"));
+  $(document).on("danbooru:open-post-edit-tab", () => {
+    Hotkeys.enabled = false;
+    // Not going to happen until the Vue app is mounted.
+    // See tag_editor.vue for the workaround.
+    $("#post_tag_string").trigger("focus");
+    window.scrollTo({ top: $("#edit").offset().top - 80, behavior: "smooth" });
+  });
   $(document).on("danbooru:close-post-edit-tab", () => Hotkeys.enabled = true);
   $("#tag-string-editor").on("e6ng:vue-mounted", () => {
     Post.update_tag_count();
-    $("#post_tag_string").trigger("focus");
   });
 
   var $fields_multiple = $("[data-autocomplete=\"tag-edit\"]");
@@ -537,9 +541,9 @@ Post.initialize_post_sections = function () {
     Post._isEditing = !Post._isEditing;
 
     if (Post._isEditing) {
-      $(document).trigger("danbooru:open-post-edit-tab");
       Post.update_tag_count();
       $("#edit").show();
+      $(document).trigger("danbooru:open-post-edit-tab");
     } else {
       $(document).trigger("danbooru:close-post-edit-tab");
       $("#edit").hide();
@@ -829,7 +833,6 @@ Post.update_tag_count = function () {
   // let count2 = 1;
 
   const input = $("#post_tag_string");
-  console.log("Updating tag count for:", input);
   if (input.length) {
     let tags = [...new Set(input.val().match(/\S+/g))];
     if (tags) {

--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -29,10 +29,16 @@ export default class PostsShowToolbar {
 
     // Initialize notes toggle
     const noteToggleButtons = $(".ptbr-notes-button")
-      .attr("enabled", NoteManager.enabled + "")
+      .attr({
+        "enabled": NoteManager.enabled + "",
+        "aria-pressed": NoteManager.enabled + "",
+      })
       .on("click", () => { NoteManager.enabled = !NoteManager.enabled; });
     $("#note-container").on("note:visible:true note:visible:false", () => {
-      noteToggleButtons.attr("enabled", NoteManager.enabled + "");
+      noteToggleButtons.attr({
+        "enabled": NoteManager.enabled + "",
+        "aria-pressed": NoteManager.enabled + "",
+      });
     });
 
     // Initialize fullscreen menu toggle
@@ -190,15 +196,17 @@ export default class PostsShowToolbar {
   initOverflowMenu () {
     const menu = $(".ptbr-etc-menu");
     let offclickHandler = null;
-    $(".ptbr-etc-toggle").on("click", () => {
+    const toggle = $(".ptbr-etc-toggle").on("click", () => {
       // Register offclick handler on the first use
       if (offclickHandler === null)
         offclickHandler = Offclick.register(".ptbr-etc-toggle", ".ptbr-etc-menu", () => {
           menu.addClass("hidden");
+          toggle.attr("aria-expanded", false);
         });
 
       offclickHandler.disabled = !offclickHandler.disabled;
       menu.toggleClass("hidden", offclickHandler.disabled);
+      toggle.attr("aria-expanded", !offclickHandler.disabled);
     });
 
     const button = $(".ptbr-etc-download").on("click.e6.prepare", (event) => {
@@ -232,7 +240,7 @@ export default class PostsShowToolbar {
         });
     });
 
-    $(".ptbr-etc-pool, .ptbr-etc-set, .ptbr-share-button, .ptbr-etc-edit").on("click", () => {
+    $(".ptbr-etc-pool, .ptbr-etc-set, .ptbr-share-button").on("click", () => {
       offclickHandler.disabled = true;
       menu.addClass("hidden");
     });

--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -62,7 +62,15 @@ export default class PostsShowToolbar {
   // Initialize voting buttons
   initVotingButtons () {
     const scoreBreakdown = $(".ptbr-breakdown").first();
+    let scoreOffclick = null;
     $(".ptbr-score").first().on("click", () => {
+      // Register offclick handler on the first use
+      if (scoreOffclick === null)
+        scoreOffclick = Offclick.register(".ptbr-score", ".ptbr-breakdown", () => {
+          scoreBreakdown.addClass("hidden");
+        });
+
+      scoreOffclick.disabled = !scoreOffclick.disabled;
       scoreBreakdown.toggleClass("hidden");
     });
 

--- a/app/javascript/src/js/pages/posts/show/related_tag.js
+++ b/app/javascript/src/js/pages/posts/show/related_tag.js
@@ -15,7 +15,9 @@ RelatedTag.init_post_show_editor = async function () {
 
   const app = createApp(TagEditor);
   app.mount("#tag-string-editor");
-  $("#tag-string-editor").trigger("e6ng:vue-mounted");
+  $("#tag-string-editor")
+    .removeClass("pending")
+    .trigger("e6ng:vue-mounted");
 };
 
 $(function () {

--- a/app/javascript/src/js/pages/posts/show/tag_editor.vue
+++ b/app/javascript/src/js/pages/posts/show/tag_editor.vue
@@ -57,7 +57,6 @@ export default {
       const el = this.$refs.otherTags;
       el.style.height = el.scrollHeight + "px";
       el.focus();
-      el.scrollIntoView();
     }, 20);
     if (Utility.meta("enable-auto-complete") !== "true")
       return;

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -18,7 +18,7 @@ div#c-posts, div#c-uploads, div#c-post-replacements {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    max-width: 95vw;
+    max-width: 90vw;
 
     @include window-larger-than(50rem) {
       &:hover {
@@ -202,6 +202,17 @@ div#c-posts {
       textarea {
         width: 100%;
         max-width: unset;
+        min-height: 5rem;
+        box-sizing: border-box;
+      }
+      div#tag-string-editor.pending {
+        min-height: 5rem;
+        background: themed("color-text-muted");
+        border-radius: 2px;
+        color: black;
+        font-family: monospace;
+        padding: 2px;
+        box-sizing: border-box;
       }
 
       #post_rating_e:checked + label {

--- a/app/javascript/src/styles/views/posts/show/_show.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.scss
@@ -119,6 +119,11 @@ body.c-posts.a-show-seq {
     background-position: themed("image-foreground-top-position", "unset");
     background-repeat: themed("image-foreground-top-repeat", "unset");
     background-size: themed("image-foreground-size", "unset");
+
+    #description {
+      background: themed("color-section");
+      border-left-color: themed("color-section-lighten-5");
+    }
   }
 
   // 3. Tab UI

--- a/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
@@ -5,11 +5,21 @@
   justify-content: center;
 
   margin: 0.5rem 0;
-  gap: 0.5rem;
+  gap: 0.75rem 0.5rem;
 
   @include window-larger-than(50rem) {
     justify-content: flex-start;
   }
+}
+
+#ptbr-wrapper .ptbr-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+#ptbr-wrapper .st-button {
+  user-select: none;
 }
 
 
@@ -144,8 +154,7 @@
 
 // Edit button
 #ptbr-wrapper .ptbr-edit {
-  display: none;
-  @include window-larger-than(40rem) { display: flex; }
+  display: flex;
 }
 #ptbr-wrapper .ptbr-edit-button {
   font-family: "Roboto", Verdana, Geneva, sans-serif;
@@ -153,8 +162,7 @@
 
 // Fullscreen button
 #ptbr-wrapper .ptbr-fullscreen {
-  display: none;
-  @include window-larger-than(40rem) { display: flex; }
+  display: flex;
 }
 #ptbr-wrapper .ptbr-fullscreen-button {
   font-family: "Roboto", Verdana, Geneva, sans-serif;
@@ -221,8 +229,7 @@
 
 // Notes toggle
 #ptbr-wrapper .ptbr-notes {
-  display: none;  // In the hamburger menu on mobile
-  @include window-larger-than(40rem) { display: flex; }
+  display: flex;
   &.hidden { display: none; }
 }
 
@@ -235,11 +242,43 @@
 }
 
 
+// Download button
+#ptbr-wrapper .ptbr-etc-download {
+  min-width: 6rem;
+  align-items: center;
+
+  svg {
+    display: none;
+    height: 1rem;
+    width: 1rem;
+    animation: spin-animation ease-in-out 1s infinite;
+  }
+
+  span {
+    text-align: center;
+  }
+
+  &[pending="true"] {
+    svg { display: inline; }
+    span { display: none; }
+  }
+  
+  @keyframes spin-animation {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+}
+
+
 // Overflow menu
 #ptbr-wrapper .ptbr-etc {
   display: flex;
   position: relative;
   gap: 0.5rem;
+
+  .ptbr-etc-toggle svg {
+    margin: -0.5rem -0.25rem; // Make it square-ish
+  }
 }
 
 #ptbr-wrapper .ptbr-etc-menu {
@@ -256,49 +295,14 @@
 
   background: themed("color-section");
   @include st-radius;
+  box-shadow: 0 0 0.5rem -0.25rem themed("color-background");
 
   &.hidden { display: none; }
 
-  // Mobile-only buttons
-  @include window-larger-than(40rem) {
-    .ptbr-etc-fullscreen { display: none; }
-    .ptbr-etc-edit { display: none; }
-    .ptbr-notes-button { display: none; }
-  }
-
   .st-button {
     font-family: "Roboto", Verdana, Geneva, sans-serif;
+    min-width: 8rem;
   }
-
-  // Download button
-  .ptbr-etc-download {
-    min-width: 6rem;
-    align-items: center;
-
-    svg {
-      display: none;
-      height: 1rem;
-      width: 1rem;
-
-      animation: spin-animation ease-in-out 1s infinite;
-    }
-    span {
-      text-align: center;
-    }
-
-    &[pending="true"] {
-      svg { display: inline; }
-      span { display: none; }
-    }
-
-    @keyframes spin-animation {
-      0% { transform: rotate(0deg); }
-      100% { transform: rotate(360deg); }
-    }
-  }
-
-  .ptbr-notes-button.hidden { display: none; }
-  .ptbr-etc-pool, .ptbr-etc-set { min-width: 6.5rem; }
 }
 
 

--- a/app/views/posts/partials/show/content/_edit.html.erb
+++ b/app/views/posts/partials/show/content/_edit.html.erb
@@ -30,7 +30,7 @@
       </span>
     </div>
 
-    <div id="tag-string-editor"></div>
+    <div id="tag-string-editor" class="pending">Loading...</div>
 
     <%= f.input :locked_tags, label: "Locked Tags", autocomplete: "tag-edit", input_html: { value: post.locked_tags || "", spellcheck: false, size: "60x2", disabled: !CurrentUser.is_admin? } %>
   </div>

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -1,5 +1,6 @@
 
 <section id="ptbr-wrapper">
+<div class="ptbr-row">
 
 <% if CurrentUser.is_member? %>
   <%# ===== VOTE ===== #%>
@@ -59,18 +60,6 @@
   </div>
 <% end %>
 
-<% if @post.visible? %>
-  <%# ===== NOTES ===== #%>
-  <div class="<%= @post.has_notes? ? "ptbr-notes" : "ptbr-notes hidden" %>">
-    <button
-      class="st-button kinetic ptbr-notes-button"
-      enabled="true"
-      data-hotkey="note-toggle"
-      title="Toggle Notes"
-    ></button>
-  </div>
-<% end %>
-
 <% if !@post.force_original_size? %>
   <%# ===== RESIZE ===== #%>
   <div class="ptbr-resize">
@@ -88,20 +77,9 @@
   </select>
   </div>
 <% end %>
+</div>
 
-<% if @post.visible? %>
-  <%# ===== FULLSCREEN ===== #%>
-  <div class="ptbr-fullscreen">
-    <a
-      href="<%= @post.file_url %>"
-      class="st-button kinetic ptbr-fullscreen-button"
-      data-hotkey="fullscreen"
-      title="View Full Size"
-    >
-      View
-    </a>
-  </div>
-<% end %>
+<div class="ptbr-row">
 <% if CurrentUser.is_member? %>
   <%# ===== EDIT ===== #%>
   <div class="ptbr-edit">
@@ -115,6 +93,34 @@
     </button>
   </div>
 <% end %>
+
+<% if @post.visible? %>
+  <%# ===== FULLSCREEN ===== #%>
+  <div class="ptbr-fullscreen">
+    <a
+      href="<%= @post.file_url %>"
+      class="st-button kinetic ptbr-fullscreen-button"
+      data-hotkey="fullscreen"
+      title="View Full Size"
+    >
+      Fullscreen
+    </a>
+  </div>
+<% end %>
+
+<% if @post.visible? %>
+  <%# ===== NOTES ===== #%>
+  <div class="<%= @post.has_notes? ? "ptbr-notes" : "ptbr-notes hidden" %>">
+    <button
+      class="st-button kinetic ptbr-notes-button"
+      enabled="true"
+      data-hotkey="note-toggle"
+      title="Toggle Notes"
+    ></button>
+  </div>
+<% end %>
+
+
 <% if @post.visible? %>
   <%# ===== OVERFLOW ===== #%>
   <div class="ptbr-etc">
@@ -122,10 +128,6 @@
       <%= svg_icon(:ellipsis_v) %>
     </button>
     <div class="ptbr-etc-menu hidden">
-      <% if CurrentUser.is_member? %>
-        <button type="button" id="menu-post-edit-link" class="st-button ptbr-etc-edit">Edit</button>
-      <% end %>
-      <a href="<%= @post.file_url %>" class="st-button ptbr-etc-fullscreen">Fullscreen</a>
       <a
         href="<%= @post.file_url %>"
         class="st-button ptbr-etc-download"
@@ -137,7 +139,6 @@
         <span>Download</span>
       </a>
       <button class="st-button ptbr-share-button" data-hotkey="share">Share</button>
-      <button class="st-button ptbr-notes-button <%= @post.has_notes? ? "" : "hidden"%>" enabled="true"></button>
       <% if CurrentUser.is_member? %>
         <button class="st-button ptbr-etc-pool add-to-pool" data-hotkey="add-to-pool">Add to Pool</button>
         <button class="st-button ptbr-etc-set add-to-set" data-hotkey="add-to-set">Add to Set</button>
@@ -146,6 +147,7 @@
   </div>
 <% end %>
 
+</div>
 </section>
 
 

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -116,6 +116,8 @@
       enabled="true"
       data-hotkey="note-toggle"
       title="Toggle Notes"
+      aria-label="Toggle Notes"
+      aria-pressed="false"
     ></button>
   </div>
 <% end %>
@@ -124,10 +126,16 @@
 <% if @post.visible? %>
   <%# ===== OVERFLOW ===== #%>
   <div class="ptbr-etc">
-    <button class="st-button kinetic ptbr-etc-toggle" title="More Options">
+    <button
+      class="st-button kinetic ptbr-etc-toggle"
+      title="More Options"
+      aria-label="More Options"
+      aria-expanded="false"
+      aria-controls="ptbr-etc-menu"
+    >
       <%= svg_icon(:ellipsis_v) %>
     </button>
-    <div class="ptbr-etc-menu hidden">
+    <div class="ptbr-etc-menu hidden" id="ptbr-etc-menu" role="menu">
       <a
         href="<%= @post.file_url %>"
         class="st-button ptbr-etc-download"

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -97,16 +97,16 @@
         <%= render "posts/partials/show/content/translated", post: @post %>
       </section>
 
-      <% if @post.description.present? %>
-        <div id="post-description-container" class="styled-dtext">
-        <%= render "posts/partials/show/content/description", post: @post %>
-        </div>
-      <% end %>
-
       <% if CurrentUser.is_member? %>
         <section id="edit" style="display: none;">
           <%= render "posts/partials/show/content/edit", :post => @post %>
         </section>
+      <% end %>
+
+      <% if @post.description.present? %>
+        <div id="post-description-container" class="styled-dtext">
+          <%= render "posts/partials/show/content/description", post: @post %>
+        </div>
       <% end %>
 
       <div


### PR DESCRIPTION
Basically, gave up on trying to fit everything into one row.
Split the toolbar into two defined rows – merged together into one if the window is wide enough.

<img width="359" height="96" alt="Capture" src="https://github.com/user-attachments/assets/d487195f-fc02-4a1e-9d12-ebda7048f2ca" />

Touched up on the post editing form to make its rollout a bit less janky.