### PR TITLE
[Uploads] Fix 500 in the show route when completed upload has nil post_id

### DIFF
--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -20,13 +20,21 @@
     </ul>
 
     <% if @upload.is_completed? %>
-      <p>This upload has finished processing. <%= link_to "View the post", post_path(@upload.post_id) %>.</p>
+      <% if @upload.post_id %>
+        <p>This upload has finished processing. <%= link_to "View the post", post_path(@upload.post_id) %>.</p>
+      <% else %>
+        <p>This upload has finished processing, but the post associated with it no longer exists.</p>
+      <% end %>
     <% elsif @upload.is_pending? %>
       <p>This upload is waiting to be processed. Please wait a few seconds.</p>
     <% elsif @upload.is_processing? %>
       <p>This upload is being processed. Please wait a few seconds.</p>
     <% elsif @upload.is_duplicate? %>
-      <p>This upload is a duplicate: <%= link_to "post ##{@upload.duplicate_post_id}", post_path(@upload.duplicate_post_id) %></p>
+      <% if @upload.duplicate_post_id %>
+        <p>This upload is a duplicate: <%= link_to "post ##{@upload.duplicate_post_id}", post_path(@upload.duplicate_post_id) %></p>
+      <% else %>
+        <p>This upload is a duplicate, but the original post no longer exists.</p>
+      <% end %>
     <% else %>
       <p>An error occurred: <%= render_status(@upload) %></p>
       <% if CurrentUser.user.is_janitor? %>

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -141,6 +141,17 @@ RSpec.describe UploadsController do
         expect(response).to redirect_to(post_path(post_record.id))
       end
     end
+
+    context "when the upload is completed but post_id is nil" do
+      before { upload.update_columns(status: "completed", post_id: nil) }
+
+      it "returns 200 instead of 500 for a janitor" do
+        sign_in_as janitor
+        get upload_path(upload)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("no longer exists")
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a nil-guard around `post_path(@upload.post_id)` and `post_path(@upload.duplicate_post_id)` in `app/views/uploads/show.html.erb` so an upload in a "completed" or "duplicate" state with a nil post id renders a friendly message instead of returning a 500.

## Why this matters

Issue #1946 reproduces the bug: when an `Upload` record is in the completed state but `post_id` is nil (associated post deleted, processing edge case left it inconsistent), `GET /uploads/:id` raises `ActionController::UrlGenerationError` from line 23 of the show template. The controller already knows this case can happen and skips the redirect for it on `app/controllers/uploads_controller.rb:30` (`if @upload.is_completed? && @upload.post_id`), but the view rendered when the controller does not redirect calls `post_path(@upload.post_id)` unconditionally and blows up.

The duplicate branch on line 29 has the same shape and the same latent bug for `duplicate_post_id`. The issue calls this out explicitly, and the fix here covers both paths.

## Changes

`app/views/uploads/show.html.erb` - the `is_completed?` branch now wraps the `link_to` in `if @upload.post_id`, with a fallback message ("This upload has finished processing, but the post associated with it no longer exists.") when the post id is nil. The same shape applied to the `is_duplicate?` branch ("This upload is a duplicate, but the original post no longer exists."). The pending / processing / error branches are unchanged.

## Testing

Reading the diff, both `link_to` calls now sit inside an `if @upload.<id>` guard so there is no path that reaches `post_path(nil)` from this template. The pending / processing / error branches were not touched.

Reproducing the original error needs an `Upload` record in the completed state with a nil `post_id` and a janitor or admin session. I did not stand up the docker-compose dev environment for that locally; the change is one ERB template with no behavior change for the happy path.

Closes #1946
