### PR TITLE
[Users] Touch up `is_member?` permission gates in the UI

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -53,14 +53,16 @@ class StaticController < ApplicationController
   end
 
   def disable_mobile_mode
-    if CurrentUser.is_member?
+    if CurrentUser.is_anonymous?
+      if cookies[:nmm]
+        cookies.delete(:nmm)
+      else
+        cookies.permanent[:nmm] = "1"
+      end
+    else
       user = CurrentUser.user
       user.disable_responsive_mode = !user.disable_responsive_mode
       user.save
-    elsif cookies[:nmm]
-      cookies.delete(:nmm)
-    else
-      cookies.permanent[:nmm] = "1"
     end
     redirect_back fallback_location: posts_path
   end
@@ -124,7 +126,7 @@ class StaticController < ApplicationController
     add_link = ->(section, label, path) { lookup[section][:links] << { label: label, path: path } }
 
     add_link[:posts, "Listing", posts_path]
-    add_link[:posts, "Upload", new_upload_path]
+    add_link[:posts, "Upload", new_upload_path] if CurrentUser.user.is_member?
     add_link[:posts, "Popular", popular_index_path]
     add_link[:posts, "Changes", post_versions_path]
     add_link[:posts, "Similar Images Search", iqdb_queries_path]
@@ -165,7 +167,7 @@ class StaticController < ApplicationController
     add_link[:notes, "Changes", note_versions_path]
 
     add_link[:pools, "Listing", gallery_pools_path]
-    add_link[:pools, "Changes", pool_versions_path]
+    add_link[:pools, "Changes", pool_versions_path] if CurrentUser.user.is_member?
 
     add_link[:wiki, "Listing", wiki_pages_path]
     add_link[:wiki, "Changes", wiki_page_versions_path]
@@ -193,7 +195,7 @@ class StaticController < ApplicationController
       add_link[:users, "User Home", home_users_path]
       add_link[:users, "Profile", user_path(CurrentUser.user)]
       add_link[:users, "Settings", settings_users_path]
-      add_link[:users, "Refresh counts", new_maintenance_user_count_fixes_path]
+      add_link[:users, "Refresh counts", new_maintenance_user_count_fixes_path] if CurrentUser.user.is_member?
     end
 
     if CurrentUser.is_staff?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -211,6 +211,9 @@ class UsersController < ApplicationController
 
   private
 
+  def load_user
+  end
+
   # Checks if the user's uploads are already disabled & if the reason is left blank.
   #
   # IDEA: Get errors showing up correctly (the green banner & empty error message box)
@@ -241,7 +244,6 @@ class UsersController < ApplicationController
 
   def check_privilege(user)
     raise User::PrivilegeError unless user.id == CurrentUser.id || CurrentUser.is_admin?
-    raise User::PrivilegeError, "Must verify account email" unless CurrentUser.is_verified?
   end
 
   def user_params(context)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -211,9 +211,6 @@ class UsersController < ApplicationController
 
   private
 
-  def load_user
-  end
-
   # Checks if the user's uploads are already disabled & if the reason is left blank.
   #
   # IDEA: Get errors showing up correctly (the green banner & empty error message box)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,10 +2,11 @@
 
 module ApplicationHelper
   def disable_mobile_mode?
-    if CurrentUser.user.present? && CurrentUser.is_member?
-      return CurrentUser.disable_responsive_mode?
+    if CurrentUser.blank? || CurrentUser.is_anonymous?
+      return cookies[:nmm].present?
     end
-    cookies[:nmm].present?
+
+    CurrentUser.disable_responsive_mode?
   end
 
   def diff_list_html(new, old, latest)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   def disable_mobile_mode?
-    if CurrentUser.blank? || CurrentUser.is_anonymous?
+    if CurrentUser.user.blank? || CurrentUser.is_anonymous?
       return cookies[:nmm].present?
     end
 

--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -36,7 +36,7 @@ class SessionLoader
       if recent_ban && recent_ban.expires_at.present?
         ban_message = "Account is suspended for another #{recent_ban.expire_days}"
       end
-      raise AuthenticationFailure.new(ban_message)
+      raise AuthenticationFailure, ban_message
     end
     update_user_login_tracking
     set_safe_mode

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1365,7 +1365,7 @@ class TagQuery
       when "fav", "-fav", "~fav", "favoritedby", "-favoritedby", "~favoritedby"
         add_to_query(type, :fav_ids) do
           if g2.downcase == "me"
-            favuser = CurrentUser.user.is_anonymous? ? nil : CurrentUser.user
+            favuser = CurrentUser.is_authenticated? ? CurrentUser.user : nil
           else
             favuser = User.find_by_name_or_id(g2) # rubocop:disable Rails/DynamicFindBy
           end

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1365,7 +1365,7 @@ class TagQuery
       when "fav", "-fav", "~fav", "favoritedby", "-favoritedby", "~favoritedby"
         add_to_query(type, :fav_ids) do
           if g2.downcase == "me"
-            favuser = CurrentUser.is_member? ? CurrentUser.user : nil
+            favuser = CurrentUser.user.is_anonymous? ? nil : CurrentUser.user
           else
             favuser = User.find_by_name_or_id(g2) # rubocop:disable Rails/DynamicFindBy
           end
@@ -1634,9 +1634,9 @@ class TagQuery
   end
 
   def privileged_user_id_or_invalid(val)
-    if CurrentUser.is_moderator?
+    if CurrentUser.user.is_moderator?
       User.name_or_id_to_id(val).presence
-    elsif CurrentUser.is_member?
+    elsif CurrentUser.user.is_authenticated?
       CurrentUser.id.presence
     end || -1
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -227,12 +227,14 @@ class Comment < ApplicationRecord
     end
 
     def can_reply?(user = CurrentUser.user)
+      return false unless user.is_member?
       return false if is_sticky?
       return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
       true
     end
 
     def can_edit?(user = CurrentUser.user)
+      return false unless user.is_member?
       return true if user.is_admin?
       return false if (post&.is_comment_locked? || post&.is_comment_disabled?) && !user.is_moderator?
       return false if was_warned?
@@ -240,6 +242,7 @@ class Comment < ApplicationRecord
     end
 
     def can_hide?(user = CurrentUser.user)
+      return false unless user.is_member?
       return true if user.is_moderator?
       return false if was_warned? || post&.is_comment_disabled?
       user.id == creator_id

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -5,7 +5,7 @@ class Favorite < ApplicationRecord
   end
 
   class HiddenError < User::PrivilegeError
-    def initialize(msg = "This users favorites are hidden")
+    def initialize(msg = "This user's favorites are hidden")
       super
     end
   end

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -55,6 +55,7 @@ class ForumPost < ApplicationRecord
 
     def can_edit?(user = CurrentUser.user)
       return false unless can_access?(user)
+      return false unless user.is_member?
       return true if user.is_admin?
       return false if was_warned?
       return false if topic.is_locked? && !topic.can_lock?(user)
@@ -64,6 +65,7 @@ class ForumPost < ApplicationRecord
 
     def can_hide?(user = CurrentUser.user)
       return false unless can_access?(user)
+      return false unless user.is_member?
       return true if user.is_moderator?
       return false if was_warned?
       return false if votable?

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -41,6 +41,7 @@ class ForumTopic < ApplicationRecord
 
     def can_edit?(user = CurrentUser.user)
       return false unless can_access?(user)
+      return false unless user.is_member?
       return true if user.is_moderator?
       return true if creator_id == user.id
       false
@@ -48,6 +49,7 @@ class ForumTopic < ApplicationRecord
 
     def can_hide?(user = CurrentUser.user)
       return false unless can_access?(user)
+      return false unless user.is_member?
       return true if user.is_moderator?
       return false unless original_post&.can_hide?(user)
       return true if user.id == creator_id
@@ -70,6 +72,7 @@ class ForumTopic < ApplicationRecord
 
     def can_reply?(user = CurrentUser.user)
       return false unless can_access?(user)
+      return false unless user.is_member?
       return false if is_locked && !can_lock?(user)
       return true if category.can_reply?(user)
       false

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -371,6 +371,10 @@ class User < ApplicationRecord
       end
     end
 
+    def is_authenticated?
+      level > Levels::ANONYMOUS
+    end
+
     def is_bd_staff?
       is_bd_staff
     end
@@ -475,7 +479,7 @@ class User < ApplicationRecord
 
   module ForumMethods
     def has_forum_been_updated?
-      return false unless is_member? && forum_notification_dot
+      return false unless is_authenticated? && forum_notification_dot
       max_updated_at = ForumTopic.visible(self).order(updated_at: :desc).first&.updated_at
       return false if max_updated_at.nil?
       return true if last_forum_read_at.nil?
@@ -1067,8 +1071,9 @@ class User < ApplicationRecord
 
   def hide_favorites?
     return false if CurrentUser.is_moderator?
+    return false if CurrentUser.user.id == id
     return true if is_blocked?
-    enable_privacy_mode? && CurrentUser.user.id != id
+    enable_privacy_mode?
   end
 
   def compact_uploader?

--- a/app/views/artist_versions/_secondary_links.html.erb
+++ b/app/views/artist_versions/_secondary_links.html.erb
@@ -1,5 +1,7 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "Listing", artists_path %>
-  <%= subnav_link_to "New", new_artist_path %>
+  <% if CurrentUser.user.is_member? %>
+    <%= subnav_link_to "New", new_artist_path %>
+  <% end %>
   <%= subnav_link_to "Search", search_artist_versions_path %>
 <% end %>

--- a/app/views/blips/_secondary_links.html.erb
+++ b/app/views/blips/_secondary_links.html.erb
@@ -1,7 +1,9 @@
 <% content_for(:secondary_links) do %>
   <li><%= render "quick_search" %></li>
   <%= subnav_link_to "List", blips_path %>
-  <%= subnav_link_to "New", new_blip_path %>
+  <% if CurrentUser.user.is_member? %>
+    <%= subnav_link_to "New", new_blip_path %>
+  <% end %>
   <% unless @blip&.response_to.nil? %>
     <li class="divider"></li>
     <%= subnav_link_to "Parent", blip_path(@blip.response_to) %>

--- a/app/views/bulk_update_requests/_secondary_links.html.erb
+++ b/app/views/bulk_update_requests/_secondary_links.html.erb
@@ -3,8 +3,14 @@
   <%= subnav_link_to "Alias Listing", tag_aliases_path %>
   <%= subnav_link_to "Implication Listing", tag_implications_path %>
   <%= subnav_link_to "MetaSearch", meta_searches_tags_path %>
-  <%= subnav_link_to "New BUR", new_bulk_update_request_path %>
-  <%= subnav_link_to "Request implication", new_tag_implication_request_path %>
-  <%= subnav_link_to "Request alias", new_tag_alias_request_path %>
+
+  <% if CurrentUser.user.is_member? %>
+    <li class="divider"></li>
+    <%= subnav_link_to "Request alias", new_tag_alias_request_path %>
+    <%= subnav_link_to "Request implication", new_tag_implication_request_path %>
+    <%= subnav_link_to "Request bulk update", new_bulk_update_request_path %>
+  <% end %>
+
+  <li class="divider"></li>
   <%= subnav_link_to "Help", help_page_path(id: "tag_relationships", anchor: "bur") %>
 <% end %>

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -43,7 +43,7 @@
   <% end %>
 
   <% if (post.is_comment_locked? || post.is_comment_disabled?) && !CurrentUser.is_moderator? %>
-  <% elsif CurrentUser.is_member? %>
+  <% elsif CurrentUser.user.is_member? %>
     <div class="new-comment">
       <% if !CurrentUser.is_anonymous? && !CurrentUser.user.is_janitor? %>
         <h2>Before commenting, read the <%= link_to "how to comment guide", wiki_pages_path(:search => {:title => "howto:comment"}) %>.</h2>
@@ -51,7 +51,7 @@
       <p><%= link_to "Post comment", new_comment_path(comment: { post_id: post.id }), :class => "expand-comment-response" %></p>
       <%= render "comments/form", comment: post.comments.new, hidden: true %>
     </div>
-  <% else %>
+  <% elsif CurrentUser.user.is_anonymous? %>
     <h5 id="respond-link"><%= link_to "Login to respond »", new_session_path %></h5>
   <% end %>
 </div>

--- a/app/views/forum_topics/show.html.erb
+++ b/app/views/forum_topics/show.html.erb
@@ -18,7 +18,7 @@
 
     <%= render "forum_posts/listing", :forum_posts => @forum_posts, :original_forum_post_id => @forum_topic.original_post.id %>
 
-    <% if CurrentUser.is_member? %>
+    <% if CurrentUser.user.is_member? %>
       <% if @forum_topic.can_reply? %>
         <p><%= link_to "Reply »", new_forum_post_path(forum_post: { topic_id: @forum_topic.id }), id: "new-response-link" %></p>
 
@@ -26,7 +26,7 @@
           <%= render "forum_posts/partials/new/form", :forum_post => ForumPost.new(:topic_id => @forum_topic.id) %>
         </div>
       <% end %>
-    <% elsif !@forum_topic.is_locked? %>
+    <% elsif CurrentUser.user.is_anonymous? && !@forum_topic.is_locked? %>
       <h5 id="respond-link"><%= link_to "Login to respond »", new_session_path %></h5>
     <% end %>
 

--- a/app/views/pools/_secondary_links.html.erb
+++ b/app/views/pools/_secondary_links.html.erb
@@ -2,23 +2,33 @@
   <li><%= render "pools/quick_search" %></li>
   <%= subnav_link_to "Gallery", gallery_pools_path %>
   <%= subnav_link_to "Listing", pools_path %>
-  <%= subnav_link_to "New", new_pool_path %>
+  <% if CurrentUser.user.is_member? %>
+    <%= subnav_link_to "New", new_pool_path %>
+  <% end %>
   <%= subnav_link_to "Help", help_page_path(id: "pools") %>
+
   <% if @pool && !@pool.new_record? %>
     <li class="divider"></li>
     <%= subnav_link_to "Show", pool_path(@pool) %>
     <%= subnav_link_to "Posts", posts_path(tags: "pool:#{@pool.id}") %>
-    <% if CurrentUser.is_member? %>
+
+    <% if CurrentUser.user.is_member? %>
       <%= subnav_link_to "Edit", edit_pool_path(@pool), data: { hotkey: "edit" } %>
     <% end %>
+
     <% if @pool.deletable_by?(CurrentUser.user) %>
       <%= subnav_link_to "Delete", pool_path(@pool), method: :delete, data: { confirm: "Are you sure you want to delete this pool?" } %>
     <% end %>
-    <%= subnav_link_to "History", pool_versions_path(search: { pool_id: @pool.id }), data: { hotkey: "history" } %>
-    <% if @pool.post_count <= 1_000 && CurrentUser.is_member? %>
+
+    <% if CurrentUser.user.is_member? %>
+      <%= subnav_link_to "History", pool_versions_path(search: { pool_id: @pool.id }), data: { hotkey: "history" } %>
+    <% end %>
+
+    <% if @pool.post_count <= 1_000 && CurrentUser.user.is_member? %>
       <%= subnav_link_to "Order", edit_pool_order_path(@pool) %>
     <% end %>
-    <% if CurrentUser.is_member? %>
+
+    <% if CurrentUser.user.is_member? %>
       <%= subnav_link_to "Report", new_ticket_path(disp_id: @pool.id, qtype: "pool") %>
     <% end %>
   <% end %>

--- a/app/views/post_sets/_secondary_links.html.erb
+++ b/app/views/post_sets/_secondary_links.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "List", post_sets_path %>
-  <%= subnav_link_to "New", new_post_set_path %>
   <%= subnav_link_to "Help", help_page_path(id: "sets") %>
-  <% if CurrentUser.is_member? %>
+  <% if CurrentUser.user.is_member? %>
+    <%= subnav_link_to "New", new_post_set_path %>
     <%= subnav_link_to "Mine", post_sets_path(search: { creator_id: CurrentUser.id }) %>
     <%= subnav_link_to "Invites", post_set_maintainers_path %>
   <% end %>

--- a/app/views/posts/partials/common/_secondary_links.html.erb
+++ b/app/views/posts/partials/common/_secondary_links.html.erb
@@ -1,17 +1,15 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "Listing", posts_path %>
-  <%= subnav_link_to "Upload", new_upload_path %>
+  <%= subnav_link_to "Upload", new_upload_path if CurrentUser.user.is_member? %>
   <%= subnav_link_to "Hot", posts_path(tags: "order:hot", d: "1") %>
   <%= subnav_link_to("Popular", popular_index_path) %>
-  <% unless CurrentUser.is_anonymous? %>
-    <%= subnav_link_to "Favorites", favorites_path %>
-  <% end %>
+  <%= subnav_link_to "Favorites", favorites_path if CurrentUser.user.is_authenticated? %>
   <%= subnav_link_to "Changes", post_versions_path %>
   <li><a href="#" id="blacklist-edit-link">Blacklist</a></li>
   <%= subnav_link_to "Help", help_page_path(id: "posts") %>
   <% if CurrentUser.can_approve_posts? %>
-  <li class="divider"></li>
-  <li><a href="#" id="janitor-toolbar-toggle">Approvals: Off</a></li>
+    <li class="divider"></li>
+    <li><a href="#" id="janitor-toolbar-toggle">Approvals: Off</a></li>
   <% end %>
 <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,7 +27,7 @@
         </section>
       <% end %>
 
-      <% if CurrentUser.is_member? %>
+      <% if CurrentUser.is_authenticated? %>
         <section id="post-history">
           <h3>History</h3>
           <%= render "posts/partials/show/sidebar/history", :post => @post %>

--- a/app/views/tag_aliases/_secondary_links.html.erb
+++ b/app/views/tag_aliases/_secondary_links.html.erb
@@ -3,8 +3,14 @@
   <%= subnav_link_to "Implication Listing", tag_implications_path %>
   <%= subnav_link_to "BUR Listing", bulk_update_requests_path %>  
   <%= subnav_link_to "MetaSearch", meta_searches_tags_path %>
-  <%= subnav_link_to "Request implication", new_tag_implication_request_path %>
-  <%= subnav_link_to "Request alias", new_tag_alias_request_path %>
-  <%= subnav_link_to "Request bulk update", new_bulk_update_request_path %>
+
+  <% if CurrentUser.user.is_member? %>
+    <li class="divider"></li>
+    <%= subnav_link_to "Request alias", new_tag_alias_request_path %>
+    <%= subnav_link_to "Request implication", new_tag_implication_request_path %>
+    <%= subnav_link_to "Request bulk update", new_bulk_update_request_path %>
+  <% end %>
+
+  <li class="divider"></li>
   <%= subnav_link_to "Help", help_page_path(id: "tag_aliases") %>
 <% end %>

--- a/app/views/tag_implications/_secondary_links.html.erb
+++ b/app/views/tag_implications/_secondary_links.html.erb
@@ -3,8 +3,14 @@
   <%= subnav_link_to "Alias Listing", tag_aliases_path %>
   <%= subnav_link_to "BUR Listing", bulk_update_requests_path %>  
   <%= subnav_link_to "MetaSearch", meta_searches_tags_path %>
-  <%= subnav_link_to "Request implication", new_tag_implication_request_path %>
-  <%= subnav_link_to "Request alias", new_tag_alias_request_path %>
-  <%= subnav_link_to "Request bulk update", new_bulk_update_request_path %>
+
+  <% if CurrentUser.user.is_member? %>
+    <li class="divider"></li>
+    <%= subnav_link_to "Request alias", new_tag_alias_request_path %>
+    <%= subnav_link_to "Request implication", new_tag_implication_request_path %>
+    <%= subnav_link_to "Request bulk update", new_bulk_update_request_path %>
+  <% end %>
+
+  <li class="divider"></li>
   <%= subnav_link_to "Help", help_page_path(id: "tag_implications") %>
 <% end %>

--- a/app/views/user_name_change_requests/new.html.erb
+++ b/app/views/user_name_change_requests/new.html.erb
@@ -2,7 +2,7 @@
   <div id="a-new">
     <% if CurrentUser.is_authenticated? && (name_error = CurrentUser.user.name_error) %>
       <div class="ui-state-highlight site-notice">
-        <p>Your current username '<%= CurrentUser.user.pretty_name %>' is invalid. You must change it to continue using the site.<p>
+        <p>Your current username '<%= CurrentUser.user.pretty_name %>' is invalid. You must change it to continue using the site.</p>
         Error: <%= name_error %>
       </div>
     <% end %>

--- a/app/views/user_name_change_requests/new.html.erb
+++ b/app/views/user_name_change_requests/new.html.erb
@@ -1,6 +1,6 @@
 <div id="c-user-name-change-requests">
   <div id="a-new">
-    <% if CurrentUser.is_member? && (name_error = CurrentUser.user.name_error) %>
+    <% if CurrentUser.is_authenticated? && (name_error = CurrentUser.user.name_error) %>
       <div class="ui-state-highlight site-notice">
         <p>Your current username '<%= CurrentUser.user.pretty_name %>' is invalid. You must change it to continue using the site.<p>
         Error: <%= name_error %>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -67,6 +67,7 @@
 
 
 <!-- Profile -->
+<% if CurrentUser.user.is_member? %>
 <tab-group name="profile">Profile</tab-group>
 
 <tab-entry tab="<%= tab_name %>" group="profile" class="<%= @user.avatar_id.present? ? "with-buttons" : "" %>" search="update change user avatar profile image pfp crop">
@@ -107,6 +108,7 @@
     %>
   </tab-body>
 </tab-entry>
+<% end %>
 
 
 <!-- Posts -->

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -3,12 +3,14 @@
 <!-- Account -->
 <tab-group name="account">Account</tab-group>
 
+<% if CurrentUser.user.is_member? %>
 <tab-entry tab="<%= tab_name %>" group="account" class="with-buttons" search="update change user profile account name username">
   <tab-head>Username</tab-head>
   <tab-body>
     <input type="text" value="<%= CurrentUser.user.pretty_name %>" disabled><%= link_to "Edit", new_user_name_change_request_path, class: "st-button" %>
   </tab-body>
 </tab-entry>
+<% end %>
 
 <tab-entry tab="<%= tab_name %>" group="account" class="with-buttons" search="update change user profile account email e-mail address">
   <tab-head>Email</tab-head>

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -17,6 +17,7 @@
   </tab-body>
 </tab-entry>
 
+<% if CurrentUser.user.is_member? %>
 <tab-entry tab="<%= tab_name %>" group="account" class="with-button" search="update change user profile account api key access">
   <tab-head>API Keys</tab-head>
   <tab-body>
@@ -26,6 +27,7 @@
     Do not give your API keys to third-party apps you do not trust.
   </tab-hint>
 </tab-entry>
+<% end %>
 
 <tab-entry tab="<%= tab_name %>" group="account" class="" id="settings-account-buttons" search="update change user profile account delete password">
   <tab-head></tab-head>

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -99,6 +99,10 @@ FactoryBot.define do
     factory :bd_auditor_user do
       is_bd_auditor { true }
     end
+
+    factory :unverified_user do
+      email_verification_key { "1" }
+    end
   end
 end
 

--- a/spec/models/comment/permissions_spec.rb
+++ b/spec/models/comment/permissions_spec.rb
@@ -7,10 +7,11 @@ require "rails_helper"
 # --------------------------------------------------------------------------- #
 
 RSpec.describe Comment do
-  let(:creator)   { create(:user, show_hidden_comments: true) }
-  let(:moderator) { create(:moderator_user, show_hidden_comments: true) }
-  let(:admin)     { create(:admin_user) }
-  let(:other)     { create(:user) }
+  let(:creator)     { create(:user, show_hidden_comments: true) }
+  let(:moderator)   { create(:moderator_user, show_hidden_comments: true) }
+  let(:admin)       { create(:admin_user) }
+  let(:other)       { create(:user) }
+  let(:unverified)  { create(:unverified_user) }
 
   before do
     CurrentUser.user    = creator
@@ -74,6 +75,11 @@ RSpec.describe Comment do
       comment = make_comment
       expect(comment.can_edit?(other)).to be false
     end
+
+    it "denies an unverified user from editing" do
+      comment = make_comment
+      expect(comment.can_edit?(unverified)).to be false
+    end
   end
 
   # -------------------------------------------------------------------------
@@ -106,6 +112,11 @@ RSpec.describe Comment do
     it "denies a non-creator non-moderator from hiding" do
       comment = make_comment
       expect(comment.can_hide?(other)).to be false
+    end
+
+    it "denies an unverified user from hiding" do
+      comment = make_comment
+      expect(comment.can_hide?(unverified)).to be false
     end
   end
 
@@ -149,6 +160,11 @@ RSpec.describe Comment do
     it "returns true for a normal comment" do
       comment = make_comment
       expect(comment.can_reply?(creator)).to be true
+    end
+
+    it "returns false for an unverified user" do
+      comment = make_comment
+      expect(comment.can_reply?(unverified)).to be false
     end
   end
 

--- a/spec/models/forum_post/instance_methods_spec.rb
+++ b/spec/models/forum_post/instance_methods_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ForumPost do
   let(:moderator)       { create(:moderator_user) }
   let(:admin)           { create(:admin_user) }
   let(:other)           { create(:user) }
+  let(:unverified)      { create(:unverified_user) }
   let(:category)        { create(:forum_category) }
   let(:admin_category)  { create(:forum_category, can_view: User::Levels::ADMIN) }
   let(:topic)           { CurrentUser.scoped(member) { create(:forum_topic, category_id: category.id) } }
@@ -124,6 +125,11 @@ RSpec.describe ForumPost do
       post = make_post
       topic.update_columns(is_locked: true)
       expect(post.reload.can_edit?(admin)).to be true
+    end
+
+    it "denies an unverified user from editing" do
+      post = make_post
+      expect(post.can_edit?(unverified)).to be false
     end
   end
 

--- a/spec/models/forum_post/instance_methods_spec.rb
+++ b/spec/models/forum_post/instance_methods_spec.rb
@@ -163,6 +163,11 @@ RSpec.describe ForumPost do
       topic.update_columns(is_hidden: true, creator_id: other.id)
       expect(post.reload.can_hide?(member)).to be false
     end
+
+    it "denies an unverified user from hiding" do
+      post = make_post
+      expect(post.can_hide?(unverified)).to be false
+    end
   end
 
   # -------------------------------------------------------------------------
@@ -235,6 +240,10 @@ RSpec.describe ForumPost do
 
     it "denies anonymous users" do
       expect(make_post.can_vote?(nil)).to be false
+    end
+
+    it "denies an unverified user from voting" do
+      expect(make_post.can_vote?(unverified)).to be false
     end
   end
 

--- a/spec/models/forum_topic/instance_methods_spec.rb
+++ b/spec/models/forum_topic/instance_methods_spec.rb
@@ -158,6 +158,11 @@ RSpec.describe ForumTopic do
       topic.update_columns(is_locked: true)
       expect(topic.can_reply?(moderator)).to be true
     end
+
+    it "denies an unverified user from replying" do
+      topic = make_topic
+      expect(topic.can_reply?(unverified)).to be false
+    end
   end
 
   # -------------------------------------------------------------------------
@@ -207,6 +212,11 @@ RSpec.describe ForumTopic do
       topic.update_columns(creator_id: other.id)
       topic.original_post.update_columns(creator_id: member.id)
       expect(topic.can_hide?(member)).to be false
+    end
+
+    it "denies an unverified user from hiding" do
+      topic = make_topic
+      expect(topic.can_hide?(unverified)).to be false
     end
   end
 

--- a/spec/models/forum_topic/instance_methods_spec.rb
+++ b/spec/models/forum_topic/instance_methods_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ForumTopic do
   let(:moderator)       { create(:moderator_user) }
   let(:admin)           { create(:admin_user) }
   let(:other)           { create(:user) }
+  let(:unverified)      { create(:unverified_user) }
   let(:category)        { create(:forum_category) }
   let(:admin_category)  { create(:forum_category, can_view: User::Levels::ADMIN) }
 
@@ -116,6 +117,11 @@ RSpec.describe ForumTopic do
       topic.update_columns(is_hidden: true, creator_id: other.id)
       # `member` is not creator and not moderator, so can_access? is false → can_edit? false
       expect(topic.can_edit?(member)).to be false
+    end
+
+    it "denies an unverified user from editing" do
+      topic = make_topic
+      expect(topic.can_edit?(unverified)).to be false
     end
   end
 


### PR DESCRIPTION
This is a necessary step before we can implement soft bans.

The end goal is to let (some) banned users log into the site, without being able to affect anything.
Most important things are already properly gated behind the `Member` role through the controllers.
This PR ensures that links that would lead to a "Permission Denied" page are hidden from view.

Additionally, members who did not verify their email can now edit some settings, including their blacklist.