### PR TITLE
[Tickets] Streamline ticket permissions

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -3,11 +3,17 @@
 class TicketsController < ApplicationController
   respond_to :html, :json, except: %i[create new]
   before_action :member_only, except: %i[index]
-  before_action :moderator_only, only: %i[update edit claim unclaim]
+  before_action :janitor_only, only: %i[update claim unclaim]
 
   def index
     @tickets = Ticket.visible(CurrentUser.user).search(search_params).paginate(params[:page], limit: params[:limit])
     respond_with(@tickets)
+  end
+
+  def show
+    @ticket = Ticket.find(params[:id])
+    check_permission(@ticket)
+    respond_with(@ticket)
   end
 
   def new
@@ -37,14 +43,11 @@ class TicketsController < ApplicationController
     end
   end
 
-  def show
-    @ticket = Ticket.find(params[:id])
-    check_permission(@ticket)
-    respond_with(@ticket)
-  end
-
   def update
     @ticket = Ticket.find(params[:id])
+
+    raise User::PrivilegeError unless @ticket.can_handle?
+
     if @ticket.claimant_id.present? && @ticket.claimant_id != CurrentUser.id && !params[:force_claim].to_s.truthy?
       flash[:notice] = "Ticket has already been claimed by somebody else, submit again to force"
       redirect_to ticket_path(@ticket, force_claim: "true")
@@ -72,6 +75,8 @@ class TicketsController < ApplicationController
 
   def claim
     @ticket = Ticket.find(params[:id])
+
+    raise User::PrivilegeError unless @ticket.can_claim?
 
     if @ticket.claimant.nil?
       @ticket.claim!

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -6,7 +6,12 @@ class TicketsController < ApplicationController
   before_action :janitor_only, only: %i[update claim unclaim]
 
   def index
-    @tickets = Ticket.visible(CurrentUser.user).search(search_params).paginate(params[:page], limit: params[:limit])
+    @tickets = Ticket
+               .includes(:creator, :accused, :claimant)
+               .visible(CurrentUser.user)
+               .search(search_params)
+               .paginate(params[:page], limit: params[:limit])
+    preload_ticket_contents(@tickets)
     respond_with(@tickets)
   end
 
@@ -107,6 +112,15 @@ class TicketsController < ApplicationController
   end
 
   private
+
+  def preload_ticket_contents(tickets)
+    tickets.group_by(&:qtype).each_value do |group|
+      model = group.first.model
+      ids = group.map(&:disp_id).compact
+      content_map = model.where(id: ids).index_by(&:id)
+      group.each { |t| t.instance_variable_set(:@content, content_map[t.disp_id]) }
+    end
+  end
 
   def ticket_params
     params.require(:ticket).permit(%i[qtype disp_id reason report_reason])

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -116,6 +116,7 @@ class TicketsController < ApplicationController
   def preload_ticket_contents(tickets)
     tickets.group_by(&:qtype).each_value do |group|
       model = group.first.model
+      next if model.nil?
       ids = group.map(&:disp_id).compact
       content_map = model.where(id: ids).index_by(&:id)
       group.each { |t| t.instance_variable_set(:@content, content_map[t.disp_id]) }

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -46,7 +46,7 @@ class TicketsController < ApplicationController
   def update
     @ticket = Ticket.find(params[:id])
 
-    raise User::PrivilegeError unless @ticket.can_handle?
+    raise User::PrivilegeError unless @ticket.can_view?(CurrentUser.user) && @ticket.can_handle?(CurrentUser.user)
 
     if @ticket.claimant_id.present? && @ticket.claimant_id != CurrentUser.id && !params[:force_claim].to_s.truthy?
       flash[:notice] = "Ticket has already been claimed by somebody else, submit again to force"
@@ -76,7 +76,7 @@ class TicketsController < ApplicationController
   def claim
     @ticket = Ticket.find(params[:id])
 
-    raise User::PrivilegeError unless @ticket.can_claim?
+    raise User::PrivilegeError unless @ticket.can_view?(CurrentUser.user) && @ticket.can_claim?(CurrentUser.user)
 
     if @ticket.claimant.nil?
       @ticket.claim!
@@ -88,6 +88,8 @@ class TicketsController < ApplicationController
 
   def unclaim
     @ticket = Ticket.find(params[:id])
+
+    raise User::PrivilegeError unless @ticket.can_view?(CurrentUser.user) && @ticket.can_claim?(CurrentUser.user)
 
     if @ticket.claimant.nil?
       flash[:notice] = "Ticket not claimed"

--- a/app/javascript/src/styles/common/tables.scss
+++ b/app/javascript/src/styles/common/tables.scss
@@ -19,6 +19,7 @@ table.striped {
             width: 100%;
             display: inline-block;
             padding: $padding-050 $padding-025;
+            box-sizing: border-box;
           }
         }
       }

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -157,8 +157,8 @@ class ForumPost < ApplicationRecord
   end
 
   def visible?(user)
-    return false unless topic&.visible?(user)
     return true if user.is_moderator?
+    return false unless topic&.visible?(user)
     return true if user.id == creator_id
     return false if is_hidden?
     true

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -157,7 +157,11 @@ class ForumPost < ApplicationRecord
   end
 
   def visible?(user)
-    user.is_moderator? || (topic.visible?(user) && (!is_hidden? || user.id == creator_id))
+    return false unless topic&.visible?(user)
+    return true if user.is_moderator?
+    return true if user.id == creator_id
+    return false if is_hidden?
+    true
   end
 
   def can_hide?(user)

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -158,7 +158,7 @@ class PostSet < ApplicationRecord
   module AccessMethods
     def can_view?(user)
       return true if is_public
-      return true if is_moderator?
+      return true if user.is_moderator?
       return true if is_owner?(user)
       false
     end

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -157,7 +157,10 @@ class PostSet < ApplicationRecord
 
   module AccessMethods
     def can_view?(user)
-      is_public || is_owner?(user) || user.is_moderator?
+      return true if is_public
+      return true if is_moderator?
+      return true if is_owner?(user)
+      false
     end
 
     def can_edit_settings?(user)

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -391,7 +391,7 @@ class Ticket < ApplicationRecord
   end
 
   def type_title
-    model.name.titlecase.to_s
+    model.name.titlecase
   end
 
   def subject

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -233,8 +233,7 @@ class Ticket < ApplicationRecord
         return super + hidden
       end
 
-      hidden += %i[claimant_id] unless CurrentUser.is_moderator?
-      hidden += %i[creator_id] unless can_see_reporter?(CurrentUser)
+      hidden += %i[claimant_id] unless CurrentUser.is_staff?
       super + hidden
     end
   end
@@ -368,14 +367,19 @@ class Ticket < ApplicationRecord
     content&.creator&.name
   end
 
-  def can_view?(user)
+  def can_view?(user = CurrentUser.user)
+    # Should not happen - individual ticket types override this method.
     return true if user.is_moderator?
     return true if user.id == creator_id
     false
   end
 
-  def can_see_reporter?(user)
-    user.is_moderator? || (user.id == creator_id)
+  def can_handle?(user = CurrentUser.user)
+    user.is_moderator?
+  end
+
+  def can_claim?(user = CurrentUser.user)
+    user.is_moderator?
   end
 
   def can_create_for?(_user)
@@ -387,7 +391,7 @@ class Ticket < ApplicationRecord
   end
 
   def type_title
-    "#{model.name.titlecase} Complaint"
+    model.name.titlecase.to_s
   end
 
   def subject

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -28,20 +28,22 @@ class Ticket < ApplicationRecord
   attr_accessor :record_type, :send_update_dmail
 
   # Permissions Table
+  # Creator can always view their own ticket. Admin always has unconditional view access.
+  # For content-gated types, staff can view even if the content no longer exists.
   #
-  # |    Type    |      Can Create     |        Visible       |
-  # |:----------:|:-------------------:|:--------------------:|
-  # |    Blip    |      Accessible     |  Janitor+ / Creator  |
-  # |   Comment  |       Visible       |  Janitor+ / Creator  |
-  # |    Dmail   | Visible & Recipient | Moderator+ / Creator |
-  # | Forum Post |       Visible       |  Janitor+ / Creator  |
-  # |    Pool    |         Any         |  Janitor+ / Creator  |
-  # |    Post    |         Any         |  Janitor+ / Creator  |
-  # |  Post Set  |       Visible       |  Janitor+ / Creator  |
-  # |    User    |         Any         | Moderator+ / Creator |
-  # |  Wiki Page |         Any         |  Janitor+ / Creator  |
-  # |    Other   |         None        | Moderator+ / Creator |
-  # |Replacement |         Any         |  Janitor+ / Creator  |
+  # |    Type    |      Can Create     |  Min. View Level  | View Content Check |
+  # |:----------:|:-------------------:|:-----------------:|:------------------:|
+  # |    Blip    |      Accessible     |     Janitor+      |     Accessible     |
+  # |   Comment  |      Accessible     |     Janitor+      |     Accessible     |
+  # |    Dmail   | Visible & Recipient |    Moderator+     |      Visible       |
+  # | Forum Post |       Visible       |     Janitor+      |      Visible       |
+  # |    Pool    |         Any         |     Janitor+      |        -           |
+  # |    Post    |         Any         |     Janitor+      |        -           |
+  # |  Post Set  |       Visible       |     Janitor+      |      Visible       |
+  # |    User    |         Any         |    Moderator+     |        -           |
+  # |  Wiki Page |         Any         |     Janitor+      |        -           |
+  # |    Other   |         None        |    Moderator+     |        -           |
+  # |Replacement |       Visible       |     Janitor+      |      Visible       |
 
   module TicketTypes
     module Blip
@@ -50,7 +52,8 @@ class Ticket < ApplicationRecord
       end
 
       def can_view?(user)
-        return true if user.is_staff?
+        return true if user.is_staff? && (content.blank? || content&.is_accessible?(user))
+        return true if user.is_admin?
         return true if user.id == creator_id
         false
       end
@@ -62,7 +65,10 @@ class Ticket < ApplicationRecord
       end
 
       def can_view?(user)
-        (user.is_staff? && content&.is_accessible?(user, bypass_user_settings: true)) || user.is_admin? || (user.id == creator_id)
+        return true if user.is_staff? && (content.blank? || content&.is_accessible?(user, bypass_user_settings: true))
+        return true if user.is_admin?
+        return true if user.id == creator_id
+        false
       end
     end
 
@@ -72,7 +78,10 @@ class Ticket < ApplicationRecord
       end
 
       def can_view?(user)
-        user.is_moderator? || (user.id == creator_id)
+        return true if user.is_moderator? && (content.blank? || content&.visible_to?(user))
+        return true if user.is_admin?
+        return true if user.id == creator_id
+        false
       end
 
       def bot_target_name
@@ -87,11 +96,14 @@ class Ticket < ApplicationRecord
       end
 
       def can_create_for?(user)
-        content.visible?(user)
+        content&.visible?(user)
       end
 
       def can_view?(user)
-        ((content.nil? || content&.visible?(user)) && user.is_staff?) || user.is_admin? || (user.id == creator_id)
+        return true if user.is_staff? && (content.blank? || content&.visible?(user))
+        return true if user.is_admin?
+        return true if user.id == creator_id
+        false
       end
     end
 
@@ -100,12 +112,14 @@ class Ticket < ApplicationRecord
         true
       end
 
-      def bot_target_name
-        content&.name
+      def can_view?(user)
+        return true if user.is_staff?
+        return true if user.id == creator_id
+        false
       end
 
-      def can_view?(user)
-        user.is_staff? || (user.id == creator_id)
+      def bot_target_name
+        content&.name
       end
     end
 
@@ -124,12 +138,14 @@ class Ticket < ApplicationRecord
         true
       end
 
-      def bot_target_name
-        content&.uploader&.name
+      def can_view?(user)
+        return true if user.is_staff?
+        return true if user.id == creator_id
+        false
       end
 
-      def can_view?(user)
-        user.is_staff? || (user.id == creator_id)
+      def bot_target_name
+        content&.uploader&.name
       end
     end
 
@@ -143,7 +159,10 @@ class Ticket < ApplicationRecord
       end
 
       def can_view?(user)
-        ((content.nil? || content&.can_view?(user)) && user.is_staff?) || user.is_admin? || (user.id == creator_id)
+        return true if user.is_staff? && (content.blank? || content&.can_view?(user))
+        return true if user.is_admin?
+        return true if user.id == creator_id
+        false
       end
     end
 
@@ -153,7 +172,9 @@ class Ticket < ApplicationRecord
       end
 
       def can_view?(user)
-        user.is_moderator? || user.id == creator_id
+        return true if user.is_moderator?
+        return true if user.id == creator_id
+        false
       end
 
       def bot_target_name
@@ -175,7 +196,9 @@ class Ticket < ApplicationRecord
       end
 
       def can_view?(user)
-        user.is_staff? || user.is_admin? || (user.id == creator_id)
+        return true if user.is_staff?
+        return true if user.id == creator_id
+        false
       end
     end
 
@@ -184,12 +207,15 @@ class Ticket < ApplicationRecord
         ::PostReplacement
       end
 
-      def can_view?(user)
-        user.is_janitor? || (user.id == creator_id)
-      end
-
       def can_create_for?(user)
         content&.visible_to?(user)
+      end
+
+      def can_view?(user)
+        return true if user.is_staff? && (content.blank? || content&.visible_to?(user))
+        return true if user.is_admin?
+        return true if user.id == creator_id
+        false
       end
 
       def subject
@@ -343,7 +369,9 @@ class Ticket < ApplicationRecord
   end
 
   def can_view?(user)
-    user.is_janitor?
+    return true if user.is_moderator?
+    return true if user.id == creator_id
+    false
   end
 
   def can_see_reporter?(user)

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -21,9 +21,10 @@
 
       <tbody>
         <% @tickets.each do |ticket| %>
-          <tr data-link="<%= ticket_path(ticket) %>">
+          <% can_view = ticket.can_view?(CurrentUser.user) %>
+          <tr data-link="<%= can_view ? ticket_path(ticket) : '' %>">
             <% if CurrentUser.is_staff? %>
-              <% if ticket.can_view?(CurrentUser.user) %>
+              <% if can_view %>
                 <%# Reporter %>
                 <td><%= link_to_user ticket.creator %></td>
 
@@ -48,7 +49,7 @@
               </td>
             <% end %>
 
-            <% if ticket.can_view?(CurrentUser.user) %>
+            <% if can_view %>
               <%# Type %>
               <td class="ticket-subject full-width-link">
                 <%= link_to ticket.type_title, ticket_path(ticket) %>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -6,45 +6,64 @@
     <table class="striped">
       <thead>
         <tr>
-          <th style="width:5%">ID</th>
-          <% if CurrentUser.is_moderator? %>
+          <% if CurrentUser.is_staff? %>
             <th style="width:10%">Reporter</th>
             <th style="width:10%">Accused</th>
             <th style="width:10%">Claimed By</th>
           <% end %>
-          <th style="width:15%">Type</th>
-          <th style="width:25%">Subject</th>
-          <th style="width:8%">Status</th>
+          <th style="width:5%">Type</th>
+          <th style="width:auto">Subject</th>
+          <th style="width:10%">Status</th>
           <th style="width:10%">Updated</th>
-          <th style="width:18%">Created</th>
+          <th style="width:10%">Created</th>
         </tr>
       </thead>
 
       <tbody>
         <% @tickets.each do |ticket| %>
           <tr data-link="<%= ticket_path(ticket) %>">
-            <td><%= link_to ticket.id, ticket_path(ticket) %></td>
-            <% if CurrentUser.is_moderator? %>
-              <td><%= link_to_user ticket.creator %></td>
+            <% if CurrentUser.is_staff? %>
+              <% if ticket.can_view?(CurrentUser.user) %>
+                <%# Reporter %>
+                <td><%= link_to_user ticket.creator %></td>
+
+                <%# Accused %>
+                <td>
+                  <% if ticket.accused %>
+                    <%= link_to_user ticket.accused %>
+                  <% end %>
+                </td>
+              <% else %>
+                <td><span class="text-muted">Hidden</span></td>
+                <td></td>
+              <% end %>
+
+              <%# Claimed By %>
               <td>
-                <% if ticket.accused %>
-                  <%= link_to_user ticket.accused %>
+                <% if ticket.claimant.nil? %>
+                  <span class="text-error">Unclaimed</span>
+                <% else %>
+                  <%= link_to_user ticket.claimant %>
                 <% end %>
               </td>
-              <td>
-              <% if ticket.claimant.nil? %>
-                <span class="text-error">Unclaimed</span>
-              <% else %>
-                <%= link_to_user ticket.claimant %>
-              <% end %>
+            <% end %>
+
+            <% if ticket.can_view?(CurrentUser.user) %>
+              <%# Type %>
+              <td class="ticket-subject full-width-link">
+                <%= link_to ticket.type_title, ticket_path(ticket) %>
               </td>
-            <% end %>
-            <td><%= link_to ticket.type_title, ticket_path(ticket) %></td>
 
-            <%= tag.td class: "ticket-subject full-width-link", title: truncate(strip_tags(format_text(ticket.reason)), length: 200) do %>
-              <%= link_to truncate(strip_tags(format_text(ticket.subject)), length: 200), ticket_path(ticket.id) %>
+              <%# Subject %>
+              <td class="ticket-subject full-width-link" title="<%= truncate(strip_tags(format_text(ticket.reason)), length: 200) %>">
+                <%= link_to truncate(strip_tags(format_text(ticket.subject)), length: 200), ticket_path(ticket.id) %>
+              </td>
+            <% else %>
+              <td><%= ticket.type_title %></td>
+              <td><span class="text-muted">Hidden</span></td>
             <% end %>
 
+            <%# Status, Timestamps %>
             <td class="<%= ticket.status %>-ticket"><%= pretty_ticket_status(ticket) %></td>
             <td style="cursor:help;"><%= time_ago_in_words_tagged(ticket.updated_at) %></td>
             <td style="cursor:help;"><%= time_ago_in_words_tagged(ticket.created_at) %></td>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -57,16 +57,16 @@
         <% elsif CurrentUser.is_staff? %>
           <tr>
             <td><span class="title">Claimed by</span></td>
-            <% if @ticket.claimant.nil? && @ticket.can_claim? %>
-              <td id="claimed_by"><%= link_to 'Claim', claim_ticket_path(@ticket), method: :post %></td>
-            <% else %>
-              <td id="claimed_by">
-                <%= link_to_user @ticket.claimant %>
-                <% if @ticket.claimant.id == CurrentUser.id %>
-                  <%= link_to "Unclaim", unclaim_ticket_path(@ticket), method: :post %>
+            <td id="claimed_by">
+              <%= link_to_user @ticket.claimant if @ticket.claimant.present? %>
+              <% if @ticket.can_claim?(CurrentUser.user) %>
+                <% if @ticket.claimant.nil? %>
+                  <%= link_to 'Claim', claim_ticket_path(@ticket), method: :post %>
+                <% elsif @ticket.claimant.id == CurrentUser.id %>
+                  | <%= link_to "Unclaim", unclaim_ticket_path(@ticket), method: :post %>
                 <% end %>
-              </td>
-            <% end %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
 
@@ -110,7 +110,7 @@
             <td><span class='title'>Response</span></td>
             <td>
               <div class="dtext-container ticket-block unmargined">
-                <%= format_text(!@ticket.response.blank? ? @ticket.response : "No response.") %>
+                <%= format_text(@ticket.response) %>
               </div>
             </td>
           </tr>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -4,16 +4,16 @@
       <h3><%= @ticket.type_title %> Ticket</h3>
 
       <table>
-        <% if @ticket.can_see_reporter?(CurrentUser) %>
-          <tr>
-            <td><span class='title'>Requested by</span></td>
-            <td>
-              <%= link_to_user @ticket.creator %>
-              (<%= link_to "Pending Tickets", tickets_path(search: { creator_id: @ticket.creator.id, status: "pending" }) %>)
-            </td>
-          </tr>
-        <% end %>
+        <%# Reporter %>
+        <tr>
+          <td><span class='title'>Requested by</span></td>
+          <td>
+            <%= link_to_user @ticket.creator %>
+            (<%= link_to "Pending Tickets", tickets_path(search: { creator_id: @ticket.creator.id, status: "pending" }) %>)
+          </td>
+        </tr>
 
+        <%# IP Address %>
         <% if CurrentUser.is_admin? %>
           <tr>
             <td><span class='title'>IP</span></td>
@@ -21,7 +21,8 @@
           </tr>
         <% end %>
 
-        <% if @ticket.accused.present? && CurrentUser.is_moderator? %>
+        <%# Accused %>
+        <% if @ticket.accused.present? %>
           <tr>
             <td><span class="title">Accused</span></td>
             <td>
@@ -33,6 +34,7 @@
           </tr>
         <% end %>
 
+        <%# Timestamps %>
         <tr>
           <td><span class="title">Created</span></td>
           <td style="cursor:help;"><%= time_ago_in_words_tagged(@ticket.created_at) %></td>
@@ -42,6 +44,7 @@
           <td style="cursor:help;"><%= time_ago_in_words_tagged(@ticket.updated_at) %></td>
         </tr>
 
+        <%# Claimed / Handled %>
         <% if @ticket.response.present? %>
           <tr>
             <td><span class='title'>Handled by</span></td>
@@ -51,22 +54,20 @@
               <td>Unknown</td>
             <% end %>
           </tr>
-          <% else %>
-            <% if CurrentUser.is_moderator? %>
-              <tr>
-                <td><span class="title">Claimed by</span></td>
-                <% if @ticket.claimant.nil? %>
-                  <td id="claimed_by"><%= link_to 'Claim', claim_ticket_path(@ticket), method: :post %></td>
-                <% else %>
-                  <td id="claimed_by">
-                    <%= link_to_user @ticket.claimant %>
-                    <% if @ticket.claimant.id == CurrentUser.id %>
-                      | <%= link_to "Unclaim", unclaim_ticket_path(@ticket), method: :post %>
-                    <% end %>
-                  </td>
+        <% elsif CurrentUser.is_staff? %>
+          <tr>
+            <td><span class="title">Claimed by</span></td>
+            <% if @ticket.claimant.nil? && @ticket.can_claim? %>
+              <td id="claimed_by"><%= link_to 'Claim', claim_ticket_path(@ticket), method: :post %></td>
+            <% else %>
+              <td id="claimed_by">
+                <%= link_to_user @ticket.claimant %>
+                <% if @ticket.claimant.id == CurrentUser.id %>
+                  <%= link_to "Unclaim", unclaim_ticket_path(@ticket), method: :post %>
                 <% end %>
-              </tr>
+              </td>
             <% end %>
+          </tr>
         <% end %>
 
         <tr>
@@ -74,7 +75,7 @@
           <td class="<%= @ticket.status %>-ticket"><%= pretty_ticket_status(@ticket) %></td>
         </tr>
 
-        <% if CurrentUser.is_moderator? %>
+        <% if CurrentUser.is_staff? %>
           <% open_duplicates = @ticket.open_duplicates.to_a %>
           <% if open_duplicates.any? %>
             <tr>
@@ -117,7 +118,7 @@
       </table>
     </div>
 
-    <% if CurrentUser.is_moderator? %>
+    <% if CurrentUser.is_staff? && @ticket.can_handle? %>
       <div class="section">
         <%= custom_form_for(@ticket) do |f| %>
           <%= f.input :status, collection: [["Investigated", "approved"], ["Under Investigation", "partial"]], selected: @ticket.status || "approved" %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -123,7 +123,7 @@
         <%= custom_form_for(@ticket) do |f| %>
           <%= f.input :status, collection: [["Investigated", "approved"], ["Under Investigation", "partial"]], selected: @ticket.status || "approved" %>
           <% if @ticket.warnable? %>
-            <%= f.input :record_type, label: "Mark the #{@ticket.content.model_name.singular.humanize(capitalize: false)} as having recieved", collection: @ticket.content.class.warning_types.to_h { |k, v| ["A #{k}", v] }, include_blank: "Nothing" %>
+            <%= f.input :record_type, label: "Mark the #{@ticket.content.model_name.singular.humanize(capitalize: false)} as having received", collection: @ticket.content.class.warning_types.to_h { |k, v| ["A #{k}", v] }, include_blank: "Nothing" %>
           <% end %>
           <% unless @ticket.pending? %>
             <%= f.input :send_update_dmail, label: "Send update DMail", as: :boolean, hint: "A DMail is always sent if the status is changed" %>

--- a/spec/models/ticket/instance_methods_spec.rb
+++ b/spec/models/ticket/instance_methods_spec.rb
@@ -114,19 +114,19 @@ RSpec.describe Ticket do
   # #type_title
   # -------------------------------------------------------------------------
   describe "#type_title" do
-    it "returns '<Model Name> Complaint' for user tickets" do
+    it "returns '<Model Name>' for user tickets" do
       ticket = create(:ticket)
-      expect(ticket.type_title).to eq("User Complaint")
+      expect(ticket.type_title).to eq("User")
     end
 
-    it "returns 'Post Complaint' for post tickets" do
+    it "returns 'Post' for post tickets" do
       ticket = create(:ticket, :post_type)
-      expect(ticket.type_title).to eq("Post Complaint")
+      expect(ticket.type_title).to eq("Post")
     end
 
-    it "returns 'Wiki Page Complaint' for wiki tickets" do
+    it "returns 'Wiki Page' for wiki tickets" do
       ticket = create(:ticket, :wiki_type)
-      expect(ticket.type_title).to eq("Wiki Page Complaint")
+      expect(ticket.type_title).to eq("Wiki Page")
     end
   end
 

--- a/spec/models/ticket/permissions_spec.rb
+++ b/spec/models/ticket/permissions_spec.rb
@@ -57,6 +57,28 @@ RSpec.describe Ticket do
       it "denies a non-creator member" do
         expect(ticket.can_view?(other)).to be false
       end
+
+      context "when the content no longer exists" do
+        let(:fresh_ticket) { Ticket.find(ticket.id) }
+
+        before { ticket; blip.destroy! }
+
+        it "allows the creator to view" do
+          expect(fresh_ticket.can_view?(creator)).to be true
+        end
+
+        it "allows a janitor to view" do
+          expect(fresh_ticket.can_view?(janitor)).to be true
+        end
+
+        it "allows an admin to view" do
+          expect(fresh_ticket.can_view?(admin)).to be true
+        end
+
+        it "denies a non-creator member" do
+          expect(fresh_ticket.can_view?(other)).to be false
+        end
+      end
     end
   end
 
@@ -97,6 +119,28 @@ RSpec.describe Ticket do
 
       it "denies a non-creator member" do
         expect(ticket.can_view?(other)).to be false
+      end
+
+      context "when the content no longer exists" do
+        let(:fresh_ticket) { Ticket.find(ticket.id) }
+
+        before { ticket; comment.destroy! }
+
+        it "allows the creator to view" do
+          expect(fresh_ticket.can_view?(creator)).to be true
+        end
+
+        it "allows a janitor to view" do
+          expect(fresh_ticket.can_view?(janitor)).to be true
+        end
+
+        it "allows an admin to view" do
+          expect(fresh_ticket.can_view?(admin)).to be true
+        end
+
+        it "denies a non-creator member" do
+          expect(fresh_ticket.can_view?(other)).to be false
+        end
       end
     end
   end
@@ -144,6 +188,32 @@ RSpec.describe Ticket do
       it "denies a non-creator member" do
         expect(ticket.can_view?(other)).to be false
       end
+
+      context "when the content no longer exists" do
+        let(:fresh_ticket) { Ticket.find(ticket.id) }
+
+        before { ticket; dmail.destroy! }
+
+        it "allows the creator to view" do
+          expect(fresh_ticket.can_view?(creator)).to be true
+        end
+
+        it "allows a moderator to view" do
+          expect(fresh_ticket.can_view?(moderator)).to be true
+        end
+
+        it "allows an admin to view" do
+          expect(fresh_ticket.can_view?(admin)).to be true
+        end
+
+        it "denies a non-creator member" do
+          expect(fresh_ticket.can_view?(other)).to be false
+        end
+
+        it "denies a janitor who is not the creator" do
+          expect(fresh_ticket.can_view?(janitor)).to be false
+        end
+      end
     end
   end
 
@@ -178,6 +248,28 @@ RSpec.describe Ticket do
 
       it "denies a non-creator member" do
         expect(ticket.can_view?(other)).to be false
+      end
+
+      context "when the content no longer exists" do
+        let(:fresh_ticket) { Ticket.find(ticket.id) }
+
+        before { ticket; ticket.content.destroy! }
+
+        it "allows the creator to view" do
+          expect(fresh_ticket.can_view?(creator)).to be true
+        end
+
+        it "allows a janitor to view" do
+          expect(fresh_ticket.can_view?(janitor)).to be true
+        end
+
+        it "allows an admin to view" do
+          expect(fresh_ticket.can_view?(admin)).to be true
+        end
+
+        it "denies a non-creator member" do
+          expect(fresh_ticket.can_view?(other)).to be false
+        end
       end
     end
   end
@@ -299,6 +391,28 @@ RSpec.describe Ticket do
       it "denies a non-creator member" do
         expect(ticket.can_view?(other)).to be false
       end
+
+      context "when the content no longer exists" do
+        let(:fresh_ticket) { Ticket.find(ticket.id) }
+
+        before { ticket; public_set.destroy! }
+
+        it "allows the creator to view" do
+          expect(fresh_ticket.can_view?(creator)).to be true
+        end
+
+        it "allows a janitor to view" do
+          expect(fresh_ticket.can_view?(janitor)).to be true
+        end
+
+        it "allows an admin to view" do
+          expect(fresh_ticket.can_view?(admin)).to be true
+        end
+
+        it "denies a non-creator member" do
+          expect(fresh_ticket.can_view?(other)).to be false
+        end
+      end
     end
   end
 
@@ -409,33 +523,29 @@ RSpec.describe Ticket do
       it "denies a non-creator member" do
         expect(ticket.can_view?(other)).to be false
       end
+
+      context "when the content no longer exists" do
+        let(:fresh_ticket) { Ticket.find(ticket.id) }
+
+        before { ticket; ticket.content.destroy! }
+
+        it "allows the creator to view" do
+          expect(fresh_ticket.can_view?(creator)).to be true
+        end
+
+        it "allows a janitor to view" do
+          expect(fresh_ticket.can_view?(janitor)).to be true
+        end
+
+        it "allows an admin to view" do
+          expect(fresh_ticket.can_view?(admin)).to be true
+        end
+
+        it "denies a non-creator member" do
+          expect(fresh_ticket.can_view?(other)).to be false
+        end
+      end
     end
   end
 
-  # -------------------------------------------------------------------------
-  # #can_see_reporter?
-  # -------------------------------------------------------------------------
-  describe "#can_see_reporter?" do
-    let(:ticket) { create(:ticket) }
-
-    it "returns true for the creator" do
-      expect(ticket.can_see_reporter?(creator)).to be true
-    end
-
-    it "returns true for a moderator" do
-      expect(ticket.can_see_reporter?(moderator)).to be true
-    end
-
-    it "returns true for an admin (level >= moderator)" do
-      expect(ticket.can_see_reporter?(admin)).to be true
-    end
-
-    it "returns false for a non-creator member" do
-      expect(ticket.can_see_reporter?(other)).to be false
-    end
-
-    it "returns false for a janitor who is not the creator" do
-      expect(ticket.can_see_reporter?(janitor)).to be false
-    end
-  end
 end

--- a/spec/models/ticket/permissions_spec.rb
+++ b/spec/models/ticket/permissions_spec.rb
@@ -61,7 +61,10 @@ RSpec.describe Ticket do
       context "when the content no longer exists" do
         let(:fresh_ticket) { Ticket.find(ticket.id) }
 
-        before { ticket; blip.destroy! }
+        before do
+          ticket
+          blip.destroy!
+        end
 
         it "allows the creator to view" do
           expect(fresh_ticket.can_view?(creator)).to be true
@@ -124,7 +127,10 @@ RSpec.describe Ticket do
       context "when the content no longer exists" do
         let(:fresh_ticket) { Ticket.find(ticket.id) }
 
-        before { ticket; comment.destroy! }
+        before do
+          ticket
+          comment.destroy!
+        end
 
         it "allows the creator to view" do
           expect(fresh_ticket.can_view?(creator)).to be true
@@ -192,7 +198,10 @@ RSpec.describe Ticket do
       context "when the content no longer exists" do
         let(:fresh_ticket) { Ticket.find(ticket.id) }
 
-        before { ticket; dmail.destroy! }
+        before do
+          ticket
+          dmail.destroy!
+        end
 
         it "allows the creator to view" do
           expect(fresh_ticket.can_view?(creator)).to be true
@@ -253,7 +262,10 @@ RSpec.describe Ticket do
       context "when the content no longer exists" do
         let(:fresh_ticket) { Ticket.find(ticket.id) }
 
-        before { ticket; ticket.content.destroy! }
+        before do
+          ticket
+          ticket.content.destroy!
+        end
 
         it "allows the creator to view" do
           expect(fresh_ticket.can_view?(creator)).to be true
@@ -395,7 +407,10 @@ RSpec.describe Ticket do
       context "when the content no longer exists" do
         let(:fresh_ticket) { Ticket.find(ticket.id) }
 
-        before { ticket; public_set.destroy! }
+        before do
+          ticket
+          public_set.destroy!
+        end
 
         it "allows the creator to view" do
           expect(fresh_ticket.can_view?(creator)).to be true
@@ -527,7 +542,10 @@ RSpec.describe Ticket do
       context "when the content no longer exists" do
         let(:fresh_ticket) { Ticket.find(ticket.id) }
 
-        before { ticket; ticket.content.destroy! }
+        before do
+          ticket
+          ticket.content.destroy!
+        end
 
         it "allows the creator to view" do
           expect(fresh_ticket.can_view?(creator)).to be true
@@ -547,5 +565,4 @@ RSpec.describe Ticket do
       end
     end
   end
-
 end

--- a/spec/requests/tickets_controller_spec.rb
+++ b/spec/requests/tickets_controller_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe TicketsController do
   end
 
   # ---------------------------------------------------------------------------
-  # PATCH /tickets/:id — update (moderator_only)
+  # PATCH /tickets/:id — update (janitor_only gate; moderator effective)
   # ---------------------------------------------------------------------------
 
   describe "PATCH /tickets/:id" do
@@ -163,6 +163,12 @@ RSpec.describe TicketsController do
 
     it "returns 403 for a member" do
       sign_in_as member
+      patch ticket_path(ticket), params: update_params
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for a janitor" do
+      sign_in_as janitor
       patch ticket_path(ticket), params: update_params
       expect(response).to have_http_status(:forbidden)
     end
@@ -208,7 +214,7 @@ RSpec.describe TicketsController do
   end
 
   # ---------------------------------------------------------------------------
-  # POST /tickets/:id/claim — claim (moderator_only)
+  # POST /tickets/:id/claim — claim (janitor_only gate; moderator effective)
   # ---------------------------------------------------------------------------
 
   describe "POST /tickets/:id/claim" do
@@ -219,6 +225,12 @@ RSpec.describe TicketsController do
 
     it "returns 403 for a member" do
       sign_in_as member
+      post claim_ticket_path(ticket)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for a janitor" do
+      sign_in_as janitor
       post claim_ticket_path(ticket)
       expect(response).to have_http_status(:forbidden)
     end
@@ -244,7 +256,7 @@ RSpec.describe TicketsController do
   end
 
   # ---------------------------------------------------------------------------
-  # POST /tickets/:id/unclaim — unclaim (moderator_only)
+  # POST /tickets/:id/unclaim — unclaim (janitor_only gate; moderator effective)
   # ---------------------------------------------------------------------------
 
   describe "POST /tickets/:id/unclaim" do
@@ -255,6 +267,12 @@ RSpec.describe TicketsController do
 
     it "returns 403 for a member" do
       sign_in_as member
+      post unclaim_ticket_path(ticket)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for a janitor" do
+      sign_in_as janitor
       post unclaim_ticket_path(ticket)
       expect(response).to have_http_status(:forbidden)
     end


### PR DESCRIPTION
Cleaned up ticket-related permissions.

Creators should always have access to their own tickets.
Generally speaking, staff members should have access to tickets that they can see.
This includes content that no longer exists (destroyed).

Janitors should have access to all ticket types, except DMail and User tickets.
Moderators should have access to everything.
Admins have a visibility bypass, just in case.

|    Type    |      Can Create     |  Min. View Level  | View Content Check |
|:----------:|:-------------------:|:-----------------:|:------------------:|
|    Blip    |      Accessible     |     Janitor+      |     Accessible     |
|   Comment  |      Accessible     |     Janitor+      |     Accessible     |
|    Dmail   | Visible & Recipient |    Moderator+     |      Visible       |
| Forum Post |       Visible       |     Janitor+      |      Visible       |
|    Pool    |         Any         |     Janitor+      |        -           |
|    Post    |         Any         |     Janitor+      |        -           |
|  Post Set  |       Visible       |     Janitor+      |      Visible       |
|    User    |         Any         |    Moderator+     |        -           |
|  Wiki Page |         Any         |     Janitor+      |        -           |
|    Other   |         None        |    Moderator+     |        -           |
|Replacement |       Visible       |     Janitor+      |      Visible       |

Also added provisions to let janitors claim, unclaim, and handle some tickets.
That does not have a purpose yet. Only moderators+ can handle things right now.