### PR TITLE
[Posts] Add indirect edit reasons for child metatags

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -981,19 +981,19 @@ class Post < ApplicationRecord
 
         when /^child:none$/i
           children.each do |post|
-            set_remove_child_edit_reason(post)
+            remove_child_edit_reason(post)
             post.update!(parent_id: nil)
           end
 
         when /^-child:(.+)$/i
           children.numeric_attribute_matches(:id, $1).each do |post|
-            set_remove_child_edit_reason(post)
+            remove_child_edit_reason(post)
             post.update!(parent_id: nil)
           end
 
         when /^child:(.+)$/i
           Post.numeric_attribute_matches(:id, $1).where.not(id: id).limit(10).each do |post|
-            set_add_child_edit_reason(post)
+            add_child_edit_reason(post)
             post.update!(parent_id: id)
           end
         end
@@ -1481,11 +1481,11 @@ class Post < ApplicationRecord
       parent.edit_reason = "Merged from post ##{self.id}"
     end
 
-    def set_remove_child_edit_reason(post)
+    def remove_child_edit_reason(post)
       post.edit_reason = "Removed as child of post ##{id}"
     end
 
-    def set_add_child_edit_reason(post)
+    def add_child_edit_reason(post)
       post.edit_reason = "Added as child of post ##{id}"
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -981,16 +981,19 @@ class Post < ApplicationRecord
 
         when /^child:none$/i
           children.each do |post|
+            set_remove_child_edit_reason(post)
             post.update!(parent_id: nil)
           end
 
         when /^-child:(.+)$/i
           children.numeric_attribute_matches(:id, $1).each do |post|
+            set_remove_child_edit_reason(post)
             post.update!(parent_id: nil)
           end
 
         when /^child:(.+)$/i
           Post.numeric_attribute_matches(:id, $1).where.not(id: id).limit(10).each do |post|
+            set_add_child_edit_reason(post)
             post.update!(parent_id: id)
           end
         end
@@ -1476,6 +1479,14 @@ class Post < ApplicationRecord
     def set_merge_edit_reason
       return unless parent_id.present?
       parent.edit_reason = "Merged from post ##{self.id}"
+    end
+
+    def set_remove_child_edit_reason(post)
+      post.edit_reason = "Removed as child of post ##{id}"
+    end
+
+    def set_add_child_edit_reason(post)
+      post.edit_reason = "Added as child of post ##{id}"
     end
   end
 

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -459,8 +459,13 @@ RSpec.describe Post do
           child1 = create(:post, parent: parent)
           child2 = create(:post, parent: parent)
           parent.update!(tag_string: "#{parent.tag_string} child:none")
-          expect(child1.reload.parent_id).to be_nil
-          expect(child2.reload.parent_id).to be_nil
+
+          child1.reload
+          child2.reload
+          expect(child1.parent_id).to be_nil
+          expect(child1.versions.last.reason).to eq("Removed as child of post ##{parent.id}")
+          expect(child2.parent_id).to be_nil
+          expect(child2.versions.last.reason).to eq("Removed as child of post ##{parent.id}")
         end
       end
 
@@ -469,7 +474,10 @@ RSpec.describe Post do
           parent = create(:post)
           child = create(:post, parent: parent)
           parent.update!(tag_string: "#{parent.tag_string} -child:#{child.id}")
-          expect(child.reload.parent_id).to be_nil
+
+          child.reload
+          expect(child.parent_id).to be_nil
+          expect(child.versions.last.reason).to eq("Removed as child of post ##{parent.id}")
         end
       end
 
@@ -478,7 +486,10 @@ RSpec.describe Post do
           parent = create(:post)
           other = create(:post)
           parent.update!(tag_string: "#{parent.tag_string} child:#{other.id}")
-          expect(other.reload.parent_id).to eq(parent.id)
+
+          other.reload
+          expect(other.parent_id).to eq(parent.id)
+          expect(other.versions.last.reason).to eq("Added as child of post ##{parent.id}")
         end
       end
     end


### PR DESCRIPTION
When adding or removing a child using metadata tags, add an edit reason to the child/ren.

Implements #1780 