### PR TITLE
[UI] Fix improper spoiler tag link navigation on mobile

### DIFF
--- a/app/javascript/src/js/core/common.js
+++ b/app/javascript/src/js/core/common.js
@@ -33,6 +33,20 @@ $(function () {
     e.preventDefault();
   });
 
+  // Prevent link navigation on first tap of a spoiler tag on touch devices.
+  $(document).on("touchend.danbooru", ".spoiler", function (e) {
+    if ($(e.target).closest("a", this).length && !$(this).hasClass("spoiler-revealed")) {
+      e.preventDefault();
+    }
+    $(this).addClass("spoiler-revealed");
+  });
+
+  $(document).on("touchstart.danbooru", function (e) {
+    if (!$(e.target).closest(".spoiler").length) {
+      $(".spoiler.spoiler-revealed").removeClass("spoiler-revealed");
+    }
+  });
+
   $(".revert-item-link").on("click", e => {
     e.preventDefault();
     const target = $(e.target);

--- a/app/javascript/src/styles/common/spoiler.scss
+++ b/app/javascript/src/styles/common/spoiler.scss
@@ -10,19 +10,10 @@
     background-color: $spoiler-background;
   }
 
-  &:hover {
+  &:hover, &.spoiler-revealed {
     color: $spoiler-hover-color;
 
     a {
-      // Prevent accidentally opening a link when tapping to reveal it
-      animation: delay-pointer-events 50ms;
-
-      @keyframes delay-pointer-events {
-        0%, 99% {
-          pointer-events: none;
-        }
-      }
-
       color: themed('color-spoiler-link');
       &:hover {
         color: themed('color-spoiler-link-hover');


### PR DESCRIPTION
This completes https://github.com/e621ng/e621ng/issues/1760 by preventing link navigation on touch devices during the user's initial tap on a spoiler tag. It also cleans up and removes the old faulty CSS-only attempt.