### PR TITLE
[Posts] Include character and copyright tags in the AvoidPosting notice

### DIFF
--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -15,7 +15,7 @@ module Moderator
         @reason = @post.pending_flag&.reason || ""
         @reason = "" if @reason =~ /uploading_guidelines/
 
-        @dnp = @post.avoid_posting_artists
+        @dnp = @post.avoid_posting_tags
       end
 
       # Deletes the given post

--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -63,7 +63,7 @@ class UploadService
       p.parent_id = upload.parent_id
       p.duration = upload.video_duration(upload.file.path)
 
-      if !upload.uploader.can_upload_free? || (!upload.uploader.can_approve_posts? && p.avoid_posting_artists.any?) || upload.upload_as_pending?
+      if !upload.uploader.can_upload_free? || (!upload.uploader.can_approve_posts? && p.avoid_posting_tags.any?) || upload.upload_as_pending?
         p.is_pending = true
       end
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1181,13 +1181,28 @@ class Post < ApplicationRecord
     end
 
     ## DB!
-    # Fetches the avoid posting data for the post's artist tags.
+    # Fetches the avoid posting data for all artist, copyright, and character tags on the post.
     # Sends a db request to lookup avoid posting data.
-    def avoid_posting_artists
-      @avoid_posting_artists ||= begin
-        artist_names = artist_tags.map(&:name)
-        return [] if artist_names.empty?
-        AvoidPosting.active.joins(:artist).where(artists: { name: artist_names }).includes(:artist).to_a
+    def avoid_posting_tags
+      Cache.fetch("post:#{id}:avoid_posting_tags", expires_in: 15.minutes) do
+        @avoid_posting_tags ||= begin
+          # We only care about artist, copyright, and character tags.
+          if @categorized_tags.nil?
+            tags = Tag
+                   .where(name: tag_array, category: [Tag.categories.artist, Tag.categories.copyright, Tag.categories.character])
+                   .pluck(:name)
+                   .filter { |tag| NON_ARTIST_TAGS.exclude?(tag) }
+          else
+            tags = tags_for_category(Tag.categories.artist) + tags_for_category(Tag.categories.copyright) + tags_for_category(Tag.categories.character)
+          end
+
+          if tags.empty?
+            []
+          else
+            # Despite the name, copyright and character tags can also have Artist and AvoidPosting entries
+            AvoidPosting.active.joins(:artist).where(artists: { name: tags }).includes(:tag).to_a
+          end
+        end
       end
     end
   end
@@ -2121,6 +2136,7 @@ class Post < ApplicationRecord
     @categorized_tags = nil
     @artist_tags = nil
     @uploader_linked_artists = nil
+    @avoit_posting_tags = nil
 
     @has_dimensions = nil
     @preview_dimensions = nil

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1194,7 +1194,11 @@ class Post < ApplicationRecord
                    .pluck(:name)
                    .filter { |tag| NON_ARTIST_TAGS.exclude?(tag) }
           else
-            tags = tags_for_category(Tag.categories.artist) + tags_for_category(Tag.categories.copyright) + tags_for_category(Tag.categories.character)
+            tags = (
+              tags_for_category(Tag.categories.artist) +
+              tags_for_category(Tag.categories.copyright) +
+              tags_for_category(Tag.categories.character)
+            ).map(&:name)
           end
 
           if tags.empty?
@@ -2141,7 +2145,7 @@ class Post < ApplicationRecord
     @categorized_tags = nil
     @artist_tags = nil
     @uploader_linked_artists = nil
-    @avoit_posting_tags = nil
+    @avoid_posting_tags = nil
 
     @has_dimensions = nil
     @preview_dimensions = nil

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1201,7 +1201,7 @@ class Post < ApplicationRecord
             []
           else
             # Despite the name, copyright and character tags can also have Artist and AvoidPosting entries
-            AvoidPosting.active.joins(:artist).where(artists: { name: tags }).includes(:tag).to_a
+            AvoidPosting.active.joins(:artist).where(artists: { name: tags }).includes(:artist).to_a
           end
         end
       end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -45,7 +45,6 @@ class Post < ApplicationRecord
   after_commit :handle_thumbnails_on_create, on: :create
   after_commit :generate_image_samples, on: :create
   after_commit :generate_video_samples, on: :create, if: :is_video?
-  after_commit :clear_avoid_posting_cache, if: :should_process_tags?
 
   belongs_to :updater, :class_name => "User", optional: true # this is handled in versions
   belongs_to :approver, class_name: "User", optional: true
@@ -1185,34 +1184,28 @@ class Post < ApplicationRecord
     # Fetches the avoid posting data for all artist, copyright, and character tags on the post.
     # Sends a db request to lookup avoid posting data.
     def avoid_posting_tags
-      Cache.fetch("post:#{id}:avoid_posting_tags", expires_in: 15.minutes) do
-        @avoid_posting_tags ||= begin
-          # We only care about artist, copyright, and character tags.
-          if @categorized_tags.nil?
-            tags = Tag
-                   .where(name: tag_array, category: [Tag.categories.artist, Tag.categories.copyright, Tag.categories.character])
-                   .pluck(:name)
-                   .filter { |tag| NON_ARTIST_TAGS.exclude?(tag) }
-          else
-            tags = (
-              tags_for_category(Tag.categories.artist) +
-              tags_for_category(Tag.categories.copyright) +
-              tags_for_category(Tag.categories.character)
-            ).map(&:name)
-          end
+      @avoid_posting_tags ||= begin
+        # We only care about artist, copyright, and character tags.
+        if @categorized_tags.nil?
+          tags = Tag
+                 .where(name: tag_array, category: [Tag.categories.artist, Tag.categories.copyright, Tag.categories.character])
+                 .pluck(:name)
+                 .filter { |tag| NON_ARTIST_TAGS.exclude?(tag) }
+        else
+          tags = (
+            tags_for_category(Tag.categories.artist) +
+            tags_for_category(Tag.categories.copyright) +
+            tags_for_category(Tag.categories.character)
+          ).map(&:name).filter { |tag| NON_ARTIST_TAGS.exclude?(tag) }
+        end
 
-          if tags.empty?
-            []
-          else
-            # Despite the name, copyright and character tags can also have Artist and AvoidPosting entries
-            AvoidPosting.active.joins(:artist).where(artists: { name: tags }).includes(:artist).to_a
-          end
+        if tags.empty?
+          []
+        else
+          # Despite the name, copyright and character tags can also have Artist and AvoidPosting entries
+          AvoidPosting.active.joins(:artist).where(artists: { name: tags }).includes(:artist).to_a
         end
       end
-    end
-
-    def clear_avoid_posting_cache
-      Cache.delete("post:#{id}:avoid_posting_tags")
     end
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -45,6 +45,7 @@ class Post < ApplicationRecord
   after_commit :handle_thumbnails_on_create, on: :create
   after_commit :generate_image_samples, on: :create
   after_commit :generate_video_samples, on: :create, if: :is_video?
+  after_commit :clear_avoid_posting_cache, if: :should_process_tags?
 
   belongs_to :updater, :class_name => "User", optional: true # this is handled in versions
   belongs_to :approver, class_name: "User", optional: true
@@ -1204,6 +1205,10 @@ class Post < ApplicationRecord
           end
         end
       end
+    end
+
+    def clear_avoid_posting_cache
+      Cache.delete("post:#{id}:avoid_posting_tags")
     end
   end
 

--- a/app/views/posts/partials/show/content/notices/_avoid_posting.html.erb
+++ b/app/views/posts/partials/show/content/notices/_avoid_posting.html.erb
@@ -1,9 +1,9 @@
-<% if post.avoid_posting_artists.any? %>
+<% if post.avoid_posting_tags.any? %>
   <div class="notice" id="avoid-posting-notice">
     <div class="avoid-posting" data-post-id="<%= post.id %>">
       <h3>Avoid Posting</h3>
       <ul>
-        <% post.avoid_posting_artists.each do |dnp| %>
+        <% post.avoid_posting_tags.each do |dnp| %>
           <li data-artist-id="<%= dnp.artist_id %>" data-avoid-posting-id="<%= dnp.id %>" data-artist-name="<%= dnp.artist_name %>">
           <% if dnp.pretty_details.blank? %>
             <span class="artist"><%= link_to dnp.artist_name, avoid_posting_path(dnp) %></span>

--- a/app/views/posts/partials/show/content/notices/_notices.html.erb
+++ b/app/views/posts/partials/show/content/notices/_notices.html.erb
@@ -63,7 +63,7 @@
   </div>
 <% end %>
 
-<% if post.is_pending? || (post.is_flagged? && post.flags.any?) %>
+<% if CurrentUser.user.is_member? && (post.is_pending? || (post.is_flagged? && post.flags.any?)) %>
   <%= render "posts/partials/show/content/notices/avoid_posting", post: post %>
 <% end %>
 

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe UploadService do
         expect(service.convert_to_post(upload).is_pending).to be true
       end
 
-      it "marks post as pending when avoid_posting_artists present and uploader cannot approve" do
+      it "marks post as pending when avoid_posting_tags present and uploader cannot approve" do
         artist = create(:artist)
         create(:avoid_posting, artist: artist)
         upload.tag_string = artist.name
@@ -298,7 +298,7 @@ RSpec.describe UploadService do
       it "does not mark post as pending when no pending conditions apply" do
         allow(upload.uploader).to receive_messages(can_upload_free?: true, can_approve_posts?: true)
         allow(upload).to receive(:upload_as_pending?).and_return(false)
-        # upload.tag_string is "tagme" which has no artist tags, so avoid_posting_artists is []
+        # upload.tag_string is "tagme" which has no artist tags, so avoid_posting_tags is []
         expect(service.convert_to_post(upload).is_pending).to be false
       end
     end

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -650,16 +650,18 @@ RSpec.describe Post do
       end
 
       it "returns AvoidPosting records for copyright tags on the post" do
-        copyright = create(:copyright)
-        avoid = create(:avoid_posting, copyright: copyright)
+        copyright = create(:artist)
+        copyright.tag.update(category: Tag.categories.copyright)
+        avoid = create(:avoid_posting, artist: copyright)
         # Use copyright: prefix to create the tag with copyright category
         post = create(:post, tag_string: "copyright:#{copyright.name} " + (1..10).map { |i| "gen_#{i}" }.join(" "))
         expect(post.avoid_posting_tags).to include(avoid)
       end
 
       it "returns AvoidPosting records for character tags on the post" do
-        character = create(:character)
-        avoid = create(:avoid_posting, character: character)
+        character = create(:artist)
+        character.tag.update(category: Tag.categories.character)
+        avoid = create(:avoid_posting, artist: character)
         # Use character: prefix to create the tag with character category
         post = create(:post, tag_string: "character:#{character.name} " + (1..10).map { |i| "gen_#{i}" }.join(" "))
         expect(post.avoid_posting_tags).to include(avoid)

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -638,7 +638,7 @@ RSpec.describe Post do
       end
     end
 
-    describe "#avoid_posting_artists" do
+    describe "#avoid_posting_tags" do
       before { skip "Avoid postings routes not available in this fork" unless Rails.application.routes.url_helpers.respond_to?(:avoid_postings_path) }
 
       it "returns AvoidPosting records for artist tags on the post" do
@@ -646,12 +646,28 @@ RSpec.describe Post do
         avoid = create(:avoid_posting, artist: artist)
         # Use artist: prefix to create the tag with artist category
         post = create(:post, tag_string: "artist:#{artist.name} " + (1..10).map { |i| "gen_#{i}" }.join(" "))
-        expect(post.avoid_posting_artists).to include(avoid)
+        expect(post.avoid_posting_tags).to include(avoid)
       end
 
-      it "returns an empty array when the post has no artist tags" do
+      it "returns AvoidPosting records for copyright tags on the post" do
+        copyright = create(:copyright)
+        avoid = create(:avoid_posting, copyright: copyright)
+        # Use copyright: prefix to create the tag with copyright category
+        post = create(:post, tag_string: "copyright:#{copyright.name} " + (1..10).map { |i| "gen_#{i}" }.join(" "))
+        expect(post.avoid_posting_tags).to include(avoid)
+      end
+
+      it "returns AvoidPosting records for character tags on the post" do
+        character = create(:character)
+        avoid = create(:avoid_posting, character: character)
+        # Use character: prefix to create the tag with character category
+        post = create(:post, tag_string: "character:#{character.name} " + (1..10).map { |i| "gen_#{i}" }.join(" "))
+        expect(post.avoid_posting_tags).to include(avoid)
+      end
+
+      it "returns an empty array when the post has no artist, copyright, or character tags" do
         post = create(:post, tag_string: (1..10).map { |i| "gen_only_#{i}" }.join(" "))
-        expect(post.avoid_posting_artists).to eq([])
+        expect(post.avoid_posting_tags).to eq([])
       end
     end
   end

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -649,6 +649,14 @@ RSpec.describe Post do
         expect(post.avoid_posting_tags).to include(avoid)
       end
 
+      it "returns AvoidPosting records with categorized_tags preloaded" do
+        artist = create(:artist)
+        avoid = create(:avoid_posting, artist: artist)
+        post = create(:post, tag_string: "artist:#{artist.name} " + (1..10).map { |i| "gen_#{i}" }.join(" "))
+        post.categorized_tags # Force preload categorized_tags
+        expect(post.avoid_posting_tags).to include(avoid)
+      end
+
       it "returns AvoidPosting records for copyright tags on the post" do
         copyright = create(:artist)
         copyright.tag.update(category: Tag.categories.copyright)


### PR DESCRIPTION
We have a couple tags that are on the Avoid Posting list, but are not in the artist category.

[paddington_and_company_limited](https://e621.net/wiki_pages/16715): copyright
[averi_(fiddleafox)](https://e621.net/wiki_pages/28699): character

This PR ensures that the Avoid Posting notice gets displayed on posts with those tags.