### PR TITLE
[SearchTrends] Move rising tag calculations into a background job

### DIFF
--- a/app/jobs/search_trend_cache_warm_job.rb
+++ b/app/jobs/search_trend_cache_warm_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class SearchTrendCacheWarmJob < ApplicationJob
+  queue_as :low_prio
+  sidekiq_options lock: :until_executing
+
+  def perform
+    SearchTrendHourly.warm_rising_tags_cache!
+  end
+end

--- a/app/models/search_trend_hourly.rb
+++ b/app/models/search_trend_hourly.rb
@@ -165,19 +165,13 @@ class SearchTrendHourly < ApplicationRecord
   end
 
   def self.rising_tags_list
-    Cache.fetch("rising_tags", expires_in: 15.minutes) do
-      tags = SearchTrendHourly.rising(min_today: Setting.trends_min_today, min_delta: Setting.trends_min_delta, min_ratio: Setting.trends_min_ratio).map(&:tag)
-      aliased_tags = TagAlias.to_aliased(tags)
-      tag_data = Tag.where(name: aliased_tags).index_by(&:name)
-      aliased_tags.map do |tag|
-        {
-          name: tag,
-          pretty_name: tag.gsub(/_+/, " "),
-          post_count: tag_data[tag]&.post_count || 0,
-          category: tag_data[tag]&.category || 0,
-        }
-      end
-    end
+    Cache.fetch("rising_tags", expires_in: 15.minutes) { compute_rising_tags_list }
+  end
+
+  def self.warm_rising_tags_cache!
+    result = compute_rising_tags_list
+    Cache.write("rising_tags", result, expires_in: 20.minutes)
+    result
   end
 
   # Delete old processed hourly records to prevent the table from growing unbounded.
@@ -207,5 +201,19 @@ class SearchTrendHourly < ApplicationRecord
     record = new(tag: tag, hour: Time.now.utc)
     TagNameValidator.new(attributes: [:tag]).validate_each(record, :tag, tag)
     record.errors[:tag].empty?
+  end
+
+  private_class_method def self.compute_rising_tags_list
+    tags = rising(min_today: Setting.trends_min_today, min_delta: Setting.trends_min_delta, min_ratio: Setting.trends_min_ratio).map(&:tag)
+    aliased_tags = TagAlias.to_aliased(tags)
+    tag_data = Tag.where(name: aliased_tags).index_by(&:name)
+    aliased_tags.map do |tag|
+      {
+        name: tag,
+        pretty_name: tag.gsub(/_+/, " "),
+        post_count: tag_data[tag]&.post_count || 0,
+        category: tag_data[tag]&.category || 0,
+      }
+    end
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -25,6 +25,11 @@ Sidekiq.configure_server do |config|
       "class" => "SearchTrendAggregateJob",
       "description" => "Aggregate unprocessed hourly search trends into daily totals",
     },
+    "SearchTrendCacheWarmJob" => {
+      "cron" => "*/15 * * * *",
+      "class" => "SearchTrendCacheWarmJob",
+      "description" => "Pre-warm the rising tags cache every 15 minutes to avoid on-request timeouts",
+    },
   }
 
   Sidekiq::Cron::Job.load_from_hash schedule

--- a/spec/jobs/search_trend_cache_warm_job_spec.rb
+++ b/spec/jobs/search_trend_cache_warm_job_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SearchTrendCacheWarmJob do
+  describe "#perform" do
+    it "calls warm_rising_tags_cache! on SearchTrendHourly" do
+      allow(SearchTrendHourly).to receive(:warm_rising_tags_cache!)
+      described_class.perform_now
+      expect(SearchTrendHourly).to have_received(:warm_rising_tags_cache!)
+    end
+  end
+end

--- a/spec/models/search_trend_hourly/class_methods_spec.rb
+++ b/spec/models/search_trend_hourly/class_methods_spec.rb
@@ -177,6 +177,35 @@ RSpec.describe SearchTrendHourly do
   end
 
   # =========================================================================
+  # .warm_rising_tags_cache!
+  # =========================================================================
+  #
+  # warm_rising_tags_cache! unconditionally computes and writes the rising tags
+  # list to the cache with a 20-minute TTL (longer than rising_tags_list's
+  # 15-minute TTL so the job-scheduled writes never expire between runs).
+  # =========================================================================
+  describe ".warm_rising_tags_cache!" do
+    before do
+      allow(Cache).to receive(:write)
+      allow(Setting).to receive_messages(
+        trends_min_today: 1,
+        trends_min_delta: 1,
+        trends_min_ratio: 1.0,
+      )
+    end
+
+    it "writes to the rising_tags cache key with a 20-minute TTL" do
+      SearchTrendHourly.warm_rising_tags_cache!
+      expect(Cache).to have_received(:write).with("rising_tags", anything, expires_in: 20.minutes)
+    end
+
+    it "returns the computed list" do
+      result = SearchTrendHourly.warm_rising_tags_cache!
+      expect(result).to be_an(Array)
+    end
+  end
+
+  # =========================================================================
   # .prune!
   # =========================================================================
   #


### PR DESCRIPTION
`SearchTrendHourly.rising_tags_list` uses `Cache.fetch` with a 15-minute TTL. When the cache expires, the first request to arrive blocks while two full 48-hour aggregate queries run - causing timeouts in production.

The fix is a background job that proactively rewrites the cache every 15 minutes with a 20-minute TTL, ensuring there is always a valid cached value and no user request ever pays the computation cost.