### PR TITLE
[Posts] Rework similar post recommendations to run through opensearch

### DIFF
--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -3,83 +3,8 @@
 class PostRecommendationsController < ApplicationController
   respond_to :json
 
-  def artist
-    @original_post = Post.find(params[:id])
-    unless Security::Lockdown.post_visible?(@original_post, CurrentUser.user)
-      render json: {
-        post_id: @original_post.id,
-        model_version: "os.artist",
-        results: [],
-        post_data: [],
-      }
-      return
-    end
-
-    if params[:limit].present?
-      # Don't write random stuff into the cache key
-      params[:limit] = params[:limit].to_i.clamp(1, 20)
-    else
-      params[:limit] = 6
-    end
-
-    tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
-    post_data = Cache.fetch("post_recs:a:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.minutes) do
-      post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit]).post_ids
-
-      # Matches the format of the recommendation engine
-      {
-        post_id: @original_post.id,
-        model_version: "os.artist",
-        order: post_ids,
-        results: post_ids.map { |post_id| { post_id: post_id, score: 1, explanation: nil } },
-      }
-    end
-
-    posts = Post.where(id: post_data[:order])
-    post_data[:post_data] = PostThumbnailBlueprint.render_as_hash(posts, collection: true)
-    post_data.delete(:order) # Don't pollute the response with redundant data
-
-    render json: post_data
-  end
-
-  def tags
-    @original_post = Post.find(params[:id])
-    unless Security::Lockdown.post_visible?(@original_post, CurrentUser.user)
-      render json: {
-        post_id: @original_post.id,
-        model_version: "os.tags",
-        results: [],
-        post_data: [],
-      }
-      return
-    end
-
-    if params[:limit].present?
-      # Don't write random stuff into the cache key
-      params[:limit] = params[:limit].to_i.clamp(1, 20)
-    else
-      params[:limit] = 6
-    end
-
-    tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
-    post_data = Cache.fetch("post_recs:t:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.minutes) do
-      post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit], mode: :tags).post_ids
-
-      # Matches the format of the recommendation engine
-      {
-        post_id: @original_post.id,
-        model_version: "os.tags",
-        order: post_ids,
-        results: post_ids.map { |post_id| { post_id: post_id, score: 1, explanation: nil } },
-      }
-    end
-
-    posts = Post.where(id: post_data[:order])
-    post_data[:post_data] = PostThumbnailBlueprint.render_as_hash(posts, collection: true)
-    post_data.delete(:order) # Don't pollute the response with redundant data
-
-    render json: post_data
-  end
+  def artist = fetch_recommendations(:artist)
+  def tags   = fetch_recommendations(:tags)
 
   def remote
     @original_post = Post.find(params[:id])
@@ -97,5 +22,38 @@ class PostRecommendationsController < ApplicationController
       model_version: "not_implemented",
       results: [],
     }
+  end
+
+  private
+
+  def fetch_recommendations(mode)
+    model_version = "os.#{mode}"
+
+    @original_post = Post.find(params[:id])
+    unless Security::Lockdown.post_visible?(@original_post, CurrentUser.user)
+      render json: { post_id: @original_post.id, model_version: model_version, results: [], post_data: [] }
+      return
+    end
+
+    params[:limit] = params[:limit].present? ? params[:limit].to_i.clamp(1, 20) : 6
+
+    tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
+    post_data = Cache.fetch("post_recs:#{mode}:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.minutes) do
+      post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit], mode: mode).post_ids
+
+      # Matches the format of the recommendation engine
+      {
+        post_id: @original_post.id,
+        model_version: model_version,
+        order: post_ids,
+        results: post_ids.map { |post_id| { post_id: post_id, score: 1, explanation: nil } },
+      }
+    end
+
+    posts = Post.where(id: post_data[:order])
+    post_data[:post_data] = PostThumbnailBlueprint.render_as_hash(posts, collection: true)
+    post_data.delete(:order) # Don't pollute the response with redundant data
+
+    render json: post_data
   end
 end

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -8,7 +8,7 @@ class PostRecommendationsController < ApplicationController
     unless Security::Lockdown.post_visible?(@original_post, CurrentUser.user)
       render json: {
         post_id: @original_post.id,
-        model_version: "opensearch",
+        model_version: "os.artist",
         results: [],
         post_data: [],
       }
@@ -23,13 +23,52 @@ class PostRecommendationsController < ApplicationController
     end
 
     tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
-    post_data = Cache.fetch("post_recs:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.minutes) do
+    post_data = Cache.fetch("post_recs:a:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.seconds) do
       post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit]).post_ids
 
       # Matches the format of the recommendation engine
       {
         post_id: @original_post.id,
-        model_version: "opensearch",
+        model_version: "os.artist",
+        order: post_ids,
+        results: post_ids.map { |post_id| { post_id: post_id, score: 1, explanation: nil } },
+      }
+    end
+
+    posts = Post.where(id: post_data[:order])
+    post_data[:post_data] = PostThumbnailBlueprint.render_as_hash(posts, collection: true)
+    post_data.delete(:order) # Don't pollute the response with redundant data
+
+    render json: post_data
+  end
+
+  def tags
+    @original_post = Post.find(params[:id])
+    unless Security::Lockdown.post_visible?(@original_post, CurrentUser.user)
+      render json: {
+        post_id: @original_post.id,
+        model_version: "os.tags",
+        results: [],
+        post_data: [],
+      }
+      return
+    end
+
+    if params[:limit].present?
+      # Don't write random stuff into the cache key
+      params[:limit] = params[:limit].to_i.clamp(1, 20)
+    else
+      params[:limit] = 6
+    end
+
+    tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
+    post_data = Cache.fetch("post_recs:t:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.seconds) do
+      post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit], mode: :tags).post_ids
+
+      # Matches the format of the recommendation engine
+      {
+        post_id: @original_post.id,
+        model_version: "os.tags",
         order: post_ids,
         results: post_ids.map { |post_id| { post_id: post_id, score: 1, explanation: nil } },
       }

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -23,7 +23,7 @@ class PostRecommendationsController < ApplicationController
     end
 
     tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
-    post_data = Cache.fetch("post_recs:a:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.seconds) do
+    post_data = Cache.fetch("post_recs:a:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.minutes) do
       post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit]).post_ids
 
       # Matches the format of the recommendation engine
@@ -62,7 +62,7 @@ class PostRecommendationsController < ApplicationController
     end
 
     tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
-    post_data = Cache.fetch("post_recs:t:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.seconds) do
+    post_data = Cache.fetch("post_recs:t:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.minutes) do
       post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit], mode: :tags).post_ids
 
       # Matches the format of the recommendation engine

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -13,6 +13,7 @@ class PostRecommendationsController < ApplicationController
         post_id: @original_post.id,
         model_version: "not_implemented",
         results: [],
+        post_data: [],
       }
       return
     end
@@ -21,6 +22,7 @@ class PostRecommendationsController < ApplicationController
       post_id: @original_post.id,
       model_version: "not_implemented",
       results: [],
+      post_data: [],
     }
   end
 

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -13,7 +13,6 @@ class PostRecommendationsController < ApplicationController
         post_id: @original_post.id,
         model_version: "not_implemented",
         results: [],
-        post_data: [],
       }
       return
     end
@@ -22,7 +21,6 @@ class PostRecommendationsController < ApplicationController
       post_id: @original_post.id,
       model_version: "not_implemented",
       results: [],
-      post_data: [],
     }
   end
 

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -37,8 +37,16 @@ class PostRecommendationsController < ApplicationController
 
     params[:limit] = params[:limit].present? ? params[:limit].to_i.clamp(1, 20) : 6
 
-    tag_hash = Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8]
-    post_data = Cache.fetch("post_recs:#{mode}:#{@original_post.id}:#{params[:limit]}:#{CurrentUser.safe_mode? ? 's' : 'e'}:#{tag_hash}", expires_in: 15.minutes) do
+    rec_cache_key = [
+      "post_recs",
+      mode,
+      @original_post.id,
+      params[:limit],
+      CurrentUser.safe_mode? ? "s" : "e",
+      Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8],
+    ]
+
+    post_data = Cache.fetch(rec_cache_key.join(":"), expires_in: 15.minutes) do
       post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit], mode: mode).post_ids
 
       # Matches the format of the recommendation engine

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -46,7 +46,7 @@ class PostRecommendationsController < ApplicationController
       Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8],
     ]
 
-    post_data = Cache.fetch(rec_cache_key.join(":"), expires_in: 15.minutes) do
+    post_data = Cache.fetch(rec_cache_key.join(":"), expires_in: 15.seconds) do
       post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit], mode: mode).post_ids
 
       # Matches the format of the recommendation engine
@@ -58,7 +58,7 @@ class PostRecommendationsController < ApplicationController
       }
     end
 
-    posts = Post.where(id: post_data[:order])
+    posts = Post.where(id: post_data[:order]).includes(:uploader)
     post_data[:post_data] = PostThumbnailBlueprint.render_as_hash(posts, collection: true)
     post_data.delete(:order) # Don't pollute the response with redundant data
 

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -46,7 +46,7 @@ class PostRecommendationsController < ApplicationController
       Digest::SHA1.hexdigest("#{@original_post.tag_string}:#{@original_post.pool_ids.sort.join(',')}")[0, 8],
     ]
 
-    post_data = Cache.fetch(rec_cache_key.join(":"), expires_in: 15.seconds) do
+    post_data = Cache.fetch(rec_cache_key.join(":"), expires_in: 15.minutes) do
       post_ids = PostSets::Recommended.new(@original_post, limit: params[:limit], mode: mode).post_ids
 
       # Matches the format of the recommendation engine

--- a/app/javascript/src/js/pages/posts/show/recommended.js
+++ b/app/javascript/src/js/pages/posts/show/recommended.js
@@ -14,19 +14,33 @@ const Recommended = {};
 Recommended.RESULT_COUNT = 6;
 Recommended.SHOW_ENGINE_RESULTS = false;
 Recommended.Logger = new Logger("Recommended");
-Recommended.allStates = ["artist", "favorites", "tags"];
-Recommended.validStates = ["artist"];
+Recommended.allStates = ["artist", "tags", "favorites"];
+Recommended.validStates = ["artist", "tags"];
 Recommended.requestID = 0;
 
-Recommended.remote_actions = ["favorites", "tags"];
+Recommended.remote_actions = ["favorites"];
 
 Recommended.init = function () {
   if (Recommended.$container.length === 0) return;
 
   Recommended.SHOW_ENGINE_RESULTS = Settings.Recommender.remote;
   if (Recommended.SHOW_ENGINE_RESULTS)
-    Recommended.validStates.push("favorites", "tags");
+    Recommended.validStates = [...Recommended.validStates, ...Recommended.remote_actions];
+
   const initialAction = Recommended.action;
+  // Determine which states are actually available based on the presence of tabs in the DOM.
+  Recommended.validStates = Recommended.validStates.filter((state) => {
+    return $(`#post-recommendations-tab-${state}`).length > 0;
+  });
+  if (Recommended.validStates.length === 0) {
+    Recommended.Logger.log("No valid recommendation states available.");
+    Recommended.$wrapper.hide();
+    return;
+  }
+
+  if (!Recommended.validStates.includes(initialAction))
+    Recommended.action = Recommended.validStates[0];
+
   Recommended.Logger.log("Loaded", {
     action: initialAction,
     showEngineResults: Recommended.SHOW_ENGINE_RESULTS,
@@ -192,8 +206,14 @@ Recommended.loadState = async function (action = Recommended.action) {
   const $container = Recommended.$container;
 
   if (!Recommended.validStates.includes(action)) {
-    Recommended.action = "artist";
-    action = "artist";
+    if (Recommended.validStates.length === 0) {
+      Recommended.Logger.log("No valid recommendation states available.");
+      Recommended.status = "error";
+      $container.html("<p class='error'>No recommendations available.</p>");
+      return;
+    }
+    action = Recommended.validStates[0];
+    Recommended.action = action;
   }
 
 
@@ -358,7 +378,10 @@ Recommended.waitUntilReady = function () {
 
 // Fetches recommendation data from the server
 Recommended.getData = async function (postId, action = "favorites") {
-  const target = Recommended.remote_actions.includes(action) ? "remote" : "artist";
+  let target;
+  if (Recommended.remote_actions.includes(action)) target = "remote";
+  else if (Recommended.validStates.includes(action)) target = action;
+  else throw new Error(`Invalid recommendation action: ${action}`);
   Recommended.Logger.log(`Fetching data: "${postId}/${action}"`);
 
   return fetch(`/posts/${postId}/similar/${target}.json?mode=${action}&limit=${Recommended.RESULT_COUNT}`)

--- a/app/javascript/src/js/pages/posts/show/recommended.js
+++ b/app/javascript/src/js/pages/posts/show/recommended.js
@@ -385,7 +385,7 @@ Recommended.getData = async function (postId, action = "favorites") {
   else throw new Error(`Invalid recommendation action: ${action}`);
   Recommended.Logger.log(`Fetching data: "${postId}/${action}"`);
 
-  return fetch(`/posts/${postId}/similar/${target}.json?mode=${action}&limit=${Recommended.RESULT_COUNT}`)
+  return fetch(`/posts/${postId}/similar/${target}.json?limit=${Recommended.RESULT_COUNT}`)
     .then(
       (response) => {
         if (!response.ok) {

--- a/app/javascript/src/js/pages/posts/show/recommended.js
+++ b/app/javascript/src/js/pages/posts/show/recommended.js
@@ -27,7 +27,7 @@ Recommended.init = function () {
   if (Recommended.SHOW_ENGINE_RESULTS)
     Recommended.validStates = [...Recommended.validStates, ...Recommended.remote_actions];
 
-  const initialAction = Recommended.action;
+  let initialAction = Recommended.action;
   // Determine which states are actually available based on the presence of tabs in the DOM.
   Recommended.validStates = Recommended.validStates.filter((state) => {
     return $(`#post-recommendations-tab-${state}`).length > 0;
@@ -39,13 +39,14 @@ Recommended.init = function () {
   }
 
   if (!Recommended.validStates.includes(initialAction))
-    Recommended.action = Recommended.validStates[0];
+    initialAction = Recommended.validStates[0];
 
-  Recommended.Logger.log("Loaded", {
-    action: initialAction,
-    showEngineResults: Recommended.SHOW_ENGINE_RESULTS,
-    validStates: Recommended.validStates,
-  });
+  Recommended.Logger.log(
+    "Loaded",
+    `\n ⤷ Initial Action: ${initialAction}`,
+    `\n ⤷ Valid Actions: ${Recommended.validStates.join(", ")}`,
+    `\n ⤷ Remote Engine Enabled: ${Recommended.SHOW_ENGINE_RESULTS}`,
+  );
 
 
   Recommended.$wrapper.attr("data-action", initialAction);

--- a/app/javascript/src/styles/views/posts/show/partials/_recommended.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_recommended.scss
@@ -33,8 +33,8 @@ div#post-recommendations {
 
   // Selected tab
   &[data-action="artist"] button[data-action="artist"],
-  &[data-action="favorites"] button[data-action="favorites"],
-  &[data-action="tags"] button[data-action="tags"] {
+  &[data-action="tags"] button[data-action="tags"],
+  &[data-action="favorites"] button[data-action="favorites"] {
     background-color: themed("color-section");
     pointer-events: none;
   }

--- a/app/logical/post_sets/recommended.rb
+++ b/app/logical/post_sets/recommended.rb
@@ -12,7 +12,7 @@ module PostSets
 
       @mode = mode
       if mode == :tags
-        @no_results = post.tags.size <= 1 # only has tagme
+        @no_results = post.tag_count <= 1 # only has tagme
       else
         @mode = :artist
         @no_results = post.known_artist_tags.empty?

--- a/app/logical/post_sets/recommended.rb
+++ b/app/logical/post_sets/recommended.rb
@@ -2,14 +2,21 @@
 
 module PostSets
   class Recommended < PostSets::Base
-    attr_reader :limit
+    attr_reader :limit, :mode
 
-    def initialize(post, limit: 6)
+    def initialize(post, limit: 6, mode: :artist)
       super()
       @original_post = post
       @limit = limit.to_i.clamp(1, 20)
       @original_post.categorized_tags # Preload categorized tags to avoid duplicate queries later
-      @no_results = post.known_artist_tags.empty?
+
+      @mode = mode
+      if mode == :tags
+        @no_results = post.tags.size <= 1 # only has tagme
+      else
+        @mode = :artist
+        @no_results = post.known_artist_tags.empty?
+      end
     end
 
     def post_ids
@@ -26,7 +33,7 @@ module PostSets
     end
 
     def search_response
-      @search_response ||= RecommendedQueryBuilder.new(@original_post).search.limit(@limit)
+      @search_response ||= RecommendedQueryBuilder.new(@original_post, mode: @mode).search.limit(@limit)
     end
   end
 end

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -5,8 +5,9 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
   COPYRIGHT_WEIGHT = 1.5
   SPECIES_WEIGHT = 1.25
 
-  def initialize(post, **kwargs)
+  def initialize(post, mode: :artist, **kwargs)
     @post = post
+    @mode = mode
     exclusion_query = "-id:#{post.id} -parent:#{post.id} -child:#{post.id} order:random randseed:#{post.id}"
     super(exclusion_query, always_show_deleted: false, **kwargs)
   end
@@ -14,6 +15,22 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
   def build
     super
 
+    if @mode == :tags
+      build_for_tags
+    else
+      build_for_artist
+    end
+  end
+
+  private
+
+  WEIGHTS_FOR_ARTIST = {
+    character: 1.25,
+    copyright: 1.1,
+    species: 1.1,
+  }.freeze
+
+  def build_for_artist
     # Add artist tags as OR constraints (minimum_should_match: 1 applied by create_query_obj)
     artist_names = @post.known_artist_tags.sort_by(&:name).first(10).map(&:name)
     should.concat(artist_names.map { |t| { term: { tags: t } } })
@@ -27,12 +44,40 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
     species_tags = @post.tags_for_category("species").min_by(10, &:post_count).map(&:name)
 
     functions = [{ random_score: { seed: @post.id, field: "id" } }]
-    functions << { filter: { terms: { tags: character_tags } }, weight: CHARACTER_WEIGHT } if character_tags.any?
-    functions << { filter: { terms: { tags: copyright_tags } }, weight: COPYRIGHT_WEIGHT } if copyright_tags.any?
-    functions << { filter: { terms: { tags: species_tags } }, weight: SPECIES_WEIGHT } if species_tags.any?
+    functions << { filter: { terms: { tags: character_tags } }, weight: WEIGHTS_FOR_ARTIST[:character] } if character_tags.any?
+    functions << { filter: { terms: { tags: copyright_tags } }, weight: WEIGHTS_FOR_ARTIST[:copyright] } if copyright_tags.any?
+    functions << { filter: { terms: { tags: species_tags } }, weight: WEIGHTS_FOR_ARTIST[:species] } if species_tags.any?
 
     @function_score = {
       functions: functions,
+      score_mode: :sum,
+      boost_mode: :replace,
+    }
+  end
+
+  MAX_TAGS = 50
+  WEIGHTS_FOR_TAGS = {
+    character: 2.0,
+    copyright: 1.5,
+    species: 1.25,
+    general: 1.0,
+  }.freeze
+
+  def build_for_tags
+    pool_ids = @post.pool_ids
+    must_not.push({ terms: { pools: pool_ids } }) if pool_ids.any?
+
+    # Pick the rarest tags first — common tags (solo, rating:s) are poor discriminators
+    selected_tags = @post.categorized_tags.values.flatten.min_by(MAX_TAGS, &:post_count)
+
+    functions = [{ random_score: { seed: @post.id, field: "id" } }]
+    selected_tags.each do |tag|
+      weight = WEIGHTS_FOR_TAGS.fetch(tag.category_name.to_sym, WEIGHTS_FOR_TAGS[:general])
+      functions << { filter: { term: { tags: tag.name } }, weight: weight }
+    end
+
+    @function_score = {
+      functions:  functions,
       score_mode: :sum,
       boost_mode: :replace,
     }

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -57,6 +57,7 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
 
   MAX_TAGS = 50
   WEIGHTS_FOR_TAGS = {
+    artist: 0.1,
     character: 2.0,
     copyright: 1.5,
     species: 1.25,

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class RecommendedQueryBuilder < ElasticPostQueryBuilder
-  CHARACTER_WEIGHT = 2.0
-  COPYRIGHT_WEIGHT = 1.5
-  SPECIES_WEIGHT = 1.25
-
   def initialize(post, mode: :artist, **kwargs)
     @post = post
     @mode = mode
@@ -25,9 +21,9 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
   private
 
   WEIGHTS_FOR_ARTIST = {
-    character: 1.25,
-    copyright: 1.1,
-    species: 1.1,
+    character: 2.0,
+    copyright: 1.5,
+    species: 1.25,
   }.freeze
 
   def build_for_artist
@@ -68,7 +64,7 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
     pool_ids = @post.pool_ids
     must_not.push({ terms: { pools: pool_ids } }) if pool_ids.any?
 
-    # Pick the rarest tags first — common tags (solo, rating:s) are poor discriminators
+    # Pick the rarest tags first — common tags (solo, mammal) are poor discriminators
     selected_tags = @post.categorized_tags.values.flatten.min_by(MAX_TAGS, &:post_count)
 
     functions = [{ random_score: { seed: @post.id, field: "id" } }]

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -74,7 +74,7 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
     end
 
     @function_score = {
-      functions:  functions,
+      functions: functions,
       score_mode: :sum,
       boost_mode: :replace,
     }

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -113,7 +113,7 @@
 
       <%# Determine which recommender tabs to show %>
       <% artist_tab_available = @post.known_artist_tags.any? %>
-      <% tags_tab_available = @post.tags.size > 1 && CurrentUser.user.is_staff? %>
+      <% tags_tab_available = @post.tag_count > 1 && CurrentUser.user.is_staff? %>
       <% favorites_tab_available = Danbooru.config.recommender_enabled? && CurrentUser.user.is_staff? %>
 
       <% if artist_tab_available || tags_tab_available || favorites_tab_available %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -113,7 +113,7 @@
 
       <%# Determine which recommender tabs to show %>
       <% artist_tab_available = @post.known_artist_tags.any? %>
-      <% tags_tab_available = @post.tags.size > 0 && CurrentUser.user.is_staff? %>
+      <% tags_tab_available = @post.tags.size > 1 && CurrentUser.user.is_staff? %>
       <% favorites_tab_available = Danbooru.config.recommender_enabled? && CurrentUser.user.is_staff? %>
 
       <% if artist_tab_available || tags_tab_available || favorites_tab_available %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -111,7 +111,12 @@
         </div>
       <% end %>
 
-      <% if @post.known_artist_tags.any? || (Danbooru.config.recommender_enabled? && CurrentUser.user.is_staff?) %>
+      <%# Determine which recommender tabs to show %>
+      <% artist_tab_available = @post.known_artist_tags.any? %>
+      <% tags_tab_available = @post.tags.size > 0 && CurrentUser.user.is_staff? %>
+      <% favorites_tab_available = Danbooru.config.recommender_enabled? && CurrentUser.user.is_staff? %>
+
+      <% if artist_tab_available || tags_tab_available || favorites_tab_available %>
         <div
           id="post-recommendations"
           data-visible="<%= cookies[:post_recs] != "1" %>"
@@ -120,6 +125,7 @@
           data-post-id="<%= @post.id %>"
         >
           <div id="post-recommendations-tabs" role="tablist">
+            <% if artist_tab_available %>
             <button
               type="button"
               role="tab"
@@ -129,16 +135,19 @@
               aria-controls="post-recommendations-list"
               aria-selected="true"
             >From the Artist</button>
-            <% if Danbooru.config.recommender_enabled? && CurrentUser.user.is_staff? %>
-              <button
-                type="button"
-                role="tab"
-                class="st-button"
-                id="post-recommendations-tab-tags"
-                data-action="tags"
-                aria-controls="post-recommendations-list"
-                aria-selected="false"
-              >Similar</button>
+            <% end %>
+            <% if tags_tab_available %>
+            <button
+              type="button"
+              role="tab"
+              class="st-button"
+              id="post-recommendations-tab-tags"
+              data-action="tags"
+              aria-controls="post-recommendations-list"
+              aria-selected="false"
+            >Similar</button>
+            <% end %>
+            <% if favorites_tab_available %>
               <button
                 type="button"
                 role="tab"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,8 +284,8 @@ Rails.application.routes.draw do
       get :comments, to: "comments#for_post"
       resource :similar, only: [], controller: "post_recommendations" do
         get :artist
+        get :tags
         get :remote
-        get :lookup
         get "", to: redirect { |params, req| "/iqdb_queries#{req.format.json? ? '.json' : ''}?post_id=#{params[:id]}" }
       end
     end

--- a/spec/logical/recommended_query_builder_spec.rb
+++ b/spec/logical/recommended_query_builder_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe RecommendedQueryBuilder do
     character_tags = opts.fetch(:character_tags, [])
     copyright_tags = opts.fetch(:copyright_tags, [])
     species_tags   = opts.fetch(:species_tags, [])
+    all_tags       = opts.fetch(:all_tags, {})
 
     post = instance_double(Post, id: id)
     allow(post).to receive_messages(
@@ -22,25 +23,16 @@ RSpec.describe RecommendedQueryBuilder do
       pairs = { "character" => character_tags, "copyright" => copyright_tags, "species" => species_tags }
       (pairs[category] || []).map { |name, count| instance_double(Tag, name: name, post_count: count) }
     end
+    allow(post).to receive(:categorized_tags) do
+      all_tags.each_with_object({}) do |(cat_name, tags_list), h|
+        h[cat_name] = tags_list.map { |name, count| instance_double(Tag, name: name, post_count: count, category_name: cat_name) }
+      end
+    end
     post
   end
 
-  def build_for(post)
-    RecommendedQueryBuilder.new(post)
-  end
-
-  describe "constants" do
-    it "CHARACTER_WEIGHT is 2.0" do
-      expect(described_class::CHARACTER_WEIGHT).to eq(2.0)
-    end
-
-    it "COPYRIGHT_WEIGHT is 1.5" do
-      expect(described_class::COPYRIGHT_WEIGHT).to eq(1.5)
-    end
-
-    it "SPECIES_WEIGHT is 1.25" do
-      expect(described_class::SPECIES_WEIGHT).to eq(1.25)
-    end
+  def build_for(post, mode: :artist)
+    RecommendedQueryBuilder.new(post, mode: mode)
   end
 
   describe "exclusion query" do
@@ -128,7 +120,7 @@ RSpec.describe RecommendedQueryBuilder do
       let(:post) { make_post(character_tags: [["char_a", 1], ["char_b", 2]]) }
 
       it "includes a character weight function covering those tags" do
-        char_fn = function_score[:functions].find { |f| f[:weight] == described_class::CHARACTER_WEIGHT }
+        char_fn = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:character] }
         expect(char_fn).to be_present
         expect(char_fn[:filter][:terms][:tags]).to include("char_a", "char_b")
       end
@@ -136,7 +128,7 @@ RSpec.describe RecommendedQueryBuilder do
 
     context "when the post has no character tags" do
       it "does not include a character weight function" do
-        char_fn = function_score[:functions].find { |f| f[:weight] == described_class::CHARACTER_WEIGHT }
+        char_fn = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:character] }
         expect(char_fn).to be_nil
       end
     end
@@ -145,7 +137,7 @@ RSpec.describe RecommendedQueryBuilder do
       let(:post) { make_post(copyright_tags: [["copy_a", 1]]) }
 
       it "includes a copyright weight function covering those tags" do
-        copy_fn = function_score[:functions].find { |f| f[:weight] == described_class::COPYRIGHT_WEIGHT }
+        copy_fn = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:copyright] }
         expect(copy_fn).to be_present
         expect(copy_fn[:filter][:terms][:tags]).to include("copy_a")
       end
@@ -153,7 +145,7 @@ RSpec.describe RecommendedQueryBuilder do
 
     context "when the post has no copyright tags" do
       it "does not include a copyright weight function" do
-        copy_fn = function_score[:functions].find { |f| f[:weight] == described_class::COPYRIGHT_WEIGHT }
+        copy_fn = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:copyright] }
         expect(copy_fn).to be_nil
       end
     end
@@ -162,7 +154,7 @@ RSpec.describe RecommendedQueryBuilder do
       let(:post) { make_post(species_tags: [["spec_a", 1]]) }
 
       it "includes a species weight function covering those tags" do
-        spec_fn = function_score[:functions].find { |f| f[:weight] == described_class::SPECIES_WEIGHT }
+        spec_fn = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:species] }
         expect(spec_fn).to be_present
         expect(spec_fn[:filter][:terms][:tags]).to include("spec_a")
       end
@@ -170,7 +162,7 @@ RSpec.describe RecommendedQueryBuilder do
 
     context "when the post has no species tags" do
       it "does not include a species weight function" do
-        spec_fn = function_score[:functions].find { |f| f[:weight] == described_class::SPECIES_WEIGHT }
+        spec_fn = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:species] }
         expect(spec_fn).to be_nil
       end
     end
@@ -194,7 +186,7 @@ RSpec.describe RecommendedQueryBuilder do
     it "selects the 10 character tags with the lowest post_count when more than 10 are present" do
       tags = (1..12).map { |n| ["char_#{n}", n * 10] } # post_counts 10, 20, ..., 120
       function_score = build_for(make_post(character_tags: tags)).instance_variable_get(:@function_score)
-      selected = function_score[:functions].find { |f| f[:weight] == described_class::CHARACTER_WEIGHT }[:filter][:terms][:tags]
+      selected = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:character] }[:filter][:terms][:tags]
       expect(selected.size).to eq(10)
       expect(selected).not_to include("char_11", "char_12") # highest post_counts excluded
     end
@@ -202,7 +194,7 @@ RSpec.describe RecommendedQueryBuilder do
     it "selects the 10 copyright tags with the lowest post_count when more than 10 are present" do
       tags = (1..12).map { |n| ["copy_#{n}", n * 10] }
       function_score = build_for(make_post(copyright_tags: tags)).instance_variable_get(:@function_score)
-      selected = function_score[:functions].find { |f| f[:weight] == described_class::COPYRIGHT_WEIGHT }[:filter][:terms][:tags]
+      selected = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:copyright] }[:filter][:terms][:tags]
       expect(selected.size).to eq(10)
       expect(selected).not_to include("copy_11", "copy_12")
     end
@@ -210,9 +202,123 @@ RSpec.describe RecommendedQueryBuilder do
     it "selects the 10 species tags with the lowest post_count when more than 10 are present" do
       tags = (1..12).map { |n| ["spec_#{n}", n * 10] }
       function_score = build_for(make_post(species_tags: tags)).instance_variable_get(:@function_score)
-      selected = function_score[:functions].find { |f| f[:weight] == described_class::SPECIES_WEIGHT }[:filter][:terms][:tags]
+      selected = function_score[:functions].find { |f| f[:weight] == described_class::WEIGHTS_FOR_ARTIST[:species] }[:filter][:terms][:tags]
       expect(selected.size).to eq(10)
       expect(selected).not_to include("spec_11", "spec_12")
+    end
+  end
+
+  describe "tags mode" do
+    def tags_function_score(post)
+      build_for(post, mode: :tags).instance_variable_get(:@function_score)
+    end
+
+    describe "pool exclusion" do
+      it "adds a must_not terms clause for the post's pool ids" do
+        builder = build_for(make_post(pool_ids: [10, 20]), mode: :tags)
+        expect(builder.must_not).to include({ terms: { pools: [10, 20] } })
+      end
+
+      it "does not add a pool must_not clause when the post has no pools" do
+        builder = build_for(make_post(pool_ids: []), mode: :tags)
+        pool_clauses = builder.must_not.select { |clause| clause[:terms]&.key?(:pools) }
+        expect(pool_clauses).to be_empty
+      end
+    end
+
+    describe "function_score structure" do
+      let(:post) { make_post(id: 7) }
+      let(:function_score) { tags_function_score(post) }
+
+      it "uses sum score mode" do
+        expect(function_score[:score_mode]).to eq(:sum)
+      end
+
+      it "uses replace boost mode" do
+        expect(function_score[:boost_mode]).to eq(:replace)
+      end
+
+      it "always includes a random_score function seeded with the post id" do
+        expect(function_score[:functions]).to include({ random_score: { seed: 7, field: "id" } })
+      end
+    end
+
+    describe "per-category tag weights" do
+      it "assigns the artist weight to artist tags" do
+        post = make_post(all_tags: { "artist" => [["artist_a", 50]] })
+        fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "artist_a" }
+        expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:artist])
+      end
+
+      it "assigns the character weight to character tags" do
+        post = make_post(all_tags: { "character" => [["char_a", 10]] })
+        fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "char_a" }
+        expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:character])
+      end
+
+      it "assigns the copyright weight to copyright tags" do
+        post = make_post(all_tags: { "copyright" => [["copy_a", 10]] })
+        fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "copy_a" }
+        expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:copyright])
+      end
+
+      it "assigns the species weight to species tags" do
+        post = make_post(all_tags: { "species" => [["spec_a", 10]] })
+        fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "spec_a" }
+        expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:species])
+      end
+
+      it "assigns the general weight to general tags" do
+        post = make_post(all_tags: { "general" => [["tag_a", 100]] })
+        fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "tag_a" }
+        expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:general])
+      end
+    end
+
+    describe "MAX_TAGS cap" do
+      it "includes all tags when the total equals MAX_TAGS" do
+        tags = (1..described_class::MAX_TAGS).map { |n| ["tag_#{n}", n] }
+        post = make_post(all_tags: { "general" => tags })
+        functions = tags_function_score(post)[:functions]
+        expect(functions.size).to eq(described_class::MAX_TAGS + 1) # tags + random_score
+      end
+
+      it "caps at MAX_TAGS tags and excludes the highest post_count tags when over the limit" do
+        tags = (1..described_class::MAX_TAGS + 5).map { |n| ["tag_#{n}", n] }
+        post = make_post(all_tags: { "general" => tags })
+        functions = tags_function_score(post)[:functions]
+        expect(functions.size).to eq(described_class::MAX_TAGS + 1)
+        tag_names_in_functions = functions.filter_map { |f| f.dig(:filter, :term, :tags) }
+        (described_class::MAX_TAGS + 1..described_class::MAX_TAGS + 5).each do |n|
+          expect(tag_names_in_functions).not_to include("tag_#{n}")
+        end
+      end
+    end
+
+    describe "rarest-first selection" do
+      it "excludes the tag with the highest post_count when trimming to MAX_TAGS" do
+        tags = (1..described_class::MAX_TAGS + 1).map { |n| ["tag_#{n}", n] }
+        post = make_post(all_tags: { "general" => tags })
+        tag_names = tags_function_score(post)[:functions].filter_map { |f| f.dig(:filter, :term, :tags) }
+        expect(tag_names).not_to include("tag_#{described_class::MAX_TAGS + 1}")
+      end
+    end
+
+    describe "empty tag set" do
+      it "produces only the random_score function when the post has no tags" do
+        post = make_post(all_tags: {})
+        functions = tags_function_score(post)[:functions]
+        expect(functions.size).to eq(1)
+        expect(functions.first).to have_key(:random_score)
+      end
+    end
+
+    describe "no artist should terms" do
+      it "does not add artist tags to the should clause" do
+        post = make_post(known_artists: %w[some_artist], all_tags: { "artist" => [["some_artist", 50]] })
+        builder = build_for(post, mode: :tags)
+        expect(builder.should).to be_empty
+      end
     end
   end
 end

--- a/spec/requests/post_recommendations_controller_spec.rb
+++ b/spec/requests/post_recommendations_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PostRecommendationsController do
       expect(response).to have_http_status(:ok)
       body = response.parsed_body
       expect(body["post_id"]).to eq(post.id)
-      expect(body["model_version"]).to eq("opensearch")
+      expect(body["model_version"]).to eq("os.artist")
       expect(body["results"]).to be_an(Array)
       expect(body["post_data"]).to be_an(Array)
     end
@@ -45,27 +45,27 @@ RSpec.describe PostRecommendationsController do
 
     it "defaults limit to 6 when not provided" do
       get artist_similar_path(post, format: :json)
-      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 6)
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 6, mode: :artist)
     end
 
     it "forwards a custom limit within range" do
       get artist_similar_path(post, format: :json), params: { limit: 10 }
-      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 10)
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 10, mode: :artist)
     end
 
     it "clamps limit below 1 up to 1" do
       get artist_similar_path(post, format: :json), params: { limit: 0 }
-      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 1)
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 1, mode: :artist)
     end
 
     it "clamps a non-numeric limit string to 1" do
       get artist_similar_path(post, format: :json), params: { limit: "abc" }
-      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 1)
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 1, mode: :artist)
     end
 
     it "clamps limit above 20 down to 20" do
       get artist_similar_path(post, format: :json), params: { limit: 999 }
-      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 20)
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 20, mode: :artist)
     end
 
     it "returns empty results and post_data when post is not visible" do
@@ -88,6 +88,90 @@ RSpec.describe PostRecommendationsController do
 
     it "returns 404 for a non-existent post" do
       get "/posts/0/similar/artist.json"
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # GET /posts/:id/similar/tags — tag-based recommendations
+  # ---------------------------------------------------------------------------
+
+  describe "GET /posts/:id/similar/tags" do
+    let(:recommended_double) { instance_double(PostSets::Recommended, post_ids: [recommended_post.id]) }
+
+    before do
+      allow(PostSets::Recommended).to receive(:new).and_return(recommended_double)
+    end
+
+    it "returns 200 with the expected JSON structure" do
+      get tags_similar_path(post, format: :json)
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["post_id"]).to eq(post.id)
+      expect(body["model_version"]).to eq("os.tags")
+      expect(body["results"]).to be_an(Array)
+      expect(body["post_data"]).to be_an(Array)
+    end
+
+    it "does not include the order key in the response" do
+      get tags_similar_path(post, format: :json)
+      expect(response.parsed_body).not_to have_key("order")
+    end
+
+    it "populates post_data with thumbnail attributes for recommended posts" do
+      get tags_similar_path(post, format: :json)
+      post_data = response.parsed_body["post_data"]
+      expect(post_data.length).to eq(1)
+      entry = post_data.first
+      expect(entry["id"]).to eq(recommended_post.id)
+      expect(entry).to include("tags", "rating", "file_ext", "uploader_id")
+    end
+
+    it "defaults limit to 6 when not provided" do
+      get tags_similar_path(post, format: :json)
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 6, mode: :tags)
+    end
+
+    it "forwards a custom limit within range" do
+      get tags_similar_path(post, format: :json), params: { limit: 10 }
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 10, mode: :tags)
+    end
+
+    it "clamps limit below 1 up to 1" do
+      get tags_similar_path(post, format: :json), params: { limit: 0 }
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 1, mode: :tags)
+    end
+
+    it "clamps a non-numeric limit string to 1" do
+      get tags_similar_path(post, format: :json), params: { limit: "abc" }
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 1, mode: :tags)
+    end
+
+    it "clamps limit above 20 down to 20" do
+      get tags_similar_path(post, format: :json), params: { limit: 999 }
+      expect(PostSets::Recommended).to have_received(:new).with(post, limit: 20, mode: :tags)
+    end
+
+    it "returns empty results and post_data when post is not visible" do
+      allow(Security::Lockdown).to receive(:post_visible?).and_return(false)
+      get tags_similar_path(post, format: :json)
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body["results"]).to eq([])
+      expect(body["post_data"]).to eq([])
+      expect(PostSets::Recommended).not_to have_received(:new)
+    end
+
+    it "returns empty results and post_data when there are no recommendations" do
+      allow(recommended_double).to receive(:post_ids).and_return([])
+      get tags_similar_path(post, format: :json)
+      body = response.parsed_body
+      expect(body["results"]).to eq([])
+      expect(body["post_data"]).to eq([])
+    end
+
+    it "returns 404 for a non-existent post" do
+      get "/posts/0/similar/tags.json"
       expect(response).to have_http_status(:not_found)
     end
   end


### PR DESCRIPTION
Replacement for the "tags" route of https://github.com/e621ng/recommender.
Testing is required to see if the results here are any better.