### PR TITLE
[Forum] Make topic update time consistent

### DIFF
--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -68,7 +68,7 @@ class ForumTopicsController < ApplicationController
   def update
     check_privilege(@forum_topic)
     @forum_topic.assign_attributes(forum_topic_params)
-    @forum_topic.save touch: false
+    @forum_topic.save
     respond_with(@forum_topic)
   end
 

--- a/spec/requests/forum_topics_controller_spec.rb
+++ b/spec/requests/forum_topics_controller_spec.rb
@@ -220,6 +220,22 @@ RSpec.describe ForumTopicsController do
       put forum_topic_path(forum_topic), params: { forum_topic: { title: "same", is_sticky: true } }
       expect(forum_topic.reload.is_sticky).to be(false)
     end
+
+    it "updates updated_at when the creator edits the topic" do
+      forum_topic.update_columns(updated_at: 1.hour.ago)
+      old_updated_at = forum_topic.updated_at
+      sign_in_as user
+      put forum_topic_path(forum_topic), params: { forum_topic: { title: "new title" } }
+      expect(forum_topic.reload.updated_at).to be > old_updated_at
+    end
+
+    it "updates updated_at when a moderator edits the topic" do
+      forum_topic.update_columns(updated_at: 1.hour.ago)
+      old_updated_at = forum_topic.updated_at
+      sign_in_as mod
+      put forum_topic_path(forum_topic), params: { forum_topic: { title: "mod title" } }
+      expect(forum_topic.reload.updated_at).to be > old_updated_at
+    end
   end
 
   # forum_topic DELETE /forum_topics/:id(.:format) forum_topics#destroy


### PR DESCRIPTION
This completes #1793 by making the update time consistent. While not the ideal solution in the long-term, it keeps consistency with the user being updated.