### PR TITLE
[Pagination] Fix NoMethodError when search params are invalid

### DIFF
--- a/app/logical/danbooru/paginator/document_store_extensions.rb
+++ b/app/logical/danbooru/paginator/document_store_extensions.rb
@@ -26,13 +26,13 @@ module Danbooru
       def paginate_sequential_before
         search.definition.update(size: records_per_page + 1, track_total_hits: records_per_page + 1)
         search.definition[:body].update(sort: [{ id: :desc }])
-        query_definition[:bool][:must].push({ range: { id: { lt: current_page } } })
+        query_definition[:bool]&.dig(:must)&.push({ range: { id: { lt: current_page } } })
       end
 
       def paginate_sequential_after
         search.definition.update(size: records_per_page + 1, track_total_hits: records_per_page + 1)
         search.definition[:body].update(sort: [{ id: :asc }])
-        query_definition[:bool][:must].push({ range: { id: { gt: current_page } } })
+        query_definition[:bool]&.dig(:must)&.push({ range: { id: { gt: current_page } } })
       end
 
       def query_definition


### PR DESCRIPTION
Specific error:

```
NoMethodError
undefined method `[]' for nil

app/logical/danbooru/paginator/document_store_extensions.rb:35:in `paginate_sequential_after'
app/logical/danbooru/paginator/base_extension.rb:18:in `paginate'
app/logical/danbooru/paginator/document_store_extensions.rb:9:in `paginate'
app/logical/post_search_context.rb:9:in `initialize'
app/controllers/posts_controller.rb:95:in `new'
app/controllers/posts_controller.rb:95:in `show_seq'
app/controllers/application_controller.rb:195:in `set_time_zone'
lib/middleware/parameter_sanitizer.rb:45:in `call'

{
  "host": "e621ng-app4a",
  "params": {
    "q": "date:yesterweek+clothing",
    "seq": "prev",
    "controller": "posts",
    "action": "show_seq",
    "id": "5785053"
  },
  "user_id": null,
  "referrer": null,
  "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36"
}
```