### PR TITLE
[AutomodDmails] Permit replies to messages addressed to automod

### DIFF
--- a/app/controllers/admin/automod_dmails_controller.rb
+++ b/app/controllers/admin/automod_dmails_controller.rb
@@ -40,7 +40,7 @@ module Admin
     private
 
     def find_system_dmail(id)
-      @dmail = Dmail.where("owner_id = ?", User.system.id).includes(:to, :from).find(id)
+      Dmail.where("owner_id = ?", User.system.id).includes(:to, :from).find(id)
     end
   end
 end

--- a/app/controllers/admin/automod_dmails_controller.rb
+++ b/app/controllers/admin/automod_dmails_controller.rb
@@ -15,8 +15,32 @@ module Admin
 
     def show
       @user = User.system
-      @dmail = Dmail.where("owner_id = ?", @user.id).includes(:to, :from).find(params[:id])
+      @dmail = find_system_dmail(params[:id])
       respond_with(@dmail)
+    end
+
+    def mark_as_read
+      @dmail = find_system_dmail(params[:id])
+      @dmail.mark_as_read!
+      respond_to do |format|
+        format.html { redirect_to(admin_automod_dmail_path(@dmail), notice: "Message marked as read") }
+        format.json
+      end
+    end
+
+    def mark_as_unread
+      @dmail = find_system_dmail(params[:id])
+      @dmail.mark_as_unread!
+      respond_to do |format|
+        format.html { redirect_to(admin_automod_dmail_path(@dmail), notice: "Message marked as unread") }
+        format.json
+      end
+    end
+
+    private
+
+    def find_system_dmail(id)
+      @dmail = Dmail.where("owner_id = ?", User.system.id).includes(:to, :from).find(id)
     end
   end
 end

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -57,15 +57,28 @@ class DmailsController < ApplicationController
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
     @dmail.mark_as_read!
+    if @dmail.to_id == User.system.id
+      respond_to do |format|
+        format.html { redirect_to(admin_automod_dmail_path(@dmail), notice: "Message marked as read") }
+        format.json
+      end
+    end
   end
 
   def mark_as_unread
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
     @dmail.mark_as_unread!
-    respond_to do |format|
-      format.html { redirect_to(dmails_path, notice: "Message marked as unread") }
-      format.json
+    if @dmail.to_id == User.system.id
+      respond_to do |format|
+        format.html { redirect_to(admin_automod_dmail_path(@dmail), notice: "Message marked as unread") }
+        format.json
+      end
+    else
+      respond_to do |format|
+        format.html { redirect_to(dmails_path, notice: "Message marked as unread") }
+        format.json
+      end
     end
   end
 

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -57,28 +57,15 @@ class DmailsController < ApplicationController
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
     @dmail.mark_as_read!
-    if @dmail.to_id == User.system.id
-      respond_to do |format|
-        format.html { redirect_to(admin_automod_dmail_path(@dmail), notice: "Message marked as read") }
-        format.json
-      end
-    end
   end
 
   def mark_as_unread
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
     @dmail.mark_as_unread!
-    if @dmail.to_id == User.system.id
-      respond_to do |format|
-        format.html { redirect_to(admin_automod_dmail_path(@dmail), notice: "Message marked as unread") }
-        format.json
-      end
-    else
-      respond_to do |format|
-        format.html { redirect_to(dmails_path, notice: "Message marked as unread") }
-        format.json
-      end
+    respond_to do |format|
+      format.html { redirect_to(dmails_path, notice: "Message marked as unread") }
+      format.json
     end
   end
 

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -240,6 +240,7 @@ class Dmail < ApplicationRecord
   end
 
   def visible_to?(user)
+    return true if user.is_janitor? && to_id == User.system.id
     return true if user.is_moderator? && (from_id == User.system.id || Ticket.where(qtype: "dmail", disp_id: id).exists?)
     return true if user.is_admin? && (to.is_admin? || from.is_admin?)
     owner_id == user.id

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -74,7 +74,7 @@ class Ticket < ApplicationRecord
 
     module Dmail
       def can_create_for?(user)
-        content&.visible_to?(user) && content.to_id == user.id
+        content&.visible_to?(user) && (content.to_id == user.id || content.to_id == ::User.system.id)
       end
 
       def can_view?(user)

--- a/app/views/admin/automod_dmails/show.html.erb
+++ b/app/views/admin/automod_dmails/show.html.erb
@@ -21,9 +21,9 @@
         <%= link_to "Respond", new_dmail_path(respond_to_id: @dmail) %>
         | <%= link_to "Forward", new_dmail_path(respond_to_id: @dmail, forward: true) %>
         <% if @dmail.is_read? %>
-          | <%= link_to "Mark as unread", mark_as_unread_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as unread?" } %>
+          | <%= link_to "Mark as unread", mark_as_unread_admin_automod_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as unread?" } %>
         <% else %>
-          | <%= link_to "Mark as read", mark_as_read_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as read?" } %>
+          | <%= link_to "Mark as read", mark_as_read_admin_automod_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as read?" } %>
         <% end %>
         | <%= link_to "Report", new_ticket_path(disp_id: @dmail.id, qtype: "dmail") %>
       </p>

--- a/app/views/admin/automod_dmails/show.html.erb
+++ b/app/views/admin/automod_dmails/show.html.erb
@@ -16,13 +16,17 @@
       <h3>Body</h3>
       <div class="dtext-container">
         <%= format_text(@dmail.body) %>
-
-        <% if @dmail.is_automated? %>
-          <p class="info">
-            This is an automated message. Responses will not be seen. If you have any questions either message a moderator or ask in the forum.
-          </p>
-        <% end %>
       </div>
+      <p>
+        <%= link_to "Respond", new_dmail_path(respond_to_id: @dmail) %>
+        | <%= link_to "Forward", new_dmail_path(respond_to_id: @dmail, forward: true) %>
+        <% if @dmail.is_read? %>
+          | <%= link_to "Mark as unread", mark_as_unread_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as unread?" } %>
+        <% else %>
+          | <%= link_to "Mark as read", mark_as_read_dmail_path(@dmail), method: :put, data: { confirm: "Are you sure you want to mark this DMail as read?" } %>
+        <% end %>
+        | <%= link_to "Report", new_ticket_path(disp_id: @dmail.id, qtype: "dmail") %>
+      </p>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,12 @@ Rails.application.routes.draw do
     resource :reowner, controller: "reowner", only: %i[new create]
     resource :stuck_dnp, controller: "stuck_dnp", only: %i[new create]
     resources :destroyed_posts, only: %i[index show update]
-    resources :automod_dmails, only: %i[index show]
+    resources :automod_dmails, only: %i[index show] do
+      member do
+        put :mark_as_read
+        put :mark_as_unread
+      end
+    end
   end
 
   namespace :security do

--- a/spec/models/ticket/permissions_spec.rb
+++ b/spec/models/ticket/permissions_spec.rb
@@ -163,6 +163,14 @@ RSpec.describe Ticket do
       t.save!(validate: false)
       t
     end
+    let(:dmail_to_system) { create(:dmail, to: User.system) }
+    let(:ticket_system) do
+      t = build(:ticket, :dmail_type, dmail: dmail_to_system)
+      t.creator_id      = CurrentUser.id
+      t.creator_ip_addr = CurrentUser.ip_addr
+      t.save!(validate: false)
+      t
+    end
 
     describe "#can_create_for?" do
       it "returns true when the user is the dmail recipient" do
@@ -171,6 +179,14 @@ RSpec.describe Ticket do
 
       it "returns false when the user is not the dmail recipient" do
         expect(ticket.can_create_for?(other)).to be false
+      end
+
+      it "returns true when the user is a janitor and the dmail recipient is the system user" do
+        expect(ticket_system.can_create_for?(janitor)).to be true
+      end
+
+      it "returns false when the user is a not janitor and the dmail recipient is the system user" do
+        expect(ticket_system.can_create_for?(other)).to be false
       end
     end
 

--- a/spec/requests/admin/automod_dmails_controller_spec.rb
+++ b/spec/requests/admin/automod_dmails_controller_spec.rb
@@ -95,4 +95,88 @@ RSpec.describe Admin::AutomodDmailsController do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # PUT /admin/automod_dmails/:id/mark_as_read — mark_as_read
+  # ---------------------------------------------------------------------------
+
+  describe "PUT /admin/automod_dmails/:id/mark_as_read" do
+    before { system_dmail.update_columns(is_read: false) }
+
+    it "redirects anonymous to the login page" do
+      put mark_as_read_admin_automod_dmail_path(system_dmail)
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 403 for a regular member" do
+      sign_in_as member
+      put mark_as_read_admin_automod_dmail_path(system_dmail)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as janitor" do
+      before { sign_in_as janitor }
+
+      it "marks the system_dmail as read and reloads (HTML)" do
+        put mark_as_read_admin_automod_dmail_path(system_dmail)
+        expect(response).to redirect_to(admin_automod_dmail_path(system_dmail))
+        expect(flash[:notice]).to eq("Message marked as read")
+        expect(system_dmail.reload.is_read).to be true
+      end
+
+      it "marks the system_dmail as read (JSON)" do
+        put mark_as_read_admin_automod_dmail_path(system_dmail, format: :json)
+        expect(response).to have_http_status(:no_content)
+        expect(system_dmail.reload.is_read).to be true
+      end
+
+      it "returns 404 for a dmail not owned by the system user" do
+        other_dmail = create(:dmail)
+        put mark_as_read_admin_automod_dmail_path(other_dmail)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # PUT /admin/automod_dmails/:id/mark_as_unread — mark_as_unread
+  # ---------------------------------------------------------------------------
+
+  describe "PUT /admin/automod_dmails/:id/mark_as_unread" do
+    before { system_dmail.update_columns(is_read: true) }
+
+    it "redirects anonymous to the login page" do
+      put mark_as_unread_admin_automod_dmail_path(system_dmail)
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 403 for a regular member" do
+      sign_in_as member
+      put mark_as_unread_admin_automod_dmail_path(system_dmail)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as janitor" do
+      before { sign_in_as janitor }
+
+      it "marks the system_dmail as unread and reloads (HTML)" do
+        put mark_as_unread_admin_automod_dmail_path(system_dmail)
+        expect(response).to redirect_to(admin_automod_dmail_path(system_dmail))
+        expect(flash[:notice]).to eq("Message marked as unread")
+        expect(system_dmail.reload.is_read).to be false
+      end
+
+      it "marks the system_dmail as unread (JSON)" do
+        put mark_as_unread_admin_automod_dmail_path(system_dmail, format: :json)
+        expect(response).to have_http_status(:no_content)
+        expect(system_dmail.reload.is_read).to be false
+      end
+
+      it "returns 404 for a dmail not owned by the system user" do
+        other_dmail = create(:dmail)
+        put mark_as_unread_admin_automod_dmail_path(other_dmail)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/requests/dmails_controller_spec.rb
+++ b/spec/requests/dmails_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe DmailsController do
   let(:sender)    { create(:user) }
   let(:recipient) { create(:user) }
   let(:other)     { create(:user) }
+  let(:janitor) { create(:janitor_user) }
   let(:moderator) { create(:moderator_user) }
   let(:admin)     { create(:admin_user) }
 
@@ -181,6 +182,13 @@ RSpec.describe DmailsController do
       expect { get dmail_path(dmail) }.not_to(change { dmail.reload.is_read })
     end
 
+    it "returns 200 for a janitor viewing a system-received dmail" do
+      dmail_to_system = create(:dmail, from: recipient, to: User.system)
+      sign_in_as janitor
+      get dmail_path(dmail_to_system)
+      expect(response).to have_http_status(:ok)
+    end
+
     it "returns 200 for a moderator viewing a system-sent dmail" do
       system_dmail = create(:dmail, from: User.system, to: recipient)
       sign_in_as moderator
@@ -252,6 +260,21 @@ RSpec.describe DmailsController do
       expect(dmail.reload.is_read).to be true
     end
 
+    it "marks the system-received dmail as unread and reloads (HTML)" do
+      dmail_to_system = create(:dmail, from: recipient, to: User.system)
+      sign_in_as janitor
+      put mark_as_read_dmail_path(dmail_to_system)
+      expect(response).to redirect_to(admin_automod_dmail_path(dmail_to_system))
+      expect(flash[:notice]).to eq("Message marked as read")
+    end
+
+    it "marks the system-received dmail as unread (JSON)" do
+      dmail_to_system = create(:dmail, from: recipient, to: User.system)
+      sign_in_as janitor
+      put mark_as_read_dmail_path(dmail_to_system, format: :json)
+      expect(dmail_to_system.reload.is_read).to be true
+    end
+
     it "returns 403 for a non-owner member" do
       sign_in_as other
       put mark_as_read_dmail_path(dmail, format: :json)
@@ -271,7 +294,7 @@ RSpec.describe DmailsController do
       expect(response).to redirect_to(new_session_path)
     end
 
-    it "marks the dmail as unread and redirects with a notice for the owner (HTML)" do
+    it "marks the user-received dmail as unread and redirects with a notice for the owner (HTML)" do
       sign_in_as recipient
       put mark_as_unread_dmail_path(dmail)
       expect(dmail.reload.is_read).to be false
@@ -283,6 +306,21 @@ RSpec.describe DmailsController do
       sign_in_as recipient
       put mark_as_unread_dmail_path(dmail, format: :json)
       expect(dmail.reload.is_read).to be false
+    end
+
+    it "marks the system-received dmail as unread and reloads (HTML)" do
+      dmail_to_system = create(:dmail, from: recipient, to: User.system)
+      sign_in_as janitor
+      put mark_as_unread_dmail_path(dmail_to_system)
+      expect(response).to redirect_to(admin_automod_dmail_path(dmail_to_system))
+      expect(flash[:notice]).to eq("Message marked as unread")
+    end
+
+    it "marks the system-received dmail as unread (JSON)" do
+      dmail_to_system = create(:dmail, from: recipient, to: User.system)
+      sign_in_as janitor
+      put mark_as_unread_dmail_path(dmail_to_system, format: :json)
+      expect(dmail_to_system.is_read).to be false
     end
 
     it "returns 403 for a non-owner member" do

--- a/spec/requests/dmails_controller_spec.rb
+++ b/spec/requests/dmails_controller_spec.rb
@@ -260,21 +260,6 @@ RSpec.describe DmailsController do
       expect(dmail.reload.is_read).to be true
     end
 
-    it "marks the system-received dmail as unread and reloads (HTML)" do
-      dmail_to_system = create(:dmail, from: recipient, to: User.system)
-      sign_in_as janitor
-      put mark_as_read_dmail_path(dmail_to_system)
-      expect(response).to redirect_to(admin_automod_dmail_path(dmail_to_system))
-      expect(flash[:notice]).to eq("Message marked as read")
-    end
-
-    it "marks the system-received dmail as unread (JSON)" do
-      dmail_to_system = create(:dmail, from: recipient, to: User.system)
-      sign_in_as janitor
-      put mark_as_read_dmail_path(dmail_to_system, format: :json)
-      expect(dmail_to_system.reload.is_read).to be true
-    end
-
     it "returns 403 for a non-owner member" do
       sign_in_as other
       put mark_as_read_dmail_path(dmail, format: :json)
@@ -294,7 +279,7 @@ RSpec.describe DmailsController do
       expect(response).to redirect_to(new_session_path)
     end
 
-    it "marks the user-received dmail as unread and redirects with a notice for the owner (HTML)" do
+    it "marks the dmail as unread and redirects with a notice for the owner (HTML)" do
       sign_in_as recipient
       put mark_as_unread_dmail_path(dmail)
       expect(dmail.reload.is_read).to be false
@@ -306,21 +291,6 @@ RSpec.describe DmailsController do
       sign_in_as recipient
       put mark_as_unread_dmail_path(dmail, format: :json)
       expect(dmail.reload.is_read).to be false
-    end
-
-    it "marks the system-received dmail as unread and reloads (HTML)" do
-      dmail_to_system = create(:dmail, from: recipient, to: User.system)
-      sign_in_as janitor
-      put mark_as_unread_dmail_path(dmail_to_system)
-      expect(response).to redirect_to(admin_automod_dmail_path(dmail_to_system))
-      expect(flash[:notice]).to eq("Message marked as unread")
-    end
-
-    it "marks the system-received dmail as unread (JSON)" do
-      dmail_to_system = create(:dmail, from: recipient, to: User.system)
-      sign_in_as janitor
-      put mark_as_unread_dmail_path(dmail_to_system, format: :json)
-      expect(dmail_to_system.is_read).to be false
     end
 
     it "returns 403 for a non-owner member" do

--- a/spec/requests/dmails_controller_spec.rb
+++ b/spec/requests/dmails_controller_spec.rb
@@ -93,6 +93,34 @@ RSpec.describe DmailsController do
         get new_dmail_path, params: { respond_to_id: dmail.id, forward: true }
         expect(response).to have_http_status(:ok)
       end
+
+      it "returns 200 for a janitor when the recipient is the system user" do
+        dmail_to_system = create(:dmail, from: sender, to: User.system, owner_id: User.system.id)
+        sign_in_as janitor
+        get new_dmail_path, params: { respond_to_id: dmail_to_system.id }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns 403 for a different user when the recipient is the system user" do
+        dmail_to_system = create(:dmail, from: sender, to: User.system, owner_id: User.system.id)
+        sign_in_as other
+        get new_dmail_path, params: { respond_to_id: dmail_to_system.id }
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "returns 200 for a forward for a janitor when the recipient is the system user" do
+        dmail_to_system = create(:dmail, from: sender, to: User.system, owner_id: User.system.id)
+        sign_in_as janitor
+        get new_dmail_path, params: { respond_to_id: dmail_to_system.id, forward: true }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns 403 for a forward for a different user when the recipient is the system user" do
+        dmail_to_system = create(:dmail, from: sender, to: User.system, owner_id: User.system.id)
+        sign_in_as other
+        get new_dmail_path, params: { respond_to_id: dmail_to_system.id, forward: true }
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 


### PR DESCRIPTION
Automod DMails now have:
- Respond
- Forward
- Mark as read/unread
- Report

These work as-if the DMail was your own.

Mark read/unread has different behaviour when the recipient is the automod: it reloads the page instead of redirecting to the index.

DMail permissions now allow all staff to view when the recipient is the automod, which is consistent with the new automod DMails route. This is necessary to make the actions work, because you need to be able to view a DMail to respond, forward or ticket it (otherwise it'd be trivial to leak the contents). This could be simplified a bit by merging it with the moderator permission to see DMails sent by the automod, so all staff can see both from and to automod. It makes sense when you consider that any automod DMail could be replied to by a user, exposing the original message to all staff.

All staff can create a ticket about a DMail sent to automod. View permissions could also be changed to allow all staff to see tickets about DMails sent to the automod, but I left this out to avoid making the ticket permissions more complicated than necessary.