### PR TITLE
[Posts] Add a comment count to mobile tab

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -189,7 +189,7 @@
       >Tags</button>
       <% unless CurrentUser.hide_comments? %>
         <button
-          type="button" 
+          type="button"
           role="tab"
           class="post-mobile-tab"
           data-action="comments"

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -189,13 +189,14 @@
       >Tags</button>
       <% unless CurrentUser.hide_comments? %>
         <button
-          type="button"
+          type="button" 
           role="tab"
           class="post-mobile-tab"
           data-action="comments"
           aria-controls="post-show-display"
           aria-selected="<%= selected_tab == "comments" %>"
-        >Comments</button>
+          aria-label="<%= "Comments (#{(@comments&.size || 0)})" %>"
+        ><%= "Comments (#{(@comments&.size || 0)})" %></button>
       <% end %>
     </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -195,8 +195,7 @@
           data-action="comments"
           aria-controls="post-show-display"
           aria-selected="<%= selected_tab == "comments" %>"
-          aria-label="<%= "Comments (#{(@comments&.size || 0)})" %>"
-        ><%= "Comments (#{(@comments&.size || 0)})" %></button>
+        ><%= "Comments (#{@post.comment_count})" %></button>
       <% end %>
     </div>
 


### PR DESCRIPTION
Adds a count (including 0) to the comments tab under a post, for mobile. 
This fulfills #1935.
Screenshot:
<img width="389" height="830" alt="image" src="https://github.com/user-attachments/assets/251ea021-bb3c-4ea2-bbdc-5a40171e0653" />
