### PR TITLE
[Comments] Fix avatar placeholder size on mobile

### DIFF
--- a/app/javascript/src/styles/common/_comment_container.scss
+++ b/app/javascript/src/styles/common/_comment_container.scss
@@ -55,7 +55,7 @@
           grid-row-start: 1;
           grid-row-end: 4;
 
-          article.thumbnail.inline {
+          article.thumbnail {
             --thumb-image-size: 50px;
           }
         }


### PR DESCRIPTION
The `--thumb-image-size` variable was only being applied to rendered avatars, not placeholders.