### PR TITLE
[IQDB] Add support for the v2 API format

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -12,10 +12,12 @@ class IqdbQueriesController < ApplicationController
     search_params = params[:search].presence || params
     throttle(search_params)
 
+    v2_format = params[:v2] == "true"
+
     @matches = []
     if search_params[:file].present?
       raise ProcessingError, "Invalid file parameter" unless search_params[:file].respond_to?(:tempfile)
-      @matches = IqdbProxy.query_file(search_params[:file].tempfile, search_params[:score_cutoff])
+      @matches = IqdbProxy.query_file(search_params[:file].tempfile, search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:url].present?
       raise ProcessingError, "Invalid URL parameter" unless search_params[:url].is_a?(String)
       parsed_url = begin
@@ -26,13 +28,13 @@ class IqdbQueriesController < ApplicationController
       raise ProcessingError, "Invalid URL" unless parsed_url
       whitelist_result = UploadWhitelist.is_whitelisted?(parsed_url)
       raise ProcessingError, "Not allowed to request content from this URL" unless whitelist_result[0]
-      @matches = IqdbProxy.query_url(parsed_url.to_s, search_params[:score_cutoff])
+      @matches = IqdbProxy.query_url(parsed_url.to_s, search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:post_id].present?
       raise ProcessingError, "Invalid post_id parameter" unless search_params[:post_id].to_s =~ /\A\d+\z/
-      @matches = IqdbProxy.query_post(Post.find_by(id: search_params[:post_id]), search_params[:score_cutoff])
+      @matches = IqdbProxy.query_post(Post.find_by(id: search_params[:post_id]), search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:hash].present?
       raise ProcessingError, "Invalid hash parameter" unless search_params[:hash].is_a?(String) && search_params[:hash] =~ /\A[0-9a-fA-F]+\z/
-      @matches = IqdbProxy.query_hash(search_params[:hash], search_params[:score_cutoff])
+      @matches = IqdbProxy.query_hash(search_params[:hash], search_params[:score_cutoff], v2_format: v2_format)
     end
 
     respond_with(@matches) do |fmt|

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -12,7 +12,7 @@ class IqdbQueriesController < ApplicationController
     search_params = params[:search].presence || params
     throttle(search_params)
 
-    v2_format = params[:v2] == "true"
+    v2_format = params[:v2] == "true" && request.format.json?
 
     @matches = []
     if search_params[:file].present?

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -78,12 +78,10 @@ module IqdbProxy
     posts = Post.where(id: post_ids).includes(:uploader).index_by(&:id)
 
     json.map do |x|
-      if x["post_id"].present?
-        x["post"] = v2_format ? PostBlueprint.render_as_hash(posts[x["post_id"]], view: :basic) : posts[x["post_id"]]
-      end
+      post = posts[x["post_id"]]
+      next if post.blank? # Skip deleted or missing posts
+      x["post"] = v2_format ? PostBlueprint.render_as_hash(posts[x["post_id"]], view: :basic) : posts[x["post_id"]]
       x
-    rescue ActiveRecord::RecordNotFound
-      nil
     end.compact
   end
 

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -37,44 +37,50 @@ module IqdbProxy
     raise Error, "iqdb request failed" if response.status != 200
   end
 
-  def query_url(image_url, score_cutoff)
+  def query_url(image_url, score_cutoff, v2_format: false)
     file, _strategy = Downloads::File.new(image_url).download!
-    query_file(file, score_cutoff)
+    query_file(file, score_cutoff, v2_format: v2_format)
   end
 
-  def query_post(post, score_cutoff)
+  def query_post(post, score_cutoff, v2_format: false)
     return [] unless post&.has_preview?
 
     File.open(post.preview_file_path) do |f|
-      query_file(f, score_cutoff)
+      query_file(f, score_cutoff, v2_format: v2_format)
     end
   rescue Errno::ENOENT # Preview file not found
     []
   end
 
-  def query_file(file, score_cutoff)
+  def query_file(file, score_cutoff, v2_format: false)
     thumb = generate_thumbnail(file.path)
     return [] unless thumb
 
     response = make_request("/query", :post, get_channels_data(thumb))
     return [] if response.status != 200
 
-    process_iqdb_result(JSON.parse(response.body), score_cutoff)
+    process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
   end
 
-  def query_hash(hash, score_cutoff)
+  def query_hash(hash, score_cutoff, v2_format: false)
     response = make_request "/query", :post, { hash: hash }
     return [] if response.status != 200
 
-    process_iqdb_result(JSON.parse(response.body), score_cutoff)
+    process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
   end
 
-  def process_iqdb_result(json, score_cutoff)
+  def process_iqdb_result(json, score_cutoff, v2_format: false)
     raise Error, "Server returned an error. Most likely the url is not found." unless json.is_a?(Array)
 
     json.filter! { |entry| (entry["score"] || 0) >= (score_cutoff.presence || 60).to_i }
+
+    post_ids = json.pluck("post_id").compact
+    posts = Post.where(id: post_ids).includes(:uploader).index_by(&:id)
+
     json.map do |x|
-      x["post"] = Post.find(x["post_id"])
+      if x["post_id"].present?
+        x["post"] = v2_format ? PostBlueprint.render_as_hash(posts[x["post_id"]], view: :basic) : posts[x["post_id"]]
+      end
       x
     rescue ActiveRecord::RecordNotFound
       nil

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -80,7 +80,7 @@ module IqdbProxy
     json.map do |x|
       post = posts[x["post_id"]]
       next if post.blank? # Skip deleted or missing posts
-      x["post"] = v2_format ? PostBlueprint.render_as_hash(posts[x["post_id"]], view: :basic) : posts[x["post_id"]]
+      x["post"] = v2_format ? PostBlueprint.render_as_hash(post, view: :basic) : post
       x
     end.compact
   end


### PR DESCRIPTION
Matches the v2 format that the posts controller has.
Also fixed an N+1 query problem along the way.

The v1 format this endpoint returns is batshit and does not match the v1 format from the posts controller.
But we'll have to maintain it for a little while for the sake of backwards compatibility.