### PR TITLE
[PostSets] Throttle set editing to 30 actions per minute

### DIFF
--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -4,6 +4,7 @@ class PostSetsController < ApplicationController
   respond_to :html, :json
   before_action :member_only, except: %i[index show]
   before_action :ensure_lockdown_disabled, except: %i[index show]
+  before_action :check_set_modify_rate_limit, only: %i[add_posts remove_posts update_posts]
 
   def index
     if params[:post_id].present?
@@ -205,5 +206,17 @@ class PostSetsController < ApplicationController
 
   def ensure_lockdown_disabled
     access_denied if Security::Lockdown.post_sets_disabled? && !CurrentUser.is_staff?
+  end
+
+  def check_set_modify_rate_limit
+    key = "post_set.modify.#{CurrentUser.id}"
+    if RateLimiter.check_limit(key, 30, 1.minute)
+      respond_to do |format|
+        format.json { render json: { message: "You are modifying sets too quickly. Try again in a minute." }, status: 429 }
+        format.html { redirect_back fallback_location: post_sets_path, notice: "You are modifying sets too quickly. Try again in a minute." }
+      end
+    else
+      RateLimiter.hit(key, 1.minute)
+    end
   end
 end

--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -142,6 +142,11 @@ class PostSetsController < ApplicationController
     check_set_post_limit(@post_set)
 
     ids = add_remove_posts_params.map(&:to_i)
+    if ids.size > Danbooru.config.max_per_page
+      render_expected_error(400, "You can only add up to #{Danbooru.config.max_per_page} posts at a time.")
+      return
+    end
+
     @post_set.add(ids)
     @post_set.reload
 
@@ -154,6 +159,11 @@ class PostSetsController < ApplicationController
     check_set_post_limit(@post_set)
 
     ids = add_remove_posts_params.map(&:to_i)
+    if ids.size > Danbooru.config.max_per_page
+      render_expected_error(400, "You can only remove up to #{Danbooru.config.max_per_page} posts at a time.")
+      return
+    end
+
     @post_set.remove(ids)
     @post_set.reload
 
@@ -211,10 +221,7 @@ class PostSetsController < ApplicationController
   def check_set_modify_rate_limit
     key = "post_set.modify.#{CurrentUser.id}"
     if RateLimiter.check_limit(key, 30, 1.minute)
-      respond_to do |format|
-        format.json { render json: { message: "You are modifying sets too quickly. Try again in a minute." }, status: 429 }
-        format.html { redirect_back fallback_location: post_sets_path, notice: "You are modifying sets too quickly. Try again in a minute." }
-      end
+      render_expected_error(429, "You are modifying sets too quickly. Wait a bit and try again.")
     else
       RateLimiter.hit(key, 1.minute)
     end

--- a/spec/requests/post_sets_controller_spec.rb
+++ b/spec/requests/post_sets_controller_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe PostSetsController do
   let(:private_set)  { create(:post_set, creator: owner) }
   let(:public_set)   { create(:public_post_set, creator: owner) }
 
+  before do
+    allow(RateLimiter).to receive(:check_limit).and_return(false)
+  end
+
   # ---------------------------------------------------------------------------
   # GET /post_sets — index
   # ---------------------------------------------------------------------------
@@ -446,6 +450,19 @@ RSpec.describe PostSetsController do
         expect(public_set.reload.post_ids).to include(new_post.id)
       end
     end
+
+    context "when adding more than the maximum allowed posts at once" do
+      before { sign_in_as owner }
+
+      it "returns a 400 error" do
+        allow(Danbooru.config.custom_configuration).to receive(:max_per_page).and_return(3)
+
+        post_ids = create_list(:post, 4).map(&:id)
+        post add_posts_post_set_path(public_set, format: :json), params: { post_ids: post_ids }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body["message"]).to match(/only add up to/)
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -486,6 +503,19 @@ RSpec.describe PostSetsController do
         post remove_posts_post_set_path(public_set, format: :json), params: { post_ids: [existing_post.id] }
         expect(response).to have_http_status(:success)
         expect(public_set.reload.post_ids).not_to include(existing_post.id)
+      end
+    end
+
+    context "when removing more than the maximum allowed posts at once" do
+      before { sign_in_as owner }
+
+      it "returns a 400 error" do
+        allow(Danbooru.config.custom_configuration).to receive(:max_per_page).and_return(3)
+
+        post_ids = create_list(:post, 4).map(&:id)
+        post remove_posts_post_set_path(public_set, format: :json), params: { post_ids: post_ids }
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body["message"]).to match(/only remove up to/)
       end
     end
   end
@@ -543,6 +573,34 @@ RSpec.describe PostSetsController do
       sign_in_as create(:janitor_user)
       get new_post_set_path
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Throttling
+  # ---------------------------------------------------------------------------
+
+  describe "throttling" do
+    let(:new_post) { create(:post) }
+
+    before do
+      sign_in_as owner
+      allow(RateLimiter).to receive(:check_limit).and_return(true)
+    end
+
+    it "returns 429 when the rate limit is exceeded while adding posts" do
+      post add_posts_post_set_path(public_set), params: { post_ids: [new_post.id] }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 when the rate limit is exceeded while removing posts" do
+      post remove_posts_post_set_path(public_set), params: { post_ids: [new_post.id] }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 when the rate limit is exceeded while updating posts" do
+      post update_posts_post_set_path(public_set), params: { post_set: { post_ids_string: new_post.id.to_s } }
+      expect(response).to have_http_status(:too_many_requests)
     end
   end
 end


### PR DESCRIPTION
Partially address some of the vulnerability concerns with PostSets.

Added a strict limit of 30 actions that must be followed by a minute of inactivity.
This includes adding to, removing from, or changing the post list.
Additionally, limited the `add_posts` and `remove_posts` routes to 320 posts.
There is no legitimate way for users to schedule more posts than that from the UI regardless.

These two changes should prevent people from scheduling jobs faster than they can be processed.

Mitigation is continued in #1983.