### PR TITLE
[ModActions] Guard search against non-integer JSONB values

### DIFF
--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -139,8 +139,11 @@ class ModAction < ApplicationRecord
       # Historical rows can hold non-integer strings (e.g. "permanent") under
       # integer-typed JSONB keys; the CASE guard skips the cast for those rows
       # instead of failing the whole query with PG::InvalidTextRepresentation.
+      # `-{0,1}` rather than `-?` so the regex contains no literal `?`,
+      # which ActiveRecord's positional bind logic in `add_range_relation`
+      # would otherwise scan as an extra placeholder.
       qualified_column = Arel.sql(
-        "CASE WHEN (values ->> '#{attribute}') ~ '^-?[0-9]+$' " \
+        "CASE WHEN (values ->> '#{attribute}') ~ '^-{0,1}[0-9]+$' " \
         "THEN (values ->> '#{attribute}')::INTEGER END",
       )
       parsed_range = ParseValue.range(range, :integer)

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -136,7 +136,13 @@ class ModAction < ApplicationRecord
     end
 
     def jsonb_numeric_attribute_matches(attribute, range)
-      qualified_column = Arel.sql("(values ->> '#{attribute}')::INTEGER")
+      # Historical rows can hold non-integer strings (e.g. "permanent") under
+      # integer-typed JSONB keys; the CASE guard skips the cast for those rows
+      # instead of failing the whole query with PG::InvalidTextRepresentation.
+      qualified_column = Arel.sql(
+        "CASE WHEN (values ->> '#{attribute}') ~ '^-?[0-9]+$' " \
+        "THEN (values ->> '#{attribute}')::INTEGER END",
+      )
       parsed_range = ParseValue.range(range, :integer)
 
       add_range_relation(parsed_range, qualified_column)

--- a/test/unit/mod_action_test.rb
+++ b/test/unit/mod_action_test.rb
@@ -10,22 +10,22 @@ class ModActionTest < ActiveSupport::TestCase
 
     context "when filtering by an integer-typed JSONB field" do
       setup do
-        @ban_30 = create(:mod_action, action: "user_ban", values: { "user_id" => 1, "duration" => 30, "reason" => "x" })
-        @ban_7  = create(:mod_action, action: "user_ban", values: { "user_id" => 2, "duration" => 7, "reason" => "y" })
+        @thirty_day_ban = create(:mod_action, action: "user_ban", values: { "user_id" => 1, "duration" => 30, "reason" => "x" })
+        @seven_day_ban  = create(:mod_action, action: "user_ban", values: { "user_id" => 2, "duration" => 7, "reason" => "y" })
         # Older user_ban rows can hold the string "permanent" under the
         # integer-typed `duration` key; an unconditional `::INTEGER` cast
         # would raise PG::InvalidTextRepresentation across the whole result.
-        @ban_permanent = create(:mod_action, action: "user_ban", values: { "user_id" => 3, "duration" => "permanent", "reason" => "z" })
+        @permanent_ban = create(:mod_action, action: "user_ban", values: { "user_id" => 3, "duration" => "permanent", "reason" => "z" })
       end
 
       should "return matching integer rows without raising on non-integer rows" do
         results = ModAction.search(action: "user_ban", duration: "30")
-        assert_equal([@ban_30.id], results.map(&:id))
+        assert_equal([@thirty_day_ban.id], results.map(&:id))
       end
 
       should "support range syntax without raising on non-integer rows" do
         results = ModAction.search(action: "user_ban", duration: "1..29")
-        assert_equal([@ban_7.id], results.map(&:id))
+        assert_equal([@seven_day_ban.id], results.map(&:id))
       end
 
       should "skip non-integer values rather than matching them" do
@@ -33,7 +33,7 @@ class ModActionTest < ActiveSupport::TestCase
         # not even when the duration parameter is empty (which falls through to
         # the action-only filter and would expose any cast that ran on every row).
         all_user_bans = ModAction.search(action: "user_ban").map(&:id)
-        assert_includes(all_user_bans, @ban_permanent.id)
+        assert_includes(all_user_bans, @permanent_ban.id)
 
         empty_match = ModAction.search(action: "user_ban", duration: "999999")
         assert_empty(empty_match.to_a)

--- a/test/unit/mod_action_test.rb
+++ b/test/unit/mod_action_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ModActionTest < ActiveSupport::TestCase
+  context "ModAction.search" do
+    setup do
+      CurrentUser.user = create(:admin_user)
+    end
+
+    context "when filtering by an integer-typed JSONB field" do
+      setup do
+        @ban_30 = create(:mod_action, action: "user_ban", values: { "user_id" => 1, "duration" => 30, "reason" => "x" })
+        @ban_7  = create(:mod_action, action: "user_ban", values: { "user_id" => 2, "duration" => 7, "reason" => "y" })
+        # Older user_ban rows can hold the string "permanent" under the
+        # integer-typed `duration` key; an unconditional `::INTEGER` cast
+        # would raise PG::InvalidTextRepresentation across the whole result.
+        @ban_permanent = create(:mod_action, action: "user_ban", values: { "user_id" => 3, "duration" => "permanent", "reason" => "z" })
+      end
+
+      should "return matching integer rows without raising on non-integer rows" do
+        results = ModAction.search(action: "user_ban", duration: "30")
+        assert_equal([@ban_30.id], results.map(&:id))
+      end
+
+      should "support range syntax without raising on non-integer rows" do
+        results = ModAction.search(action: "user_ban", duration: "1..29")
+        assert_equal([@ban_7.id], results.map(&:id))
+      end
+
+      should "skip non-integer values rather than matching them" do
+        # The "permanent" row must never appear in any integer-comparison result,
+        # not even when the duration parameter is empty (which falls through to
+        # the action-only filter and would expose any cast that ran on every row).
+        all_user_bans = ModAction.search(action: "user_ban").map(&:id)
+        assert_includes(all_user_bans, @ban_permanent.id)
+
+        empty_match = ModAction.search(action: "user_ban", duration: "999999")
+        assert_empty(empty_match.to_a)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #1943.

## What

Wraps the integer cast in `ModAction.jsonb_numeric_attribute_matches` with a
`CASE` guard so a single legacy row can no longer crash a whole search.

```sql
-- before
(values ->> 'duration')::INTEGER

-- after
CASE WHEN (values ->> 'duration') ~ '^-?[0-9]+$'
     THEN (values ->> 'duration')::INTEGER
END
```

Non-numeric values (e.g. the historical `"permanent"` strings flagged in
the issue) now evaluate to `NULL`, fall out of every integer comparison
in `add_range_relation`, and never reach the `::INTEGER` cast.

## Why

`(values ->> 'duration')::INTEGER` is applied across every row that
matches the `action=user_ban` filter. As soon as one row has the string
`"permanent"` in its JSONB `duration` (the issue traces this back to an
older code path that called `humanized_duration` instead of the integer
`duration` accessor before logging the mod action), Postgres raises
`PG::InvalidTextRepresentation` and the entire `/mod_actions` search
500s. Issue #1943 has the full repro and pointer chain into the affected
files.

The issue suggested two complementary fixes: a data migration to
normalize stale `"permanent"` values, plus a guard at the search layer.
This PR ships only the search-layer guard - that's the one that prevents
new crashes regardless of what shape any future historical row turns up
in, and it leaves any future cleanup migration as a separate change.

## How to test

Existing tests still pass via the standard CI flow
(`bin/rails db:create && bin/rails db:schema:load && bin/rails tests`).

The new regression test (`test/unit/mod_action_test.rb`) covers:

- exact match (`duration: "30"`) returns the integer-duration row
- range match (`duration: "1..29"`) returns the matching integer row
- the `"permanent"` row is still findable by an action-only search but
  never matches an integer-comparison search, including the case that
  used to trip the cast on every row in the result set

## Notes

The CASE expression uses `^-?[0-9]+$` rather than `\A-?\d+\z` to keep
the regex inside the SQL literal portable across Postgres versions and
to avoid any backslash-escape surprises in the surrounding double-quoted
Ruby string. `~` is single-line by default in Postgres so `^`/`$` here
behave as start/end-of-string anchors, which is what we want.
