### PR TITLE
[ForumTopics] Rework forum visibility methods

### DIFF
--- a/app/controllers/forum_post_votes_controller.rb
+++ b/app/controllers/forum_post_votes_controller.rb
@@ -4,9 +4,10 @@ class ForumPostVotesController < ApplicationController
   respond_to :json
   before_action :member_only
   before_action :load_forum_post
-  before_action :validate_forum_post
-  before_action :validate_no_vote_on_own_post, only: [:create]
   before_action :load_vote, only: [:destroy]
+
+  before_action :ensure_can_vote
+  before_action :ensure_no_vote_on_own_post, only: [:create]
   before_action :ensure_lockdown_disabled
 
   def create
@@ -35,17 +36,21 @@ class ForumPostVotesController < ApplicationController
     @forum_post = ForumPost.find(params[:forum_post_id])
   end
 
-  def validate_forum_post
-    raise User::PrivilegeError unless @forum_post.can_access?
+  def forum_post_vote_params
+    params.fetch(:forum_post_vote, {}).permit(:score)
+  end
+
+  #############################
+  ###     Access checks     ###
+  #############################
+
+  def ensure_can_vote
+    raise User::PrivilegeError unless @forum_post.can_vote?
     raise User::PrivilegeError unless @forum_post.votable?
   end
 
-  def validate_no_vote_on_own_post
+  def ensure_no_vote_on_own_post
     raise User::PrivilegeError, "You cannot vote on your own requests" if @forum_post.creator == CurrentUser.user
-  end
-
-  def forum_post_vote_params
-    params.fetch(:forum_post_vote, {}).permit(:score)
   end
 
   def ensure_lockdown_disabled

--- a/app/controllers/forum_post_votes_controller.rb
+++ b/app/controllers/forum_post_votes_controller.rb
@@ -36,7 +36,7 @@ class ForumPostVotesController < ApplicationController
   end
 
   def validate_forum_post
-    raise User::PrivilegeError unless @forum_post.visible?(CurrentUser.user)
+    raise User::PrivilegeError unless @forum_post.can_access?
     raise User::PrivilegeError unless @forum_post.votable?
   end
 

--- a/app/controllers/forum_post_votes_controller.rb
+++ b/app/controllers/forum_post_votes_controller.rb
@@ -54,6 +54,6 @@ class ForumPostVotesController < ApplicationController
   end
 
   def ensure_lockdown_disabled
-    render_expected_error(403, "Votes are disabled") if Security::Lockdown.votes_disabled? && !CurrentUser.is_staff?
+    render_expected_error(403, "Votes are disabled") if Security::Lockdown.votes_disabled? && !CurrentUser.user.is_staff?
   end
 end

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -95,8 +95,8 @@ class ForumPostsController < ApplicationController
 
   def check_min_level
     raise User::PrivilegeError unless @forum_topic.visible?(CurrentUser.user)
-    raise User::PrivilegeError if @forum_topic.is_hidden? && !@forum_topic.can_hide?(CurrentUser.user)
-    raise User::PrivilegeError if @forum_post.is_hidden? && !@forum_post.can_hide?(CurrentUser.user)
+    raise User::PrivilegeError if @forum_topic.is_hidden? && !@forum_topic.visible?(CurrentUser.user)
+    raise User::PrivilegeError if @forum_post.is_hidden? && !@forum_post.visible?(CurrentUser.user)
   end
 
   def check_editable(forum_post)

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -5,7 +5,7 @@ class ForumPostsController < ApplicationController
   before_action :member_only, except: %i[index show search]
   before_action :load_post, only: %i[edit show update destroy hide unhide warning]
 
-  before_action :ensure_can_access, only: %i[edit show update destroy hide unhide]
+  before_action :ensure_can_access, only: %i[edit show update destroy hide unhide warning]
   before_action :ensure_can_edit, only: %i[edit update]
   before_action :ensure_can_hide, only: %i[hide]
   before_action :ensure_can_unhide, only: %i[unhide]

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -6,8 +6,15 @@ class ForumPostsController < ApplicationController
   before_action :moderator_only, only: %i[unhide warning]
   before_action :admin_only, only: [:destroy]
   before_action :load_post, only: %i[edit show update destroy hide unhide warning]
-  before_action :check_min_level, only: %i[edit show update destroy hide unhide]
+
+  before_action :ensure_can_access, only: %i[edit show update destroy hide unhide]
+  before_action :ensure_can_edit, only: %i[edit update]
+  before_action :ensure_can_hide, only: %i[hide]
+  before_action :ensure_can_unhide, only: %i[unhide]
+  before_action :ensure_can_warn, only: %i[warning]
+  before_action :ensure_can_destroy, only: %i[destroy]
   before_action :ensure_lockdown_disabled, except: %i[index show search]
+
   skip_before_action :api_check
 
   def index
@@ -32,7 +39,6 @@ class ForumPostsController < ApplicationController
   end
 
   def edit
-    check_editable(@forum_post)
     respond_with(@forum_post)
   end
 
@@ -42,8 +48,7 @@ class ForumPostsController < ApplicationController
   def create
     @forum_post = ForumPost.new(forum_post_params(:create))
     if @forum_post.valid?
-      @forum_topic = @forum_post.topic
-      check_min_level
+      ensure_can_access
       @forum_post.save
       respond_with(@forum_post, location: forum_topic_path(@forum_post.topic, page: @forum_post.forum_topic_page, anchor: "forum_post_#{@forum_post.id}"))
     else
@@ -52,25 +57,21 @@ class ForumPostsController < ApplicationController
   end
 
   def update
-    check_editable(@forum_post)
     @forum_post.update(forum_post_params(:update))
     respond_with(@forum_post, location: forum_topic_path(@forum_post.topic, page: @forum_post.forum_topic_page, anchor: "forum_post_#{@forum_post.id}"))
   end
 
   def destroy
-    check_editable(@forum_post)
     @forum_post.destroy
     respond_with(@forum_post)
   end
 
   def hide
-    check_hidable(@forum_post)
     @forum_post.hide!
     respond_with(@forum_post)
   end
 
   def unhide
-    check_hidable(@forum_post)
     @forum_post.unhide!
     respond_with(@forum_post)
   end
@@ -81,7 +82,8 @@ class ForumPostsController < ApplicationController
     else
       @forum_post.user_warned!(params[:record_type], CurrentUser.user)
     end
-    html = render_to_string partial: "forum_posts/forum_post", locals: { forum_post: @forum_post, original_forum_post_id: @forum_post.topic.original_post.id }, formats: [:html]
+    @forum_topic = @forum_post.topic
+    html = render_to_string partial: "forum_posts/forum_post", locals: { forum_post: @forum_post, original_forum_post_id: @forum_topic.original_post.id }, formats: [:html]
     render json: { html: html, posts: deferred_posts }
   end
 
@@ -89,21 +91,7 @@ class ForumPostsController < ApplicationController
 
   def load_post
     @forum_post = ForumPost.includes(topic: [:category]).find(params[:id])
-    @forum_topic = @forum_post.topic
-    raise ActiveRecord::RecordNotFound, "Forum post has no associated topic" if @forum_topic.nil?
-  end
-
-  def check_min_level
-    raise User::PrivilegeError unless @forum_topic.visible?(CurrentUser.user)
-    raise User::PrivilegeError if @forum_post.is_hidden? && !@forum_post.visible?(CurrentUser.user)
-  end
-
-  def check_editable(forum_post)
-    raise User::PrivilegeError unless forum_post.editable_by?(CurrentUser.user)
-  end
-
-  def check_hidable(forum_post)
-    raise User::PrivilegeError unless forum_post.can_hide?(CurrentUser.user)
+    raise ActiveRecord::RecordNotFound, "Forum post has no associated topic" if @forum_post.topic.nil?
   end
 
   def forum_post_params(context)
@@ -113,7 +101,35 @@ class ForumPostsController < ApplicationController
     params.fetch(:forum_post, {}).permit(permitted_params)
   end
 
+  #############################
+  ###     Access checks     ###
+  #############################
+
+  def ensure_can_access
+    raise User::PrivilegeError unless @forum_post.can_access?
+  end
+
+  def ensure_can_edit
+    raise User::PrivilegeError unless @forum_post.can_edit?
+  end
+
+  def ensure_can_hide
+    raise User::PrivilegeError unless @forum_post.can_hide?
+  end
+
+  def ensure_can_unhide
+    raise User::PrivilegeError unless @forum_post.can_unhide?
+  end
+
+  def ensure_can_warn
+    raise User::PrivilegeError unless @forum_post.can_warn?
+  end
+
+  def ensure_can_destroy
+    raise User::PrivilegeError unless @forum_post.can_destroy?
+  end
+
   def ensure_lockdown_disabled
-    access_denied if Security::Lockdown.forums_disabled? && !CurrentUser.is_staff?
+    access_denied if Security::Lockdown.forums_disabled? && !CurrentUser.user.is_staff?
   end
 end

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -3,8 +3,6 @@
 class ForumPostsController < ApplicationController
   respond_to :html, :json
   before_action :member_only, except: %i[index show search]
-  before_action :moderator_only, only: %i[unhide warning]
-  before_action :admin_only, only: [:destroy]
   before_action :load_post, only: %i[edit show update destroy hide unhide warning]
 
   before_action :ensure_can_access, only: %i[edit show update destroy hide unhide]
@@ -48,7 +46,6 @@ class ForumPostsController < ApplicationController
   def create
     @forum_post = ForumPost.new(forum_post_params(:create))
     if @forum_post.valid?
-      ensure_can_access
       @forum_post.save
       respond_with(@forum_post, location: forum_topic_path(@forum_post.topic, page: @forum_post.forum_topic_page, anchor: "forum_post_#{@forum_post.id}"))
     else

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -95,7 +95,6 @@ class ForumPostsController < ApplicationController
 
   def check_min_level
     raise User::PrivilegeError unless @forum_topic.visible?(CurrentUser.user)
-    raise User::PrivilegeError if @forum_topic.is_hidden? && !@forum_topic.visible?(CurrentUser.user)
     raise User::PrivilegeError if @forum_post.is_hidden? && !@forum_post.visible?(CurrentUser.user)
   end
 

--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -3,12 +3,16 @@
 class ForumTopicsController < ApplicationController
   respond_to :html, :json
   before_action :member_only, except: %i[index show]
-  before_action :moderator_only, only: [:unhide]
-  before_action :admin_only, only: [:destroy]
   before_action :normalize_search_params, only: [:index]
   before_action :load_topic, only: %i[edit show update destroy hide unhide subscribe unsubscribe]
-  before_action :check_min_level, only: %i[show edit update destroy hide unhide subscribe unsubscribe]
+
+  before_action :ensure_can_access, only: %i[show edit update destroy hide unhide subscribe unsubscribe]
+  before_action :ensure_can_edit, only: %i[edit update]
+  before_action :ensure_can_hide, only: %i[hide]
+  before_action :ensure_can_unhide, only: %i[unhide]
+  before_action :ensure_can_destroy, only: %i[destroy]
   before_action :ensure_lockdown_disabled, except: %i[index show]
+
   skip_before_action :api_check
 
   def index
@@ -56,7 +60,6 @@ class ForumTopicsController < ApplicationController
   end
 
   def edit
-    check_privilege(@forum_topic)
     respond_with(@forum_topic)
   end
 
@@ -66,14 +69,12 @@ class ForumTopicsController < ApplicationController
   end
 
   def update
-    check_privilege(@forum_topic)
     @forum_topic.assign_attributes(forum_topic_params)
     @forum_topic.save
     respond_with(@forum_topic)
   end
 
   def destroy
-    check_privilege(@forum_topic)
     @forum_topic.destroy
     if @forum_topic.errors.none?
       flash[:notice] = "Topic destroyed"
@@ -84,7 +85,6 @@ class ForumTopicsController < ApplicationController
   end
 
   def hide
-    check_privilege(@forum_topic)
     @forum_topic.hide!
     @forum_topic.create_mod_action_for_hide
     flash[:notice] = "Topic hidden"
@@ -92,7 +92,6 @@ class ForumTopicsController < ApplicationController
   end
 
   def unhide
-    check_privilege(@forum_topic)
     @forum_topic.unhide!
     @forum_topic.create_mod_action_for_unhide
     flash[:notice] = "Topic unhidden"
@@ -140,20 +139,6 @@ class ForumTopicsController < ApplicationController
     end
   end
 
-  def check_privilege(forum_topic)
-    unless forum_topic.editable_by?(CurrentUser.user)
-      raise User::PrivilegeError
-    end
-  end
-
-  def load_topic
-    @forum_topic = ForumTopic.includes(:category).find(params[:id])
-  end
-
-  def check_min_level
-    raise User::PrivilegeError unless @forum_topic.visible?(CurrentUser.user)
-  end
-
   def forum_topic_params
     permitted_params = [:title, :category_id, { original_post_attributes: %i[id body] }]
     permitted_params += %i[is_sticky is_locked] if CurrentUser.is_moderator?
@@ -161,7 +146,35 @@ class ForumTopicsController < ApplicationController
     params.fetch(:forum_topic, {}).permit(permitted_params)
   end
 
+  def load_topic
+    @forum_topic = ForumTopic.includes(:category).find(params[:id])
+  end
+
+  #############################
+  ###     Access checks     ###
+  #############################
+
+  def ensure_can_access
+    raise User::PrivilegeError unless @forum_topic.can_access?
+  end
+
+  def ensure_can_edit
+    raise User::PrivilegeError unless @forum_topic.can_edit?
+  end
+
+  def ensure_can_hide
+    raise User::PrivilegeError unless @forum_topic.can_hide?
+  end
+
+  def ensure_can_unhide
+    raise User::PrivilegeError unless @forum_topic.can_unhide?
+  end
+
+  def ensure_can_destroy
+    raise User::PrivilegeError unless @forum_topic.can_destroy?
+  end
+
   def ensure_lockdown_disabled
-    access_denied if Security::Lockdown.forums_disabled? && !CurrentUser.is_staff?
+    access_denied if Security::Lockdown.forums_disabled? && !CurrentUser.user.is_staff?
   end
 end

--- a/app/models/forum_category.rb
+++ b/app/models/forum_category.rb
@@ -12,10 +12,6 @@ class ForumCategory < ApplicationRecord
     ForumTopic.where(category: id).update_all(category_id: ForumCategory.order(:id).first.id)
   end
 
-  def can_create_within?(user = CurrentUser.user)
-    user.level >= can_create
-  end
-
   def self.reverse_mapping
     order(:cat_order).all.map { |rec| [rec.name, rec.id] }
   end
@@ -25,6 +21,25 @@ class ForumCategory < ApplicationRecord
   end
 
   def self.visible(user = CurrentUser.user)
-    where('can_view <= ?', user.level)
+    where("can_view <= ?", user.level)
   end
+
+  module AccessMethods
+    def can_access?(user = CurrentUser.user)
+      return false if user.blank?
+      user.level >= can_view
+    end
+
+    def can_create?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      user.level >= can_create
+    end
+
+    def can_reply?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      user.level >= can_reply
+    end
+  end
+
+  include AccessMethods
 end

--- a/app/models/forum_category.rb
+++ b/app/models/forum_category.rb
@@ -25,10 +25,14 @@ class ForumCategory < ApplicationRecord
   end
 
   module AccessMethods
+    ### Standard Permissions ###
+
     def can_access?(user = CurrentUser.user)
       return false if user.blank?
       user.level >= can_view
     end
+
+    ### Model Specific ###
 
     def can_create?(user = CurrentUser.user)
       return false unless can_access?(user)

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -54,12 +54,12 @@ class ForumPost < ApplicationRecord
 
     def permitted(user)
       q = joins(topic: :category).where("forum_categories.can_view <= ?", user.level)
-      q = q.joins(:topic).where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id) unless user.is_moderator?
+      q = q.joins(:topic).where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id) unless user.is_staff?
       q
     end
 
     def active(user)
-      return all if user.is_moderator?
+      return all if user.is_staff?
       where("forum_posts.is_hidden = FALSE OR forum_posts.creator_id = ?", user.id)
     end
 
@@ -157,7 +157,7 @@ class ForumPost < ApplicationRecord
   end
 
   def visible?(user)
-    return true if user.is_moderator?
+    return true if user.is_staff?
     return false unless topic&.visible?(user)
     return true if user.id == creator_id
     return false if is_hidden?

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -81,7 +81,10 @@ class ForumPost < ApplicationRecord
     end
 
     def can_vote?(user = CurrentUser.user)
+      # Note that this does not check whether there is a valid votable request here.
+      # Due to the explosive nature of queries involved, that check is done separately.
       return false unless can_access?(user)
+      return false unless user.is_member?
       true
     end
 

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -57,6 +57,7 @@ class ForumPost < ApplicationRecord
       return false unless can_access?(user)
       return true if user.is_admin?
       return false if was_warned?
+      return false if topic.is_locked? && !topic.can_lock?(user)
       return true if creator_id == user.id
       false
     end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -158,7 +158,7 @@ class ForumPost < ApplicationRecord
     end
 
     def validate_topic_can_reply
-      return true if topic&.can_reply?(creator)
+      return true if topic&.can_reply?(new_record? ? creator : (updater || creator))
 
       errors.add(:topic, "does not allow replies")
       false

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -42,6 +42,8 @@ class ForumPost < ApplicationRecord
   attr_accessor :bypass_limits
 
   module AccessMethods
+    ### Standard Permissions ###
+
     def can_access?(user = CurrentUser.user)
       return false if user.blank?
       return false unless topic&.can_access?(user)
@@ -74,23 +76,28 @@ class ForumPost < ApplicationRecord
       false
     end
 
+    def can_destroy?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_admin?
+      false
+    end
+
+    ### Warnable ###
+
     def can_warn?(user = CurrentUser.user)
       return false unless can_access?(user)
       return true if user.is_moderator?
       false
     end
 
+    ### Model Specific ###
+
     def can_vote?(user = CurrentUser.user)
-      # Note that this does not check whether there is a valid votable request here.
-      # Due to the explosive nature of queries involved, that check is done separately.
       return false unless can_access?(user)
       return false unless user.is_member?
+      # Note that this does not check whether there is a valid votable request here.
+      # Due to the explosive nature of queries involved, that check is done separately.
       true
-    end
-
-    def can_destroy?(user = CurrentUser.user)
-      return true if user.is_admin?
-      false
     end
   end
 

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -19,13 +19,13 @@ class ForumPost < ApplicationRecord
   after_destroy :update_topic_updated_at_on_destroy
   normalizes :body, with: ->(body) { body.gsub("\r\n", "\n") }
 
-  validates :body, :creator_id, presence: true
+  validates :body, presence: true
   validates :body, length: { minimum: 1, maximum: Danbooru.config.forum_post_max_size }
   validates :creator_id, presence: true
 
   validate :validate_topic_is_valid
   validate :validate_topic_can_access, on: :create
-  validate :validate_topic_can_reply
+  validate :validate_topic_can_reply, if: -> { will_save_change_to_body? }
   validate :validate_creator_is_not_limited, on: :create
 
   after_save :delete_topic_if_original_post
@@ -106,7 +106,7 @@ class ForumPost < ApplicationRecord
 
     def permitted(user)
       q = joins(topic: :category).where("forum_categories.can_view <= ?", user.level)
-      q = q.joins(:topic).where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id) unless user.is_staff?
+      q = q.where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id) unless user.is_staff?
       q
     end
 

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -16,16 +16,18 @@ class ForumPost < ApplicationRecord
   before_validation :initialize_is_hidden, on: :create
   before_save :readd_tag_change_request_label, if: :will_save_change_to_body?
   after_create :update_topic_updated_at_on_create
-  before_destroy :validate_topic_is_unlocked
   after_destroy :update_topic_updated_at_on_destroy
   normalizes :body, with: ->(body) { body.gsub("\r\n", "\n") }
+
   validates :body, :creator_id, presence: true
   validates :body, length: { minimum: 1, maximum: Danbooru.config.forum_post_max_size }
-  validate :validate_topic_is_unlocked
-  validate :topic_id_not_invalid
-  validate :topic_is_not_restricted, on: :create
-  validate :category_allows_replies, on: :create
+  validates :creator_id, presence: true
+
+  validate :validate_topic_is_valid
+  validate :validate_topic_can_access, on: :create
+  validate :validate_topic_can_reply
   validate :validate_creator_is_not_limited, on: :create
+
   after_save :delete_topic_if_original_post
   after_update(if: ->(rec) { !rec.saved_change_to_is_hidden? && rec.updater_id != rec.creator_id }) do |rec|
     ModAction.log(:forum_post_update, { forum_post_id: rec.id, forum_topic_id: rec.topic_id, user_id: rec.creator_id })
@@ -38,6 +40,56 @@ class ForumPost < ApplicationRecord
   end
 
   attr_accessor :bypass_limits
+
+  module AccessMethods
+    def can_access?(user = CurrentUser.user)
+      return false if user.blank?
+      return false unless topic&.can_access?(user)
+      return true if user.is_staff?
+      return true if user.id == creator_id
+      return false if is_hidden?
+      true
+    end
+
+    def can_edit?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_admin?
+      return false if was_warned?
+      return true if creator_id == user.id
+      false
+    end
+
+    def can_hide?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      return false if was_warned?
+      return false if votable?
+      return true if user.id == creator_id
+      false
+    end
+
+    def can_unhide?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      false
+    end
+
+    def can_warn?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      false
+    end
+
+    def can_vote?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      true
+    end
+
+    def can_destroy?(user = CurrentUser.user)
+      return true if user.is_admin?
+      false
+    end
+  end
 
   module SearchMethods
     def topic_title_matches(title)
@@ -87,7 +139,43 @@ class ForumPost < ApplicationRecord
     end
   end
 
+  module ValidationMethods
+    def validate_topic_is_valid
+      return true unless topic_id.present? && topic.blank?
+
+      errors.add(:base, "Topic ID is invalid")
+      false
+    end
+
+    def validate_topic_can_access
+      return true if topic&.can_access?(creator)
+
+      errors.add(:topic, "is restricted")
+      false
+    end
+
+    def validate_topic_can_reply
+      return true if topic&.can_reply?(creator)
+
+      errors.add(:topic, "does not allow replies")
+      false
+    end
+
+    def validate_creator_is_not_limited
+      return true if bypass_limits
+
+      allowed = creator.can_forum_post_with_reason
+      if allowed != true
+        errors.add(:creator, User.throttle_reason(allowed))
+        return false
+      end
+      true
+    end
+  end
+
   extend SearchMethods
+  include AccessMethods
+  include ValidationMethods
 
   def tag_change_request
     bulk_update_request || tag_alias || tag_implication
@@ -106,73 +194,6 @@ class ForumPost < ApplicationRecord
     TagAlias.where(forum_post_id: id).exists? ||
       TagImplication.where(forum_post_id: id).exists? ||
       BulkUpdateRequest.where(forum_post_id: id).exists?
-  end
-
-  def validate_topic_is_unlocked
-    return if CurrentUser.is_moderator?
-    return if topic.nil?
-
-    if topic.is_locked?
-      errors.add(:topic, "is locked")
-      throw :abort
-    end
-  end
-
-  def validate_creator_is_not_limited
-    return true if bypass_limits
-
-    allowed = creator.can_forum_post_with_reason
-    if allowed != true
-      errors.add(:creator, User.throttle_reason(allowed))
-      return false
-    end
-    true
-  end
-
-  def topic_id_not_invalid
-    if topic_id && !topic
-      errors.add(:base, "Topic ID is invalid")
-      return false
-    end
-  end
-
-  def topic_is_not_restricted
-    if topic && !topic.visible?(creator)
-      errors.add(:topic, "is restricted")
-      return false
-    end
-  end
-
-  def category_allows_replies
-    if topic && !topic.can_reply?(creator)
-      errors.add(:topic, "does not allow replies")
-      return false
-    end
-  end
-
-  def editable_by?(user)
-    return true if user.is_admin?
-    return false if was_warned?
-    creator_id == user.id && visible?(user)
-  end
-
-  def visible?(user)
-    return true if user.is_staff?
-    return false unless topic&.visible?(user)
-    return true if user.id == creator_id
-    return false if is_hidden?
-    true
-  end
-
-  def can_hide?(user)
-    return true if user.is_moderator?
-    return false if was_warned?
-    return false if votable?
-    user.id == creator_id
-  end
-
-  def can_delete?(user)
-    user.is_admin?
   end
 
   def update_topic_updated_at_on_create

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -144,7 +144,7 @@ class ForumTopic < ApplicationRecord
   end
 
   def visible?(user)
-    return false if is_hidden && !can_hide?(user)
+    return false if is_hidden && !can_hide?(user) && !user.is_staff?
     user.level >= category.can_view
   end
 

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -28,6 +28,8 @@ class ForumTopic < ApplicationRecord
   end
 
   module AccessMethods
+    ### Standard Permissions ###
+
     def can_access?(user = CurrentUser.user)
       return false if user.blank?
       return false unless category&.can_access?(user)
@@ -41,13 +43,6 @@ class ForumTopic < ApplicationRecord
       return false unless can_access?(user)
       return true if user.is_moderator?
       return true if creator_id == user.id
-      false
-    end
-
-    def can_reply?(user = CurrentUser.user)
-      return false unless can_access?(user)
-      return false if is_locked && !can_lock?(user)
-      return true if category.can_reply?(user)
       false
     end
 
@@ -65,6 +60,20 @@ class ForumTopic < ApplicationRecord
       false
     end
 
+    def can_destroy?(user = CurrentUser.user)
+      return true if user.is_admin?
+      false
+    end
+
+    ### Model Specific ###
+
+    def can_reply?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return false if is_locked && !can_lock?(user)
+      return true if category.can_reply?(user)
+      false
+    end
+
     def can_sticky?(user = CurrentUser.user)
       return false unless can_access?(user)
       return true if user.is_moderator?
@@ -74,11 +83,6 @@ class ForumTopic < ApplicationRecord
     def can_lock?(user = CurrentUser.user)
       return false unless can_access?(user)
       return true if user.is_moderator?
-      false
-    end
-
-    def can_destroy?(user = CurrentUser.user)
-      return true if user.is_admin?
       false
     end
   end

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -55,7 +55,7 @@ class ForumTopic < ApplicationRecord
   module SearchMethods
     def visible(user)
       q = joins(:category).where("forum_categories.can_view <= ?", user.level)
-      q = q.where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id) unless user.is_moderator?
+      q = q.where("forum_topics.is_hidden = FALSE OR forum_topics.creator_id = ?", user.id) unless user.is_staff?
       q
     end
 

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -35,7 +35,7 @@ class ForumTopic < ApplicationRecord
       return false unless category&.can_access?(user)
       return true if user.is_staff?
       return true if user.id == creator_id
-      return false if is_hidden
+      return false if is_hidden?
       true
     end
 
@@ -61,6 +61,7 @@ class ForumTopic < ApplicationRecord
     end
 
     def can_destroy?(user = CurrentUser.user)
+      return false unless can_access?(user)
       return true if user.is_admin?
       false
     end
@@ -152,13 +153,13 @@ class ForumTopic < ApplicationRecord
     end
   end
 
-  def validate_category
-    return true if category.present?
-    errors.add(:category, "is invalid")
-    throw :abort
-  end
-
   module ValidationMethods
+    def validate_category
+      return true if category.present?
+      errors.add(:category, "is invalid")
+      throw :abort
+    end
+
     def validate_category_allows_creation
       return true if category.blank?
       return true if category.can_create?(creator)

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -7,16 +7,19 @@ class ForumTopic < ApplicationRecord
   has_many :posts, -> {order("forum_posts.id asc")}, :class_name => "ForumPost", :foreign_key => "topic_id", :dependent => :destroy
   has_one :original_post, -> {order("forum_posts.id asc")}, class_name: "ForumPost", foreign_key: "topic_id", inverse_of: :topic
   has_many :subscriptions, :class_name => "ForumSubscription"
-  before_validation :initialize_is_hidden, :on => :create
-  validate :category_valid
-  validates :title, :creator_id, presence: true
+
+  before_validation :initialize_is_hidden, on: :create
+  validates :creator_id, presence: true
+  validate :validate_category
+  validate :validate_category_allows_creation, on: :create
+  validates :original_post, presence: true
   validates_associated :original_post
-  validates_presence_of :original_post
-  validates :title, :length => {:maximum => 250}
-  validate :category_allows_creation, on: :create
+  validates :title, presence: true
+  validates :title, length: { maximum: 250 }
+
   accepts_nested_attributes_for :original_post
-  before_destroy :create_mod_action_for_delete
   after_update :update_original_post
+  before_destroy :create_mod_action_for_delete
   after_save(:if => ->(rec) {rec.saved_change_to_is_locked?}) do |rec|
     ModAction.log(rec.is_locked ? :forum_topic_lock : :forum_topic_unlock, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
   end
@@ -24,31 +27,74 @@ class ForumTopic < ApplicationRecord
     ModAction.log(rec.is_sticky ? :forum_topic_stick : :forum_topic_unstick, {forum_topic_id: rec.id, forum_topic_title: rec.title, user_id: rec.creator_id})
   end
 
+  module AccessMethods
+    def can_access?(user = CurrentUser.user)
+      return false if user.blank?
+      return false unless category&.can_access?(user)
+      return true if user.is_staff?
+      return true if user.id == creator_id
+      return false if is_hidden
+      true
+    end
+
+    def can_edit?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      return true if creator_id == user.id
+      false
+    end
+
+    def can_reply?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return false if is_locked && !can_lock?(user)
+      return true if category.can_reply?(user)
+      false
+    end
+
+    def can_hide?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      return false unless original_post&.can_hide?(user)
+      return true if user.id == creator_id
+      false
+    end
+
+    def can_unhide?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      false
+    end
+
+    def can_sticky?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      false
+    end
+
+    def can_lock?(user = CurrentUser.user)
+      return false unless can_access?(user)
+      return true if user.is_moderator?
+      false
+    end
+
+    def can_destroy?(user = CurrentUser.user)
+      return true if user.is_admin?
+      false
+    end
+  end
+
   module CategoryMethods
     extend ActiveSupport::Concern
 
     module ClassMethods
       def for_category_id(cid)
-        where(:category_id => cid)
+        where(category_id: cid)
       end
     end
 
     def category_name
-      return '(Unknown)' unless category
+      return "(Unknown)" unless category
       category.name
-    end
-
-    def category_valid
-      return if category
-      errors.add(:category, "is invalid")
-      throw :abort
-    end
-
-    def category_allows_creation
-      if category && !category.can_create_within?(creator)
-        errors.add(:category, "does not allow new topics")
-        return false
-      end
     end
   end
 
@@ -96,6 +142,28 @@ class ForumTopic < ApplicationRecord
     end
   end
 
+  module SubscriptionMethods
+    def user_subscription(user)
+      subscriptions.where(user_id: user.id).first
+    end
+  end
+
+  def validate_category
+    return true if category.present?
+    errors.add(:category, "is invalid")
+    throw :abort
+  end
+
+  module ValidationMethods
+    def validate_category_allows_creation
+      return true if category.blank?
+      return true if category.can_create?(creator)
+
+      errors.add(:category, "does not allow new topics")
+      false
+    end
+  end
+
   module VisitMethods
     def read_by?(user = nil)
       user ||= CurrentUser.user
@@ -128,39 +196,12 @@ class ForumTopic < ApplicationRecord
     end
   end
 
-  module SubscriptionMethods
-    def user_subscription(user)
-      subscriptions.where(:user_id => user.id).first
-    end
-  end
-
   extend SearchMethods
+  include AccessMethods
   include CategoryMethods
-  include VisitMethods
   include SubscriptionMethods
-
-  def editable_by?(user)
-    (creator_id == user.id || user.is_moderator?) && visible?(user)
-  end
-
-  def visible?(user)
-    return false if is_hidden && !can_hide?(user) && !user.is_staff?
-    user.level >= category.can_view
-  end
-
-  def can_reply?(user = CurrentUser.user)
-    user.level >= category.can_reply
-  end
-
-  def can_hide?(user)
-    return true if user.is_moderator?
-    return false unless original_post&.can_hide?(user)
-    user.id == creator_id
-  end
-
-  def can_delete?(user)
-    user.is_admin?
-  end
+  include ValidationMethods
+  include VisitMethods
 
   def create_mod_action_for_delete
     ModAction.log(:forum_topic_delete, {forum_topic_id: id, forum_topic_title: title, user_id: creator_id})

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -96,11 +96,11 @@ class Ticket < ApplicationRecord
       end
 
       def can_create_for?(user)
-        content&.visible?(user)
+        content&.can_access?(user)
       end
 
       def can_view?(user)
-        return true if user.is_staff? && (content.blank? || content&.visible?(user))
+        return true if user.is_staff? && (content.blank? || content&.can_access?(user))
         return true if user.is_admin?
         return true if user.id == creator_id
         false

--- a/app/views/forum_post_votes/_list.html.erb
+++ b/app/views/forum_post_votes/_list.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (votes:, forum_post:, votable: true) -%>
 
 <% own_vote = votes.find { |vote| vote.creator == CurrentUser.user } %>
-<% is_votable = CurrentUser.user.is_member? && forum_post.tag_change_request&.is_pending? && votable && forum_post.tag_change_request&.creator_id != CurrentUser.user.id %>
+<% is_votable = forum_post.can_vote? && forum_post.tag_change_request&.is_pending? && votable && forum_post.tag_change_request&.creator_id != CurrentUser.user.id %>
 <% categorized_votes = { 1 => [], 0 => [], -1 => [] }.merge(votes.group_by(&:score)) %>
 
 <ul

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -5,7 +5,7 @@
     data-forum-post-id="<%= forum_post.id %>"
     data-creator="<%= forum_post.creator&.name.downcase %>"
     data-creator-id="<%= forum_post.creator_id %>"
-    data-is-hidden="<%= forum_post.id == original_forum_post_id ? @forum_topic.is_hidden? : forum_post.is_hidden? %>"
+    data-is-hidden="<%= forum_post.id == original_forum_post_id ? forum_post.topic.is_hidden? : forum_post.is_hidden? %>"
   >
     <div class="author-info">
       <div class="name-rank">

--- a/app/views/forum_posts/_forum_post.html.erb
+++ b/app/views/forum_posts/_forum_post.html.erb
@@ -1,8 +1,12 @@
-<% if forum_post.visible?(CurrentUser.user) %>
-  <article class="forum-post comment-post-grid" id="forum_post_<%= forum_post.id %>"
-           data-forum-post-id="<%= forum_post.id %>" data-creator="<%= forum_post.creator&.name.downcase %>"
-           data-creator-id="<%= forum_post.creator_id %>"
-           data-is-hidden="<%= forum_post.id == original_forum_post_id ? @forum_topic.is_hidden? : forum_post.is_hidden? %>">
+<% if forum_post.can_access? %>
+  <article
+    class="forum-post comment-post-grid"
+    id="forum_post_<%= forum_post.id %>"
+    data-forum-post-id="<%= forum_post.id %>"
+    data-creator="<%= forum_post.creator&.name.downcase %>"
+    data-creator-id="<%= forum_post.creator_id %>"
+    data-is-hidden="<%= forum_post.id == original_forum_post_id ? @forum_topic.is_hidden? : forum_post.is_hidden? %>"
+  >
     <div class="author-info">
       <div class="name-rank">
         <h4 class="author-name"><%= link_to_user forum_post.creator %></h4>
@@ -26,47 +30,55 @@
       <%= render "application/warned_notice", record: forum_post if forum_post.was_warned? %>
       <div class="content-menu">
         <menu>
-          <% if CurrentUser.is_member? && @forum_topic && params[:controller] != "forum_posts" %>
+          <% if params[:controller] != "forum_posts" && @forum_topic && @forum_topic.can_reply?  %>
             <li><%= tag.a "Reply", href: '#', class: "reply-link forum-post-reply-link" %></li>
           <% end %>
+
+          <%# Hide / Unhide %>
           <% if !forum_post.is_original_post?(original_forum_post_id) %>
-            <% if forum_post.is_hidden? && CurrentUser.is_moderator? %>
+            <% if forum_post.is_hidden? && forum_post.can_unhide? %>
               <li><%= tag.a "Unhide", href: '#', class: 'forum-post-unhide-link' %></li>
-            <% elsif !forum_post.is_hidden? && forum_post.can_hide?(CurrentUser.user) %>
+            <% elsif !forum_post.is_hidden? && forum_post.can_hide? %>
               <li><%= tag.a "Hide", href: '#', class: 'forum-post-hide-link' %></li>
             <% end %>
-            <% if forum_post.can_delete?(CurrentUser.user) %>
+            <% if forum_post.can_destroy? %>
               <li><%= link_to "Delete", forum_post_path(forum_post.id), :data => {:confirm => "Are you sure you want to delete this forum post?"}, method: :delete %></li>
             <% end %>
           <% else %>
-            <% if forum_post.topic.is_hidden? && CurrentUser.is_moderator? %>
+            <% if forum_post.topic.is_hidden? && forum_post.topic.can_unhide? %>
               <li><%= link_to "Unhide", unhide_forum_topic_path(forum_post.topic.id), method: :post %></li>
-            <% elsif forum_post.topic.can_hide?(CurrentUser.user) %>
+            <% elsif forum_post.topic.can_hide? %>
               <li><%= link_to "Hide", hide_forum_topic_path(forum_post.topic.id), :data => {:confirm => "Are you sure you want to hide this forum topic?"}, method: :post %></li>
             <% end %>
-            <% if forum_post.topic.can_delete?(CurrentUser.user) %>
+            <% if forum_post.topic.can_destroy? %>
               <li><%= link_to "Delete", forum_topic_path(forum_post.topic), :data => {:confirm => "Are you sure you want to delete this forum topic?"}, method: :delete %></li>
             <% end %>
           <% end %>
-          <% if forum_post.editable_by?(CurrentUser.user) %>
+
+          <%# Edit %>
+          <% if forum_post.can_edit? %>
             <% if forum_post.is_original_post?(original_forum_post_id) %>
               <li><%= link_to "Edit", edit_forum_topic_path(forum_post.topic), :id => "edit_forum_topic_link_#{forum_post.topic.id}", :class => "edit_forum_topic_link" %></li>
             <% else %>
               <li><%= link_to "Edit", edit_forum_post_path(forum_post.id), :id => "edit_forum_post_link_#{forum_post.id}", :class => "edit_forum_post_link" %></li>
             <% end %>
           <% end %>
+
+          <%# Miscellaneous %>
           <% if params[:controller] == "forum_posts" %>
             <li><%= link_to "Parent", forum_topic_path(forum_post.topic, :page => forum_post.forum_topic_page, :anchor => "forum_post_#{forum_post.id}") %></li>
           <% end %>
-          <% if CurrentUser.is_member? %>
+          <% if CurrentUser.user.is_member? %>
             <li><%= link_to "Report", new_ticket_path(disp_id: forum_post.id, qtype: 'forum') %></li>
           <% end %>
-          <% if CurrentUser.is_moderator? %>
+
+          <%# Staff Tools %>
+          <% if CurrentUser.user.is_moderator? %>
             <li>|</li>
             <li><%= link_to "Show Edits", edit_history_path(id: forum_post.id, type: 'ForumPost') %></li>
             <%= render "user_warnable/buttons", model: forum_post %>
           <% end %>
-          <% if CurrentUser.is_admin? %>
+          <% if CurrentUser.user.is_admin? %>
             <li>|</li>
             <li>
               <strong>IP</strong>
@@ -79,7 +91,8 @@
         <% elsif forum_post.votable? %>
           <%= render "forum_post_votes/list", votes: forum_post.votes, forum_post: forum_post %>
         <% end %>
-        <% if forum_post.editable_by?(CurrentUser.user) %>
+
+        <% if forum_post.can_edit? %>
           <% if forum_post.is_original_post?(original_forum_post_id) %>
             <%= render "forum_topics/form", :forum_topic => forum_post.topic %>
           <% else %>

--- a/app/views/forum_topics/_secondary_links.html.erb
+++ b/app/views/forum_topics/_secondary_links.html.erb
@@ -14,31 +14,48 @@
   <%= subnav_link_to "Help", help_page_path(id: "forum") %>
   <% if CurrentUser.is_member? && @forum_topic && !@forum_topic.new_record? %>
     <li class="divider"></li>
-    <%= subnav_link_to "Reply", new_forum_post_path(forum_post: { topic_id: @forum_topic.id }) %>
+
+    <% if @forum_topic.can_reply? %>
+      <%= subnav_link_to "Reply", new_forum_post_path(forum_post: { topic_id: @forum_topic.id }) %>
+    <% end %>
+
     <% if @forum_topic.user_subscription(CurrentUser.user) %>
       <%= subnav_link_to "Unsubscribe", unsubscribe_forum_topic_path(@forum_topic), method: :post %>
     <% else %>
       <%= subnav_link_to "Subscribe", subscribe_forum_topic_path(@forum_topic), method: :post, data: { confirm: "Are you sure you want to receive email notifications for this forum topic?" } %>
     <% end %>
-    <% if !@forum_topic.new_record? && @forum_topic.editable_by?(CurrentUser.user) %>
+
+    <% if !@forum_topic.new_record? && @forum_topic.can_edit? %>
+      <%# Edit %>
       <%= subnav_link_to "Edit", edit_forum_topic_path(@forum_topic), data: { hotkey: "edit" } %>
-      <% if CurrentUser.is_moderator? %>
+
+      <%# Hide / Unhide %>
+      <% if @forum_topic.can_hide? %>
         <% if @forum_topic.is_hidden? %>
           <%= subnav_link_to "Unhide", unhide_forum_topic_path(@forum_topic), method: :post %>
         <% else %>
           <%= subnav_link_to "Hide", hide_forum_topic_path(@forum_topic), method: :post, data: { confirm: "Are you sure you want to hide this forum topic?" } %>
         <% end %>
+      <% end %>
+
+      <%# Lock / Unlock %>
+      <% if @forum_topic.can_lock? %>
         <% if @forum_topic.is_locked? %>
           <%= subnav_link_to "Unlock", forum_topic_path(@forum_topic, forum_topic: { is_locked: false }), method: :put, data: { confirm: "Are you sure you want to unlock this forum topic?" } %>
         <% else %>
           <%= subnav_link_to "Lock", forum_topic_path(@forum_topic, forum_topic: { is_locked: true }), method: :put, data: { confirm: "Are you sure you want to lock this forum topic?" } %>
         <% end %>
+      <% end %>
+
+      <%# Sticky / Unsticky %>
+      <% if @forum_topic.can_sticky? %>
         <% if @forum_topic.is_sticky? %>
           <%= subnav_link_to "Unsticky", forum_topic_path(@forum_topic, forum_topic: { is_sticky: false }), method: :put, data: { confirm: "Are you sure you want to unsticky this forum topic?" } %>
         <% else %>
           <%= subnav_link_to "Sticky", forum_topic_path(@forum_topic, forum_topic: { is_sticky: true }), method: :put, data: { confirm: "Are you sure you want to sticky this forum topic?" } %>
         <% end %>
       <% end %>
+
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/forum_topics/show.html.erb
+++ b/app/views/forum_topics/show.html.erb
@@ -19,7 +19,7 @@
     <%= render "forum_posts/listing", :forum_posts => @forum_posts, :original_forum_post_id => @forum_topic.original_post.id %>
 
     <% if CurrentUser.is_member? %>
-      <% if CurrentUser.is_moderator? || !@forum_topic.is_locked? %>
+      <% if @forum_topic.can_reply? %>
         <p><%= link_to "Reply »", new_forum_post_path(forum_post: { topic_id: @forum_topic.id }), id: "new-response-link" %></p>
 
         <div style="display: none;" id="topic-response">

--- a/spec/models/forum_category_spec.rb
+++ b/spec/models/forum_category_spec.rb
@@ -32,38 +32,6 @@ RSpec.describe ForumCategory do
       end
     end
 
-    it "respects can_create_within?" do
-      member = create(:user)
-      janitor = create(:janitor_user)
-      moderator = create(:moderator_user)
-      admin = create(:admin_user)
-
-      member_category = create(:forum_category, can_create: User::Levels::MEMBER)
-      janitor_category = create(:forum_category, can_create: User::Levels::JANITOR)
-      moderator_category = create(:forum_category, can_create: User::Levels::MODERATOR)
-      admin_category = create(:forum_category, can_create: User::Levels::ADMIN)
-
-      expect(member_category.can_create_within?(member)).to be true
-      expect(member_category.can_create_within?(janitor)).to be true
-      expect(member_category.can_create_within?(moderator)).to be true
-      expect(member_category.can_create_within?(admin)).to be true
-
-      expect(janitor_category.can_create_within?(member)).to be false
-      expect(janitor_category.can_create_within?(janitor)).to be true
-      expect(janitor_category.can_create_within?(moderator)).to be true
-      expect(janitor_category.can_create_within?(admin)).to be true
-
-      expect(moderator_category.can_create_within?(member)).to be false
-      expect(moderator_category.can_create_within?(janitor)).to be false
-      expect(moderator_category.can_create_within?(moderator)).to be true
-      expect(moderator_category.can_create_within?(admin)).to be true
-
-      expect(admin_category.can_create_within?(member)).to be false
-      expect(admin_category.can_create_within?(janitor)).to be false
-      expect(admin_category.can_create_within?(moderator)).to be false
-      expect(admin_category.can_create_within?(admin)).to be true
-    end
-
     it "can reverse mapping" do
       category0 = ForumCategory.find(1) # Seeded category, always has ID 1
       category1 = create(:forum_category, name: "Category 1", cat_order: 2)
@@ -97,6 +65,104 @@ RSpec.describe ForumCategory do
       expect(ForumCategory.visible(janitor)).to eq([category0, member_category, janitor_category])
       expect(ForumCategory.visible(moderator)).to eq([category0, member_category, janitor_category, moderator_category])
       expect(ForumCategory.visible(admin)).to eq([category0, member_category, janitor_category, moderator_category, admin_category])
+    end
+  end
+
+  describe "access methods" do
+    it "#can_access" do
+      member = create(:user)
+      janitor = create(:janitor_user)
+      moderator = create(:moderator_user)
+      admin = create(:admin_user)
+
+      member_category = create(:forum_category, can_view: User::Levels::MEMBER)
+      janitor_category = create(:forum_category, can_view: User::Levels::JANITOR)
+      moderator_category = create(:forum_category, can_view: User::Levels::MODERATOR)
+      admin_category = create(:forum_category, can_view: User::Levels::ADMIN)
+
+      expect(member_category.can_access?(member)).to be true
+      expect(member_category.can_access?(janitor)).to be true
+      expect(member_category.can_access?(moderator)).to be true
+      expect(member_category.can_access?(admin)).to be true
+
+      expect(janitor_category.can_access?(member)).to be false
+      expect(janitor_category.can_access?(janitor)).to be true
+      expect(janitor_category.can_access?(moderator)).to be true
+      expect(janitor_category.can_access?(admin)).to be true
+
+      expect(moderator_category.can_access?(member)).to be false
+      expect(moderator_category.can_access?(janitor)).to be false
+      expect(moderator_category.can_access?(moderator)).to be true
+      expect(moderator_category.can_access?(admin)).to be true
+
+      expect(admin_category.can_access?(member)).to be false
+      expect(admin_category.can_access?(janitor)).to be false
+      expect(admin_category.can_access?(moderator)).to be false
+      expect(admin_category.can_access?(admin)).to be true
+    end
+
+    it "#can_create" do
+      member = create(:user)
+      janitor = create(:janitor_user)
+      moderator = create(:moderator_user)
+      admin = create(:admin_user)
+
+      member_category = create(:forum_category, can_create: User::Levels::MEMBER)
+      janitor_category = create(:forum_category, can_create: User::Levels::JANITOR)
+      moderator_category = create(:forum_category, can_create: User::Levels::MODERATOR)
+      admin_category = create(:forum_category, can_create: User::Levels::ADMIN)
+
+      expect(member_category.can_create?(member)).to be true
+      expect(member_category.can_create?(janitor)).to be true
+      expect(member_category.can_create?(moderator)).to be true
+      expect(member_category.can_create?(admin)).to be true
+
+      expect(janitor_category.can_create?(member)).to be false
+      expect(janitor_category.can_create?(janitor)).to be true
+      expect(janitor_category.can_create?(moderator)).to be true
+      expect(janitor_category.can_create?(admin)).to be true
+
+      expect(moderator_category.can_create?(member)).to be false
+      expect(moderator_category.can_create?(janitor)).to be false
+      expect(moderator_category.can_create?(moderator)).to be true
+      expect(moderator_category.can_create?(admin)).to be true
+
+      expect(admin_category.can_create?(member)).to be false
+      expect(admin_category.can_create?(janitor)).to be false
+      expect(admin_category.can_create?(moderator)).to be false
+      expect(admin_category.can_create?(admin)).to be true
+    end
+
+    it "#can_reply" do
+      member = create(:user)
+      janitor = create(:janitor_user)
+      moderator = create(:moderator_user)
+      admin = create(:admin_user)
+
+      member_category = create(:forum_category, can_reply: User::Levels::MEMBER)
+      janitor_category = create(:forum_category, can_reply: User::Levels::JANITOR)
+      moderator_category = create(:forum_category, can_reply: User::Levels::MODERATOR)
+      admin_category = create(:forum_category, can_reply: User::Levels::ADMIN)
+
+      expect(member_category.can_reply?(member)).to be true
+      expect(member_category.can_reply?(janitor)).to be true
+      expect(member_category.can_reply?(moderator)).to be true
+      expect(member_category.can_reply?(admin)).to be true
+
+      expect(janitor_category.can_reply?(member)).to be false
+      expect(janitor_category.can_reply?(janitor)).to be true
+      expect(janitor_category.can_reply?(moderator)).to be true
+      expect(janitor_category.can_reply?(admin)).to be true
+
+      expect(moderator_category.can_reply?(member)).to be false
+      expect(moderator_category.can_reply?(janitor)).to be false
+      expect(moderator_category.can_reply?(moderator)).to be true
+      expect(moderator_category.can_reply?(admin)).to be true
+
+      expect(admin_category.can_reply?(member)).to be false
+      expect(admin_category.can_reply?(janitor)).to be false
+      expect(admin_category.can_reply?(moderator)).to be false
+      expect(admin_category.can_reply?(admin)).to be true
     end
   end
 end

--- a/spec/models/forum_post/instance_methods_spec.rb
+++ b/spec/models/forum_post/instance_methods_spec.rb
@@ -112,6 +112,19 @@ RSpec.describe ForumPost do
       topic.update_columns(is_hidden: true, creator_id: other.id)
       expect(post.reload.can_edit?(member)).to be false
     end
+
+    it "denies when the topic is locked" do
+      post = make_post
+      post.update_columns(creator_id: member.id)
+      topic.update_columns(is_locked: true)
+      expect(post.reload.can_edit?(member)).to be false
+    end
+
+    it "allows when the topic is locked but the user can lock" do
+      post = make_post
+      topic.update_columns(is_locked: true)
+      expect(post.reload.can_edit?(admin)).to be true
+    end
   end
 
   # -------------------------------------------------------------------------

--- a/spec/models/forum_post/instance_methods_spec.rb
+++ b/spec/models/forum_post/instance_methods_spec.rb
@@ -7,12 +7,14 @@ require "rails_helper"
 # --------------------------------------------------------------------------- #
 
 RSpec.describe ForumPost do
-  let(:member)    { create(:user) }
-  let(:moderator) { create(:moderator_user) }
-  let(:admin)     { create(:admin_user) }
-  let(:other)     { create(:user) }
-  let(:category)  { create(:forum_category) }
-  let(:topic)     { CurrentUser.scoped(member) { create(:forum_topic, category_id: category.id) } }
+  let(:member)          { create(:user) }
+  let(:janitor)         { create(:janitor_user) }
+  let(:moderator)       { create(:moderator_user) }
+  let(:admin)           { create(:admin_user) }
+  let(:other)           { create(:user) }
+  let(:category)        { create(:forum_category) }
+  let(:admin_category)  { create(:forum_category, can_view: User::Levels::ADMIN) }
+  let(:topic)           { CurrentUser.scoped(member) { create(:forum_topic, category_id: category.id) } }
 
   before do
     CurrentUser.user = member
@@ -29,61 +31,86 @@ RSpec.describe ForumPost do
   end
 
   # -------------------------------------------------------------------------
-  # #visible?
+  # #can_access?
   # -------------------------------------------------------------------------
-  describe "#visible?" do
-    it "is visible to a moderator even when hidden" do
+  describe "#can_access?" do
+    it "returns false for blank users" do
+      post = make_post
+      expect(post.can_access?(nil)).to be false
+    end
+
+    it "is visible to a staff member even when hidden" do
       post = make_post
       post.update_columns(is_hidden: true)
-      expect(post.visible?(moderator)).to be true
+      expect(post.can_access?(janitor)).to be true
     end
 
     it "is visible to a member when not hidden and in an accessible topic" do
-      expect(make_post.visible?(member)).to be true
+      expect(make_post.can_access?(member)).to be true
     end
 
     it "is not visible to an unrelated member when hidden" do
       post = make_post
       post.update_columns(is_hidden: true)
-      expect(post.visible?(other)).to be false
+      expect(post.can_access?(other)).to be false
     end
 
     it "is visible to the creator even when hidden" do
       post = make_post
       post.update_columns(is_hidden: true, creator_id: member.id)
-      expect(post.visible?(member)).to be true
+      expect(post.can_access?(member)).to be true
     end
 
     it "is not visible to a member when the topic is hidden from them" do
       post = make_post
       topic.update_columns(is_hidden: true, creator_id: other.id)
-      expect(post.reload.visible?(member)).to be false
+      expect(post.reload.can_access?(member)).to be false
+    end
+
+    it "is not visible to a janitor when the topic is hidden from them" do
+      post = make_post
+      topic.update_columns(category_id: admin_category.id)
+      expect(post.reload.can_access?(janitor)).to be false
+    end
+
+    it "is not visible if the topic is missing" do
+      post = make_post
+      # topic_id is readonly, so we have to stub it instead
+      allow(post).to receive(:topic).and_return(nil)
+      expect(post.can_access?(member)).to be false
     end
   end
 
   # -------------------------------------------------------------------------
-  # #editable_by?
+  # #can_edit?
   # -------------------------------------------------------------------------
-  describe "#editable_by?" do
+  describe "#can_edit?" do
     it "allows an admin to edit any post" do
-      expect(make_post.editable_by?(admin)).to be true
+      expect(make_post.can_edit?(admin)).to be true
     end
 
     it "allows the creator to edit their own visible, non-warned post" do
       post = make_post
       post.update_columns(creator_id: member.id)
-      expect(post.editable_by?(member)).to be true
+      expect(post.can_edit?(member)).to be true
     end
 
     it "denies the creator when the post has a warning" do
       post = make_post
       post.update_columns(creator_id: member.id, warning_type: 1, warning_user_id: moderator.id)
-      expect(post.editable_by?(member)).to be false
+      expect(post.can_edit?(member)).to be false
     end
 
     it "denies a non-creator non-admin" do
       post = make_post
-      expect(post.editable_by?(other)).to be false
+      expect(post.can_edit?(other)).to be false
+    end
+
+    it "denies when the topic is hidden from the user" do
+      post = make_post
+      post.update_columns(creator_id: member.id)
+      topic.update_columns(is_hidden: true, creator_id: other.id)
+      expect(post.reload.can_edit?(member)).to be false
     end
   end
 
@@ -110,22 +137,98 @@ RSpec.describe ForumPost do
     it "denies an unrelated user" do
       expect(make_post.can_hide?(other)).to be false
     end
+
+    it "denies when the topic is hidden from the user" do
+      post = make_post
+      post.update_columns(creator_id: member.id)
+      topic.update_columns(is_hidden: true, creator_id: other.id)
+      expect(post.reload.can_hide?(member)).to be false
+    end
   end
 
   # -------------------------------------------------------------------------
-  # #can_delete?
+  # #can_unhide?
   # -------------------------------------------------------------------------
-  describe "#can_delete?" do
-    it "allows an admin to delete a post" do
-      expect(make_post.can_delete?(admin)).to be true
+  describe "#can_unhide?" do
+    it "allows a moderator to unhide any post" do
+      expect(make_post.can_unhide?(moderator)).to be true
     end
 
-    it "denies a moderator" do
-      expect(make_post.can_delete?(moderator)).to be false
+    it "does not allow regular members to unhide posts" do
+      post = make_post
+      post.update_columns(creator_id: member.id)
+      expect(post.can_unhide?(member)).to be false
+    end
+
+    it "denies an unrelated user" do
+      expect(make_post.can_unhide?(other)).to be false
+    end
+
+    it "denies when the topic is hidden from the user" do
+      post = make_post
+      post.update_columns(creator_id: member.id)
+      topic.update_columns(creator_id: other.id, category_id: admin_category.id)
+      expect(post.reload.can_unhide?(member)).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #can_warn?
+  # -------------------------------------------------------------------------
+  describe "#can_warn?" do
+    it "allows a moderator to warn a post" do
+      expect(make_post.can_warn?(moderator)).to be true
+    end
+
+    it "denies a janitor" do
+      expect(make_post.can_warn?(janitor)).to be false
     end
 
     it "denies a regular member" do
-      expect(make_post.can_delete?(member)).to be false
+      expect(make_post.can_warn?(member)).to be false
+    end
+
+    it "denies when the topic is hidden from the user" do
+      post = make_post
+      post.update_columns(creator_id: member.id)
+      topic.update_columns(creator_id: member.id, category_id: admin_category.id)
+      expect(post.reload.can_warn?(moderator)).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #can_vote?
+  # -------------------------------------------------------------------------
+  describe "#can_vote?" do
+    it "allows a member to vote on a post" do
+      expect(make_post.can_vote?(member)).to be true
+    end
+
+    it "allows a moderator to vote on a post" do
+      expect(make_post.can_vote?(moderator)).to be true
+    end
+
+    it "denies when the topic is hidden from the user" do
+      post = make_post
+      topic.update_columns(is_hidden: true, creator_id: other.id)
+      expect(post.reload.can_vote?(member)).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #can_destroy?
+  # -------------------------------------------------------------------------
+  describe "#can_destroy?" do
+    it "allows an admin to destroy a post" do
+      expect(make_post.can_destroy?(admin)).to be true
+    end
+
+    it "denies a moderator" do
+      expect(make_post.can_destroy?(moderator)).to be false
+    end
+
+    it "denies a regular member" do
+      expect(make_post.can_destroy?(member)).to be false
     end
   end
 

--- a/spec/models/forum_post/instance_methods_spec.rb
+++ b/spec/models/forum_post/instance_methods_spec.rb
@@ -213,6 +213,10 @@ RSpec.describe ForumPost do
       topic.update_columns(is_hidden: true, creator_id: other.id)
       expect(post.reload.can_vote?(member)).to be false
     end
+
+    it "denies anonymous users" do
+      expect(make_post.can_vote?(nil)).to be false
+    end
   end
 
   # -------------------------------------------------------------------------

--- a/spec/models/forum_post/validations_spec.rb
+++ b/spec/models/forum_post/validations_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ForumPost do
   end
 
   # -------------------------------------------------------------------------
-  # topic existence
+  # topic is valid
   # -------------------------------------------------------------------------
   describe "topic" do
     it "is invalid when topic_id references a non-existent record" do
@@ -77,14 +77,14 @@ RSpec.describe ForumPost do
   end
 
   # -------------------------------------------------------------------------
-  # topic lock
+  # topic accepts replies
   # -------------------------------------------------------------------------
-  describe "validate_topic_is_unlocked" do
+  describe "validate_topic_can_reply" do
     it "is invalid when the topic is locked and the current user is not a moderator" do
       topic.update_columns(is_locked: true)
       record = build(:forum_post, topic_id: topic.id)
       expect(record).not_to be_valid
-      expect(record.errors[:topic]).to include("is locked")
+      expect(record.errors[:topic]).to include("does not allow replies")
     end
 
     it "is valid when the topic is locked but the current user is a moderator" do

--- a/spec/models/forum_topic/instance_methods_spec.rb
+++ b/spec/models/forum_topic/instance_methods_spec.rb
@@ -7,11 +7,12 @@ require "rails_helper"
 # --------------------------------------------------------------------------- #
 
 RSpec.describe ForumTopic do
-  let(:member)    { create(:user) }
-  let(:moderator) { create(:moderator_user) }
-  let(:admin)     { create(:admin_user) }
-  let(:other)     { create(:user) }
-  let(:category)  { create(:forum_category) }
+  let(:member)          { create(:user) }
+  let(:moderator)       { create(:moderator_user) }
+  let(:admin)           { create(:admin_user) }
+  let(:other)           { create(:user) }
+  let(:category)        { create(:forum_category) }
+  let(:admin_category)  { create(:forum_category, can_view: User::Levels::ADMIN) }
 
   before do
     CurrentUser.user = member
@@ -44,65 +45,77 @@ RSpec.describe ForumTopic do
   end
 
   # -------------------------------------------------------------------------
-  # #visible?
+  # #can_access?
   # -------------------------------------------------------------------------
-  describe "#visible?" do
+  describe "#can_access?" do
+    it "returns false for blank users" do
+      topic = make_topic
+      expect(topic.can_access?(nil)).to be false
+    end
+
     it "is visible to a member when not hidden and category level allows it" do
       topic = make_topic
-      expect(topic.visible?(member)).to be true
+      expect(topic.can_access?(member)).to be true
     end
 
     it "is not visible to an unrelated member when hidden" do
       topic = make_topic
       topic.update_columns(is_hidden: true)
-      expect(topic.visible?(other)).to be false
+      expect(topic.can_access?(other)).to be false
     end
 
     it "is visible to the creator even when hidden" do
       topic = make_topic
       topic.update_columns(is_hidden: true, creator_id: member.id)
-      expect(topic.visible?(member)).to be true
+      expect(topic.can_access?(member)).to be true
     end
 
     it "is visible to a moderator even when hidden" do
       topic = make_topic
       topic.update_columns(is_hidden: true)
-      expect(topic.visible?(moderator)).to be true
+      expect(topic.can_access?(moderator)).to be true
     end
 
     it "is not visible to a member when category requires a higher level" do
       restricted = create(:forum_category, can_view: User::Levels::MODERATOR)
-      topic = CurrentUser.scoped(moderator) { create(:forum_topic, category_id: restricted.id) }
-      expect(topic.visible?(member)).to be false
+      topic = create(:forum_topic)
+      topic.update_columns(category_id: restricted.id)
+      expect(topic.can_access?(member)).to be false
+    end
+
+    it "is not visible when the category is invalid" do
+      topic = make_topic
+      topic.update_columns(category_id: 9999)
+      expect(topic.can_access?(member)).to be false
     end
   end
 
   # -------------------------------------------------------------------------
-  # #editable_by?
+  # #can_edit?
   # -------------------------------------------------------------------------
-  describe "#editable_by?" do
+  describe "#can_edit?" do
     it "allows the creator to edit their own visible topic" do
       topic = make_topic
       topic.update_columns(creator_id: member.id)
-      expect(topic.editable_by?(member)).to be true
+      expect(topic.can_edit?(member)).to be true
     end
 
     it "allows a moderator to edit any visible topic" do
       topic = make_topic
-      expect(topic.editable_by?(moderator)).to be true
+      expect(topic.can_edit?(moderator)).to be true
     end
 
     it "denies a non-creator non-moderator" do
       topic = make_topic
-      expect(topic.editable_by?(other)).to be false
+      expect(topic.can_edit?(other)).to be false
     end
 
     it "denies the creator when the topic is hidden (not visible to them)" do
       # A topic hidden by someone else — the creator is a different user
       topic = make_topic
       topic.update_columns(is_hidden: true, creator_id: other.id)
-      # `member` is not creator and not moderator, so visible? is false → editable_by? false
-      expect(topic.editable_by?(member)).to be false
+      # `member` is not creator and not moderator, so can_access? is false → can_edit? false
+      expect(topic.can_edit?(member)).to be false
     end
   end
 
@@ -117,8 +130,27 @@ RSpec.describe ForumTopic do
 
     it "returns false when user level is below the category requirement" do
       restricted = create(:forum_category, can_reply: User::Levels::MODERATOR)
-      topic = CurrentUser.scoped(moderator) { create(:forum_topic, category_id: restricted.id) }
+      topic = create(:forum_topic)
+      topic.update_columns(category_id: restricted.id)
       expect(topic.can_reply?(member)).to be false
+    end
+
+    it "returns false when the category is invalid" do
+      topic = make_topic
+      topic.update_columns(category_id: 9999)
+      expect(topic.can_reply?(member)).to be false
+    end
+
+    it "returns false when the topic is locked and the user cannot lock" do
+      topic = make_topic
+      topic.update_columns(is_locked: true)
+      expect(topic.can_reply?(member)).to be false
+    end
+
+    it "returns true when the topic is locked but the user can lock" do
+      topic = make_topic
+      topic.update_columns(is_locked: true)
+      expect(topic.can_reply?(moderator)).to be true
     end
   end
 
@@ -141,25 +173,119 @@ RSpec.describe ForumTopic do
       topic = make_topic
       expect(topic.can_hide?(other)).to be false
     end
+
+    it "denies the creator when the original post cannot be hidden" do
+      topic = make_topic
+      topic.update_columns(creator_id: member.id)
+      topic.original_post.update_columns(warning_type: 1)
+      expect(topic.can_hide?(member)).to be false
+    end
+
+    it "denies the creator if the topic category changed to a restricted one" do
+      restricted = create(:forum_category, can_view: User::Levels::MODERATOR)
+      topic = make_topic
+      topic.update_columns(creator_id: member.id, category_id: restricted.id)
+      expect(topic.can_hide?(member)).to be false
+    end
+
+    it "returns false when the original post is missing" do
+      topic = make_topic
+      topic.original_post.destroy
+      topic.reload
+      expect(topic.can_hide?(member)).to be false
+    end
+
+    it "returns false if the topic's creator is different to the original post's creator" do
+      # This is virtually impossible in production, but we should handle it gracefully just in case.
+      topic = make_topic
+      topic.update_columns(creator_id: other.id)
+      topic.original_post.update_columns(creator_id: member.id)
+      expect(topic.can_hide?(member)).to be false
+    end
   end
 
   # -------------------------------------------------------------------------
-  # #can_delete?
+  # #can_unhide?
   # -------------------------------------------------------------------------
-  describe "#can_delete?" do
-    it "allows an admin to delete a topic" do
+  describe "#can_unhide?" do
+    it "allows a moderator to unhide any topic" do
       topic = make_topic
-      expect(topic.can_delete?(admin)).to be true
-    end
-
-    it "denies a moderator" do
-      topic = make_topic
-      expect(topic.can_delete?(moderator)).to be false
+      topic.update_columns(is_hidden: true)
+      expect(topic.can_unhide?(moderator)).to be true
     end
 
     it "denies a regular member" do
       topic = make_topic
-      expect(topic.can_delete?(member)).to be false
+      topic.update_columns(is_hidden: true)
+      expect(topic.can_unhide?(member)).to be false
+    end
+
+    it "denies if the topic is hidden from the user" do
+      topic = make_topic
+      topic.update_columns(is_hidden: true, creator_id: other.id, category_id: admin_category.id)
+      expect(topic.can_unhide?(moderator)).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #can_sticky?
+  # -------------------------------------------------------------------------
+  describe "#can_sticky?" do
+    it "allows a moderator to sticky any topic" do
+      topic = make_topic
+      expect(topic.can_sticky?(moderator)).to be true
+    end
+
+    it "denies a regular member" do
+      topic = make_topic
+      expect(topic.can_sticky?(member)).to be false
+    end
+
+    it "denies when the topic is hidden from the user" do
+      topic = make_topic
+      topic.update_columns(is_hidden: true, creator_id: other.id, category_id: admin_category.id)
+      expect(topic.can_sticky?(moderator)).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #can_lock?
+  # -------------------------------------------------------------------------
+  describe "#can_lock?" do
+    it "allows a moderator to lock any topic" do
+      topic = make_topic
+      expect(topic.can_lock?(moderator)).to be true
+    end
+
+    it "denies a regular member" do
+      topic = make_topic
+      expect(topic.can_lock?(member)).to be false
+    end
+
+    it "denies when the topic is hidden from the user" do
+      topic = make_topic
+      topic.update_columns(is_hidden: true, creator_id: other.id, category_id: admin_category.id)
+      expect(topic.can_lock?(moderator)).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #can_destroy?
+  # -------------------------------------------------------------------------
+  describe "#can_destroy?" do
+    it "allows an admin to destroy a topic" do
+      topic = make_topic
+      expect(topic.can_destroy?(admin)).to be true
+    end
+
+    it "denies a moderator" do
+      topic = make_topic
+      expect(topic.can_destroy?(moderator)).to be false
+    end
+
+    it "denies a regular member" do
+      topic = make_topic
+      expect(topic.can_destroy?(member)).to be false
     end
   end
 

--- a/spec/requests/forum_posts_controller_spec.rb
+++ b/spec/requests/forum_posts_controller_spec.rb
@@ -247,8 +247,23 @@ RSpec.describe ForumPostsController do
       expect(forum_post.reload.body).to eq("admin edit")
     end
 
+    it "updates the post when editor is admin and the topic is locked" do
+      forum_topic.update(is_locked: true)
+      sign_in_as create(:admin_user)
+      put forum_post_path(forum_post), params: { forum_post: { body: "admin edit" } }
+      expect(response).to redirect_to(forum_topic_path(forum_topic, page: forum_post.forum_topic_page, anchor: "forum_post_#{forum_post.id}"))
+      expect(forum_post.reload.body).to eq("admin edit")
+    end
+
     it "returns forbidden when editor is a different member" do
       sign_in_as create(:user)
+      put forum_post_path(forum_post), params: { forum_post: { body: "nope" } }
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns forbidden when editor is the creator but the topic is locked" do
+      forum_topic.update(is_locked: true)
+      sign_in_as user
       put forum_post_path(forum_post), params: { forum_post: { body: "nope" } }
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/forum_topics_controller_spec.rb
+++ b/spec/requests/forum_topics_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe ForumTopicsController do
       expect(response).to have_http_status(:success)
     end
 
-    it "returns 403 for a hidden topic when the user is not a moderator or creator" do
+    it "returns 403 for a hidden topic when the user is not staff or creator" do
       forum_topic.update_columns(is_hidden: true)
       other_user = create(:user)
       sign_in_as other_user
@@ -120,7 +120,7 @@ RSpec.describe ForumTopicsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "allows a moderator to view a hidden topic" do
+    it "allows staff to view a hidden topic" do
       forum_topic.update_columns(is_hidden: true)
       sign_in_as mod
       get forum_topic_path(forum_topic)

--- a/spec/requests/forum_topics_controller_spec.rb
+++ b/spec/requests/forum_topics_controller_spec.rb
@@ -17,6 +17,7 @@ require "rails_helper"
 RSpec.describe ForumTopicsController do
   let(:user) { RSpec::Mocks.with_temporary_scope { create(:user) } }
   let(:mod) { create(:moderator_user) }
+  let(:janitor) { create(:janitor_user) }
   let(:admin) { create(:admin_user) }
   let(:forum_topic) do
     CurrentUser.scoped(user) { create(:forum_topic, title: "my forum topic") }
@@ -122,7 +123,7 @@ RSpec.describe ForumTopicsController do
 
     it "allows staff to view a hidden topic" do
       forum_topic.update_columns(is_hidden: true)
-      sign_in_as mod
+      sign_in_as janitor
       get forum_topic_path(forum_topic)
       expect(response).to have_http_status(:success)
     end


### PR DESCRIPTION
Thorough rework of the forum visibility methods.
Covers both topics, posts, and categories.

**Unified naming:** every model now exposes `can_*?` predicates.
The `can_access?`, `can_edit?`, `can_hide?`, `can_unhide?` and `can_destroy?` are the standard.
The mix of `visible?` / `editable_by?` / `can_hide?` / `can_delete?` is gone.

**Per-action filters:** `ensure_can_access` / `ensure_can_edit` / `ensure_can_hide` etc. replace the brittle `check_min_level` + `check_editable` + `check_hidable` triad. Each filter has one job; the controllers are essentially declarative now.

**Views defer to predicates:** `_forum_post.html.erb` and `_secondary_links.html.erb` now use `forum_post.can_edit?` / `topic.can_hide?` / `topic.can_lock?` etc., instead of hardcoding `CurrentUser.is_moderator?`. The UI now matches the controller exactly.

**Better test coverage:** per-predicate describe blocks in both `forum_post/instance_methods_spec.rb` and `forum_topic/instance_methods_spec.rb`, plus actual access-method tests for `forum_category_spec.rb`.