### PR TITLE
[AutoMod] Add a staff-only route that displays automod dmails

### DIFF
--- a/app/controllers/admin/automod_dmails_controller.rb
+++ b/app/controllers/admin/automod_dmails_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Admin
+  class AutomodDmailsController < ApplicationController
+    respond_to :html, :json
+    before_action :janitor_only
+
+    def index
+      @user = User.system
+      @query = Dmail.where("owner_id = ?", @user.id).search(search_params).includes(:to, :from)
+      @dmails = @query.paginate(params[:page], limit: params[:limit])
+
+      respond_with @dmails.to_json
+    end
+
+    def show
+      @user = User.system
+      @dmail = Dmail.find(params[:id])
+      respond_with(@dmail)
+    end
+  end
+end

--- a/app/controllers/admin/automod_dmails_controller.rb
+++ b/app/controllers/admin/automod_dmails_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def index
       @user = User.system
-      @query = Dmail.where("owner_id = ?", @user.id).search(search_params).includes(:to, :from)
+      @query = Dmail.where("owner_id = ?", @user.id).includes(:to, :from).search(search_params)
       @dmails = @query.paginate(params[:page], limit: params[:limit])
 
       respond_with @dmails.to_json
@@ -15,7 +15,7 @@ module Admin
 
     def show
       @user = User.system
-      @dmail = Dmail.find(params[:id])
+      @dmail = Dmail.where("owner_id = ?", @user.id).includes(:to, :from).find(params[:id])
       respond_with(@dmail)
     end
   end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -197,6 +197,7 @@ class StaticController < ApplicationController
     end
 
     if CurrentUser.is_staff?
+      add_link[:admin, "AutoMod DMails", admin_automod_dmails_path]
       add_link[:staff, "Mod Dashboard", moderator_dashboard_path]
       add_link[:posts, "Upload Listing", uploads_path]
     end

--- a/app/views/admin/automod_dmails/_quick_search.html.erb
+++ b/app/views/admin/automod_dmails/_quick_search.html.erb
@@ -1,0 +1,3 @@
+<%= form_tag(admin_automod_dmails_path, method: :get) do %>
+  <%= text_field "search", "message_matches", id: "quick_search_message_matches", placeholder: "Search messages" %>
+<% end %>

--- a/app/views/admin/automod_dmails/_search.html.erb
+++ b/app/views/admin/automod_dmails/_search.html.erb
@@ -1,0 +1,6 @@
+<%= form_search(path: admin_automod_dmails_path) do |f| %>
+  <%= f.input :title_matches, label: "Title", hint: "Use * for wildcard" %>
+  <%= f.input :message_matches, label: "Message", hint: "Use * for wildcard" %>
+  <%= f.user :to %>
+  <%= f.user :from %>
+<% end %>

--- a/app/views/admin/automod_dmails/_secondary_links.html.erb
+++ b/app/views/admin/automod_dmails/_secondary_links.html.erb
@@ -1,0 +1,4 @@
+<% content_for(:secondary_links) do %>
+  <li><%= render "quick_search" %></li>
+  <%= subnav_link_to "All", admin_automod_dmails_path %>
+<% end %>

--- a/app/views/admin/automod_dmails/index.html.erb
+++ b/app/views/admin/automod_dmails/index.html.erb
@@ -1,0 +1,49 @@
+<div id="c-dmails">
+  <div id="a-index">
+    <% if params[:folder] == "sent" %>
+      <h1>Sent Messages</h1>
+    <% elsif params[:folder] == "received" %>
+      <h1>Received Messages</h1>
+    <% else %>
+      <h1>Messages</h1>
+    <% end %>
+
+    <%= render "search" %>
+
+    <table class="striped">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>From</th>
+          <th>To</th>
+          <th>Subject</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @dmails.each do |dmail| %>
+          <tr class="read-<%= dmail.is_read? %>">
+            <td><%= compact_time(dmail.created_at) %></td>
+            <td>
+              <%= link_to_user dmail.from %>
+            </td>
+            <td><%= link_to_user dmail.to %></td>
+            <td>
+              <%= link_to dmail.title, admin_automod_dmail_path(dmail), class: "dmail-entry" %>
+              <% if dmail.is_deleted? %>
+                (deleted)
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= render PaginatorComponent.new(records: @dmails) %>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Messages
+<% end %>

--- a/app/views/admin/automod_dmails/show.html.erb
+++ b/app/views/admin/automod_dmails/show.html.erb
@@ -1,0 +1,34 @@
+<div id="c-dmails">
+  <div id="a-show">
+    <div class="dmail">
+      <h1>Show Message</h1>
+      <h2><%= @dmail.title %></h2>
+
+      <ul style="margin-bottom: 1em;">
+        <li><strong>Sender</strong>: <%= link_to_user @dmail.from %></li>
+        <li><strong>Recipient</strong>: <%= link_to_user @dmail.to %></li>
+        <li><strong>Date</strong>: <%= compact_time(@dmail.created_at) %></li>
+        <% if CurrentUser.is_admin? %>
+          <li><strong>Sender IP</strong>: <%= link_to_ip @dmail.creator_ip_addr %></li>
+        <% end %>
+      </ul>
+
+      <h3>Body</h3>
+      <div class="dtext-container">
+        <%= format_text(@dmail.body) %>
+
+        <% if @dmail.is_automated? %>
+          <p class="info">
+            This is an automated message. Responses will not be seen. If you have any questions either message a moderator or ask in the forum.
+          </p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Message - <%= @dmail.title %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     resource :reowner, controller: "reowner", only: %i[new create]
     resource :stuck_dnp, controller: "stuck_dnp", only: %i[new create]
     resources :destroyed_posts, only: %i[index show update]
+    resources :automod_dmails, only: %i[index show]
   end
 
   namespace :security do

--- a/spec/requests/admin/automod_dmails_controller_spec.rb
+++ b/spec/requests/admin/automod_dmails_controller_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::AutomodDmailsController do
+  include_context "as admin"
+
+  let(:janitor) { create(:janitor_user) }
+  let(:member)  { create(:user) }
+
+  let(:system_dmail) { create(:dmail, from: User.system, to: create(:user), owner_id: User.system.id) }
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/automod_dmails
+  # ---------------------------------------------------------------------------
+
+  describe "GET /admin/automod_dmails" do
+    it "redirects anonymous to the login page" do
+      get admin_automod_dmails_path
+      expect(response).to redirect_to(new_session_path(url: admin_automod_dmails_path))
+    end
+
+    it "returns 403 for a regular member" do
+      sign_in_as member
+      get admin_automod_dmails_path
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as janitor" do
+      before { sign_in_as janitor }
+
+      it "returns 200" do
+        get admin_automod_dmails_path
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns a JSON response" do
+        get admin_automod_dmails_path(format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "only lists dmails owned by the system user" do
+        system_dmail
+        other_dmail = create(:dmail)
+        get admin_automod_dmails_path(format: :json)
+        ids = response.parsed_body.pluck("id")
+        expect(ids).to include(system_dmail.id)
+        expect(ids).not_to include(other_dmail.id)
+      end
+
+      it "filters by title when a search param is provided" do
+        matching   = create(:dmail, title: "AutomodAlert123", from: User.system, to: create(:user), owner_id: User.system.id)
+        unmatching = create(:dmail, title: "UnrelatedTitle",  from: User.system, to: create(:user), owner_id: User.system.id)
+        get admin_automod_dmails_path(format: :json, search: { title_matches: "AutomodAlert123" })
+        ids = response.parsed_body.pluck("id")
+        expect(ids).to include(matching.id)
+        expect(ids).not_to include(unmatching.id)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /admin/automod_dmails/:id
+  # ---------------------------------------------------------------------------
+
+  describe "GET /admin/automod_dmails/:id" do
+    it "redirects anonymous to the login page" do
+      get admin_automod_dmail_path(system_dmail)
+      expect(response).to redirect_to(new_session_path(url: admin_automod_dmail_path(system_dmail)))
+    end
+
+    it "returns 403 for a regular member" do
+      sign_in_as member
+      get admin_automod_dmail_path(system_dmail)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as janitor" do
+      before { sign_in_as janitor }
+
+      it "returns 200" do
+        get admin_automod_dmail_path(system_dmail)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns a JSON response" do
+        get admin_automod_dmail_path(system_dmail, format: :json)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns 404 for a dmail not owned by the system user" do
+        other_dmail = create(:dmail)
+        get admin_automod_dmail_path(other_dmail)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As requested by the team.

Note that automod does not keep copies of DMails it sends.
For example, if automod notifies someone of the feedback they received, only the recipient's copy gets created.
That is acceptable here, since we are mostly interested in the users' responses.