### PR TITLE
[WikiSearch] Unhandled ActiveRecord::RangeError when out-of-range integer passed as search param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,6 +91,8 @@ class ApplicationController < ActionController::Base
       render_error_page(500, exception, message: "The database timed out running your query.")
     when ActionDispatch::Http::Parameters::ParseError, ActionController::BadRequest, PostVersion::UndoError
       render_error_page(400, exception)
+    when ActiveRecord::RangeError
+      render_expected_error(400, "Invalid request parameters")
     when SessionLoader::AuthenticationFailure
       session.delete(:user_id)
       cookies.delete :remember

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,8 +91,6 @@ class ApplicationController < ActionController::Base
       render_error_page(500, exception, message: "The database timed out running your query.")
     when ActionDispatch::Http::Parameters::ParseError, ActionController::BadRequest, PostVersion::UndoError
       render_error_page(400, exception)
-    when ActiveRecord::RangeError
-      render_expected_error(400, "Invalid request parameters")
     when SessionLoader::AuthenticationFailure
       session.delete(:user_id)
       cookies.delete :remember

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -18,7 +18,8 @@ class WikiPageVersion < ApplicationRecord
       q = q.where_user(:updater_id, :updater, params)
 
       if params[:wiki_page_id].present?
-        q = q.where("wiki_page_id = ?", params[:wiki_page_id].to_i)
+        q = q.where("wiki_page_id = ?", ParseValue.safe_id(params[:wiki_page_id]))
+        # If the wiki_page_id is out of range, the id will be -1, so there will be no results
       end
 
       q = q.attribute_matches(:title, params[:title])

--- a/spec/models/wiki_page_version/search_spec.rb
+++ b/spec/models/wiki_page_version/search_spec.rb
@@ -54,6 +54,11 @@ RSpec.describe WikiPageVersion do
         result = WikiPageVersion.search({})
         expect(result).to include(version_alpha, version_beta)
       end
+
+      it "returns no results when wiki_page_id is too large" do
+        result = WikiPageVersion.search(wiki_page_id: "995859912741")
+        expect(result).to be_empty
+      end
     end
 
     # -------------------------------------------------------------------------

--- a/spec/requests/wiki_page_versions_controller_spec.rb
+++ b/spec/requests/wiki_page_versions_controller_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe WikiPageVersionsController do
         expect(ids).to include(v.id)
         expect(ids).not_to include(other_v.id)
       end
+
+      it "returns no results for an out-of-range wiki_page_id" do
+        get wiki_page_versions_path(format: :json, search: { wiki_page_id: "995859912741" })
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body).to eq([])
+      end
     end
 
     describe "search by title" do


### PR DESCRIPTION
Ensure wiki_page_id is a safe int, and rescue ActiveRecord::RangeError high above (for safety).
This fulfills #1845.
