### PR TITLE
[Posts] Add deletion flag ID placeholder to deletion DMails

### DIFF
--- a/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
+++ b/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
@@ -38,12 +38,13 @@ PostDeletion.init = function () {
       // Don't overwrite the input's text unless necessary
       let titleChanged = force, messageChanged = force;
       if (!Utility.blank(newReason)) {
-        if (newTitle.indexOf("%REASON%") >= 0) {
-          newTitle = newTitle.replaceAll("%REASON%", newReason);
+        const reasonPlaceholder = "%REASON%";
+        if (newTitle.indexOf(reasonPlaceholder) >= 0) {
+          newTitle = newTitle.replaceAll(reasonPlaceholder, newReason);
           titleChanged = true;
         }
-        if (newMessage.indexOf("%REASON%") >= 0) {
-          newMessage = newMessage.replaceAll("%REASON%", newReason);
+        if (newMessage.indexOf(reasonPlaceholder) >= 0) {
+          newMessage = newMessage.replaceAll(reasonPlaceholder, newReason);
           messageChanged = true;
         }
       }

--- a/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
+++ b/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
@@ -31,21 +31,33 @@ PostDeletion.init = function () {
         dMailTextArea.attr("disabled", "disabled");
       }
     };
-    updateDMailReason = function () {
+    updateDMailReason = function (force = false) {
       const newReason = input.val()?.toString();
       let newTitle = dMailTemplate.selectedOptions[0].getAttribute("data-dmail-title");
       let newMessage = dMailTemplate.value;
+      // Don't overwrite the input's text unless necessary
+      let titleChanged = force, messageChanged = force;
       if (!Utility.blank(newReason)) {
-        newTitle = newTitle.replaceAll("%REASON%", newReason);
-        newMessage = newMessage.replaceAll("%REASON%", newReason);
+        if (newTitle.indexOf("%REASON%") >= 0) {
+          newTitle = newTitle.replaceAll("%REASON%", newReason);
+          titleChanged = true;
+        }
+        if (newMessage.indexOf("%REASON%") >= 0) {
+          newMessage = newMessage.replaceAll("%REASON%", newReason);
+          messageChanged = true;
+        }
       }
-      dMailTitleInput.val(newTitle);
-      dMailTextArea.val(newMessage);
+      if (titleChanged) {
+        dMailTitleInput.val(newTitle);
+      }
+      if (messageChanged) {
+        dMailTextArea.val(newMessage);
+      }
     };
     dMailCheckBox.addEventListener("click", () => updateDMailActivation());
     dMailTemplate.addEventListener("change", () => updateDMailReason());
     updateDMailActivation();
-    updateDMailReason();
+    updateDMailReason(true);
   }
   // #endregion DMail Notification
 

--- a/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
+++ b/app/javascript/src/js/pages/moderator/post/posts/post_delete.js
@@ -55,7 +55,7 @@ PostDeletion.init = function () {
       }
     };
     dMailCheckBox.addEventListener("click", () => updateDMailActivation());
-    dMailTemplate.addEventListener("change", () => updateDMailReason());
+    dMailTemplate.addEventListener("change", () => updateDMailReason(true));
     updateDMailActivation();
     updateDMailReason(true);
   }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1658,6 +1658,9 @@ class Post < ApplicationRecord
       if reason
         text = text.gsub("%REASON%", reason)
       end
+      if (flag_id = deletion_flag&.id)
+        text = text.gsub("%FLAG_ID%", flag_id.to_s)
+      end
       text.gsub("%POST_ID%", id.to_s)
           .gsub("%STAFF_NAME%", CurrentUser.name)
           .gsub("%STAFF_ID%", CurrentUser.id.to_s)

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -622,6 +622,7 @@ module Danbooru
     # The template for the auto-dispatched notification DMail to uploaders of post auto-deletion.
     # Replaces the following strings with their values:
     # * `%POST_ID%`: The id of the deleted post
+    # * `%FLAG_ID%`: The id of the deletion flag
     # * `%UPLOADER_ID%`: The id of the uploader
     #
     # ## Example Value
@@ -637,6 +638,7 @@ module Danbooru
     # Strings used as templates for the optional notification DMail to uploaders on post deletion.
     # Replaces the following strings with their values:
     # * `%POST_ID%`: The id of the deleted post
+    # * `%FLAG_ID%`: The id of the deletion flag
     # * `%STAFF_NAME%`: The name of the deleting staff member
     # * `%STAFF_ID%`: The id of the deleting staff member
     # * `%UPLOADER_ID%`: The id of the uploader
@@ -652,7 +654,7 @@ module Danbooru
 
 This is a courtesy notification; you don't need to take further action if you don't want to.
 
-If you would like to contest the deletion, you can follow the procedure outlined \"here\":[/help/faq#deleted]
+If you would like to contest the deletion, click \"this link\":[/appeals/new?disp_id=%FLAG_ID%&qtype=flag].
 
 You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOADER_ID%]; you can access this at any time by going to \"your profile page\":[/users/%UPLOADER_ID%] & selecting the `deleted` tab on the `Upload` pane, or you can search {{user:!%UPLOADER_ID% status:deleted}}.",
         },

--- a/spec/models/post/deletion_methods_spec.rb
+++ b/spec/models/post/deletion_methods_spec.rb
@@ -202,6 +202,13 @@ RSpec.describe Post do
         expect(result).to include(post.id.to_s)
       end
 
+      it "substitutes %FLAG_ID% with the deletion flag id" do
+        post = create(:post)
+        post.delete!("bogus")
+        result = post.substitute_deletion_dmail_template("Post #%FLAG_ID%")
+        expect(result).to include(post.deletion_flag.id.to_s)
+      end
+
       it "substitutes %REASON% when a reason is provided" do
         post = create(:post)
         result = post.substitute_deletion_dmail_template("Reason: %REASON%", "test reason")


### PR DESCRIPTION
Add `%FLAG_ID%` so you can have a link to the appeal form in a deletion DMail.
Also minor improvement to the deletion DMail UI, to stop it overwriting your changes even when there's no "reason" (pun intended).