### PR TITLE
[Appeals] Allow artists to appeal deletion of their artwork

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -44,7 +44,7 @@ class Appeal < ApplicationRecord
       def can_create_for?(user)
         return false if content.blank?
         return false if content.post.blank?
-        return false unless content.post.uploader_id == user.id
+        return false unless content.can_appeal?(user)
         true
       end
 

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -41,6 +41,16 @@ class PostFlag < ApplicationRecord
 
   attr_accessor :parent_id, :reason_name, :force_flag
 
+  module AccessMethods
+    def can_appeal?(user = CurrentUser.user)
+      return false unless is_deletion?
+      return true if post.linked_users.include?(user.id) # Verified artists can appeal deletions of their own posts
+      return false if reason =~ /takedown #\d+/i
+      return true if post.uploader_id == user.id # Uploaders can appeal anything except for takedowns
+      false
+    end
+  end
+
   module SearchMethods
     def post_tags_match(query)
       where(post_id: Post.tag_match_sql(query))
@@ -112,8 +122,9 @@ class PostFlag < ApplicationRecord
     end
   end
 
-  extend SearchMethods
+  include AccessMethods
   include ApiMethods
+  extend SearchMethods
 
   def type
     return :deletion if is_deletion

--- a/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
+++ b/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
@@ -10,7 +10,7 @@
         <% if flag.creator_id == post.uploader_id && !flag.is_deletion %>
           <%= svg_icon(:octagon_alert, class: "text-inline", title: "Flag created by the current uploader") %>
         <% end %>
-        <% if CurrentUser.is_admin? %>
+        <% if CurrentUser.user.is_admin? %>
           (<%= link_to_ip(flag.creator_ip_addr) %>)
         <% end %>
       <% end %>
@@ -25,7 +25,7 @@
         <div class="post-flag-note">
           <div class="post-flag-note-header"><%= svg_icon(:chevron_right) %> Notes</div>
           <div class="dtext-container post-flag-note-body">
-            <% if CurrentUser.is_staff? %>
+            <% if CurrentUser.user.is_staff? %>
               <%= link_to svg_icon(:trash), clear_note_post_flag_path(flag), method: :post, data: { confirm: "Are you sure you want to clear this note?" }, class: "post-flag-clear-note-link" %>
             <% end %>
             <%= format_text flag.note %>
@@ -33,13 +33,13 @@
         </div>
       <% end %>
 
-      <% if flag.is_deletion? && post.uploader_id == CurrentUser.user.id %>
+      <% if flag.can_appeal?(CurrentUser.user) %>
         <div class="post-flag-appeal">
           <%= link_to "Appeal Deletion", new_appeal_path(qtype: "flag", disp_id: flag.id), class: "st-button" %>
         </div>
       <% end %>
     </li>
-    <% if post.is_deleted? && flag.is_deletion && !CurrentUser.is_janitor? %>
+    <% if post.is_deleted? && flag.is_deletion && !CurrentUser.user.is_staff? %>
       <% break %>
     <% end %>
   <% end %>

--- a/spec/factories/appeal_factory.rb
+++ b/spec/factories/appeal_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     # (e.g. via include_context "as member") before using this factory.
 
     transient do
-      post_flag { create(:post_flag) }
+      post_flag { create(:deletion_post_flag) }
     end
 
     after(:build) do |appeal, evaluator|

--- a/spec/models/post_flag/permissions_spec.rb
+++ b/spec/models/post_flag/permissions_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe PostFlag do
         expect(deletion.can_appeal?(user)).to be(true)
       end
 
-      it "returns false for non-linked users if reason contains 'takedown #'" do
+      it "returns false for non-linked users if reason matches 'takedown #<id>'" do
         deletion.update(reason: "takedown #123")
         expect(deletion.can_appeal?(create(:user))).to be(false)
       end
@@ -137,7 +137,7 @@ RSpec.describe PostFlag do
         expect(deletion.can_appeal?(user)).to be(true)
       end
 
-      it "returns false for the uploader if reason contains 'takedown #'" do
+      it "returns false for the uploader if reason matches 'takedown #<id>'" do
         deletion.update(reason: "takedown #123")
         user = User.find(post.uploader_id)
         expect(deletion.can_appeal?(user)).to be(false)

--- a/spec/models/post_flag/permissions_spec.rb
+++ b/spec/models/post_flag/permissions_spec.rb
@@ -102,4 +102,47 @@ RSpec.describe PostFlag do
       expect(flag.method_attributes).to include(:type)
     end
   end
+
+  # -------------------------------------------------------------------------
+  # #can_appeal?
+  # -------------------------------------------------------------------------
+  describe "#can_appeal?" do
+    let(:post) { create(:post) }
+    let(:flag) { create(:post_flag, post: post) }
+    let(:deletion) { create(:deletion_post_flag, post: post) }
+
+    context "when the flag is not a deletion flag" do
+      it "returns false" do
+        expect(flag.can_appeal?(create(:user))).to be(false)
+      end
+    end
+
+    context "when the flag is a deletion flag" do
+      it "returns true for linked users" do
+        user = create(:user)
+        post.linked_users << user
+        expect(deletion.can_appeal?(user)).to be(true)
+      end
+
+      it "returns false for non-linked users if reason contains 'takedown'" do
+        deletion.update(reason: "Takedown request")
+        expect(deletion.can_appeal?(create(:user))).to be(false)
+      end
+
+      it "returns true for the uploader" do
+        user = User.find(post.uploader_id)
+        expect(deletion.can_appeal?(user)).to be(true)
+      end
+
+      it "returns false for the uploader if reason contains 'takedown'" do
+        deletion.update(reason: "Takedown request")
+        user = User.find(post.uploader_id)
+        expect(deletion.can_appeal?(user)).to be(false)
+      end
+
+      it "returns false for other users" do
+        expect(deletion.can_appeal?(create(:user))).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/post_flag/permissions_spec.rb
+++ b/spec/models/post_flag/permissions_spec.rb
@@ -120,12 +120,15 @@ RSpec.describe PostFlag do
     context "when the flag is a deletion flag" do
       it "returns true for linked users" do
         user = create(:user)
-        post.linked_users << user
+        artist = create(:artist, name: "linked_artist", linked_user_id: user.id)
+        post.tag_string += " #{artist.name}"
+        post.save!
+        post.reload
         expect(deletion.can_appeal?(user)).to be(true)
       end
 
-      it "returns false for non-linked users if reason contains 'takedown'" do
-        deletion.update(reason: "Takedown request")
+      it "returns false for non-linked users if reason contains 'takedown #'" do
+        deletion.update(reason: "takedown #123")
         expect(deletion.can_appeal?(create(:user))).to be(false)
       end
 
@@ -134,8 +137,8 @@ RSpec.describe PostFlag do
         expect(deletion.can_appeal?(user)).to be(true)
       end
 
-      it "returns false for the uploader if reason contains 'takedown'" do
-        deletion.update(reason: "Takedown request")
+      it "returns false for the uploader if reason contains 'takedown #'" do
+        deletion.update(reason: "takedown #123")
         user = User.find(post.uploader_id)
         expect(deletion.can_appeal?(user)).to be(false)
       end

--- a/spec/requests/appeals_controller_spec.rb
+++ b/spec/requests/appeals_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AppealsController do
   let(:admin)        { create(:admin_user) }
   # uploader must be passed explicitly — the :post factory always creates its own uploader user.
   let(:flagged_post) { create(:post, uploader: uploader) }
-  let(:post_flag)    { CurrentUser.scoped(other_member) { create(:post_flag, post: flagged_post) } }
+  let(:post_flag)    { CurrentUser.scoped(other_member) { create(:deletion_post_flag, post: flagged_post) } }
   let(:appeal)       { CurrentUser.scoped(uploader) { create(:appeal, post_flag: post_flag) } }
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Requires the user account to be linked to the artist record, naturally.
Also added a guard against uploaders appealing takedown deletions.