### PR TITLE
[ForumPostVotes] Fix former staff user class after voting

### DIFF
--- a/app/javascript/src/js/pages/forum_posts/ForumPostVote.ts
+++ b/app/javascript/src/js/pages/forum_posts/ForumPostVote.ts
@@ -125,7 +125,7 @@ export default class ForumPostVote {
         "href": `/users/${vote.creator_id}`,
         "rel": "nofollow",
       })
-      .addClass("with-style user-" + User.levelString.toLowerCase())
+      .addClass("with-style user-" + User.levelString.replace(/ /g, "-").toLowerCase())
       .text(vote.creator_name.replace(/_+/g, " "));
     const $li = $("<li>").addClass("forum-post-vote own-forum-vote").append($link);
     $votesList.append($li);


### PR DESCRIPTION
The level string for former staff is "Former Staff", which results in the class list "with-style user-former staff", resulting in no coloring until the page is reloaded.