### PR TITLE
[ForumPosts] Fix avatars having extra margins

### DIFF
--- a/app/javascript/src/styles/specific/forum.scss
+++ b/app/javascript/src/styles/specific/forum.scss
@@ -1,5 +1,5 @@
 div.list-of-forum-posts {
-  article {
+  article.forum-post {
     margin: 1em 0em;
 
     a.voted {


### PR DESCRIPTION
The style assumed that the only `<article>` element was the forum post itself.