### PR TITLE
[Misc] Add project-name flag to development runner script

### DIFF
--- a/.vscode/run-in-container.sh
+++ b/.vscode/run-in-container.sh
@@ -14,12 +14,12 @@ if [ -n "${REMOTE_CONTAINERS:-}" ] || [ -n "${DEVCONTAINER:-}" ] || [ -n "${CODE
   fi
 else # outside the devcontainer
   if [ "$#" -eq 1 ]; then  # for tests/rubocop, there are no extra args
-    exec docker compose run --rm "$@"
+    exec docker compose -p "${COMPOSE_PROJECT_NAME:-e621ng}" run --rm "$@"
   elif [ "$1" = "linter" ]; then # eslint breaks if you pass arguments
-    exec docker compose run --rm "$1"
+    exec docker compose -p "${COMPOSE_PROJECT_NAME:-e621ng}" run --rm "$1"
   else
     service="$1"
     shift
-    exec docker compose run --rm "$service" sh -lc "$@"
+    exec docker compose -p "${COMPOSE_PROJECT_NAME:-e621ng}" run --rm "$service" sh -lc "$@"
   fi
 fi


### PR DESCRIPTION
By default, this is just `-p e621ng`, ie, `--project-name e621ng`, if the variable is missing. `COMPOSE_PROJECT_NAME` is also set in `.devcontainer/.env.devcontainer` to `e621ng`, so users in a devcontainer will also use it by default. 