### PR TITLE
[Home] Compute mascot image server-side

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -47,7 +47,8 @@ class StaticController < ApplicationController
     selected_mascot ||= mascot_list[mascot_list.keys.sample]
 
     if selected_mascot.present?
-      @mascot_background_url = CGI.escape_html(selected_mascot["background_url"])
+      @mascot_id = selected_mascot["id"]
+      @mascot_background_url = selected_mascot["background_url"]
       @mascot_artist_name = selected_mascot["artist_name"]
       @mascot_artist_url = selected_mascot["artist_url"]
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -41,6 +41,28 @@ class StaticController < ApplicationController
   end
 
   def home
+    @mascot_id = cookies[:mascot].to_i
+    if @mascot_id > 0 && Mascot.active_for_browser[@mascot_id].present?
+      selected_mascot = Mascot.active_for_browser[@mascot_id]
+    else
+      # Grab random mascot if user does not have one selected, or if the selected mascot is invalid
+      selected_mascot_id = Mascot.active_for_browser.keys.sample
+      selected_mascot = Mascot.active_for_browser[selected_mascot_id]
+    end
+
+    if selected_mascot.present?
+      @mascot_background_url = selected_mascot[:background_url]
+      @extra_body_args = {
+        style: [
+          "--bg-image: url(#{@mascot_background_url})",
+          "--bg-color: #{selected_mascot[:background_color]}",
+          "--fg-color: #{selected_mascot[:foreground_color]}",
+        ].join(";"),
+      }
+      @mascot_artist_name = selected_mascot[:artist_name]
+      @mascot_artist_url = selected_mascot[:artist_url]
+    end
+
     render layout: "blank", formats: [:html]
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -58,6 +58,7 @@ class StaticController < ApplicationController
           "--bg-color: #{selected_mascot['background_color']}",
           "--fg-color: #{selected_mascot['foreground_color']}",
         ].join(";"),
+        layered: ("true" if selected_mascot["is_layered"]),
       }
     end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -42,25 +42,22 @@ class StaticController < ApplicationController
 
   def home
     @mascot_id = cookies[:mascot].to_i
-    if @mascot_id > 0 && Mascot.active_for_browser[@mascot_id].present?
-      selected_mascot = Mascot.active_for_browser[@mascot_id]
-    else
-      # Grab random mascot if user does not have one selected, or if the selected mascot is invalid
-      selected_mascot_id = Mascot.active_for_browser.keys.sample
-      selected_mascot = Mascot.active_for_browser[selected_mascot_id]
-    end
+    mascot_list = Mascot.active_for_browser
+    selected_mascot = @mascot_id > 0 ? mascot_list[@mascot_id] : nil
+    selected_mascot ||= mascot_list[mascot_list.keys.sample]
 
     if selected_mascot.present?
-      @mascot_background_url = selected_mascot[:background_url]
+      @mascot_background_url = CGI.escape_html(selected_mascot["background_url"])
+      @mascot_artist_name = selected_mascot["artist_name"]
+      @mascot_artist_url = selected_mascot["artist_url"]
+
       @extra_body_args = {
         style: [
-          "--bg-image: url(#{@mascot_background_url})",
-          "--bg-color: #{selected_mascot[:background_color]}",
-          "--fg-color: #{selected_mascot[:foreground_color]}",
+          "--bg-image: url('#{@mascot_background_url}')",
+          "--bg-color: #{selected_mascot['background_color']}",
+          "--fg-color: #{selected_mascot['foreground_color']}",
         ].join(";"),
       }
-      @mascot_artist_name = selected_mascot[:artist_name]
-      @mascot_artist_url = selected_mascot[:artist_url]
     end
 
     render layout: "blank", formats: [:html]

--- a/app/javascript/src/js/core/themes.js
+++ b/app/javascript/src/js/core/themes.js
@@ -1,5 +1,6 @@
 import Page from "@/utility/Page";
 import LStorage from "@/utility/storage";
+import CStorage from "@/utility/StorageC";
 
 const Theme = {};
 
@@ -51,11 +52,11 @@ Theme.initialize_selector = function () {
 Theme.initialize_buttons = function () {
   if (!LStorage.isAvailable()) return;
 
-  if (LStorage.Site.Mascot !== 0) {
+  if (CStorage.mascotID !== 0) {
     $("#mascot-state").show();
-    $("#mascot-value").text(LStorage.Site.Mascot);
+    $("#mascot-value").text(CStorage.mascotID);
     $("#mascot-reset").on("click", () => {
-      LStorage.Site.Mascot = 0;
+      CStorage.mascotID = 0;
       $("#mascot-state").hide();
     });
   }

--- a/app/javascript/src/js/pages/static/home/Home.ts
+++ b/app/javascript/src/js/pages/static/home/Home.ts
@@ -9,6 +9,7 @@ class Home {
 
     let isEmpty = !tags.value;
     let wasEmpty = isEmpty;
+    // Start in default state, switch to non-empty if tags are pre-filled (ex. from navigating back to the page)
     if (!isEmpty) form.classList.remove("empty");
 
     tags.addEventListener("input", () => {

--- a/app/javascript/src/js/pages/static/home/Home.ts
+++ b/app/javascript/src/js/pages/static/home/Home.ts
@@ -9,7 +9,7 @@ class Home {
 
     let isEmpty = !tags.value;
     let wasEmpty = isEmpty;
-    if (isEmpty) form.classList.add("empty");
+    if (!isEmpty) form.classList.remove("empty");
 
     tags.addEventListener("input", () => {
       wasEmpty = isEmpty;

--- a/app/javascript/src/js/pages/static/home/MascotManager.ts
+++ b/app/javascript/src/js/pages/static/home/MascotManager.ts
@@ -18,8 +18,6 @@ export default class MascotManager {
 
     if (!this.mascots[this.current + ""])
       this._current = this.availableIDs[Math.floor(Math.random() * this.availableIDs.length)];
-
-    document.getElementById("mascot-swap")?.addEventListener("click", this.handleChangeMascot.bind(this));
   }
 
   /**

--- a/app/javascript/src/js/pages/static/home/MascotManager.ts
+++ b/app/javascript/src/js/pages/static/home/MascotManager.ts
@@ -3,12 +3,14 @@ import StorageC from "@/utility/StorageC";
 
 export default class MascotManager {
 
+  public isAvailable = false;
   private mascots: Record<string, MascotData> = {};
   private availableIDs: number[];
 
   public constructor () {
     if (!this.loadMascotData())
       return;
+    this.isAvailable = true;
     // Backwards compatibility
     window["mascots"] = this.mascots;
 
@@ -116,6 +118,8 @@ export default class MascotManager {
       const artistLink = document.createElement("a");
       artistLink.textContent = mascot.artist_name;
       artistLink.href = safeUrl;
+      artistLink.target = "_blank";
+      artistLink.rel = "noopener noreferrer";
       mascotArtist.append(artistLink);
     } else mascotArtist.textContent = "";
   }
@@ -144,6 +148,7 @@ State.onReady(() => {
   let instance: MascotManager = null;
   document.getElementById("mascot-swap")?.addEventListener("click", function (event) {
     if (!instance) instance = new MascotManager();
+    if (!instance.isAvailable) return;
     instance.handleChangeMascot(event);
   });
 });

--- a/app/javascript/src/js/pages/static/home/MascotManager.ts
+++ b/app/javascript/src/js/pages/static/home/MascotManager.ts
@@ -1,11 +1,12 @@
 import State from "@/utility/StateUtils";
+import StorageC from "@/utility/StorageC";
 
 export default class MascotManager {
 
   private mascots: Record<string, MascotData> = {};
   private availableIDs: number[];
 
-  private constructor () {
+  public constructor () {
     if (!this.loadMascotData())
       return;
     // Backwards compatibility
@@ -17,7 +18,6 @@ export default class MascotManager {
 
     if (!this.mascots[this.current + ""])
       this._current = this.availableIDs[Math.floor(Math.random() * this.availableIDs.length)];
-    this.showMascot();
 
     document.getElementById("mascot-swap")?.addEventListener("click", this.handleChangeMascot.bind(this));
   }
@@ -53,6 +53,13 @@ export default class MascotManager {
       return false;
     }
 
+    let current = parseInt(mascotsElement.getAttribute("data-current") || "0");
+    if (isNaN(current) || !this.mascots[current + ""]) {
+      console.warn("Invalid current mascot ID, defaulting to 0");
+      current = 0;
+    }
+    this._current = current;
+
     return true;
   }
 
@@ -63,9 +70,8 @@ export default class MascotManager {
 
   private _current: number;
   private get current (): number {
-    if (typeof this._current !== "number") {
-      this._current = parseInt(localStorage.getItem("mascot") || "0") || 0;
-    }
+    if (typeof this._current !== "number")
+      this._current = StorageC.mascotID;
     return this._current;
   }
 
@@ -76,10 +82,8 @@ export default class MascotManager {
       this._current = 0;
     }
 
-    if (!this._current)
-      localStorage.removeItem("mascot");
-    else
-      localStorage.setItem("mascot", this._current.toString());
+    if (!this._current) StorageC.mascotID = 0;
+    else StorageC.mascotID = this._current;
   }
 
 
@@ -118,25 +122,13 @@ export default class MascotManager {
     } else mascotArtist.textContent = "";
   }
 
-  private handleChangeMascot (event: MouseEvent) {
+  public handleChangeMascot (event: MouseEvent) {
     event.preventDefault();
 
     const currentMascotIndex = this.availableIDs.indexOf(this.current);
     this.current = this.availableIDs[(currentMascotIndex + 1) % this.availableIDs.length];
 
     this.showMascot();
-  }
-
-
-  /* ============================== */
-  /* ====== Singleton Pattern ===== */
-  /* ============================== */
-
-  private static _instance: MascotManager;
-  static get instance () {
-    if (!MascotManager._instance)
-      MascotManager._instance = new MascotManager();
-    return MascotManager._instance;
   }
 }
 
@@ -151,5 +143,9 @@ interface MascotData {
 }
 
 State.onReady(() => {
-  void MascotManager.instance;
+  let instance: MascotManager = null;
+  document.getElementById("mascot-swap")?.addEventListener("click", function (event) {
+    if (!instance) instance = new MascotManager();
+    instance.handleChangeMascot(event);
+  });
 });

--- a/app/javascript/src/js/pages/static/home/MascotManager.ts
+++ b/app/javascript/src/js/pages/static/home/MascotManager.ts
@@ -52,7 +52,7 @@ export default class MascotManager {
     }
 
     let current = parseInt(mascotsElement.getAttribute("data-current") || "0");
-    if (isNaN(current) || !this.mascots[current + ""]) {
+    if (current !== 0 && (isNaN(current) || !this.mascots[current + ""])) {
       console.warn("Invalid current mascot ID, defaulting to 0");
       current = 0;
     }

--- a/app/javascript/src/js/utility/StorageC.ts
+++ b/app/javascript/src/js/utility/StorageC.ts
@@ -80,6 +80,7 @@ class CookieJar {
    * The cookie is set with the path "/" and SameSite=Lax for security.
    * @param name The name of the cookie to set.
    * @param value The value to store in the cookie.
+   * @param path The path for which the cookie is valid (default is "/").
    * @param days The number of days until the cookie expires (default is 365).
    */
   public static set (name: string, value: string, path: string = "/", days: number = 365): void {
@@ -111,6 +112,7 @@ class CookieJar {
    * The cookie will expire after the specified number of days.
    * @param name The name of the cookie to set.
    * @param value The boolean value to store in the cookie.
+   * @param path The path for which the cookie is valid (default is "/").
    * @param days The number of days until the cookie expires (default is 365).
    */
   public static setBool (name: string, value: boolean, path: string = "/", days: number = 365): void {

--- a/app/javascript/src/js/utility/StorageC.ts
+++ b/app/javascript/src/js/utility/StorageC.ts
@@ -12,52 +12,57 @@ export default class CStorage {
 
   /** @returns true if the DMail notice is hidden, otherwise false */
   static get hideDMailNotice (): boolean {
-    return this._getBoolCookie("hide_dmail_notice");
+    return CookieJar.getBool("hide_dmail_notice");
   }
 
-  /** @param value true to hide the DMail notice, otherwise false */
   static set hideDMailNotice (value: boolean) {
-    if (value) this._setBoolCookie("hide_dmail_notice", true);
-    else this._deleteBoolCookie("hide_dmail_notice");
+    if (value) CookieJar.setBool("hide_dmail_notice", true);
+    else CookieJar.deleteBool("hide_dmail_notice");
   }
+
 
   /** @returns "comments" if the post tab is set to comments, otherwise "tags" */
   static get postMobileTabState (): "comments" | "tags" {
-    return this._getBoolCookie("post_tab") ? "comments" : "tags";
+    return CookieJar.getBool("post_tab") ? "comments" : "tags";
   }
 
-  /** @param value "comments" to set the post tab to comments, otherwise "tags" */
   static set postMobileTabState (value: "comments" | "tags") {
-    if (value === "comments") this._setBoolCookie("post_tab", true);
-    else this._deleteBoolCookie("post_tab");
+    if (value === "comments") CookieJar.setBool("post_tab", true);
+    else CookieJar.deleteBool("post_tab");
   }
+
 
   /** @returns true if the post recommender is hidden, otherwise false */
   static get postRecommenderHidden (): boolean {
-    return this._getBoolCookie("post_recs");
+    return CookieJar.getBool("post_recs");
   }
 
-  /** @param value true to hide the post recommender, otherwise false */
   static set postRecommenderHidden (value: boolean) {
-    if (value) this._setBoolCookie("post_recs", true);
-    else this._deleteBoolCookie("post_recs");
+    if (value) CookieJar.setBool("post_recs", true);
+    else CookieJar.deleteBool("post_recs");
   }
 
-  /* ===== Utility Methods ===== */
 
+  /** @returns The ID of the currently selected mascot, or 0 if the default mascot is being used */
+  static get mascotID (): number {
+    const id = CookieJar.get("mascot");
+    return id ? (parseInt(id) || 0) : 0;
+  }
+
+  static set mascotID (value: number) {
+    if (value > 0) CookieJar.set("mascot", value.toString());
+    else CookieJar.delete("mascot");
+  }
+}
+
+class CookieJar {
   /**
    * Retrieves a boolean value from a cookie. The cookie is expected to be "1" for true and "0" for false.
    * @param name The name of the cookie to retrieve.
    * @returns True if the cookie value is "1", otherwise false.
    */
-  private static _getBoolCookie (name: string): boolean {
-    const cookies = document.cookie.split(";");
-    for (const cookie of cookies) {
-      const [key, value] = cookie.trim().split("=");
-      if (key === name)
-        return value === "1";
-    }
-    return false;
+  public static getBool (name: string): boolean {
+    return this.get(name) === "1";
   }
 
   /**
@@ -67,17 +72,50 @@ export default class CStorage {
    * @param value The boolean value to store in the cookie.
    * @param days The number of days until the cookie expires (default is 365).
    */
-  private static _setBoolCookie (name: string, value: boolean, days: number = 365): void {
-    const cookieValue = value ? "1" : "0";
-    const expires = new Date(Date.now() + (days * 24 * 60 * 60 * 1000)).toUTCString();
-    document.cookie = `${name}=${cookieValue}; expires=${expires}; path=/; SameSite=Lax;`;
+  public static setBool (name: string, value: boolean, path: string = "/", days: number = 365): void {
+    this.set(name, value ? "1" : "0", path, days);
   }
 
   /**
    * Deletes a boolean value from a cookie by setting its expiration date to a past date.
    * @param name The name of the cookie to delete.
    */
-  private static _deleteBoolCookie (name: string): void {
+  public static deleteBool (name: string): void {
+    this.delete(name);
+  }
+
+  /**
+   * Retrieves the value of a cookie by its name. If the cookie does not exist, it returns null.
+   * @param name The name of the cookie to retrieve.
+   * @returns The value of the cookie, or null if the cookie does not exist.
+   */
+  public static get (name: string): string | null {
+    const cookies = document.cookie.split(";");
+    for (const cookie of cookies) {
+      const [key, value] = cookie.trim().split("=");
+      if (key === name)
+        return value;
+    }
+    return null;
+  }
+
+  /**
+   * Sets a cookie with the specified name, value, and expiration in days.
+   * The cookie is set with the path "/" and SameSite=Lax for security.
+   * @param name The name of the cookie to set.
+   * @param value The value to store in the cookie.
+   * @param days The number of days until the cookie expires (default is 365).
+   */
+  public static set (name: string, value: string, path: string = "/", days: number = 365): void {
+    const expires = new Date(Date.now() + (days * 24 * 60 * 60 * 1000)).toUTCString();
+    document.cookie = `${name}=${value}; expires=${expires}; path=${path}; SameSite=Lax;`;
+  }
+
+  /**
+   * Deletes a cookie by setting its expiration date to a past date, effectively removing it from the browser.
+   * @param name The name of the cookie to delete.
+   */
+  public static delete (name: string): void {
     document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax;`;
   }
 }

--- a/app/javascript/src/js/utility/StorageC.ts
+++ b/app/javascript/src/js/utility/StorageC.ts
@@ -50,7 +50,7 @@ export default class CStorage {
   }
 
   static set mascotID (value: number) {
-    if (value > 0) CookieJar.set("mascot", value.toString());
+    if (value > 0) CookieJar.set("mascot", value.toString(), "/");
     else CookieJar.delete("mascot");
   }
 }

--- a/app/javascript/src/js/utility/StorageC.ts
+++ b/app/javascript/src/js/utility/StorageC.ts
@@ -17,7 +17,7 @@ export default class CStorage {
 
   static set hideDMailNotice (value: boolean) {
     if (value) CookieJar.setBool("hide_dmail_notice", true);
-    else CookieJar.deleteBool("hide_dmail_notice");
+    else CookieJar.delete("hide_dmail_notice");
   }
 
 
@@ -28,7 +28,7 @@ export default class CStorage {
 
   static set postMobileTabState (value: "comments" | "tags") {
     if (value === "comments") CookieJar.setBool("post_tab", true);
-    else CookieJar.deleteBool("post_tab");
+    else CookieJar.delete("post_tab");
   }
 
 
@@ -39,7 +39,7 @@ export default class CStorage {
 
   static set postRecommenderHidden (value: boolean) {
     if (value) CookieJar.setBool("post_recs", true);
-    else CookieJar.deleteBool("post_recs");
+    else CookieJar.delete("post_recs");
   }
 
 
@@ -55,35 +55,11 @@ export default class CStorage {
   }
 }
 
+/**
+ * Helper class for managing cookies.
+ * Should not be used directly - add helper methods to CStorage instead.
+ */
 class CookieJar {
-  /**
-   * Retrieves a boolean value from a cookie. The cookie is expected to be "1" for true and "0" for false.
-   * @param name The name of the cookie to retrieve.
-   * @returns True if the cookie value is "1", otherwise false.
-   */
-  public static getBool (name: string): boolean {
-    return this.get(name) === "1";
-  }
-
-  /**
-   * Sets a boolean value in a cookie. The value is stored as "1" for true and "0" for false.  
-   * The cookie will expire after the specified number of days.
-   * @param name The name of the cookie to set.
-   * @param value The boolean value to store in the cookie.
-   * @param days The number of days until the cookie expires (default is 365).
-   */
-  public static setBool (name: string, value: boolean, path: string = "/", days: number = 365): void {
-    this.set(name, value ? "1" : "0", path, days);
-  }
-
-  /**
-   * Deletes a boolean value from a cookie by setting its expiration date to a past date.
-   * @param name The name of the cookie to delete.
-   */
-  public static deleteBool (name: string): void {
-    this.delete(name);
-  }
-
   /**
    * Retrieves the value of a cookie by its name. If the cookie does not exist, it returns null.
    * @param name The name of the cookie to retrieve.
@@ -114,8 +90,30 @@ class CookieJar {
   /**
    * Deletes a cookie by setting its expiration date to a past date, effectively removing it from the browser.
    * @param name The name of the cookie to delete.
+   * @param path The path of the cookie to delete (default is "/").
    */
-  public static delete (name: string): void {
-    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=Lax;`;
+  public static delete (name: string, path: string = "/"): void {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=${path}; SameSite=Lax;`;
+  }
+
+
+  /**
+   * Retrieves a boolean value from a cookie. The cookie is expected to be "1" for true and "0" for false.
+   * @param name The name of the cookie to retrieve.
+   * @returns True if the cookie value is "1", otherwise false.
+   */
+  public static getBool (name: string): boolean {
+    return this.get(name) === "1";
+  }
+
+  /**
+   * Sets a boolean value in a cookie. The value is stored as "1" for true and "0" for false.  
+   * The cookie will expire after the specified number of days.
+   * @param name The name of the cookie to set.
+   * @param value The boolean value to store in the cookie.
+   * @param days The number of days until the cookie expires (default is 365).
+   */
+  public static setBool (name: string, value: boolean, path: string = "/", days: number = 365): void {
+    this.set(name, value ? "1" : "0", path, days);
   }
 }

--- a/app/javascript/src/js/utility/storage.js
+++ b/app/javascript/src/js/utility/storage.js
@@ -53,9 +53,6 @@ Object.defineProperty(LStorage, "Debug", {
 
 // Content that does not belong anywhere else
 LStorage.Site = {
-  /** @returns {number} Currently displayed Mascot ID, or 0 if none is selected */
-  Mascot: ["mascot", 0],
-
   /** @returns {number} Last news update ID, or 0 if none is selected */
   NewsID: ["hide_news_notice", 0],
 

--- a/app/javascript/src/styles/views/static/_home.scss
+++ b/app/javascript/src/styles/views/static/_home.scss
@@ -112,28 +112,15 @@ body.c-static.a-home {
 
     a {
       flex: 1;
-
-      display: flex;
-      justify-content: center;
-      gap: 0.25rem;
-
-      background: #25477b;
-      font-size: 0.9rem;
-      line-height: 1rem;
-      font-family: "Roboto", Verdana, Geneva, sans-serif;
-      font-weight: bold;
-      color: white;
-
-      padding: 0.5rem;
-      @include st-radius;
-      
-      &:hover { background: #2b538e; }
+      font-size: 0.85rem;
 
       svg {
         height: 1.25rem;
-        margin: -0.125rem 0;
+        width: 1.25rem;
+        padding: 0.375rem;
         color: #e8c446;
       }
+      span { flex: unset; }
     }
   }
 
@@ -159,22 +146,8 @@ body.c-static.a-home {
 
     @include st-radius-top;
 
-    a#mascot-swap {
-
-      display: flex;
-      justify-content: center;
-      gap: 0.25rem;
-
-      background: #25477b;
-      font-size: 0.85rem;
-      line-height: 1rem;
-      font-family: "Roboto", Verdana, Geneva, sans-serif;
-      color: white;
-
-      padding: 0.25rem 0.5rem;
-      @include st-radius;
-      
-      &:hover { background: #2b538e; }
+    button#mascot-swap {
+      margin: -0.5rem;
     }
   }
 

--- a/app/views/layouts/blank.html.erb
+++ b/app/views/layouts/blank.html.erb
@@ -3,7 +3,7 @@
 <head>
   <%= render "layouts/head" %>
 </head>
-<%= tag.body **body_attributes(CurrentUser.user) do %>
+<%= tag.body **body_attributes(CurrentUser.user).merge(@extra_body_args || {}) do %>
   <%= render "layouts/theme_include" %>
   <%= render "layouts/navigation/navigation" %>
 

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -1,10 +1,9 @@
 <div id="c-static"><div id="a-home">
-  <script type="text/plain" id="home-mascots" data-encoding="base64"><%= Mascot.active_for_browser_base64 %></script>
-
+  <script type="text/plain" id="home-mascots" data-encoding="base64" data-current="<%= @mascot_id %>"><%= Mascot.active_for_browser_base64 %></script>
   <section class="mascot-section"></section>
 
   <section class="home-section home-search-section">
-    <%= form_tag(posts_path, method: "get", id: "home-search-form") do %>
+    <%= form_tag(posts_path, method: "get", id: "home-search-form", class: "empty") do %>
 
       <!-- Primary Searchbar -->
       <div class="home-search">
@@ -14,11 +13,11 @@
 
       <!-- Secondary search buttons -->
       <div class="home-buttons">
-        <a href="<%= posts_path %>" data-tags="">
+        <a href="<%= posts_path %>" class="st-button" data-tags="">
           <%= svg_icon(:sparkles) %>
           <span>Latest</span>
         </a>
-        <a href="<%= posts_path(tags: "order:hot") %>" data-tags="order:hot">
+        <a href="<%= posts_path(tags: "order:hot") %>" class="st-button" data-tags="order:hot">
           <%= svg_icon(:flame) %>
           <span>Popular</span>
         </a>
@@ -47,10 +46,19 @@
   <% end %>
 
   <section class="home-footer-top">
-    <div id="mascot-artist"></div>
-    <a href="#" id="mascot-swap">
-      <span>Swap Mascot</span>
-    </a>
+    <div id="mascot-artist">
+      <% if @mascot_artist_name.present? && @mascot_artist_url.present? %>
+        Mascot by <a href="<%= @mascot_artist_url %>" target="_blank" rel="noopener noreferrer"><%= @mascot_artist_name %></a>
+      <% end %>
+    </div>
+    <button type="button" id="mascot-swap" class="st-button">
+      Swap Mascot
+    </button>
+    <noscript>
+      <style type="text/css">
+        #mascot-swap { display: none; }
+      </style>
+    </noscript>
   </section>
   <section class="home-footer-bottom">
     <div class="home-footer-counter">
@@ -71,6 +79,9 @@
 </div></div>
 
 <% content_for(:html_header) do -%>
+  <% if @mascot_background_url.present? %>
+    <%= tag.link(rel: "preload", as: "image", href: @mascot_background_url, fetchpriority: "high") %>
+  <% end %>
   <meta name="enable-auto-complete" content="<%= CurrentUser.user.enable_auto_complete %>">
   <%= tag.meta(name: "description", content: Danbooru.config.description) %>
   <%= tag.meta(property: "og:site_name", content: Danbooru.config.app_name) %>


### PR DESCRIPTION
This has a few benefits.
* Mascots are now displayed even if JS is unavailable.
* Mascot image is now preloaded in the `<head>`, rather than filled-in later.
* Smoother loading experience: less mascot image pop-in.