### PR TITLE
[Blips] Restructure permissions to match comments

### DIFF
--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -11,58 +11,26 @@ class BlipsController < ApplicationController
   rescue_from BlipTooOld, with: :blip_too_old
 
   def index
-    @blips = Blip.visible.search(search_params).paginate(params[:page], limit: params[:limit])
+    @blips = Blip.search(search_params).paginate(params[:page], limit: params[:limit])
     respond_with(@blips)
   end
 
   def show
     @blip = Blip.find(params[:id])
-    check_visible(@blip)
+    check_accessible(@blip)
     @parent = @blip.response_to
-    @children = Blip.visible.where("response_to = ?", @blip.id).paginate(params[:page])
+    @children = Blip.where("response_to = ?", @blip.id).paginate(params[:page])
     respond_with(@blip)
-  end
-
-  def edit
-    @blip = Blip.find(params[:id])
-    check_edit_privilege(@blip)
-    respond_with(@blip)
-  end
-
-  def update
-    @blip = Blip.find(params[:id])
-    check_edit_privilege(@blip)
-    @blip.update(blip_params(:update))
-    flash[:notice] = "Blip updated"
-    respond_with(@blip)
-  end
-
-  def delete
-    @blip = Blip.find(params[:id])
-    check_delete_privilege(@blip)
-    @blip.delete!
-    respond_with(@blip)
-  end
-
-  def undelete
-    @blip = Blip.find(params[:id])
-    @blip.undelete!
-    respond_with(@blip)
-  end
-
-  def destroy
-    @blip = Blip.find(params[:id])
-    @blip.destroy
-    flash[:notice] = "Blip destroyed"
-    respond_with(@blip) do |format|
-      format.html do
-        respond_with(@blip)
-      end
-    end
   end
 
   def new
     @blip = Blip.new
+  end
+
+  def edit
+    @blip = Blip.find(params[:id])
+    check_can_edit(@blip)
+    respond_with(@blip)
   end
 
   def create
@@ -72,6 +40,38 @@ class BlipsController < ApplicationController
     respond_with(@blip) do |format|
       format.html do
         redirect_back(fallback_location: blips_path)
+      end
+    end
+  end
+
+  def update
+    @blip = Blip.find(params[:id])
+    check_can_edit(@blip)
+    @blip.update(blip_params(:update))
+    flash[:notice] = "Blip updated"
+    respond_with(@blip)
+  end
+
+  def delete
+    @blip = Blip.find(params[:id])
+    check_can_delete(@blip)
+    @blip.delete!
+    redirect_back(fallback_location: blips_path, flash: { notice: "Blip deleted" })
+  end
+
+  def undelete
+    @blip = Blip.find(params[:id])
+    @blip.undelete!
+    redirect_back(fallback_location: blips_path, flash: { notice: "Blip undeleted" })
+  end
+
+  def destroy
+    @blip = Blip.find(params[:id])
+    @blip.destroy
+    flash[:notice] = "Blip destroyed"
+    respond_with(@blip) do |format|
+      format.html do
+        respond_with(@blip)
       end
     end
   end
@@ -112,15 +112,15 @@ class BlipsController < ApplicationController
     end
   end
 
-  def check_visible(blip)
-    raise User::PrivilegeError unless blip.visible_to?(CurrentUser.user)
+  def check_accessible(blip)
+    raise User::PrivilegeError unless blip.is_accessible?
   end
 
-  def check_delete_privilege(blip)
+  def check_can_delete(blip)
     raise User::PrivilegeError unless blip.can_delete?(CurrentUser.user)
   end
 
-  def check_edit_privilege(blip)
+  def check_can_edit(blip)
     raise BlipTooOld if blip.created_at < 5.minutes.ago && !CurrentUser.is_admin?
     raise User::PrivilegeError unless blip.can_edit?(CurrentUser.user)
   end

--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -117,12 +117,12 @@ class BlipsController < ApplicationController
   end
 
   def check_can_delete(blip)
-    raise User::PrivilegeError unless blip.can_delete?(CurrentUser.user)
+    raise User::PrivilegeError unless blip.can_delete?
   end
 
   def check_can_edit(blip)
     raise BlipTooOld if blip.created_at < 5.minutes.ago && !CurrentUser.is_admin?
-    raise User::PrivilegeError unless blip.can_edit?(CurrentUser.user)
+    raise User::PrivilegeError unless blip.can_edit?
   end
 
   def ensure_lockdown_disabled

--- a/app/controllers/blips_controller.rb
+++ b/app/controllers/blips_controller.rb
@@ -19,7 +19,7 @@ class BlipsController < ApplicationController
     @blip = Blip.find(params[:id])
     check_accessible(@blip)
     @parent = @blip.response_to
-    @children = Blip.where("response_to = ?", @blip.id).paginate(params[:page])
+    @children = Blip.accessible.where("response_to = ?", @blip.id).paginate(params[:page])
     respond_with(@blip)
   end
 

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -52,13 +52,13 @@ class Blip < ApplicationRecord
       true
     end
 
-    def can_edit?(user)
+    def can_edit?(user = CurrentUser.user)
       return true if user.is_admin?
       return false if was_warned?
       creator_id == user.id && created_at > 5.minutes.ago
     end
 
-    def can_delete?(user)
+    def can_delete?(user = CurrentUser.user)
       return true if user.is_moderator?
       return false if was_warned?
       user.id == creator_id

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -3,8 +3,14 @@
 class Blip < ApplicationRecord
   include UserWarnable
   simple_versioning
+
   belongs_to_creator
   belongs_to_updater optional: true
+  belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
+  belongs_to :warning_user, class_name: "User", optional: true
+  has_many :responses, class_name: "Blip", foreign_key: "response_to"
+  user_status_counter :blip_count
+
   normalizes :body, with: ->(body) { body.gsub("\r\n", "\n") }
   validates :body, presence: true
   validates :body, length: { minimum: 5, maximum: Danbooru.config.blip_max_size }
@@ -22,12 +28,7 @@ class Blip < ApplicationRecord
     ModAction.log(action, { blip_id: rec.id, user_id: rec.creator_id })
   end
 
-  user_status_counter :blip_count
-  belongs_to :parent, class_name: "Blip", foreign_key: "response_to", optional: true
-  belongs_to :warning_user, class_name: "User", optional: true
-  has_many :responses, class_name: "Blip", foreign_key: "response_to"
-
-  def response?
+  def is_response?
     parent.present?
   end
 
@@ -35,28 +36,22 @@ class Blip < ApplicationRecord
     responses.any?
   end
 
-  def validate_creator_is_not_limited
-    allowed = creator.can_blip_with_reason
-    if allowed != true
-      errors.add(:creator, User.throttle_reason(allowed))
-      return false
-    end
-    true
+  def delete!
+    update(is_deleted: true)
   end
 
-  def validate_parent_exists
-    if response_to.present?
-      errors.add(:response_to, "must exist") unless Blip.exists?(response_to)
-    end
+  def undelete!
+    update(is_deleted: false)
   end
 
-  module ApiMethods
-    def method_attributes
-      super + [:creator_name]
+  module AccessMethods
+    def is_accessible?(user = CurrentUser.user)
+      return true if user.is_staff?
+      return true if user.id == creator_id
+      return false if is_deleted
+      true
     end
-  end
 
-  module PermissionsMethods
     def can_edit?(user)
       return true if user.is_admin?
       return false if was_warned?
@@ -68,35 +63,43 @@ class Blip < ApplicationRecord
       return false if was_warned?
       user.id == creator_id
     end
+  end
 
-    def visible_to?(user)
-      return true unless is_deleted
-      user.is_moderator? || user.id == creator_id
+  module ApiMethods
+    def method_attributes
+      super + [:creator_name]
     end
   end
 
   module SearchMethods
-    def visible(user = CurrentUser)
-      if user.is_moderator?
+    # NOTE: Ensure that logic here matches that in AccessMethods
+
+    # ============================== #
+    # ===== Visibility Methods ===== #
+    # ============================== #
+
+    def accessible(user = CurrentUser)
+      if user.is_staff?
         all
       else
         where("is_deleted = ?", false)
       end
     end
 
-    def for_creator(user_id)
-      user_id.present? ? where("creator_id = ?", user_id) : none
-    end
+    # ============================== #
+    # ======= Search Methods ======= #
+    # ============================== #
 
     def search(params)
-      q = super
+      q = super.accessible
+               .includes(:creator, :responses, :parent)
 
-      q = q.includes(:creator).includes(:responses).includes(:parent)
-
+      # NOTE: If we start to experience performance issues with this,
+      # consider similar optimizations used in Comment.search
       q = q.attribute_matches(:body, params[:body_matches])
 
       if params[:response_to].present?
-        q = q.where('response_to = ?', params[:response_to].to_i)
+        q = q.where("response_to = ?", params[:response_to].to_i)
       end
 
       q = q.where_user(:creator_id, :creator, params)
@@ -114,17 +117,35 @@ class Blip < ApplicationRecord
 
       q
     end
+
+    # ============================== #
+    # ======= Other Methods ======== #
+    # ============================== #
+
+    def for_creator(user_id)
+      user_id.present? ? where("creator_id = ?", user_id) : none
+    end
   end
 
-  include PermissionsMethods
-  extend SearchMethods
+  module ValidatorMethods
+    def validate_creator_is_not_limited
+      allowed = creator.can_blip_with_reason
+      if allowed != true
+        errors.add(:creator, User.throttle_reason(allowed))
+        return false
+      end
+      true
+    end
+
+    def validate_parent_exists
+      if response_to.present? && !Blip.exists?(response_to)
+        errors.add(:response_to, "must exist")
+      end
+    end
+  end
+
+  include AccessMethods
   include ApiMethods
-
-  def delete!
-    update(is_deleted: true)
-  end
-
-  def undelete!
-    update(is_deleted: false)
-  end
+  extend SearchMethods
+  include ValidatorMethods
 end

--- a/app/models/blip.rb
+++ b/app/models/blip.rb
@@ -72,12 +72,12 @@ class Blip < ApplicationRecord
   end
 
   module SearchMethods
-    # NOTE: Ensure that logic here matches that in AccessMethods
-
     # ============================== #
     # ===== Visibility Methods ===== #
     # ============================== #
 
+    # NOTE: This scope does not currently match the logic in #is_accessible? because
+    # there is currently no toggle for showing creators their own deleted blips.
     def accessible(user = CurrentUser)
       if user.is_staff?
         all

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -31,7 +31,7 @@ class Ticket < ApplicationRecord
   #
   # |    Type    |      Can Create     |        Visible       |
   # |:----------:|:-------------------:|:--------------------:|
-  # |    Blip    |       Visible       |  Janitor+ / Creator  |
+  # |    Blip    |      Accessible     |  Janitor+ / Creator  |
   # |   Comment  |       Visible       |  Janitor+ / Creator  |
   # |    Dmail   | Visible & Recipient | Moderator+ / Creator |
   # | Forum Post |       Visible       |  Janitor+ / Creator  |
@@ -46,11 +46,13 @@ class Ticket < ApplicationRecord
   module TicketTypes
     module Blip
       def can_create_for?(user)
-        content&.visible_to?(user)
+        content&.is_accessible?(user)
       end
 
       def can_view?(user)
-        (user.is_staff? && content&.visible_to?(user)) || user.is_admin? || (user.id == creator_id)
+        return true if user.is_staff?
+        return true if user.id == creator_id
+        false
       end
     end
 

--- a/app/views/blips/index.html.erb
+++ b/app/views/blips/index.html.erb
@@ -9,7 +9,7 @@
         <h4>No blips</h4>
       <% else %>
         <% @blips.each do |blip| %>
-          <% if blip.visible_to?(CurrentUser.user) %>
+          <% if blip.is_accessible? %>
             <div class="response-list">
               <%= render partial: "blips/partials/show/blip", locals: {blip: blip} %>
             </div>

--- a/app/views/blips/partials/show/_blip.html.erb
+++ b/app/views/blips/partials/show/_blip.html.erb
@@ -1,4 +1,4 @@
-<% if blip.visible_to?(CurrentUser.user) %>
+<% if blip.is_accessible? %>
   <article class="blip comment-post-grid"
     data-blip-id="<%= blip.id %>"
     data-is-deleted="<%= blip.is_deleted? %>"
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div class="content">
-      <% if blip.response? %>
+      <% if blip.is_response? %>
         <h6><%= link_to "In response to blip ##{blip.response_to}", blip_path(id: blip.response_to) %> </h6>
       <% end %>
       <div class="body dtext-container">

--- a/app/views/blips/show.html.erb
+++ b/app/views/blips/show.html.erb
@@ -7,7 +7,7 @@
       <h4>Responses</h4>
       <% unless @children.nil? %>
         <% @children.each do |c| %>
-          <% next unless c.visible_to?(CurrentUser.user) %>
+          <% next unless c.is_accessible? %>
           <%= render partial: "blips/partials/show/blip", locals: {blip: c} %>
         <% end %>
       <% end %>

--- a/spec/models/blip/instance_methods_spec.rb
+++ b/spec/models/blip/instance_methods_spec.rb
@@ -14,18 +14,18 @@ RSpec.describe Blip do
   end
 
   # -------------------------------------------------------------------------
-  # #response?
+  # #is_response?
   # -------------------------------------------------------------------------
-  describe "#response?" do
+  describe "#is_response?" do
     it "returns false when the blip has no parent" do
       blip = make_blip
-      expect(blip.response?).to be false
+      expect(blip.is_response?).to be false
     end
 
     it "returns true when the blip is a reply to another blip" do
       parent = make_blip
       reply  = make_blip(response_to: parent.id)
-      expect(reply.response?).to be true
+      expect(reply.is_response?).to be true
     end
   end
 

--- a/spec/models/blip/permissions_spec.rb
+++ b/spec/models/blip/permissions_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Blip do
   let(:creator)   { create(:user) }
   let(:other)     { create(:user) }
   let(:admin)     { create(:admin_user) }
+  let(:janitor)   { create(:janitor_user) }
   let(:moderator) { create(:moderator_user) }
 
   before do
@@ -84,30 +85,30 @@ RSpec.describe Blip do
   end
 
   # -------------------------------------------------------------------------
-  # #visible_to?
+  # #is_accessible?
   # -------------------------------------------------------------------------
-  describe "#visible_to?" do
-    it "is visible to anyone when not deleted" do
+  describe "#is_accessible?" do
+    it "is accessible to anyone when not deleted" do
       blip = make_blip
-      expect(blip.visible_to?(other)).to be true
+      expect(blip.is_accessible?).to be true
     end
 
-    it "is visible to a moderator when deleted" do
+    it "is accessible to a staff member when deleted" do
       blip = make_blip
       blip.delete!
-      expect(blip.visible_to?(moderator)).to be true
+      expect(blip.is_accessible?(janitor)).to be true
     end
 
-    it "is visible to the creator when deleted" do
+    it "is accessible to the creator when deleted" do
       blip = make_blip
       blip.delete!
-      expect(blip.visible_to?(creator)).to be true
+      expect(blip.is_accessible?(creator)).to be true
     end
 
-    it "is not visible to an unrelated user when deleted" do
+    it "is not accessible to an unrelated user when deleted" do
       blip = make_blip
       blip.delete!
-      expect(blip.visible_to?(other)).to be false
+      expect(blip.is_accessible?(other)).to be false
     end
   end
 end

--- a/spec/models/blip/permissions_spec.rb
+++ b/spec/models/blip/permissions_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Blip do
   describe "#is_accessible?" do
     it "is accessible to anyone when not deleted" do
       blip = make_blip
-      expect(blip.is_accessible?).to be true
+      expect(blip.is_accessible?(other)).to be true
     end
 
     it "is accessible to a staff member when deleted" do

--- a/spec/models/blip/search_spec.rb
+++ b/spec/models/blip/search_spec.rb
@@ -98,24 +98,24 @@ RSpec.describe Blip do
   end
 
   # -------------------------------------------------------------------------
-  # .visible scope
+  # .accessible scope
   # -------------------------------------------------------------------------
-  describe ".visible" do
-    it "returns all blips (including deleted) for a moderator" do
-      moderator = create(:moderator_user)
-      result = Blip.visible(moderator)
+  describe ".accessible" do
+    it "returns all blips (including deleted) for a janitor" do
+      janitor = create(:janitor_user)
+      result = Blip.accessible(janitor)
       expect(result).to include(blip_deleted)
     end
 
     it "excludes deleted blips for a regular member" do
       member = create(:user)
-      result = Blip.visible(member)
+      result = Blip.accessible(member)
       expect(result).not_to include(blip_deleted)
     end
 
     it "includes non-deleted blips for a regular member" do
       member = create(:user)
-      result = Blip.visible(member)
+      result = Blip.accessible(member)
       expect(result).to include(blip_alpha, blip_beta)
     end
   end

--- a/spec/requests/blips_controller_spec.rb
+++ b/spec/requests/blips_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe BlipsController do
 
   let(:creator)      { create(:user) }
   let(:other_member) { create(:user) }
+  let(:janitor)      { create(:janitor_user) }
   let(:moderator)    { create(:moderator_user) }
   let(:admin)        { create(:admin_user) }
   # belongs_to_creator only sets creator_ip_addr when creator_id is nil, so
@@ -60,8 +61,8 @@ RSpec.describe BlipsController do
         expect(response).to have_http_status(:ok)
       end
 
-      it "returns 200 for a moderator" do
-        sign_in_as moderator
+      it "returns 200 for a janitor" do
+        sign_in_as janitor
         get blip_path(blip)
         expect(response).to have_http_status(:ok)
       end
@@ -275,6 +276,12 @@ RSpec.describe BlipsController do
       expect { post delete_blip_path(blip) }.to change { blip.reload.is_deleted }.from(false).to(true)
     end
 
+    it "returns 403 for a janitor" do
+      sign_in_as janitor
+      post delete_blip_path(blip)
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it "returns 403 for a non-creator non-moderator member" do
       sign_in_as other_member
       post delete_blip_path(blip)
@@ -303,6 +310,12 @@ RSpec.describe BlipsController do
 
     it "returns 403 for a regular member" do
       sign_in_as creator
+      post undelete_blip_path(blip)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for a janitor" do
+      sign_in_as janitor
       post undelete_blip_path(blip)
       expect(response).to have_http_status(:forbidden)
     end
@@ -360,6 +373,12 @@ RSpec.describe BlipsController do
       expect(response).to have_http_status(:forbidden)
     end
 
+    it "returns 403 for a janitor" do
+      sign_in_as janitor
+      post warning_blip_path(blip), params: { record_type: "warning" }
+      expect(response).to have_http_status(:forbidden)
+    end
+
     context "as a moderator" do
       before { sign_in_as moderator }
 
@@ -401,8 +420,8 @@ RSpec.describe BlipsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "allows staff (moderator) through when locked down" do
-      sign_in_as moderator
+    it "allows staff (janitor) through when locked down" do
+      sign_in_as janitor
       get new_blip_path
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
Generally speaking:

Everyone can see non-deleted blips.
Members can create blips.
Creators can edit their own blips, within 5 minutes of creation.
Creators can delete their own blips, and also see their own deleted blips.
Staff members can see deleted blips, as well as any blip tickets.
Moderators delete anyone's blips.
Admins can edit and destroy blips.