### PR TITLE
[CORS] Extract CORS headers into middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,8 @@ gem "faraday"
 gem "faraday-follow_redirects"
 gem "faraday-retry"
 
+gem "rack-cors"
+
 gem "rails-settings-cached", "~> 2.9"
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,9 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-proxy (0.7.7)
       rack
     rack-session (2.1.2)
@@ -475,6 +478,7 @@ DEPENDENCIES
   pg
   pitchfork
   puma
+  rack-cors
   rails (~> 8.1.0)
   rails-settings-cached (~> 2.9)
   recaptcha

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   class APIThrottled < StandardError; end
   class FeatureUnavailable < StandardError; end
 
-  skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? || request.options? }
+  skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? }
   before_action :reset_current_user
   before_action :sanitize_params
   before_action :set_current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,11 @@ class ApplicationController < ActionController::Base
   class APIThrottled < StandardError; end
   class FeatureUnavailable < StandardError; end
 
+  # NOTE: this gets flagged by CodeQL as a CSRF vulnerability, but it's a false positive.
+  # This check is only skipped for requests with API authentication, which are made by clients
+  # that don't support CSRF tokens. All browser-based actions still require CSRF protection.
   skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? }
+
   before_action :reset_current_user
   before_action :sanitize_params
   before_action :set_current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,6 @@ class ApplicationController < ActionController::Base
   before_action :validate_pagination_param_types
   before_action :normalize_search
   before_action :api_check
-  before_action :enable_cors
   before_action :check_valid_username
   after_action :reset_current_user
   layout "default"
@@ -29,12 +28,6 @@ class ApplicationController < ActionController::Base
   # This is raised on requests to `/blah.js`. Rails has already rendered StaticController#not_found
   # here, so calling `rescue_exception` would cause a double render error.
   rescue_from ActionController::InvalidCrossOriginRequest, with: -> {}
-
-  def enable_cors
-    response.headers["Access-Control-Allow-Origin"] = "*"
-    response.headers["Access-Control-Allow-Headers"] = "Authorization, User-Agent"
-    response.headers["Access-Control-Allow-Methods"] = "POST, PUT, PATCH, DELETE, GET, HEAD, OPTIONS"
-  end
 
   def check_valid_username
     return if params[:controller] == "user_name_change_requests"

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
-# Be sure to restart your server when you modify this file.
+# Insert Rack::Cors above the ParameterSanitizer so it wraps every response,
+# including early rejections from the sanitizer and any controller that does
+# not inherit from ApplicationController (e.g. Rails::HealthController at
+# /status).
+Rails.application.config.middleware.insert_before Middleware::ParameterSanitizer, Rack::Cors do
+  allow do
+    origins "*"
 
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
-
-# Read more: https://github.com/cyu/rack-cors
-
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+    resource "*",
+             headers: %w[Authorization User-Agent],
+             methods: %i[get post put patch delete options head]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -9,7 +9,7 @@ Rails.application.config.middleware.insert_before Middleware::ParameterSanitizer
     origins "*"
 
     resource "*",
-             headers: %w[Authorization User-Agent],
+             headers: :any,
              methods: %i[get post put patch delete options head]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -445,8 +445,6 @@ Rails.application.routes.draw do
     end
   end
 
-  options "*all", to: "application#enable_cors"
-
   # aliases
   resources :wpages, controller: "wiki_pages"
   resources :ftopics, controller: "forum_topics"

--- a/lib/middleware/parameter_sanitizer.rb
+++ b/lib/middleware/parameter_sanitizer.rb
@@ -30,14 +30,8 @@ module Middleware
           begin
             JSON.parse(body)
           rescue JSON::ParserError
-            headers = {
-              "Content-Type" => "application/json",
-              "Access-Control-Allow-Origin" => "*",
-              "Access-Control-Allow-Headers" => "Authorization, User-Agent",
-              "Access-Control-Allow-Methods" => "POST, PUT, PATCH, DELETE, GET, HEAD, OPTIONS",
-            }
             body = { success: false, message: "Invalid JSON body", code: nil }.to_json
-            return [400, headers, [body]]
+            return [400, { "Content-Type" => "application/json" }, [body]]
           end
         end
       end

--- a/spec/middleware/parameter_sanitizer_spec.rb
+++ b/spec/middleware/parameter_sanitizer_spec.rb
@@ -157,14 +157,6 @@ RSpec.describe Middleware::ParameterSanitizer do
         expect(parsed).to eq("success" => false, "message" => "Invalid JSON body", "code" => nil)
       end
 
-      it "includes CORS headers" do
-        env = json_env("bad json")
-        _status, headers, _body, _env = call(env)
-        expect(headers["Access-Control-Allow-Origin"]).to eq("*")
-        expect(headers["Access-Control-Allow-Headers"]).to eq("Authorization, User-Agent")
-        expect(headers["Access-Control-Allow-Methods"]).to eq("POST, PUT, PATCH, DELETE, GET, HEAD, OPTIONS")
-      end
-
       it "does not call the downstream app" do
         inner_app = instance_spy(Proc)
         mw = described_class.new(inner_app)

--- a/spec/requests/cors_spec.rb
+++ b/spec/requests/cors_spec.rb
@@ -25,13 +25,17 @@ RSpec.describe "CORS handling" do
     it "responds 200 with the preflight headers" do
       process :options, "/posts.json", headers: {
         "HTTP_ORIGIN" => "https://example.com",
-        "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "GET",
-        "HTTP_ACCESS_CONTROL_REQUEST_HEADERS" => "Authorization",
+        "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "POST",
+        "HTTP_ACCESS_CONTROL_REQUEST_HEADERS" => "Authorization, Content-Type",
       }
       expect(response).to have_http_status(:ok)
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
-      expect(response.headers["Access-Control-Allow-Methods"]).to include("GET")
-      expect(response.headers["Access-Control-Allow-Headers"]).to include("Authorization")
+      expect(response.headers["Access-Control-Allow-Methods"]).to include("POST")
+      # `headers: :any` makes rack-cors reflect every requested header back, so
+      # browser JSON POSTs (which trigger preflight for Content-Type) succeed.
+      allowed = response.headers["Access-Control-Allow-Headers"]
+      expect(allowed).to include("Authorization")
+      expect(allowed).to include("Content-Type")
     end
   end
 end

--- a/spec/requests/cors_spec.rb
+++ b/spec/requests/cors_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CORS handling" do
+  describe "endpoints that do not inherit from ApplicationController" do
+    # Regression: /status is routed to Rails::HealthController, which bypasses
+    # ApplicationController. Prior to wiring up rack-cors at the middleware
+    # layer, cross-origin requests to /status.json had no Access-Control-*
+    # headers and were rejected by browsers.
+    it "emits Access-Control-Allow-Origin on /status.json for cross-origin requests" do
+      get "/status.json", headers: { "HTTP_ORIGIN" => "https://example.com" }
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+    end
+
+    it "omits CORS headers on /status.json when no Origin header is sent" do
+      get "/status.json"
+      expect(response).to have_http_status(:ok)
+      expect(response.headers).not_to have_key("Access-Control-Allow-Origin")
+    end
+  end
+
+  describe "preflight OPTIONS requests" do
+    it "responds 200 with the preflight headers" do
+      process :options, "/posts.json", headers: {
+        "HTTP_ORIGIN" => "https://example.com",
+        "HTTP_ACCESS_CONTROL_REQUEST_METHOD" => "GET",
+        "HTTP_ACCESS_CONTROL_REQUEST_HEADERS" => "Authorization",
+      }
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+      expect(response.headers["Access-Control-Allow-Methods"]).to include("GET")
+      expect(response.headers["Access-Control-Allow-Headers"]).to include("Authorization")
+    end
+  end
+end


### PR DESCRIPTION
Reduces code duplication and potential for confusion by defining the CORS headers once, rather than three separate times.
This also fixes `/status.json` not responding to requests properly.