### PR TITLE
[PostSets] Rework PostSetSyncJob

### DIFF
--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -102,7 +102,7 @@ class PostSetsController < ApplicationController
         if total_changes <= 1
           @post_set.sync_posts_for_delta(added_ids: actually_added, removed_ids: actually_removed)
         else
-          PostSetPostsSyncJob.perform_later(@post_set.id, added_ids: actually_added, removed_ids: actually_removed)
+          PostSetPostsSyncJob.perform_later(@post_set.id)
         end
       end
 

--- a/app/jobs/bulk_index_update_job.rb
+++ b/app/jobs/bulk_index_update_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class BulkIndexUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform(klass_name, ids)
+    klass = klass_name.constantize
+    klass.document_store.import(query: { id: ids })
+  end
+end

--- a/app/jobs/post_set_posts_sync_job.rb
+++ b/app/jobs/post_set_posts_sync_job.rb
@@ -4,7 +4,8 @@ class PostSetPostsSyncJob < ApplicationJob
   queue_as :default
   sidekiq_options lock: :until_executing, lock_args_method: :lock_args
 
-  def self.lock_args(args)
+  def self.lock_args(args, _legacy_args = nil, **_kwargs)
+    # Includes legacy args to make sure older versions of this job do not fail.
     [args.first]
   end
 

--- a/app/jobs/post_set_posts_sync_job.rb
+++ b/app/jobs/post_set_posts_sync_job.rb
@@ -2,11 +2,48 @@
 
 class PostSetPostsSyncJob < ApplicationJob
   queue_as :default
-  sidekiq_options lock: :until_executing
+  sidekiq_options lock: :until_executing, lock_args_method: :lock_args
 
-  def perform(set_id, added_ids: [], removed_ids: [])
-    set = PostSet.find(set_id)
-    set.sync_posts_for_delta(added_ids: added_ids, removed_ids: removed_ids)
+  def self.lock_args(args)
+    [args.first]
+  end
+
+  def perform(set_id)
+    set   = PostSet.find(set_id)
+    token = "set:#{set_id}"
+
+    current_ids = set.post_ids.to_set
+    token_ids   = Post.where("? = ANY(string_to_array(pool_string, ' '))", token)
+                      .pluck(:id).to_set
+
+    to_add    = (current_ids - token_ids).to_a
+    to_remove = (token_ids - current_ids).to_a
+    return if to_add.empty? && to_remove.empty?
+
+    pg = Post.connection.raw_connection
+
+    if to_add.any?
+      pg.exec_params(
+        "UPDATE posts
+         SET pool_string = trim(pool_string || $1)
+         WHERE id = ANY($2::int[])
+           AND NOT ($3 = ANY(string_to_array(pool_string, ' ')))",
+        [" #{token}", "{#{to_add.join(',')}}", token],
+      )
+    end
+
+    if to_remove.any?
+      pg.exec_params(
+        "UPDATE posts
+         SET pool_string = array_to_string(
+               array_remove(string_to_array(pool_string, ' '), $1), ' ')
+         WHERE id = ANY($2::int[])
+           AND $1 = ANY(string_to_array(pool_string, ' '))",
+        [token, "{#{to_remove.join(',')}}"],
+      )
+    end
+
+    BulkIndexUpdateJob.perform_later("Post", to_add + to_remove)
   rescue ActiveRecord::RecordNotFound
     # Set was deleted; nothing to do.
   end

--- a/app/jobs/post_set_posts_sync_job.rb
+++ b/app/jobs/post_set_posts_sync_job.rb
@@ -4,8 +4,7 @@ class PostSetPostsSyncJob < ApplicationJob
   queue_as :default
   sidekiq_options lock: :until_executing, lock_args_method: :lock_args
 
-  def self.lock_args(args, _legacy_args = nil, **_kwargs)
-    # Includes legacy args to make sure older versions of this job do not fail.
+  def self.lock_args(args)
     [args.first]
   end
 
@@ -14,7 +13,7 @@ class PostSetPostsSyncJob < ApplicationJob
     token = "set:#{set_id}"
 
     current_ids = set.post_ids.to_set
-    token_ids   = Post.where("? = ANY(string_to_array(pool_string, ' '))", token)
+    token_ids   = Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", token)
                       .pluck(:id).to_set
 
     to_add    = (current_ids - token_ids).to_a

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -212,7 +212,7 @@ class PostSet < ApplicationRecord
       if added.size <= 1
         sync_posts_for_delta(added_ids: added) if added.any?
       else
-        PostSetPostsSyncJob.perform_later(id, added_ids: added)
+        PostSetPostsSyncJob.perform_later(id)
       end
       added
     end
@@ -335,7 +335,7 @@ class PostSet < ApplicationRecord
       if removed.size <= 1
         sync_posts_for_delta(removed_ids: removed) if removed.any?
       else
-        PostSetPostsSyncJob.perform_later(id, removed_ids: removed)
+        PostSetPostsSyncJob.perform_later(id)
       end
       removed
     end

--- a/spec/jobs/bulk_index_update_job_spec.rb
+++ b/spec/jobs/bulk_index_update_job_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe BulkIndexUpdateJob do
     it "re-indexes the specified records via import" do
       posts = create_list(:post, 3)
       ids   = posts.map(&:id)
-      expect(Post.document_store).to receive(:import).with(query: { id: ids })
+      allow(Post.document_store).to receive(:import)
       job.perform_now("Post", ids)
+      expect(Post.document_store).to have_received(:import).with(query: { id: ids })
     end
 
     it "does not raise when the id list is empty" do

--- a/spec/jobs/bulk_index_update_job_spec.rb
+++ b/spec/jobs/bulk_index_update_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BulkIndexUpdateJob do
+  subject(:job) { described_class }
+
+  include_context "as member"
+
+  describe "#perform" do
+    it "re-indexes the specified records via import" do
+      posts = create_list(:post, 3)
+      ids   = posts.map(&:id)
+      expect(Post.document_store).to receive(:import).with(query: { id: ids })
+      job.perform_now("Post", ids)
+    end
+
+    it "does not raise when the id list is empty" do
+      allow(Post.document_store).to receive(:import)
+      expect { job.perform_now("Post", []) }.not_to raise_error
+    end
+  end
+end

--- a/spec/jobs/post_set_posts_sync_job_spec.rb
+++ b/spec/jobs/post_set_posts_sync_job_spec.rb
@@ -3,21 +3,94 @@
 require "rails_helper"
 
 RSpec.describe PostSetPostsSyncJob do
-  describe "#perform" do
-    context "when the set exists" do
-      let(:post_set) { create(:post_set) }
+  subject(:job) { described_class }
 
-      it "calls sync_posts_for_delta on the set" do
-        allow(PostSet).to receive(:find).with(post_set.id).and_return(post_set)
-        allow(post_set).to receive(:sync_posts_for_delta)
-        described_class.perform_now(post_set.id, added_ids: [1], removed_ids: [2])
-        expect(post_set).to have_received(:sync_posts_for_delta).with(added_ids: [1], removed_ids: [2])
-      end
+  include_context "as member"
+
+  describe ".lock_args" do
+    it "returns only the set_id, ignoring any extra arguments" do
+      expect(job.lock_args([42, { added_ids: [1, 2] }])).to eq([42])
     end
+  end
+
+  describe "#perform" do
+    let(:post_set) { create(:post_set) }
 
     context "when the set does not exist" do
       it "does not raise an error" do
-        expect { described_class.perform_now(-1) }.not_to raise_error
+        expect { job.perform_now(-1) }.not_to raise_error
+      end
+    end
+
+    context "when a post is in post_ids but missing the token" do
+      let(:post) { create(:post) }
+
+      before { Post.where(id: post.id).update_all(pool_string: "") }
+
+      it "adds the token to pool_string" do
+        post_set.update_column(:post_ids, [post.id])
+        job.perform_now(post_set.id)
+        expect(post.reload.pool_string).to include("set:#{post_set.id}")
+      end
+
+      it "enqueues a BulkIndexUpdateJob for the post" do
+        post_set.update_column(:post_ids, [post.id])
+        expect { job.perform_now(post_set.id) }
+          .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
+      end
+    end
+
+    context "when a post has the token but is not in post_ids" do
+      let(:post) { create(:post) }
+
+      before { Post.where(id: post.id).update_all(pool_string: "set:#{post_set.id}") }
+
+      it "removes the token from pool_string" do
+        post_set.update_column(:post_ids, [])
+        job.perform_now(post_set.id)
+        expect(post.reload.pool_string).not_to include("set:#{post_set.id}")
+      end
+
+      it "enqueues a BulkIndexUpdateJob for the post" do
+        post_set.update_column(:post_ids, [])
+        expect { job.perform_now(post_set.id) }
+          .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
+      end
+    end
+
+    context "when a post is correctly in both post_ids and pool_string" do
+      let(:post) { create(:post) }
+
+      before { Post.where(id: post.id).update_all(pool_string: "set:#{post_set.id}") }
+
+      it "does not change pool_string" do
+        post_set.update_column(:post_ids, [post.id])
+        expect { job.perform_now(post_set.id) }
+          .not_to(change { post.reload.pool_string })
+      end
+
+      it "does not enqueue an IndexUpdateJob" do
+        post_set.update_column(:post_ids, [post.id])
+        expect { job.perform_now(post_set.id) }
+          .not_to have_enqueued_job(IndexUpdateJob)
+      end
+    end
+
+    context "when a post is correctly absent from both post_ids and pool_string" do
+      let(:post) { create(:post) }
+
+      before { Post.where(id: post.id).update_all(pool_string: "") }
+
+      it "does not change pool_string" do
+        post_set.update_column(:post_ids, [])
+        expect { job.perform_now(post_set.id) }
+          .not_to(change { post.reload.pool_string })
+      end
+
+      it "does not enqueue an IndexUpdateJob" do
+        post_set.update_column(:post_ids, [])
+        expect { job.perform_now(post_set.id) }
+          .not_to have_enqueued_job(IndexUpdateJob)
       end
     end
   end

--- a/spec/jobs/post_set_posts_sync_job_spec.rb
+++ b/spec/jobs/post_set_posts_sync_job_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe PostSetPostsSyncJob do
           .not_to(change { post.reload.pool_string })
       end
 
-      it "does not enqueue an IndexUpdateJob" do
+      it "does not enqueue a BulkIndexUpdateJob" do
         post_set.update_column(:post_ids, [post.id])
         expect { job.perform_now(post_set.id) }
           .not_to have_enqueued_job(BulkIndexUpdateJob)
@@ -87,7 +87,7 @@ RSpec.describe PostSetPostsSyncJob do
           .not_to(change { post.reload.pool_string })
       end
 
-      it "does not enqueue an IndexUpdateJob" do
+      it "does not enqueue a BulkIndexUpdateJob" do
         post_set.update_column(:post_ids, [])
         expect { job.perform_now(post_set.id) }
           .not_to have_enqueued_job(BulkIndexUpdateJob)

--- a/spec/jobs/post_set_posts_sync_job_spec.rb
+++ b/spec/jobs/post_set_posts_sync_job_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe PostSetPostsSyncJob do
       it "does not enqueue an IndexUpdateJob" do
         post_set.update_column(:post_ids, [post.id])
         expect { job.perform_now(post_set.id) }
-          .not_to have_enqueued_job(IndexUpdateJob)
+          .not_to have_enqueued_job(BulkIndexUpdateJob)
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe PostSetPostsSyncJob do
       it "does not enqueue an IndexUpdateJob" do
         post_set.update_column(:post_ids, [])
         expect { job.perform_now(post_set.id) }
-          .not_to have_enqueued_job(IndexUpdateJob)
+          .not_to have_enqueued_job(BulkIndexUpdateJob)
       end
     end
   end


### PR DESCRIPTION
Second part to #1982.

Addresses the core of the issue: it is possible to trigger 10,000 database queries, and then spawn 10,000 jobs with one request.

This PR reworks the PostSetSync job to do two things:
1. Update the `pool_string` columns with two SQL statements, rather than one per updated post.
2. Bulk update all affected posts' OpenSearch indexes in one job, rather than 10,000.

That said, even with this in place we should consider restricting the usage of the `update_posts` route.