### PR TITLE
[TagRelationships] Fix post count desync issues

### DIFF
--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -9,7 +9,8 @@ class TagAliasFinalizeJob < ApplicationJob
   end
 
   def perform(alias_id, reindex_tag_name)
-    ta = TagAlias.find(alias_id)
+    ta = TagAlias.find_by(id: alias_id)
+    return unless ta
     Post.document_store.import(
       query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
     )

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class TagAliasFinalizeJob < ApplicationJob
+  queue_as :default
+  sidekiq_options lock: :until_executing, lock_args_method: :lock_args
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(alias_id, reindex_tag_name)
+    ta = TagAlias.find(alias_id)
+    Post.document_store.import(
+      query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
+    )
+    ta.antecedent_tag&.fix_post_count
+    ta.consequent_tag&.fix_post_count
+  end
+end

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class TagAliasFinalizeJob < ApplicationJob
-  queue_as :default
-  sidekiq_options lock: :until_executing, lock_args_method: :lock_args
+  queue_as :tags
+  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -9,7 +9,8 @@ class TagImplicationFinalizeJob < ApplicationJob
   end
 
   def perform(implication_id, reindex_tag_name)
-    ti = TagImplication.find(implication_id)
+    ti = TagImplication.find_by(id: implication_id)
+    return unless ti
     Post.document_store.import(
       query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
     )

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class TagImplicationFinalizeJob < ApplicationJob
+  queue_as :default
+  sidekiq_options lock: :until_executing, lock_args_method: :lock_args
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(implication_id, reindex_tag_name)
+    ti = TagImplication.find(implication_id)
+    Post.document_store.import(
+      query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
+    )
+    ti.antecedent_tag&.fix_post_count
+    ti.consequent_tag&.fix_post_count
+  end
+end

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class TagImplicationFinalizeJob < ApplicationJob
-  queue_as :default
-  sidekiq_options lock: :until_executing, lock_args_method: :lock_args
+  queue_as :tags
+  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
 
   def self.lock_args(args)
     [args[0]]

--- a/app/logical/document_store/model.rb
+++ b/app/logical/document_store/model.rb
@@ -23,6 +23,7 @@ module DocumentStore
     def update_index(queue: :high_prio)
       # TODO: race condition hack, makes tests SLOW!!!
       return document_store.update_index refresh: "true" if Rails.env.test?
+      return if Thread.current[:skip_post_index_update]
 
       IndexUpdateJob.set(queue: queue).perform_later(self.class.to_s, id)
     end

--- a/app/logical/document_store/model.rb
+++ b/app/logical/document_store/model.rb
@@ -21,9 +21,8 @@ module DocumentStore
     end
 
     def update_index(queue: :high_prio)
-      # TODO: race condition hack, makes tests SLOW!!!
-      return document_store.update_index refresh: "true" if Rails.env.test?
       return if Thread.current[:skip_post_index_update]
+      return document_store.update_index refresh: "true" if Rails.env.test?
 
       IndexUpdateJob.set(queue: queue).perform_later(self.class.to_s, id)
     end

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -187,6 +187,7 @@ class TagAlias < TagRelationship
   end
 
   def update_posts_undo
+    Thread.current[:skip_post_index_update] = true
     Post.without_timeout do
       tag_rel_undos.where(applied: false).each do |tu|
         Post.where(id: tu.undo_data).find_each do |post|
@@ -195,11 +196,10 @@ class TagAlias < TagRelationship
           post.save
         end
       end
-
-      # TODO: Race condition with indexing jobs here.
-      antecedent_tag.fix_post_count if antecedent_tag
-      consequent_tag.fix_post_count if consequent_tag
     end
+    TagAliasFinalizeJob.perform_later(id, antecedent_name)
+  ensure
+    Thread.current[:skip_post_index_update] = false
   end
 
   def rename_artist_undo
@@ -225,9 +225,7 @@ class TagAlias < TagRelationship
         rename_artist
         forum_updater.update(approval_message(approver), "APPROVED") if update_topic
         update(status: 'active', post_count: consequent_tag.post_count)
-        # TODO: Race condition with indexing jobs here.
-        antecedent_tag.fix_post_count if antecedent_tag
-        consequent_tag.fix_post_count if consequent_tag
+        TagAliasFinalizeJob.perform_later(id, consequent_name)
       end
     rescue Exception => e
       Rails.logger.error("[TA] #{e.message}\n#{e.backtrace}")

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -133,6 +133,7 @@ class TagImplication < TagRelationship
           update!(status: "processing")
           create_undo_information
           update_posts
+          TagImplicationFinalizeJob.perform_later(id, consequent_name)
           update(status: "active")
           update_descendant_names_for_parents
           forum_updater.update(approval_message(approver), "APPROVED") if update_topic
@@ -150,6 +151,7 @@ class TagImplication < TagRelationship
     end
 
     def update_posts
+      Thread.current[:skip_post_index_update] = true
       Post.without_timeout do
         Post.sql_raw_tag_match(antecedent_name).find_each do |post|
           next if post.tag_array.include?(consequent_name)
@@ -162,6 +164,8 @@ class TagImplication < TagRelationship
           end
         end
       end
+    ensure
+      Thread.current[:skip_post_index_update] = false
     end
 
     def create_undo_information
@@ -243,6 +247,7 @@ class TagImplication < TagRelationship
     end
 
     def update_posts_undo
+      Thread.current[:skip_post_index_update] = true
       Post.without_timeout do
         tag_rel_undos.where(applied: false).each do |tu|
           Post.where(id: tu.undo_data.keys).find_each do |post|
@@ -255,11 +260,10 @@ class TagImplication < TagRelationship
             post.save
           end
         end
-
-        # TODO: Race condition with indexing jobs here.
-        antecedent_tag.fix_post_count if antecedent_tag
-        consequent_tag.fix_post_count if consequent_tag
       end
+      TagImplicationFinalizeJob.perform_later(id, antecedent_name)
+    ensure
+      Thread.current[:skip_post_index_update] = false
     end
   end
 

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -133,7 +133,7 @@ class TagImplication < TagRelationship
           update!(status: "processing")
           create_undo_information
           update_posts
-          TagImplicationFinalizeJob.perform_later(id, consequent_name)
+          TagImplicationFinalizeJob.perform_later(id, antecedent_name)
           update(status: "active")
           update_descendant_names_for_parents
           forum_updater.update(approval_message(approver), "APPROVED") if update_topic

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -219,6 +219,7 @@ class TagRelationship < ApplicationRecord
   end
 
   def update_posts
+    Thread.current[:skip_post_index_update] = true
     Post.without_timeout do
       Post.sql_raw_tag_match(antecedent_name).find_each do |post|
         post.with_lock do
@@ -230,6 +231,8 @@ class TagRelationship < ApplicationRecord
         end
       end
     end
+  ensure
+    Thread.current[:skip_post_index_update] = false
   end
 
   extend SearchMethods

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TagAliasFinalizeJob do
+  include_context "as admin"
+
+  describe "#perform" do
+    let(:ta) { create(:tag_alias) }
+
+    before do
+      ta.update_columns(status: "active", approver_id: create(:admin_user).id)
+      allow(Post.document_store).to receive(:import)
+      allow(ta.antecedent_tag).to receive(:fix_post_count)
+      allow(ta.consequent_tag).to receive(:fix_post_count)
+      allow(TagAlias).to receive(:find).with(ta.id).and_return(ta)
+    end
+
+    it "bulk-reindexes posts matching the given tag name" do
+      described_class.perform_now(ta.id, ta.consequent_name)
+      expect(Post.document_store).to have_received(:import).with(
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ta.consequent_name],
+      )
+    end
+
+    it "fixes post counts on both tags after reindexing" do
+      described_class.perform_now(ta.id, ta.consequent_name)
+      expect(ta.antecedent_tag).to have_received(:fix_post_count)
+      expect(ta.consequent_tag).to have_received(:fix_post_count)
+    end
+
+    it "uses antecedent_name as the reindex target when called for an undo" do
+      described_class.perform_now(ta.id, ta.antecedent_name)
+      expect(Post.document_store).to have_received(:import).with(
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ta.antecedent_name],
+      )
+    end
+  end
+end

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TagAliasFinalizeJob do
     it "bulk-reindexes posts matching the given tag name" do
       described_class.perform_now(ta.id, ta.consequent_name)
       expect(Post.document_store).to have_received(:import).with(
-        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ta.consequent_name],
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ta.consequent_name],
       )
     end
 
@@ -32,7 +32,7 @@ RSpec.describe TagAliasFinalizeJob do
     it "uses antecedent_name as the reindex target when called for an undo" do
       described_class.perform_now(ta.id, ta.antecedent_name)
       expect(Post.document_store).to have_received(:import).with(
-        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ta.antecedent_name],
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ta.antecedent_name],
       )
     end
   end

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TagAliasFinalizeJob do
       allow(Post.document_store).to receive(:import)
       allow(ta.antecedent_tag).to receive(:fix_post_count)
       allow(ta.consequent_tag).to receive(:fix_post_count)
-      allow(TagAlias).to receive(:find).with(ta.id).and_return(ta)
+      allow(TagAlias).to receive(:find_by).with(id: ta.id).and_return(ta)
     end
 
     it "bulk-reindexes posts matching the given tag name" do

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TagImplicationFinalizeJob do
       allow(Post.document_store).to receive(:import)
       allow(ti.antecedent_tag).to receive(:fix_post_count)
       allow(ti.consequent_tag).to receive(:fix_post_count)
-      allow(TagImplication).to receive(:find).with(ti.id).and_return(ti)
+      allow(TagImplication).to receive(:find_by).with(id: ti.id).and_return(ti)
     end
 
     it "bulk-reindexes posts matching the given tag name" do

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TagImplicationFinalizeJob do
     it "bulk-reindexes posts matching the given tag name" do
       described_class.perform_now(ti.id, ti.consequent_name)
       expect(Post.document_store).to have_received(:import).with(
-        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ti.consequent_name],
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ti.consequent_name],
       )
     end
 
@@ -32,7 +32,7 @@ RSpec.describe TagImplicationFinalizeJob do
     it "uses antecedent_name as the reindex target when called for an undo" do
       described_class.perform_now(ti.id, ti.antecedent_name)
       expect(Post.document_store).to have_received(:import).with(
-        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ti.antecedent_name],
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ti.antecedent_name],
       )
     end
   end

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TagImplicationFinalizeJob do
+  include_context "as admin"
+
+  describe "#perform" do
+    let(:ti) { create(:tag_implication) }
+
+    before do
+      ti.update_columns(status: "active", approver_id: create(:admin_user).id)
+      allow(Post.document_store).to receive(:import)
+      allow(ti.antecedent_tag).to receive(:fix_post_count)
+      allow(ti.consequent_tag).to receive(:fix_post_count)
+      allow(TagImplication).to receive(:find).with(ti.id).and_return(ti)
+    end
+
+    it "bulk-reindexes posts matching the given tag name" do
+      described_class.perform_now(ti.id, ti.consequent_name)
+      expect(Post.document_store).to have_received(:import).with(
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ti.consequent_name],
+      )
+    end
+
+    it "fixes post counts on both tags after reindexing" do
+      described_class.perform_now(ti.id, ti.consequent_name)
+      expect(ti.antecedent_tag).to have_received(:fix_post_count)
+      expect(ti.consequent_tag).to have_received(:fix_post_count)
+    end
+
+    it "uses antecedent_name as the reindex target when called for an undo" do
+      described_class.perform_now(ti.id, ti.antecedent_name)
+      expect(Post.document_store).to have_received(:import).with(
+        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::varchar[]", ti.antecedent_name],
+      )
+    end
+  end
+end

--- a/spec/models/tag_alias/instance_methods_spec.rb
+++ b/spec/models/tag_alias/instance_methods_spec.rb
@@ -186,17 +186,12 @@ RSpec.describe TagAlias do
       expect(post.reload.tag_string).to include(ta.antecedent_name)
     end
 
-    it "calls fix_post_count for antecedent and consequent tags" do
+    it "enqueues TagAliasFinalizeJob with antecedent_name" do
       ta = create(:active_tag_alias)
       ta.tag_rel_undos.create!(undo_data: [])
 
-      allow(ta.antecedent_tag).to receive(:fix_post_count)
-      allow(ta.consequent_tag).to receive(:fix_post_count)
-
-      ta.update_posts_undo
-
-      expect(ta.antecedent_tag).to have_received(:fix_post_count)
-      expect(ta.consequent_tag).to have_received(:fix_post_count)
+      expect { ta.update_posts_undo }
+        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.antecedent_name)
     end
   end
 

--- a/spec/models/tag_alias/process_methods_spec.rb
+++ b/spec/models/tag_alias/process_methods_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe TagAlias do
 
       expect(ta.reload.post_count).to eq(7)
     end
+
+    it "enqueues TagAliasFinalizeJob with consequent_name on success" do
+      ta = create(:tag_alias)
+      ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
+
+      expect { ta.process!(update_topic: false) }
+        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.consequent_name)
+    end
+
+    it "does not call fix_post_count directly" do
+      ta = create(:tag_alias)
+      ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
+      allow(ta.antecedent_tag).to receive(:fix_post_count)
+      allow(ta.consequent_tag).to receive(:fix_post_count)
+
+      ta.process!(update_topic: false)
+
+      expect(ta.antecedent_tag).not_to have_received(:fix_post_count)
+      expect(ta.consequent_tag).not_to have_received(:fix_post_count)
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -73,6 +93,26 @@ RSpec.describe TagAlias do
       )
 
       expect { ta.process_undo!(update_topic: false) }.to raise_error(RuntimeError, /something is wrong/)
+    end
+
+    it "enqueues TagAliasFinalizeJob with antecedent_name" do
+      ta = create(:active_tag_alias)
+      ta.update_columns(approver_id: create(:admin_user).id)
+
+      expect { ta.process_undo!(update_topic: false) }
+        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.antecedent_name)
+    end
+
+    it "does not call fix_post_count directly" do
+      ta = create(:active_tag_alias)
+      ta.update_columns(approver_id: create(:admin_user).id)
+      allow(ta.antecedent_tag).to receive(:fix_post_count)
+      allow(ta.consequent_tag).to receive(:fix_post_count)
+
+      ta.process_undo!(update_topic: false)
+
+      expect(ta.antecedent_tag).not_to have_received(:fix_post_count)
+      expect(ta.consequent_tag).not_to have_received(:fix_post_count)
     end
   end
 end

--- a/spec/models/tag_implication/approval_methods_spec.rb
+++ b/spec/models/tag_implication/approval_methods_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe TagImplication do
 
       expect(ti.reload.status).to start_with("error:")
     end
+
+    it "enqueues TagImplicationFinalizeJob with consequent_name on success" do
+      ti = create(:tag_implication)
+      ti.update_columns(status: "queued", approver_id: create(:admin_user).id)
+      allow(ti).to receive_messages(
+        create_undo_information: nil,
+        update_posts: nil,
+        update_descendant_names_for_parents: nil,
+      )
+
+      expect { ti.process!(update_topic: false) }
+        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.consequent_name)
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -181,6 +194,15 @@ RSpec.describe TagImplication do
       ti.update_posts_undo
 
       expect(post.reload.tag_string.split).not_to include("species_b")
+    end
+
+    it "enqueues TagImplicationFinalizeJob with antecedent_name" do
+      ti = create(:active_tag_implication)
+      ti.update_columns(status: "pending")
+      ti.tag_rel_undos.create!(undo_data: {})
+
+      expect { ti.update_posts_undo }
+        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name)
     end
 
     it "skips posts where the consequent was already in the original tag string" do

--- a/spec/models/tag_implication/approval_methods_spec.rb
+++ b/spec/models/tag_implication/approval_methods_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe TagImplication do
       expect(ti.reload.status).to start_with("error:")
     end
 
-    it "enqueues TagImplicationFinalizeJob with consequent_name on success" do
+    it "enqueues TagImplicationFinalizeJob with antecedent_name on success" do
       ti = create(:tag_implication)
       ti.update_columns(status: "queued", approver_id: create(:admin_user).id)
       allow(ti).to receive_messages(
@@ -81,7 +81,7 @@ RSpec.describe TagImplication do
       )
 
       expect { ti.process!(update_topic: false) }
-        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.consequent_name)
+        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name)
     end
   end
 


### PR DESCRIPTION
Both TagAlias and TagImplication models can cause `post_count` drift in tags.

This is caused by a race condition within the `process!` methods.
The `process!` method makes changes to posts by touching their `tag_string`, which resolves aliases and implications and schedules an `IndexUpdateJob` for every affected post.
As soon as all posts are processed, the `fix_post_count` method is called. That method uses OpenSearch to count posts, and then saves that value to `post_count`. Since it does not wait for all `IndexUpdateJob` instances to complete, it pulls stale data instead.

This solution delegates OpenSearch updates to the `TagAliasFinalizeJob` and `TagImplicationFinalizeJob`.
These jobs update the relevant OpenSearch indexes in bulk, and only then update the post count value.

As a side effect, this also means that processing large aliases or implications will no longer spawn tens of thousands of jobs, clogging up the sidekiq queue and causing other jobs to be delayed.