### PR TITLE
[Posts] Improve and add more source sanitizers

### DIFF
--- a/app/logical/sources/alternates.rb
+++ b/app/logical/sources/alternates.rb
@@ -11,6 +11,10 @@ module Sources
         Alternates::Inkbunny,
         Alternates::Youtube,
         Alternates::Derpibooru,
+        Alternates::Facebook,
+        Alternates::Webtoons,
+        Alternates::Tapas,
+        Alternates::Imgur,
       ]
     end
 

--- a/app/logical/sources/alternates/base.rb
+++ b/app/logical/sources/alternates/base.rb
@@ -30,7 +30,7 @@ module Sources
 
       def force_https?
         return false if @parsed_url.blank?
-        secure_domains = %w[weasyl.com e-hentai.org hentai-foundry.com paheal.net imgur.com]
+        secure_domains = %w[weasyl.com e-hentai.org hentai-foundry.com paheal.net]
         secure_domains.include?(@parsed_url.domain)
       end
 

--- a/app/logical/sources/alternates/facebook.rb
+++ b/app/logical/sources/alternates/facebook.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Sources
+  module Alternates
+    class Facebook < Base
+      def force_https?
+        true
+      end
+
+      def domains
+        ["facebook.com"]
+      end
+
+      def original_url
+        # Convert mobile/alternate subdomain URLs to www
+        if %w[m.facebook.com web.facebook.com].include?(@parsed_url.host)
+          @parsed_url.host = "www.facebook.com"
+        end
+        # Normalize /photo and /photo/ to /photo.php
+        if @parsed_url.path.match?(%r{\A/photo/?\z})
+          @parsed_url.path = "/photo.php"
+        end
+        # Keep only fbid param for photo.php URLs
+        if @parsed_url.path == "/photo.php" && @parsed_url.query_values&.key?("fbid")
+          @parsed_url.query_values = { "fbid" => @parsed_url.query_values["fbid"] }
+        end
+        # Keep only story_fbid and id params for story.php URLs
+        if @parsed_url.path == "/story.php" && @parsed_url.query_values&.key?("story_fbid")
+          @parsed_url.query_values = @parsed_url.query_values.slice("story_fbid", "id")
+        end
+        @url = @parsed_url.to_s
+      end
+    end
+  end
+end

--- a/app/logical/sources/alternates/furaffinity.rb
+++ b/app/logical/sources/alternates/furaffinity.rb
@@ -15,6 +15,9 @@ module Sources
         # Handle old CDN or old broken CDN
         if ["d.facdn.net", "d2.facdn.net"].include?(@parsed_url.host)
           @parsed_url.host = "d.furaffinity.net"
+        # Handle SFW subdoamain
+        elsif @parsed_url.host == "sfw.furaffinity.net"
+          @parsed_url.host = "www.furaffinity.net"
         end
         # Convert /full/ submission links to /view/ links
         if @parsed_url.path.start_with?("/full/")

--- a/app/logical/sources/alternates/furaffinity.rb
+++ b/app/logical/sources/alternates/furaffinity.rb
@@ -15,7 +15,7 @@ module Sources
         # Handle old CDN or old broken CDN
         if ["d.facdn.net", "d2.facdn.net"].include?(@parsed_url.host)
           @parsed_url.host = "d.furaffinity.net"
-        # Handle SFW subdoamain
+        # Handle SFW subdomain
         elsif @parsed_url.host == "sfw.furaffinity.net"
           @parsed_url.host = "www.furaffinity.net"
         end

--- a/app/logical/sources/alternates/imgur.rb
+++ b/app/logical/sources/alternates/imgur.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sources
+  module Alternates
+    class Imgur < Base
+      def force_https?
+        true
+      end
+
+      def domains
+        ["imgur.com"]
+      end
+
+      def original_url
+        # Convert mobile URLs to base ones
+        if @parsed_url.host == "m.imgur.com"
+          @parsed_url.host = "imgur.com"
+        end
+        @url = @parsed_url.to_s
+      end
+    end
+  end
+end

--- a/app/logical/sources/alternates/imgur.rb
+++ b/app/logical/sources/alternates/imgur.rb
@@ -3,10 +3,6 @@
 module Sources
   module Alternates
     class Imgur < Base
-      def force_https?
-        true
-      end
-
       def domains
         ["imgur.com"]
       end

--- a/app/logical/sources/alternates/imgur.rb
+++ b/app/logical/sources/alternates/imgur.rb
@@ -3,6 +3,10 @@
 module Sources
   module Alternates
     class Imgur < Base
+      def force_https?
+        true
+      end
+
       def domains
         ["imgur.com"]
       end

--- a/app/logical/sources/alternates/pixiv.rb
+++ b/app/logical/sources/alternates/pixiv.rb
@@ -23,6 +23,8 @@ module Sources
       def original_url
         id = id_from_submission
         return submission_url_from_id(id) if id
+        id = id_from_profile
+        return profile_url_from_id(id) if id
         @url
       end
 
@@ -30,6 +32,10 @@ module Sources
 
       def submission_url_from_id(id)
         "https://www.pixiv.net/artworks/#{id}"
+      end
+
+      def profile_url_from_id(id)
+        "https://www.pixiv.net/users/#{id}"
       end
 
       def id_from_submission
@@ -48,6 +54,21 @@ module Sources
         # https://www.pixiv.net/artworks/80169645
         elsif (match = parsed_url.path.match(%r{\A/(?:i|(?:en/)?artworks)/(?<illust_id>\d+)\z}i))
           id = match[:illust_id].to_i
+          return id if id > 0
+        end
+
+        nil
+      end
+
+      def id_from_profile
+        return nil unless parsed_url&.host == "www.pixiv.net"
+
+        if parsed_url.path == "/member.php" && parsed_url.query_values.present? && parsed_url.query_values["id"].present?
+          id = parsed_url.query_values["id"].to_i
+          return id if id > 0
+
+        elsif (match = parsed_url.path.match(%r{\A/(?:en/)?users/(?<user_id>\d+)/?\z}i))
+          id = match[:user_id].to_i
           return id if id > 0
         end
 

--- a/app/logical/sources/alternates/tapas.rb
+++ b/app/logical/sources/alternates/tapas.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sources
+  module Alternates
+    class Tapas < Base
+      def force_https?
+        true
+      end
+
+      def domains
+        ["tapas.io"]
+      end
+
+      def original_url
+        # Convert mobile URLs to base ones
+        if @parsed_url.host == "m.tapas.io"
+          @parsed_url.host = "tapas.io"
+        end
+        @url = @parsed_url.to_s
+      end
+    end
+  end
+end

--- a/app/logical/sources/alternates/webtoons.rb
+++ b/app/logical/sources/alternates/webtoons.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sources
+  module Alternates
+    class Webtoons < Base
+      def force_https?
+        true
+      end
+
+      def domains
+        ["webtoons.com"]
+      end
+
+      def original_url
+        # Convert mobile URLs to base ones
+        if @parsed_url.host == "m.webtoons.com"
+          @parsed_url.host = "www.webtoons.com"
+        end
+        @url = @parsed_url.to_s
+      end
+    end
+  end
+end

--- a/spec/logical/sources/alternates/base_spec.rb
+++ b/spec/logical/sources/alternates/base_spec.rb
@@ -31,10 +31,6 @@ RSpec.describe Sources::Alternates::Base do
   # #force_https?
   # -------------------------------------------------------------------------
   describe "#force_https?" do
-    it "upgrades http://imgur.com URLs to HTTPS" do
-      expect(described_class.new("http://imgur.com/gallery/abc").url).to start_with("https://")
-    end
-
     it "upgrades http://weasyl.com URLs to HTTPS" do
       expect(described_class.new("http://weasyl.com/submission/12345").url).to start_with("https://")
     end

--- a/spec/logical/sources/alternates/facebook_spec.rb
+++ b/spec/logical/sources/alternates/facebook_spec.rb
@@ -97,12 +97,12 @@ RSpec.describe Sources::Alternates::Facebook do
   describe "#original_url — story.php query strip" do
     it "strips tracking params from pfbid story.php URLs, keeping story_fbid and id" do
       expect(transform("https://m.facebook.com/story.php?story_fbid=pfbid021Xh5bfEy1wjHgqKCcNpyn5f6pfFyp3wNW6ziaPUrP999cLUanJgnf95XfuwLCAGAl&id=100070332554180&mibextid=NOb6eG&_rdr")).to \
-        eq("https://www.facebook.com/story.php?story_fbid=pfbid021Xh5bfEy1wjHgqKCcNpyn5f6pfFyp3wNW6ziaPUrP999cLUanJgnf95XfuwLCAGAl&id=100070332554180")
+        eq("https://www.facebook.com/story.php?id=100070332554180&story_fbid=pfbid021Xh5bfEy1wjHgqKCcNpyn5f6pfFyp3wNW6ziaPUrP999cLUanJgnf95XfuwLCAGAl")
     end
 
-    it "passes through already-clean fbid story.php URLs unchanged" do
-      url = "https://www.facebook.com/story.php?story_fbid=3192370837660222&id=1515778811986108"
-      expect(transform(url)).to eq(url)
+    it "canonicalizes fbid story.php URLs to sorted param order" do
+      expect(transform("https://www.facebook.com/story.php?story_fbid=3192370837660222&id=1515778811986108")).to \
+        eq("https://www.facebook.com/story.php?id=1515778811986108&story_fbid=3192370837660222")
     end
 
     it "does not alter story.php URLs without a story_fbid param" do

--- a/spec/logical/sources/alternates/facebook_spec.rb
+++ b/spec/logical/sources/alternates/facebook_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# --------------------------------------------------------------------------- #
+#                   Sources::Alternates::Facebook                             #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe Sources::Alternates::Facebook do
+  def transform(url)
+    described_class.new(url).original_url
+  end
+
+  # -------------------------------------------------------------------------
+  # #match?
+  # -------------------------------------------------------------------------
+  describe "#match?" do
+    it "matches facebook.com" do
+      expect(described_class.new("https://www.facebook.com/photo.php?fbid=123456789").match?).to be true
+    end
+
+    it "matches m.facebook.com" do
+      expect(described_class.new("https://m.facebook.com/photo.php?fbid=123456789").match?).to be true
+    end
+
+    it "matches web.facebook.com" do
+      expect(described_class.new("https://web.facebook.com/photo.php?fbid=123456789").match?).to be true
+    end
+
+    it "does not match unrelated domains" do
+      expect(described_class.new("https://example.com/foo").match?).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #force_https?
+  # -------------------------------------------------------------------------
+  describe "#force_https?" do
+    it "upgrades http:// facebook.com URLs to https://" do
+      expect(described_class.new("http://www.facebook.com/photo.php?fbid=123456789").url).to start_with("https://")
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #original_url — alternate subdomains to desktop
+  # -------------------------------------------------------------------------
+  describe "converts alternate subdomains to desktop" do
+    it "converts m.facebook.com to www.facebook.com" do
+      expect(transform("https://m.facebook.com/photo.php?fbid=3058563794264742&id=896121230509020&set=a.291602508185194&source=43")).to \
+        eq("https://www.facebook.com/photo.php?fbid=3058563794264742")
+    end
+
+    it "converts web.facebook.com to www.facebook.com" do
+      expect(transform("https://web.facebook.com/photo.php?fbid=3058563794264742")).to \
+        eq("https://www.facebook.com/photo.php?fbid=3058563794264742")
+    end
+
+    it "does not alter already-desktop URLs" do
+      url = "https://www.facebook.com/photo.php?fbid=3058563794264742"
+      expect(transform(url)).to eq(url)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #original_url — photo.php query strip
+  # -------------------------------------------------------------------------
+  describe "#original_url — photo.php query strip" do
+    it "strips all params except fbid from /photo.php" do
+      expect(transform("https://www.facebook.com/photo.php?fbid=3058563794264742&id=896121230509020&set=a.291602508185194&source=43")).to \
+        eq("https://www.facebook.com/photo.php?fbid=3058563794264742")
+    end
+
+    it "rewrites /photo to /photo.php and strips tracking params" do
+      expect(transform("https://www.facebook.com/photo?fbid=3058563794264742&set=a.291602508185194&source=43")).to \
+        eq("https://www.facebook.com/photo.php?fbid=3058563794264742")
+    end
+
+    it "rewrites /photo/ to /photo.php and strips tracking params" do
+      expect(transform("https://www.facebook.com/photo/?fbid=3058563794264742&set=a.291602508185194")).to \
+        eq("https://www.facebook.com/photo.php?fbid=3058563794264742")
+    end
+
+    it "does not alter photo.php URLs that have no fbid" do
+      url = "https://www.facebook.com/photo.php?set=a.291602508185194"
+      expect(transform(url)).to eq(url)
+    end
+
+    it "does not alter non-photo.php URLs" do
+      url = "https://www.facebook.com/artist/posts/123456789"
+      expect(transform(url)).to eq(url)
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #original_url — story.php query strip
+  # -------------------------------------------------------------------------
+  describe "#original_url — story.php query strip" do
+    it "strips tracking params from pfbid story.php URLs, keeping story_fbid and id" do
+      expect(transform("https://m.facebook.com/story.php?story_fbid=pfbid021Xh5bfEy1wjHgqKCcNpyn5f6pfFyp3wNW6ziaPUrP999cLUanJgnf95XfuwLCAGAl&id=100070332554180&mibextid=NOb6eG&_rdr")).to \
+        eq("https://www.facebook.com/story.php?story_fbid=pfbid021Xh5bfEy1wjHgqKCcNpyn5f6pfFyp3wNW6ziaPUrP999cLUanJgnf95XfuwLCAGAl&id=100070332554180")
+    end
+
+    it "passes through already-clean fbid story.php URLs unchanged" do
+      url = "https://www.facebook.com/story.php?story_fbid=3192370837660222&id=1515778811986108"
+      expect(transform(url)).to eq(url)
+    end
+
+    it "does not alter story.php URLs without a story_fbid param" do
+      url = "https://www.facebook.com/story.php?id=100070332554180"
+      expect(transform(url)).to eq(url)
+    end
+  end
+end

--- a/spec/logical/sources/alternates/furaffinity_spec.rb
+++ b/spec/logical/sources/alternates/furaffinity_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe Sources::Alternates::Furaffinity do
   end
 
   # -------------------------------------------------------------------------
+  # #original_url — SFW subdomain normalization
+  # -------------------------------------------------------------------------
+  describe "#original_url — SFW subdomain normalization" do
+    it "converts sfw.furaffinity.net to furaffinity.net" do
+      expect(transform("https://sfw.furaffinity.net/view/61758609")).to \
+        eq("https://www.furaffinity.net/view/61758609")
+    end
+  end
+
+  # -------------------------------------------------------------------------
   # #original_url — /full/ → /view/ path conversion
   # -------------------------------------------------------------------------
   describe "#original_url — /full/ to /view/ path conversion" do

--- a/spec/logical/sources/alternates/imgur_spec.rb
+++ b/spec/logical/sources/alternates/imgur_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# --------------------------------------------------------------------------- #
+#                   Sources::Alternates::Imgur                                #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe Sources::Alternates::Imgur do
+  def transform(url)
+    described_class.new(url).original_url
+  end
+
+  # -------------------------------------------------------------------------
+  # #match?
+  # -------------------------------------------------------------------------
+  describe "#match?" do
+    it "matches imgur.com" do
+      expect(described_class.new("https://imgur.com/a/zZkdMts").match?).to be true
+    end
+
+    it "matches m.imgur.com" do
+      expect(described_class.new("https://m.imgur.com/a/zZkdMts").match?).to be true
+    end
+
+    it "does not match unrelated domains" do
+      expect(described_class.new("https://example.com/foo").match?).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #force_https?
+  # -------------------------------------------------------------------------
+  describe "#force_https?" do
+    it "upgrades http:// imgur.com URLs to https://" do
+      expect(described_class.new("http://imgur.com/a/zZkdMts").url).to start_with("https://")
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #original_url — mobile to desktop
+  # -------------------------------------------------------------------------
+  describe "#original_url — mobile to desktop" do
+    it "converts m.imgur.com to imgur.com" do
+      expect(transform("https://m.imgur.com/a/zZkdMts")).to eq("https://imgur.com/a/zZkdMts")
+    end
+
+    it "does not alter already-desktop URLs" do
+      url = "https://imgur.com/a/zZkdMts"
+      expect(transform(url)).to eq(url)
+    end
+  end
+end

--- a/spec/logical/sources/alternates/pixiv_spec.rb
+++ b/spec/logical/sources/alternates/pixiv_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe Sources::Alternates::Pixiv do
   end
 
   # -------------------------------------------------------------------------
+  # #original_url — profile page canonicalization
+  # -------------------------------------------------------------------------
+  describe "#original_url — profile page canonicalization" do
+    it "canonicalizes /en/users/{id} to /users/{id}" do
+      expect(transform("https://www.pixiv.net/en/users/107143906")).to eq("https://www.pixiv.net/users/107143906")
+    end
+
+    it "canonicalizes member.php?id={id} to /users/{id}" do
+      expect(transform("https://www.pixiv.net/member.php?id=923628")).to eq("https://www.pixiv.net/users/923628")
+    end
+  end
+
+  # -------------------------------------------------------------------------
   # #submission_url — extracted from image URLs during parse
   # -------------------------------------------------------------------------
   describe "#submission_url — extracted from image URLs during parse" do

--- a/spec/logical/sources/alternates/tapas_spec.rb
+++ b/spec/logical/sources/alternates/tapas_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# --------------------------------------------------------------------------- #
+#                   Sources::Alternates::Tapas                                #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe Sources::Alternates::Tapas do
+  def transform(url)
+    described_class.new(url).original_url
+  end
+
+  # -------------------------------------------------------------------------
+  # #match?
+  # -------------------------------------------------------------------------
+  describe "#match?" do
+    it "matches tapas.io" do
+      expect(described_class.new("https://tapas.io/episode/189498").match?).to be true
+    end
+
+    it "matches m.tapas.io" do
+      expect(described_class.new("https://m.tapas.io/episode/189498").match?).to be true
+    end
+
+    it "does not match unrelated domains" do
+      expect(described_class.new("https://example.com/foo").match?).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #force_https?
+  # -------------------------------------------------------------------------
+  describe "#force_https?" do
+    it "upgrades http:// tapas.io URLs to https://" do
+      expect(described_class.new("http://tapas.io/episode/189498").url).to start_with("https://")
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #original_url — mobile to desktop
+  # -------------------------------------------------------------------------
+  describe "#original_url — mobile to desktop" do
+    it "converts m.tapas.io to tapas.io" do
+      expect(transform("https://m.tapas.io/episode/189498")).to eq("https://tapas.io/episode/189498")
+    end
+
+    it "does not alter already-desktop URLs" do
+      url = "https://tapas.io/episode/189498"
+      expect(transform(url)).to eq(url)
+    end
+  end
+end

--- a/spec/logical/sources/alternates/webtoons_spec.rb
+++ b/spec/logical/sources/alternates/webtoons_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# --------------------------------------------------------------------------- #
+#                   Sources::Alternates::Webtoons                             #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe Sources::Alternates::Webtoons do
+  def transform(url)
+    described_class.new(url).original_url
+  end
+
+  # -------------------------------------------------------------------------
+  # #match?
+  # -------------------------------------------------------------------------
+  describe "#match?" do
+    it "matches webtoons.com" do
+      expect(described_class.new("https://www.webtoons.com/en/canvas/forestdale/forestdale-314-missed-birthday/viewer?title_no=856922&episode_no=314").match?).to be true
+    end
+
+    it "matches m.webtoons.com" do
+      expect(described_class.new("https://m.webtoons.com/en/canvas/forestdale/forestdale-314-missed-birthday/viewer?title_no=856922&episode_no=314").match?).to be true
+    end
+
+    it "does not match unrelated domains" do
+      expect(described_class.new("https://example.com/foo").match?).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #force_https?
+  # -------------------------------------------------------------------------
+  describe "#force_https?" do
+    it "upgrades http:// webtoons.com URLs to https://" do
+      expect(described_class.new("http://www.webtoons.com/en/canvas/forestdale/forestdale-314-missed-birthday/viewer?title_no=856922&episode_no=314").url).to start_with("https://")
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #original_url — mobile to desktop
+  # -------------------------------------------------------------------------
+  describe "#original_url — mobile to desktop" do
+    it "converts m.webtoons.com to www.webtoons.com" do
+      expect(transform("https://m.webtoons.com/en/canvas/forestdale/forestdale-314-missed-birthday/viewer?title_no=856922&episode_no=314")).to \
+        eq("https://www.webtoons.com/en/canvas/forestdale/forestdale-314-missed-birthday/viewer?title_no=856922&episode_no=314")
+    end
+
+    it "does not alter already-desktop URLs" do
+      url = "https://www.webtoons.com/en/canvas/forestdale/forestdale-314-missed-birthday/viewer?title_no=856922&episode_no=314"
+      expect(transform(url)).to eq(url)
+    end
+  end
+end

--- a/spec/logical/sources/alternates_spec.rb
+++ b/spec/logical/sources/alternates_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Sources::Alternates do
   # .all
   # -------------------------------------------------------------------------
   describe ".all" do
-    it "returns exactly 7 handler classes" do
-      expect(described_class.all.length).to eq(7)
+    it "returns exactly 11 handler classes" do
+      expect(described_class.all.length).to eq(11)
     end
 
     it "includes all expected handler classes" do
@@ -24,6 +24,10 @@ RSpec.describe Sources::Alternates do
         Sources::Alternates::Inkbunny,
         Sources::Alternates::Youtube,
         Sources::Alternates::Derpibooru,
+        Sources::Alternates::Facebook,
+        Sources::Alternates::Webtoons,
+        Sources::Alternates::Tapas,
+        Sources::Alternates::Imgur,
       )
     end
 
@@ -62,6 +66,22 @@ RSpec.describe Sources::Alternates do
 
     it "returns a Derpibooru instance for a derpibooru.org URL" do
       expect(described_class.find("https://derpibooru.org/images/12345")).to be_a(Sources::Alternates::Derpibooru)
+    end
+
+    it "returns a Facebook instance for a facebook.com URL" do
+      expect(described_class.find("https://www.facebook.com/photo.php?fbid=123456789")).to be_a(Sources::Alternates::Facebook)
+    end
+
+    it "returns a Webtoons instance for a webtoons.com URL" do
+      expect(described_class.find("https://www.webtoons.com/en/canvas/forestdale/viewer?title_no=856922&episode_no=314")).to be_a(Sources::Alternates::Webtoons)
+    end
+
+    it "returns a Tapas instance for a tapas.io URL" do
+      expect(described_class.find("https://tapas.io/episode/189498")).to be_a(Sources::Alternates::Tapas)
+    end
+
+    it "returns an Imgur instance for an imgur.com URL" do
+      expect(described_class.find("https://imgur.com/a/zZkdMts")).to be_a(Sources::Alternates::Imgur)
     end
 
     it "returns a Null instance for an unrecognised URL by default" do

--- a/spec/logical/sources/alternates_spec.rb
+++ b/spec/logical/sources/alternates_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe Sources::Alternates do
   # .all
   # -------------------------------------------------------------------------
   describe ".all" do
-    it "returns exactly 11 handler classes" do
-      expect(described_class.all.length).to eq(11)
-    end
-
     it "includes all expected handler classes" do
       expect(described_class.all).to include(
         Sources::Alternates::Furaffinity,


### PR DESCRIPTION
Implements some of the items in https://github.com/e621ng/e621ng/issues/1753 and more by extending the existing source URL sanitizers as well as adding new ones. 

Completes (from said issue):

- Pixiv old account style (Convert deprecated member.php?id= to /users/ format)

- Pixiv /en/ account (Canonicalize /en/users/ to /users/)

- Facebook mobile site (Convert mobile subdomain to www.facebook.com)

- Webtoons mobile site (Convert mobile subdomain to www.webtoons.com)

- Tapas mobile site (Convert mobile subdomain to tapas.io)

- Imgur mobile site (Convert mobile subdomain to imgur.com)

- FurAffinity SFW subdomain (Convert sfw subdomain to www.furaffinity.net)

- Facebook fbid & (Strip unneeded parameters, keep only fbid identifier)

Additionally:
- Facebook: Canonicalize friendly-link /photo/ into only /photo.php.
- Facebook: Strip unneeded parameters from /story.php, keep only story_fbid and id.
- Facebook: Convert web.facebook.com into www.facebook.com.

Some Notes: Facebook sources take on additional forms but the number of posts make those negligible. It would be nice to canonicalize story.php into photo.php, but each has a unique fbid resolved only through the /photo/ endpoint.