### PR TITLE
[Pagination] Enforce consistent validation rules

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -247,7 +247,9 @@ class ApplicationController < ActionController::Base
     return unless request.get? || request.head?
 
     # Coerce top-level params that must be scalars — reject hashes, unwrap single-element arrays.
-    %i[q page limit id user_id expiry].each do |key|
+    # NOTE: :page and :limit are deliberately not included here. The paginator validates them
+    # and raises Danbooru::Paginator::PaginationError on malformed input.
+    %i[q id user_id expiry].each do |key|
       next unless params.key?(key)
       params[key] = case params[key]
                     when String, Numeric then params[key]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :sanitize_params
   before_action :set_current_user
   around_action :set_time_zone
+  before_action :validate_pagination_param_types
   before_action :normalize_search
   before_action :api_check
   before_action :enable_cors
@@ -239,6 +240,23 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Reject pagination params that aren't scalars. Several call sites read
+  # params[:page] / params[:limit] directly (e.g. `.to_i`, conditionals, redirect
+  # helpers) before pagination runs, so a hash or array here would either crash
+  # or get silently mishandled. The paginator does its own value validation —
+  # this guard only enforces the type contract.
+  def validate_pagination_param_types
+    page = params[:page]
+    unless page.nil? || page.is_a?(String) || page.is_a?(Numeric)
+      raise Danbooru::Paginator::PaginationError, "Invalid page number."
+    end
+
+    limit = params[:limit]
+    unless limit.nil? || limit.is_a?(String) || limit.is_a?(Numeric)
+      raise Danbooru::Paginator::PaginationError, "Invalid limit."
+    end
+  end
+
   # Remove blank `search` params from the url.
   #
   # /tags?search[name]=touhou&search[category]=&search[order]=
@@ -247,8 +265,8 @@ class ApplicationController < ActionController::Base
     return unless request.get? || request.head?
 
     # Coerce top-level params that must be scalars — reject hashes, unwrap single-element arrays.
-    # NOTE: :page and :limit are deliberately not included here. The paginator validates them
-    # and raises Danbooru::Paginator::PaginationError on malformed input.
+    # NOTE: :page and :limit are intentionally excluded here. Their type is enforced by
+    # validate_pagination_param_types, and the paginator validates the values themselves.
     %i[q id user_id expiry].each do |key|
       next unless params.key?(key)
       params[key] = case params[key]

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -39,6 +39,7 @@ module Danbooru
       end
 
       def max_numbered_pages
+        return 1 if records_per_page == 0
         if @paginator_options[:max_count]
           [Danbooru.config.max_numbered_pages, @paginator_options[:max_count] / records_per_page].min
         else

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -41,7 +41,8 @@ module Danbooru
       def max_numbered_pages
         return 1 if records_per_page == 0
         if @paginator_options[:max_count]
-          [Danbooru.config.max_numbered_pages, @paginator_options[:max_count] / records_per_page].min
+          page_count = (@paginator_options[:max_count].to_f / records_per_page).ceil
+          page_count.clamp(1, Danbooru.config.max_numbered_pages)
         else
           Danbooru.config.max_numbered_pages
         end

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -3,11 +3,12 @@
 module Danbooru
   module Paginator
     module BaseExtension
-      attr_reader :current_page, :pagination_mode
+      attr_reader :current_page, :pagination_mode, :records_per_page
 
       def paginate(page, options = {})
         @paginator_options = options
-        @current_page, @pagination_mode = extract_page_options(page.to_s)
+        @records_per_page = parse_limit(options[:limit])
+        @current_page, @pagination_mode = parse_page(page)
 
         case @pagination_mode
         when :numbered
@@ -25,6 +26,8 @@ module Danbooru
         paginate(page, options)
       end
 
+      ### Counting and Page Calculation ###
+
       def total_pages
         if @pagination_mode == :numbered
           if records_per_page > 0
@@ -35,46 +38,12 @@ module Danbooru
         end
       end
 
-      def extract_page_options(page)
-        if page.blank?
-          [1, :numbered]
-        elsif page =~ /\A\d+\z/
-          if page.to_i > max_numbered_pages
-            raise Danbooru::Paginator::PaginationError, "You cannot go beyond page #{max_numbered_pages}. Please narrow your search terms."
-          end
-          [[page.to_i, 1].max, :numbered]
-        elsif page =~ /b(\d+)/
-          id = validate_bigint($1)
-          [id, :sequential_before]
-        elsif page =~ /a(\d+)/
-          id = validate_bigint($1)
-          [id, :sequential_after]
-        else
-          raise Danbooru::Paginator::PaginationError, "Invalid page number."
-        end
-      end
-
-      def validate_bigint(value)
-        int_value = value.to_i
-        # NOTE: Despite the method name, many tables still use integer for IDs.
-        # Integer max is 2_147_483_647, while bigint max is 9_223_372_036_854_775_807.
-        if int_value > 2_147_483_647 || int_value < 0
-          raise Danbooru::Paginator::PaginationError, "Page parameter is out of valid range."
-        end
-        int_value
-      end
-
       def max_numbered_pages
         if @paginator_options[:max_count]
           [Danbooru.config.max_numbered_pages, @paginator_options[:max_count] / records_per_page].min
         else
           Danbooru.config.max_numbered_pages
         end
-      end
-
-      def records_per_page
-        limit = @paginator_options.try(:[], :limit) || Danbooru.config.records_per_page
-        limit.to_i.clamp(0, Danbooru.config.max_per_page)
       end
 
       # When paginating large tables, we want to avoid doing an expensive count query
@@ -88,6 +57,61 @@ module Danbooru
         return @paginator_options[:total_count] if @paginator_options[:total_count]
 
         real_count
+      end
+
+      ### Parsing and Validation ###
+
+      def parse_limit(limit)
+        return Danbooru.config.records_per_page if limit.blank?
+
+        int_value =
+          case limit
+          when Integer
+            limit
+          when String
+            raise Danbooru::Paginator::PaginationError, "Invalid limit." unless limit.match?(/\A\d+\z/)
+            limit.to_i
+          else
+            raise Danbooru::Paginator::PaginationError, "Invalid limit."
+          end
+
+        unless int_value.between?(0, Danbooru.config.max_per_page)
+          raise Danbooru::Paginator::PaginationError, "Limit must be between 0 and #{Danbooru.config.max_per_page}."
+        end
+        int_value
+      end
+
+      def parse_page(page)
+        return [1, :numbered] if page.blank?
+
+        case page.to_s
+        when /\A\d+\z/
+          [validate_numbered_page!(Regexp.last_match(0).to_i), :numbered]
+        when /\Ab(\d+)\z/
+          [validate_sequential_page!(Regexp.last_match(1)), :sequential_before]
+        when /\Aa(\d+)\z/
+          [validate_sequential_page!(Regexp.last_match(1)), :sequential_after]
+        else
+          raise Danbooru::Paginator::PaginationError, "Invalid page number."
+        end
+      end
+
+      def validate_numbered_page!(value)
+        raise Danbooru::Paginator::PaginationError, "Invalid page number." if value < 1
+        if value > max_numbered_pages
+          raise Danbooru::Paginator::PaginationError, "You cannot go beyond page #{max_numbered_pages}. Please narrow your search terms."
+        end
+        value
+      end
+
+      def validate_sequential_page!(value)
+        int_value = value.to_i
+        # Many tables still use 32-bit integer IDs, so we cap at integer max
+        # rather than bigint max to avoid Postgres errors on the underlying query.
+        if int_value > 2_147_483_647 || int_value < 0
+          raise Danbooru::Paginator::PaginationError, "Page parameter is out of valid range."
+        end
+        int_value
       end
     end
   end

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -87,7 +87,7 @@ module Danbooru
 
         case page.to_s
         when /\A\d+\z/
-          [validate_numbered_page!(Regexp.last_match(0).to_i), :numbered]
+          [validate_numbered_page!(page.to_s.to_i), :numbered]
         when /\Ab(\d+)\z/
           [validate_sequential_page!(Regexp.last_match(1)), :sequential_before]
         when /\Aa(\d+)\z/

--- a/app/logical/danbooru/paginator/base_extension.rb
+++ b/app/logical/danbooru/paginator/base_extension.rb
@@ -41,8 +41,9 @@ module Danbooru
       def max_numbered_pages
         return 1 if records_per_page == 0
         if @paginator_options[:max_count]
-          page_count = (@paginator_options[:max_count].to_f / records_per_page).ceil
-          page_count.clamp(1, Danbooru.config.max_numbered_pages)
+          # max_count caps the OpenSearch result window (from + size).
+          # We have to round down here to avoid "Result window is too large" on the last page.
+          [Danbooru.config.max_numbered_pages, @paginator_options[:max_count] / records_per_page].min
         else
           Danbooru.config.max_numbered_pages
         end

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -6,7 +6,7 @@
     <%= render "posts/partials/common/inline_blacklist" %>
 
     <ul class="sortable">
-      <% @pool.posts.each do |post| %>
+      <% @pool.posts.limit(Danbooru.config.pool_post_limit(nil)).each do |post| %>
         <li class="sortable-thumbnail" data-id="<%= post.id %>">
           <% component = PostThumbnailComponent.new(post: post, stats: false, show_deleted: true, no_blacklist: true) %>
           <% if component.render? %>

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -6,7 +6,7 @@
     <%= render "posts/partials/common/inline_blacklist" %>
 
     <ul class="sortable">
-      <% @pool.posts.paginate(1, limit: 1_000).each do |post| %>
+      <% @pool.posts.each do |post| %>
         <li class="sortable-thumbnail" data-id="<%= post.id %>">
           <% component = PostThumbnailComponent.new(post: post, stats: false, show_deleted: true, no_blacklist: true) %>
           <% if component.render? %>

--- a/spec/logical/danbooru/paginator/base_extension_spec.rb
+++ b/spec/logical/danbooru/paginator/base_extension_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Danbooru::Paginator::BaseExtension do
+  let(:klass) do
+    Class.new do
+      include Danbooru::Paginator::BaseExtension
+
+      def paginate_numbered
+        self
+      end
+
+      def paginate_sequential_before
+        self
+      end
+
+      def paginate_sequential_after
+        self
+      end
+    end
+  end
+  let(:relation) { klass.new }
+
+  describe "#parse_limit" do
+    it "falls back to the configured default when the limit is blank" do
+      relation.paginate(nil, limit: nil)
+      expect(relation.records_per_page).to eq(Danbooru.config.records_per_page)
+
+      relation.paginate(nil, limit: "")
+      expect(relation.records_per_page).to eq(Danbooru.config.records_per_page)
+    end
+
+    it "accepts integers between 0 and the configured max" do
+      relation.paginate(nil, limit: 0)
+      expect(relation.records_per_page).to eq(0)
+
+      relation.paginate(nil, limit: Danbooru.config.max_per_page)
+      expect(relation.records_per_page).to eq(Danbooru.config.max_per_page)
+    end
+
+    it "accepts numeric strings in range" do
+      relation.paginate(nil, limit: "50")
+      expect(relation.records_per_page).to eq(50)
+    end
+
+    it "raises on integers outside the allowed range" do
+      expect { relation.paginate(nil, limit: -1) }.to raise_error(Danbooru::Paginator::PaginationError)
+      expect { relation.paginate(nil, limit: Danbooru.config.max_per_page + 1) }.to raise_error(Danbooru::Paginator::PaginationError)
+    end
+
+    it "raises on negative string values" do
+      expect { relation.paginate(nil, limit: "-1") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid limit/)
+    end
+
+    it "raises on float strings" do
+      expect { relation.paginate(nil, limit: "10.5") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid limit/)
+    end
+
+    it "raises on non-numeric strings" do
+      expect { relation.paginate(nil, limit: "abc") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid limit/)
+    end
+
+    it "raises on hash values" do
+      expect { relation.paginate(nil, limit: { foo: 1 }) }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid limit/)
+    end
+
+    it "raises on array values" do
+      expect { relation.paginate(nil, limit: [1, 2]) }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid limit/)
+    end
+  end
+
+  describe "#parse_page" do
+    it "defaults to page 1 in numbered mode when blank" do
+      relation.paginate(nil)
+      expect(relation.current_page).to eq(1)
+      expect(relation.pagination_mode).to eq(:numbered)
+
+      relation.paginate("")
+      expect(relation.current_page).to eq(1)
+      expect(relation.pagination_mode).to eq(:numbered)
+    end
+
+    context "with a numbered page" do
+      it "accepts integers from 1 up to max_numbered_pages" do
+        relation.paginate("1")
+        expect(relation.current_page).to eq(1)
+
+        relation.paginate(Danbooru.config.max_numbered_pages.to_s)
+        expect(relation.current_page).to eq(Danbooru.config.max_numbered_pages)
+      end
+
+      it "raises on page 0" do
+        expect { relation.paginate("0") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+
+      it "raises on values above max_numbered_pages" do
+        expect { relation.paginate((Danbooru.config.max_numbered_pages + 1).to_s) }
+          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond/)
+      end
+
+      it "raises on negative values" do
+        expect { relation.paginate("-1") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+
+      it "raises on float strings" do
+        expect { relation.paginate("10.5") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+
+      it "raises on non-numeric strings" do
+        expect { relation.paginate("abc") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+
+      it "respects a tighter cap derived from max_count" do
+        relation.paginate("1", limit: 10, max_count: 50)
+        expect { relation.paginate("6", limit: 10, max_count: 50) }
+          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 5/)
+      end
+    end
+
+    context "with a sequential page" do
+      it "accepts b<id> and a<id> for ids in range" do
+        relation.paginate("b100")
+        expect(relation.current_page).to eq(100)
+        expect(relation.pagination_mode).to eq(:sequential_before)
+
+        relation.paginate("a200")
+        expect(relation.current_page).to eq(200)
+        expect(relation.pagination_mode).to eq(:sequential_after)
+      end
+
+      it "accepts a0 and b0" do
+        expect { relation.paginate("a0") }.not_to raise_error
+        expect { relation.paginate("b0") }.not_to raise_error
+      end
+
+      it "accepts the 32-bit integer max" do
+        relation.paginate("a2147483647")
+        expect(relation.current_page).to eq(2_147_483_647)
+      end
+
+      it "raises when the id exceeds the 32-bit integer max" do
+        expect { relation.paginate("a2147483648") }
+          .to raise_error(Danbooru::Paginator::PaginationError, /out of valid range/)
+      end
+
+      it "raises on negative sequential ids" do
+        expect { relation.paginate("a-1") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+
+      it "raises on float sequential ids" do
+        expect { relation.paginate("a26.5") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+
+      it "raises on trailing characters" do
+        expect { relation.paginate("a123foo") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+
+      it "raises on uppercase prefixes" do
+        expect { relation.paginate("A100") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+        expect { relation.paginate("B100") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
+      end
+    end
+  end
+end

--- a/spec/logical/danbooru/paginator/base_extension_spec.rb
+++ b/spec/logical/danbooru/paginator/base_extension_spec.rb
@@ -110,11 +110,35 @@ RSpec.describe Danbooru::Paginator::BaseExtension do
       it "raises on non-numeric strings" do
         expect { relation.paginate("abc") }.to raise_error(Danbooru::Paginator::PaginationError, /Invalid page number/)
       end
+    end
 
-      it "respects a tighter cap derived from max_count" do
+    context "with max_count specified" do
+      it "respects a tighter cap" do
+        relation.paginate("1", limit: 10, max_count: 45)
+        expect { relation.paginate("5", limit: 10, max_count: 45) }.not_to raise_error
+        expect { relation.paginate("6", limit: 10, max_count: 45) }
+          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 5/)
+      end
+
+      it "respects a cap when max_count is a multiple of the limit" do
         relation.paginate("1", limit: 10, max_count: 50)
+        expect { relation.paginate("5", limit: 10, max_count: 50) }.not_to raise_error
         expect { relation.paginate("6", limit: 10, max_count: 50) }
           .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 5/)
+      end
+
+      it "respects a cap when max_count is lower than max_numbered_pages" do
+        relation.paginate("1", limit: 10, max_count: 5)
+        expect { relation.paginate("1", limit: 10, max_count: 5) }.not_to raise_error
+        expect { relation.paginate("2", limit: 10, max_count: 5) }
+          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 1/)
+      end
+
+      it "does not exceed Danbooru.config.max_numbered_pages" do
+        relation.paginate("1", limit: 10, max_count: 1_000_000)
+        expect { relation.paginate(Danbooru.config.max_numbered_pages.to_s, limit: 10, max_count: 1_000_000) }.not_to raise_error
+        expect { relation.paginate((Danbooru.config.max_numbered_pages + 1).to_s, limit: 10, max_count: 1_000_000) }
+          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page #{Danbooru.config.max_numbered_pages}/)
       end
     end
 

--- a/spec/logical/danbooru/paginator/base_extension_spec.rb
+++ b/spec/logical/danbooru/paginator/base_extension_spec.rb
@@ -113,25 +113,23 @@ RSpec.describe Danbooru::Paginator::BaseExtension do
     end
 
     context "with max_count specified" do
-      it "respects a tighter cap" do
-        relation.paginate("1", limit: 10, max_count: 45)
-        expect { relation.paginate("5", limit: 10, max_count: 45) }.not_to raise_error
-        expect { relation.paginate("6", limit: 10, max_count: 45) }
-          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 5/)
+      it "caps at floor(max_count / limit) when not a multiple" do
+        relation.paginate("4", limit: 10, max_count: 45)
+        expect { relation.paginate("5", limit: 10, max_count: 45) }
+          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 4/)
       end
 
-      it "respects a cap when max_count is a multiple of the limit" do
-        relation.paginate("1", limit: 10, max_count: 50)
-        expect { relation.paginate("5", limit: 10, max_count: 50) }.not_to raise_error
+      it "caps at max_count / limit when max_count is a multiple of the limit" do
+        relation.paginate("5", limit: 10, max_count: 50)
         expect { relation.paginate("6", limit: 10, max_count: 50) }
           .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 5/)
       end
 
-      it "respects a cap when max_count is lower than max_numbered_pages" do
-        relation.paginate("1", limit: 10, max_count: 5)
-        expect { relation.paginate("1", limit: 10, max_count: 5) }.not_to raise_error
-        expect { relation.paginate("2", limit: 10, max_count: 5) }
-          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 1/)
+      it "rejects all pages when max_count is smaller than the limit" do
+        # max_count represents the underlying search window (from + size).
+        # A single page of `limit` documents will exceed this window, so no pages should be valid.
+        expect { relation.paginate("1", limit: 10, max_count: 5) }
+          .to raise_error(Danbooru::Paginator::PaginationError, /cannot go beyond page 0/)
       end
 
       it "does not exceed Danbooru.config.max_numbered_pages" do

--- a/spec/requests/pagination_spec.rb
+++ b/spec/requests/pagination_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe "Pagination parameter validation" do
       expect(response).to have_http_status(:gone)
       expect(response.body).to include("Invalid limit")
     end
+
+    it "rejects array-valued limit" do
+      get notes_path, params: { limit: ["10"] }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Invalid limit")
+    end
   end
 
   describe "page" do
@@ -110,6 +116,12 @@ RSpec.describe "Pagination parameter validation" do
 
     it "rejects hash-valued page" do
       get notes_path, params: { page: { test: "10" } }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Invalid page number")
+    end
+
+    it "rejects array-valued page" do
+      get notes_path, params: { page: ["10"] }
       expect(response).to have_http_status(:gone)
       expect(response.body).to include("Invalid page number")
     end

--- a/spec/requests/pagination_spec.rb
+++ b/spec/requests/pagination_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Pagination parameter validation" do
+  include_context "as member"
+
+  describe "limit" do
+    it "accepts a valid integer string" do
+      get notes_path, params: { limit: "20" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "falls back to default when blank" do
+      get notes_path, params: { limit: "" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects negative values" do
+      get notes_path, params: { limit: "-1" }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Invalid limit")
+    end
+
+    it "rejects float strings" do
+      get notes_path, params: { limit: "10.5" }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Invalid limit")
+    end
+
+    it "rejects non-numeric strings" do
+      get notes_path, params: { limit: "abc" }
+      expect(response).to have_http_status(:gone)
+    end
+
+    it "rejects values above the configured maximum" do
+      get notes_path, params: { limit: (Danbooru.config.max_per_page + 1).to_s }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Limit must be between")
+    end
+
+    it "rejects hash-valued limit" do
+      get notes_path, params: { limit: { test: "10" } }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Invalid limit")
+    end
+  end
+
+  describe "page" do
+    it "accepts a valid numbered page" do
+      get notes_path, params: { page: "1" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "falls back to page 1 when blank" do
+      get notes_path, params: { page: "" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects page 0" do
+      get notes_path, params: { page: "0" }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Invalid page number")
+    end
+
+    it "rejects negative pages" do
+      get notes_path, params: { page: "-1" }
+      expect(response).to have_http_status(:gone)
+    end
+
+    it "rejects pages beyond max_numbered_pages" do
+      get notes_path, params: { page: (Danbooru.config.max_numbered_pages + 1).to_s }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("cannot go beyond")
+    end
+
+    it "rejects float pages" do
+      get notes_path, params: { page: "10.5" }
+      expect(response).to have_http_status(:gone)
+    end
+
+    it "rejects non-numeric pages" do
+      get notes_path, params: { page: "abc" }
+      expect(response).to have_http_status(:gone)
+    end
+
+    it "accepts sequential pages" do
+      get notes_path, params: { page: "a100" }
+      expect(response).to have_http_status(:ok)
+
+      get notes_path, params: { page: "b100" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "rejects sequential ids beyond 32-bit integer max" do
+      get notes_path, params: { page: "a2147483648" }
+      expect(response).to have_http_status(:gone)
+    end
+
+    it "rejects malformed sequential pages" do
+      get notes_path, params: { page: "a-1" }
+      expect(response).to have_http_status(:gone)
+
+      get notes_path, params: { page: "a26.5" }
+      expect(response).to have_http_status(:gone)
+
+      get notes_path, params: { page: "a123foo" }
+      expect(response).to have_http_status(:gone)
+    end
+
+    it "rejects hash-valued page" do
+      get notes_path, params: { page: { test: "10" } }
+      expect(response).to have_http_status(:gone)
+      expect(response.body).to include("Invalid page number")
+    end
+  end
+end


### PR DESCRIPTION
I've had enough of inconsistencies in pagination parameters.

`limit` can only be an integer between 0 and 320.
`page` can be one of two things:
 - integer between 1 and 750
 - string that begins with either `a` or `b`, followed by an integer betwen 0 and 2147483647

Anything else returns an error.

We are not rounding float values anymore.
We are not coercing page 0 to 1 anymore.
We do not allow random garbage in sequential pagination anymore.
We don't just ignore hash values anymore.

Consistent rules, consistent errors if those rules are broken.