### PR TITLE
[ExceptionLog] Improve scrubbing of sensitive information

### DIFF
--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -99,4 +99,40 @@ class ExceptionLog < ApplicationRecord
 
     total
   end
+
+  def viewable_message
+    if CurrentUser.is_admin?
+      message
+    else
+      scrub_emails(scrub_ips(message))
+    end
+  end
+
+  def viewable_extra_params
+    if CurrentUser.is_admin?
+      extra_params
+    else
+      extra_params.deep_transform_values do |value|
+        # exclude user agent from scrub since it will likely contain version numbers:
+        if value == extra_params[:user_agent]
+          value
+        elsif value.is_a?(String)
+          scrub_emails(scrub_ips(value))
+        else # rubocop:disable Lint/DuplicateBranch
+          value
+        end
+      end
+    end
+  end
+
+  private
+
+  def scrub_ips(text)
+    text.gsub(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/, "[IP PROTECTED]") # IPv4
+        .gsub(/\b(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}\b/i, "[IP PROTECTED]") # IPv6
+  end
+
+  def scrub_emails(text)
+    text.gsub(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i, "[EMAIL PROTECTED]")
+  end
 end

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -143,7 +143,7 @@ class ExceptionLog < ApplicationRecord
 
     text.gsub(candidate_regex) do |match|
       token = Regexp.last_match(1)
-      candidate = token.sub(/\d+\z/, "").sub(/%.+\z/, "")
+      candidate = token.sub(%r{/\d+\z}, "").sub(/%.+\z/, "")
 
       # Skip the literal "::" separator to avoid false positives in log messages
       if candidate == "::"

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -113,14 +113,9 @@ class ExceptionLog < ApplicationRecord
       extra_params
     else
       extra_params.deep_transform_values do |value|
-        # exclude user agent from scrub since it will likely contain version numbers:
-        if value == extra_params[:user_agent]
-          value
-        elsif value.is_a?(String)
-          scrub_emails(scrub_ips(value))
-        else # rubocop:disable Lint/DuplicateBranch
-          value
-        end
+        next value unless value.is_a?(String)
+        next value if value == extra_params["user_agent"]
+        scrub_emails(scrub_ips(value))
       end
     end
   end

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -114,8 +114,8 @@ class ExceptionLog < ApplicationRecord
     else
       extra_params.deep_transform_values do |value|
         next value unless value.is_a?(String)
-        next value if value == extra_params["user_agent"]
-        scrub_emails(scrub_ips(value))
+        next scrub_emails(value) if value == extra_params["user_agent"]
+        scrub_ips(scrub_emails(value))
       end
     end
   end
@@ -123,8 +123,40 @@ class ExceptionLog < ApplicationRecord
   private
 
   def scrub_ips(text)
-    text.gsub(/\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/, "[IP PROTECTED]") # IPv4
-        .gsub(/\b(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}\b/i, "[IP PROTECTED]") # IPv6
+    return text unless text.is_a?(String)
+
+    # First, explicitly replace dotted IPv4 addresses (with optional port/brackets/CIDR)
+    ipv4_regex = %r{/(?:\b|\[)((?:\d{1,3}\.){3}\d{1,3})(?:\]|\b)(?::\d{1,5})?/}
+
+    text = text.gsub(ipv4_regex) do |match|
+      ip = Regexp.last_match(1)
+      begin
+        IPAddr.new(ip)
+        "[IP PROTECTED]"
+      rescue StandardError
+        match
+      end
+    end
+
+    # Then handle IPv6 and other candidate tokens (bracketed or bare), stripping CIDR/zone ids
+    candidate_regex = %r{(?:\b|\[)([0-9A-Fa-f:.%/]+)(?:\]|\b)(?::\d{1,5})?}
+
+    text.gsub(candidate_regex) do |match|
+      token = Regexp.last_match(1)
+      candidate = token.sub(%r{/\d+\z}, "").sub(%r{/%.+\z/}, "")
+
+      # Skip the literal "::" separator to avoid false positives in log messages
+      if candidate == "::"
+        match
+      else
+        begin
+          IPAddr.new(candidate)
+          "[IP PROTECTED]"
+        rescue StandardError
+          match
+        end
+      end
+    end
   end
 
   def scrub_emails(text)

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -104,7 +104,7 @@ class ExceptionLog < ApplicationRecord
     if CurrentUser.is_admin?
       message
     else
-      scrub_emails(scrub_ips(message))
+      scrub_ips(scrub_emails(message))
     end
   end
 
@@ -126,7 +126,7 @@ class ExceptionLog < ApplicationRecord
     return text unless text.is_a?(String)
 
     # First, explicitly replace dotted IPv4 addresses (with optional port/brackets/CIDR)
-    ipv4_regex = %r{/(?:\b|\[)((?:\d{1,3}\.){3}\d{1,3})(?:\]|\b)(?::\d{1,5})?/}
+    ipv4_regex = /(?:\b|\[)((?:\d{1,3}\.){3}\d{1,3})(?:\]|\b)(?::\d{1,5})?/
 
     text = text.gsub(ipv4_regex) do |match|
       ip = Regexp.last_match(1)
@@ -143,7 +143,7 @@ class ExceptionLog < ApplicationRecord
 
     text.gsub(candidate_regex) do |match|
       token = Regexp.last_match(1)
-      candidate = token.sub(%r{/\d+\z}, "").sub(%r{/%.+\z/}, "")
+      candidate = token.sub(/\d+\z/, "").sub(/%.+\z/, "")
 
       # Skip the literal "::" separator to avoid false positives in log messages
       if candidate == "::"

--- a/app/views/admin/exceptions/index.html.erb
+++ b/app/views/admin/exceptions/index.html.erb
@@ -23,7 +23,7 @@
         <td><%= link_to_user(exception_log.user) %></td>
         <td><%= exception_log.code %></td>
         <td>
-          <%= exception_log.viewable_extra_params.dig("params", "controller") %>/<%= exception_log.viewable_extra_params.dig("params", "action") %>
+          <%= exception_log.extra_params.dig("params", "controller") %>/<%= exception_log.extra_params.dig("params", "action") %>
         </td>
         <td>
           <b><%= exception_log.class_name %></b><br />

--- a/app/views/admin/exceptions/index.html.erb
+++ b/app/views/admin/exceptions/index.html.erb
@@ -23,11 +23,11 @@
         <td><%= link_to_user(exception_log.user) %></td>
         <td><%= exception_log.code %></td>
         <td>
-          <%= exception_log.extra_params.dig("params", "controller") %>/<%= exception_log.extra_params.dig("params", "action") %>
+          <%= exception_log.viewable_extra_params.dig("params", "controller") %>/<%= exception_log.viewable_extra_params.dig("params", "action") %>
         </td>
         <td>
           <b><%= exception_log.class_name %></b><br />
-          <%= truncate(exception_log.message, length: 500) %>
+          <%= truncate(exception_log.viewable_message, length: 500) %>
         </td>
         <td><%= link_to "View", admin_exception_path(exception_log) %></td>
       </tr>

--- a/app/views/admin/exceptions/show.html.erb
+++ b/app/views/admin/exceptions/show.html.erb
@@ -1,7 +1,7 @@
 <div>
   <div class="box-section">
     <h3><%= @exception_log.class_name %></h3>
-    <pre><code><%= @exception_log.message %></code></pre>
+    <pre><code><%= @exception_log.viewable_message %></code></pre>
     <br>
     <div>
       Error Code: <%= @exception_log.code %><br/>
@@ -14,7 +14,7 @@
     </div>
   </div>
   <strong>Extra Params:</strong>
-  <pre class="box-section"><%= JSON.pretty_generate(@exception_log.extra_params) %></pre>
+  <pre class="box-section"><%= JSON.pretty_generate(@exception_log.viewable_extra_params) %></pre>
   <strong>Stacktrace:</strong>
   <pre class="box-section"><%= Rails.backtrace_cleaner.clean(@exception_log.trace.split("\n")).join("\n") %></pre>
   <strong>Raw Stacktrace:</strong>

--- a/spec/models/exception_log/instance_methods_spec.rb
+++ b/spec/models/exception_log/instance_methods_spec.rb
@@ -44,4 +44,52 @@ RSpec.describe ExceptionLog do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #viewable_message and #viewable_extra_params
+  # ---------------------------------------------------------------------------
+
+  describe "#viewable_message" do
+    it "returns the full message for admins" do
+      log = make_log(message: "Error from 1.2.3.4 and admin@example.com")
+      expect(log.viewable_message).to eq("Error from 1.2.3.4 and admin@example.com")
+    end
+
+    context "when not admin" do
+      include_context "as member"
+
+      it "scrubs IPs and emails from the message" do
+        log = make_log(message: "Error from 1.2.3.4 and admin@example.com")
+        expect(log.viewable_message).to eq("Error from [IP PROTECTED] and [EMAIL PROTECTED]")
+      end
+    end
+  end
+
+  describe "#viewable_extra_params" do
+    let(:raw_extra) do
+      {
+        "user_agent" => "Mozilla/5.0",
+        "note" => "Contact user@example.com 1.2.3.4",
+        "nested" => { "inner" => "admin@example.com 4.3.2.1" },
+      }
+    end
+
+    it "returns raw extra params for admins" do
+      log = make_log(extra_params: raw_extra)
+      expect(log.viewable_extra_params).to eq(raw_extra)
+    end
+
+    context "when not admin" do
+      include_context "as member"
+
+      it "preserves the user agent but scrubs emails and IPs in other fields" do
+        log = make_log(extra_params: raw_extra)
+        ve = log.viewable_extra_params
+
+        expect(ve["user_agent"]).to eq("Mozilla/5.0")
+        expect(ve["note"]).to eq("Contact [EMAIL PROTECTED] [IP PROTECTED]")
+        expect(ve["nested"]["inner"]).to eq("[EMAIL PROTECTED] [IP PROTECTED]")
+      end
+    end
+  end
 end

--- a/spec/models/exception_log/instance_methods_spec.rb
+++ b/spec/models/exception_log/instance_methods_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe ExceptionLog do
   describe "#viewable_extra_params" do
     let(:raw_extra) do
       {
-        "user_agent" => "Mozilla/5.0",
+        "user_agent" => "MyAwesomeBot/1.2.3.4 (by User1234)",
         "note" => "Contact user@example.com 1.2.3.4",
         "nested" => { "inner" => "admin@example.com 4.3.2.1" },
       }
@@ -86,7 +86,7 @@ RSpec.describe ExceptionLog do
         log = make_log(extra_params: raw_extra)
         ve = log.viewable_extra_params
 
-        expect(ve["user_agent"]).to eq("Mozilla/5.0")
+        expect(ve["user_agent"]).to eq("MyAwesomeBot/1.2.3.4 (by User1234)")
         expect(ve["note"]).to eq("Contact [EMAIL PROTECTED] [IP PROTECTED]")
         expect(ve["nested"]["inner"]).to eq("[EMAIL PROTECTED] [IP PROTECTED]")
       end


### PR DESCRIPTION
Replaces IPv4, IPv6, and emails with `[PROTECTED]`-like scrubs