### PR TITLE
[Moderation] Error when searching for malformed IP addresses

### DIFF
--- a/app/controllers/moderator/ip_addrs_controller.rb
+++ b/app/controllers/moderator/ip_addrs_controller.rb
@@ -5,6 +5,8 @@ module Moderator
     before_action :admin_only
     respond_to :html, :json
 
+    rescue_from IpAddrSearch::InvalidIpAddr, with: :render_invalid_ip_addr
+
     def index
       search = IpAddrSearch.new(params[:search])
       @results = search.execute
@@ -19,6 +21,12 @@ module Moderator
           render json: @results[:ip_addrs].uniq
         end
       end
+    end
+
+    private
+
+    def render_invalid_ip_addr(exception)
+      render_expected_error(422, exception.message)
     end
   end
 end

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -23,7 +23,7 @@ module Moderator
             mask = IPAddr.new(ip_addrs[0]).ipv4? ? 24 : 64
             ip_addrs[0] = "#{ip_addrs[0]}/#{mask}"
           rescue IPAddr::InvalidAddressError
-            render_expected_error(422, "Invalid IP address format: #{ip_addrs[0]}")
+            raise InvalidIpAddr, "Invalid IP address format: #{ip_addrs[0]}"
           end
         end
         validate_ip_addrs(ip_addrs)

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -2,6 +2,8 @@
 
 module Moderator
   class IpAddrSearch
+    class InvalidIpAddr < StandardError; end
+
     attr_reader :params
 
     def initialize(params)
@@ -17,9 +19,14 @@ module Moderator
       elsif params[:ip_addr].present?
         ip_addrs = params[:ip_addr].split(",").map(&:strip)
         if params[:add_ip_mask].to_s.truthy? && ip_addrs.count == 1 && ip_addrs[0].exclude?("/")
-          mask = IPAddr.new(ip_addrs[0]).ipv4? ? 24 : 64
-          ip_addrs[0] = "#{ip_addrs[0]}/#{mask}"
+          begin
+            mask = IPAddr.new(ip_addrs[0]).ipv4? ? 24 : 64
+            ip_addrs[0] = "#{ip_addrs[0]}/#{mask}"
+          rescue IPAddr::InvalidAddressError
+            render_expected_error(422, "Invalid IP address format: #{ip_addrs[0]}")
+          end
         end
+        validate_ip_addrs(ip_addrs)
         search_by_ip_addr(ip_addrs, with_history)
       else
         []
@@ -85,6 +92,14 @@ module Moderator
         target.merge!({ name => klass.where("#{ip_field} <<= ?", ips[0]).group(id_field).count })
       else
         target.merge!({ name => klass.where(ip_field => ips).group(id_field).count })
+      end
+    end
+
+    def validate_ip_addrs(ip_addrs)
+      ip_addrs.each do |ip|
+        IPAddr.new(ip)
+      rescue IPAddr::InvalidAddressError
+        raise InvalidIpAddr, "Invalid IP address format: #{ip}"
       end
     end
   end

--- a/spec/requests/moderator/ip_addrs_controller_spec.rb
+++ b/spec/requests/moderator/ip_addrs_controller_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Moderator::IpAddrsController do
           get moderator_ip_addrs_path, params: { search: { ip_addr: "127.0.0.1" } }
           expect(response).to have_http_status(:ok)
         end
+
+        it "returns 422 for invalid IP address" do
+          get moderator_ip_addrs_path, params: { search: { ip_addr: "*dylan*dolly*" } }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "returns 422 for invalid CIDR prefix" do
+          get moderator_ip_addrs_path, params: { search: { ip_addr: "127.0.0.1/999" } }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
       end
     end
   end
@@ -140,12 +150,17 @@ RSpec.describe Moderator::IpAddrsController do
       # which has no :ip_addrs key. The export action then calls
       # @results[:ip_addrs].uniq on nil, raising NoMethodError. This test is
       # commented out until the controller handles the ip_addr search path.
-      # context "when searching by ip_addr" do
-      #   it "returns 200 JSON" do
-      #     get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "127.0.0.1" } }
-      #     expect(response).to have_http_status(:ok)
-      #   end
-      # end
+      context "when searching by ip_addr" do
+        it "returns 422 for invalid IP address" do
+          get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "*dylan*dolly*" } }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it "returns 422 for invalid CIDR prefix" do
+          get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "127.0.0.1/999" } }
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fulfills #1945.
In moderator IP address search, validate IP addresses used in search, and show 422 for failed validation.
Screenshot: 
<img width="1222" height="219" alt="image" src="https://github.com/user-attachments/assets/e6cbb411-36d8-4846-ac83-79575d2dc5e7" />
