### PR TITLE
[PostFlags] Realign self-flagger icon

### DIFF
--- a/app/javascript/src/styles/common/user_styles.scss
+++ b/app/javascript/src/styles/common/user_styles.scss
@@ -30,8 +30,9 @@ svg.chexagon {
   .check { color: themed("color-text"); }
 }
 
+/* Used for the icon indicating a flag was made by the uploader. */
 svg.text-inline {
   height: 1em;
   width: 1em;
-  vertical-align: baseline;
+  vertical-align: middle;
 }


### PR DESCRIPTION
Center aligns the icon indicating a self-flagging uploader to better match the text's alignment.

Current version
<img width="132" height="44" alt="image" src="https://github.com/user-attachments/assets/58f2c96a-0b8e-4c18-8063-5f9306ecb7ab" />
<img width="152" height="52" alt="image" src="https://github.com/user-attachments/assets/1a48732c-c1cf-47aa-b1bc-1468f0c13488" />
Changed version
<img width="132" height="44" alt="image" src="https://github.com/user-attachments/assets/6a7bce03-b010-41aa-9eda-532b7943e9fb" />
<img width="112" height="42" alt="image" src="https://github.com/user-attachments/assets/fe23a903-8781-4726-8079-64b2042e5bef" />
