### PR TITLE
[Users] Fix former staff badge color

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -15,7 +15,7 @@ module UsersHelper
   def user_level_badge(user)
     return if user.nil?
 
-    tag.span(class: "level-badge level-#{user.level_string.downcase}") do
+    tag.span(class: "level-badge #{user.level_css_class}") do
       user.level_string.upcase
     end
   end
@@ -24,7 +24,7 @@ module UsersHelper
     return if user.nil?
     return if user.custom_title.blank?
 
-    tag.span(class: "level-badge level-#{user.level_string.downcase}") do
+    tag.span(class: "level-badge #{user.level_css_class}") do
       user.custom_title.upcase
     end
   end

--- a/app/javascript/src/styles/views/application/_level_badge.scss
+++ b/app/javascript/src/styles/views/application/_level_badge.scss
@@ -23,12 +23,12 @@ $user-level-text: (
   @include st-radius;
 
   @each $level in $user-levels {
-    &.level-#{$level} {
-      background: themed("color-user-" + $level);
+    &.user-#{$level} {
+      background-color: themed("color-user-#{$level}");
     }
   }
   @each $level, $color in $user-level-text {
-    &.level-#{$level} {
+    &.user-#{$level} {
       color: $color;
     }
   }

--- a/app/javascript/src/styles/views/application/_level_badge.scss
+++ b/app/javascript/src/styles/views/application/_level_badge.scss
@@ -24,7 +24,7 @@ $user-level-text: (
 
   @each $level in $user-levels {
     &.user-#{$level} {
-      background-color: themed("color-user-#{$level}");
+      background-color: themed("color-user-#{$level}", themed("color-user-member"));
     }
   }
   @each $level, $color in $user-level-text {

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -36,6 +36,10 @@ FactoryBot.define do
       level { User::Levels::PRIVILEGED }
     end
 
+    factory :former_staff_user do
+      level { User::Levels::FORMER_STAFF }
+    end
+
     factory :janitor_user do
       level { User::Levels::JANITOR }
     end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe UsersHelper do
   let(:user) { build(:user) }
-  let(:former_staff_user) { build(:former_staff_user) }
+  let(:former_staff) { build(:former_staff_user) }
   let(:moderator) { build(:moderator_user) }
   let(:admin) { build(:admin_user) }
 
@@ -20,7 +20,7 @@ RSpec.describe UsersHelper do
 
     it "includes the correct CSS class for the user's level" do
       expect(helper.user_level_badge(user)).to include("user-member")
-      expect(helper.user_level_badge(former_staff_user)).to include("user-former-staff")
+      expect(helper.user_level_badge(former_staff)).to include("user-former-staff")
       expect(helper.user_level_badge(moderator)).to include("user-moderator")
       expect(helper.user_level_badge(admin)).to include("user-admin")
     end

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -4,23 +4,31 @@ require "rails_helper"
 
 RSpec.describe UsersHelper do
   let(:user) { build(:user) }
+  let(:former_staff_user) { build(:former_staff_user) }
+  let(:moderator) { build(:moderator_user) }
+  let(:admin) { build(:admin_user) }
 
   describe "#user_level_badge" do
-    context "when user does not have a custom title" do
-      it "displays the level string in uppercase" do
-        badge_html = helper.user_level_badge(user)
-        expect(badge_html).to include("MEMBER")
-      end
+    it "returns nil if the user is nil" do
+      expect(helper.user_level_badge(nil)).to be_nil
+    end
 
-      it "does not display the custom title badge" do
-        badge_html = helper.user_custom_title_badge(user)
-        expect(badge_html).to be_nil
-      end
+    it "displays the level string in uppercase" do
+      badge_html = helper.user_level_badge(user)
+      expect(badge_html).to include("MEMBER")
+    end
 
-      it "does not display the level string if the user is nil" do
-        badge_html = helper.user_level_badge(nil)
-        expect(badge_html).to be_nil
-      end
+    it "includes the correct CSS class for the user's level" do
+      expect(helper.user_level_badge(user)).to include("user-member")
+      expect(helper.user_level_badge(former_staff_user)).to include("user-former-staff")
+      expect(helper.user_level_badge(moderator)).to include("user-moderator")
+      expect(helper.user_level_badge(admin)).to include("user-admin")
+    end
+  end
+
+  describe "#user_custom_title_badge" do
+    it "returns nil if the user is nil" do
+      expect(helper.user_custom_title_badge(nil)).to be_nil
     end
 
     context "when user has a custom title" do
@@ -30,24 +38,25 @@ RSpec.describe UsersHelper do
         badge_html = helper.user_custom_title_badge(user)
         expect(badge_html).to include("CUSTOM TITLE")
       end
+    end
 
-      it "does not display the custom title badge if the user is nil" do
-        badge_html = helper.user_custom_title_badge(nil)
-        expect(badge_html).to be_nil
+    context "when user does not have a custom title" do
+      it "returns nil" do
+        expect(helper.user_custom_title_badge(user)).to be_nil
       end
     end
   end
 
   describe "#user_level_plain" do
+    it "returns nil if the user is nil" do
+      expect(helper.user_level_plain(nil)).to be_nil
+    end
+
     context "when user has a custom title" do
       it "returns the custom title" do
         user.custom_title = "Custom Title"
 
         expect(helper.user_level_plain(user)).to eq("Custom Title")
-      end
-
-      it "returns nil if the user is nil" do
-        expect(helper.user_level_plain(nil)).to be_nil
       end
     end
 
@@ -61,6 +70,10 @@ RSpec.describe UsersHelper do
   end
 
   describe "#user_bd_staff_badge" do
+    it "returns nil if the user is nil" do
+      expect(helper.user_bd_staff_badge(nil)).to be_nil
+    end
+
     context "when user is BD staff" do
       it "displays the BD STAFF badge" do
         user.is_bd_staff = true
@@ -71,16 +84,10 @@ RSpec.describe UsersHelper do
     end
 
     context "when user is not BD staff" do
-      it "does not display the BD STAFF badge" do
+      it "returns nil" do
         user.is_bd_staff = false
 
-        badge_html = helper.user_bd_staff_badge(user)
-        expect(badge_html).to be_nil
-      end
-
-      it "does not display the BD STAFF badge if the user is nil" do
-        badge_html = helper.user_bd_staff_badge(nil)
-        expect(badge_html).to be_nil
+        expect(helper.user_bd_staff_badge(user)).to be_nil
       end
     end
   end


### PR DESCRIPTION
Switched to a more standard `User#level_css_class` method.
Previous approach did not deal with spaces in level string properly.

Also reorganized the helper spec file a little.