### PR TITLE
[Misc] Add missing bsky link favicons

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -150,6 +150,8 @@ module LinkHelper
 
     # image servers
     "4cdn.org" => "4chan.org",
+    "bsky.network" => "bsky.app",
+    "bsky.social" => "bsky.app",
     "cdn.donmai.us" => "danbooru.donmai.us",
     "cohostcdn.org" => "cohost.org",
     "discordapp.com" => "discord.com",


### PR DESCRIPTION
Minor tweak - added `bsky.network` and `bsky.social` as aliases to `bsky.app` in the link decorator.