### PR TITLE
[Posts] Replace pool string with pool and set ID arrays

### DIFF
--- a/app/jobs/post_set_cleanup_job.rb
+++ b/app/jobs/post_set_cleanup_job.rb
@@ -4,23 +4,23 @@ class PostSetCleanupJob < ApplicationJob
   queue_as :default
   sidekiq_options lock: :until_executing
 
-  # General cleanup for post membership tokens in pool_string.
+  # General cleanup for post membership arrays.
   def perform(type, obj_id)
     type = type.to_sym
 
     case type
     when :set
-      token_prefix = "set:"
+      column = :set_ids
       removal_method = :remove_set!
     when :pool
-      token_prefix = "pool:"
+      column = :pool_ids
       removal_method = :remove_pool!
     else
       raise ArgumentError, "Invalid type: #{type.inspect}"
     end
 
-    tag = "#{token_prefix}#{obj_id}"
-    scope = Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", tag)
+    array_type = type == :set ? "bigint" : "integer"
+    scope = Post.where("#{column} @> ARRAY[?]::#{array_type}[]", obj_id)
 
     # Pools check for whether the user account is older than 7 days.
     CurrentUser.as_system do

--- a/app/jobs/post_set_posts_sync_job.rb
+++ b/app/jobs/post_set_posts_sync_job.rb
@@ -9,15 +9,13 @@ class PostSetPostsSyncJob < ApplicationJob
   end
 
   def perform(set_id)
-    set   = PostSet.find(set_id)
-    token = "set:#{set_id}"
+    set = PostSet.find(set_id)
 
     current_ids = set.post_ids.to_set
-    token_ids   = Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", token)
-                      .pluck(:id).to_set
+    synced_ids  = Post.where("set_ids @> ARRAY[?]::bigint[]", set_id).pluck(:id).to_set
 
-    to_add    = (current_ids - token_ids).to_a
-    to_remove = (token_ids - current_ids).to_a
+    to_add    = (current_ids - synced_ids).to_a
+    to_remove = (synced_ids - current_ids).to_a
     return if to_add.empty? && to_remove.empty?
 
     pg = Post.connection.raw_connection
@@ -25,21 +23,20 @@ class PostSetPostsSyncJob < ApplicationJob
     if to_add.any?
       pg.exec_params(
         "UPDATE posts
-         SET pool_string = trim(pool_string || $1)
+         SET set_ids = array_append(set_ids, $1::bigint)
          WHERE id = ANY($2::int[])
-           AND NOT ($3 = ANY(string_to_array(pool_string, ' ')))",
-        [" #{token}", "{#{to_add.join(',')}}", token],
+           AND NOT ($1::bigint = ANY(set_ids))",
+        [set_id, "{#{to_add.join(',')}}"],
       )
     end
 
     if to_remove.any?
       pg.exec_params(
         "UPDATE posts
-         SET pool_string = array_to_string(
-               array_remove(string_to_array(pool_string, ' '), $1), ' ')
+         SET set_ids = array_remove(set_ids, $1::bigint)
          WHERE id = ANY($2::int[])
-           AND $1 = ANY(string_to_array(pool_string, ' '))",
-        [token, "{#{to_remove.join(',')}}"],
+           AND $1::bigint = ANY(set_ids)",
+        [set_id, "{#{to_remove.join(',')}}"],
       )
     end
 

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -128,9 +128,9 @@ class PostQueryBuilder
     end
 
     if q[:pool] == "none" || q[:inpool_must_not] || (q[:inpool] == false)
-      relation = relation.where("posts.pool_string = ''")
+      relation = relation.where("cardinality(posts.pool_ids) = 0")
     elsif q[:pool] == "any" || q[:inpool] || (q[:inpool_must_not] == false)
-      relation = relation.where("posts.pool_string != ''")
+      relation = relation.where("cardinality(posts.pool_ids) > 0")
     end
 
     q[:uploader_ids]&.each do |uploader_id|

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1283,30 +1283,30 @@ class Post < ApplicationRecord
 
   module SetMethods
     def set_ids
-      pool_string.scan(/set:(\d+)/).map { |set| ParseValue.safe_id(set[0]) }
+      self[:set_ids] || []
     end
 
     def post_sets
       @post_sets ||= begin
-        return PostSet.none if pool_string.blank?
+        return PostSet.none if set_ids.blank?
         PostSet.where(id: set_ids)
       end
     end
 
     def belongs_to_post_set(set)
-      pool_string =~ /(?:\A| )set:#{set.id}(?:\z| )/
+      set_ids.include?(set.id)
     end
 
     def add_set!(set, force = false)
       return if belongs_to_post_set(set) && !force
       with_lock do
-        self.pool_string = "#{pool_string} set:#{set.id}".strip
+        self.set_ids = (set_ids + [set.id]).uniq
       end
     end
 
     def remove_set!(set)
       with_lock do
-        self.pool_string = (pool_string.split(' ') - ["set:#{set.id}"]).join(' ').strip
+        self.set_ids = set_ids - [set.id]
       end
     end
 
@@ -1333,12 +1333,12 @@ class Post < ApplicationRecord
 
   module PoolMethods
     def pool_ids
-      pool_string.scan(/pool:(\d+)/).map { |pool| ParseValue.safe_id(pool[0]) }
+      self[:pool_ids] || []
     end
 
     def pools
       @pools ||= begin
-        return Pool.none if pool_string.blank?
+        return Pool.none if pool_ids.blank?
         Pool.where(id: pool_ids).series_first
       end
     end
@@ -1348,14 +1348,14 @@ class Post < ApplicationRecord
     end
 
     def belongs_to_pool?(pool)
-      pool_string =~ /(?:\A| )pool:#{pool.id}(?:\Z| )/
+      pool_ids.include?(pool.id)
     end
 
     def add_pool!(pool)
       return if belongs_to_pool?(pool)
 
       with_lock do
-        self.pool_string = "#{pool_string} pool:#{pool.id}".strip
+        self.pool_ids = (pool_ids + [pool.id]).uniq
       end
     end
 
@@ -1364,7 +1364,7 @@ class Post < ApplicationRecord
       return unless CurrentUser.user.can_remove_from_pools?
 
       with_lock do
-        self.pool_string = pool_string.gsub(/(?:\A| )pool:#{pool.id}(?:\Z| )/, " ").strip
+        self.pool_ids = pool_ids - [pool.id]
       end
     end
 
@@ -1766,7 +1766,7 @@ class Post < ApplicationRecord
 
   module ApiMethods
     def hidden_attributes
-      list = super + [:pool_string, :fav_string]
+      list = super + [:set_ids, :fav_string]
       if !visible?
         list += [:md5, :file_ext]
       end

--- a/db/migrate/20260518193044_replace_pool_string_with_pool_and_set_ids.rb
+++ b/db/migrate/20260518193044_replace_pool_string_with_pool_and_set_ids.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+class ReplacePoolStringWithPoolAndSetIds < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  INDEX_POOL_IDS = "index_posts_on_pool_ids"
+  INDEX_SET_IDS = "index_posts_on_set_ids"
+  INDEX_POOL_STRING_TOKENS = "index_posts_on_pool_string_tokens"
+
+  def up
+    add_column :posts, :pool_ids, :integer, array: true, null: false, default: []
+    add_column :posts, :set_ids, :bigint, array: true, null: false, default: []
+
+    Post.without_timeout { backfill_pool_ids }
+    Post.without_timeout { backfill_set_ids }
+
+    add_index :posts, :pool_ids, using: :gin, name: INDEX_POOL_IDS, algorithm: :concurrently
+    add_index :posts, :set_ids, using: :gin, name: INDEX_SET_IDS, algorithm: :concurrently
+
+    remove_index :posts, name: INDEX_POOL_STRING_TOKENS, algorithm: :concurrently
+    remove_column :posts, :pool_string
+  end
+
+  def down
+    add_column :posts, :pool_string, :text, null: false, default: ""
+
+    Post.without_timeout { restore_pool_string }
+
+    add_index :posts, "string_to_array(pool_string, ' ')", using: :gin, name: INDEX_POOL_STRING_TOKENS, algorithm: :concurrently
+
+    remove_index :posts, name: INDEX_POOL_IDS, algorithm: :concurrently
+    remove_index :posts, name: INDEX_SET_IDS, algorithm: :concurrently
+
+    remove_column :posts, :pool_ids
+    remove_column :posts, :set_ids
+  end
+
+  private
+
+  def backfill_pool_ids
+    execute <<~SQL.squish
+      UPDATE posts
+      SET pool_ids = COALESCE(pool_memberships.pool_ids, '{}')
+      FROM (
+        SELECT post_id, array_agg(pool_id ORDER BY pool_id) AS pool_ids
+        FROM (
+          SELECT post_ids.post_id, pools.id AS pool_id
+          FROM pools
+          CROSS JOIN LATERAL unnest(pools.post_ids) AS post_ids(post_id)
+
+          UNION
+
+          SELECT posts.id AS post_id, substring(tokens.token FROM '^pool:(\\d+)$')::int AS pool_id
+          FROM posts
+          CROSS JOIN LATERAL unnest(string_to_array(posts.pool_string, ' ')) AS tokens(token)
+          WHERE tokens.token ~ '^pool:\\d+$'
+        ) combined_pool_memberships
+        GROUP BY post_id
+      ) pool_memberships
+      WHERE posts.id = pool_memberships.post_id
+    SQL
+  end
+
+  def backfill_set_ids
+    execute <<~SQL.squish
+      UPDATE posts
+      SET set_ids = COALESCE(set_memberships.set_ids, '{}')
+      FROM (
+        SELECT post_id, array_agg(set_id ORDER BY set_id) AS set_ids
+        FROM (
+          SELECT post_ids.post_id, post_sets.id AS set_id
+          FROM post_sets
+          CROSS JOIN LATERAL unnest(post_sets.post_ids) AS post_ids(post_id)
+
+          UNION
+
+          SELECT posts.id AS post_id, substring(tokens.token FROM '^set:(\\d+)$')::bigint AS set_id
+          FROM posts
+          CROSS JOIN LATERAL unnest(string_to_array(posts.pool_string, ' ')) AS tokens(token)
+          WHERE tokens.token ~ '^set:\\d+$'
+        ) combined_set_memberships
+        GROUP BY post_id
+      ) set_memberships
+      WHERE posts.id = set_memberships.post_id
+    SQL
+  end
+
+  def restore_pool_string
+    execute <<~SQL.squish
+      UPDATE posts
+      SET pool_string = COALESCE(pool_tokens.pool_string, '')
+      FROM (
+        SELECT post_id, array_to_string(array_agg(token ORDER BY token_type, token_id), ' ') AS pool_string
+        FROM (
+          SELECT posts.id AS post_id, 'pool:' || pool_id AS token, 0 AS token_type, pool_id::bigint AS token_id
+          FROM posts
+          CROSS JOIN LATERAL unnest(posts.pool_ids) AS pool_ids(pool_id)
+
+          UNION
+
+          SELECT posts.id AS post_id, 'set:' || set_id AS token, 1 AS token_type, set_id AS token_id
+          FROM posts
+          CROSS JOIN LATERAL unnest(posts.set_ids) AS set_ids(set_id)
+        ) tokens
+        GROUP BY post_id
+      ) pool_tokens
+      WHERE posts.id = pool_tokens.post_id
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1793,7 +1793,6 @@ CREATE TABLE public.posts (
     uploader_ip_addr inet NOT NULL,
     approver_id integer,
     fav_string text DEFAULT ''::text NOT NULL,
-    pool_string text DEFAULT ''::text NOT NULL,
     last_noted_at timestamp without time zone,
     last_comment_bumped_at timestamp without time zone,
     fav_count integer DEFAULT 0 NOT NULL,
@@ -1825,7 +1824,9 @@ CREATE TABLE public.posts (
     is_comment_disabled boolean DEFAULT false NOT NULL,
     is_comment_locked boolean DEFAULT false NOT NULL,
     tag_count_contributor integer DEFAULT 0 NOT NULL,
-    video_samples jsonb DEFAULT '{}'::jsonb NOT NULL
+    video_samples jsonb DEFAULT '{}'::jsonb NOT NULL,
+    pool_ids integer[] DEFAULT '{}'::integer[] NOT NULL,
+    set_ids bigint[] DEFAULT '{}'::bigint[] NOT NULL
 );
 
 
@@ -4749,10 +4750,17 @@ CREATE INDEX index_posts_on_parent_id ON public.posts USING btree (parent_id);
 
 
 --
--- Name: index_posts_on_pool_string_tokens; Type: INDEX; Schema: public; Owner: -
+-- Name: index_posts_on_pool_ids; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_posts_on_pool_string_tokens ON public.posts USING gin (string_to_array(pool_string, ' '::text));
+CREATE INDEX index_posts_on_pool_ids ON public.posts USING gin (pool_ids);
+
+
+--
+-- Name: index_posts_on_set_ids; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_set_ids ON public.posts USING gin (set_ids);
 
 
 --
@@ -5436,6 +5444,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260518193044'),
 ('20260505163626'),
 ('20260503072727'),
 ('20260501134813'),

--- a/spec/jobs/post_set_cleanup_job_spec.rb
+++ b/spec/jobs/post_set_cleanup_job_spec.rb
@@ -12,34 +12,35 @@ RSpec.describe PostSetCleanupJob do
   describe "#perform" do
     context "with type :set" do
       let(:set_id) { 42 }
-      let!(:post_in_set) { create(:post).tap { |p| p.update_columns(pool_string: "set:#{set_id}") } }
+      let!(:post_in_set) { create(:post).tap { |p| p.update_columns(set_ids: [set_id]) } }
       let!(:post_not_in_set) { create(:post) }
 
-      it "removes the set token from posts belonging to the set" do
+      it "removes the set id from posts belonging to the set" do
         perform(:set, set_id)
-        expect(post_in_set.reload.pool_string).not_to include("set:#{set_id}")
+        expect(post_in_set.reload.set_ids).not_to include(set_id)
       end
 
       it "does not modify posts that do not belong to the set" do
-        original = post_not_in_set.pool_string.dup
+        original = post_not_in_set.set_ids.dup
         perform(:set, set_id)
-        expect(post_not_in_set.reload.pool_string).to eq(original)
+        expect(post_not_in_set.reload.set_ids).to eq(original)
       end
 
       context "when the post also belongs to other sets" do
         let(:other_set_id) { 99 }
-        let!(:post_in_both) { create(:post).tap { |p| p.update_columns(pool_string: "set:#{set_id} set:#{other_set_id}") } }
+        let!(:post_in_both) { create(:post).tap { |p| p.update_columns(set_ids: [set_id, other_set_id]) } }
 
-        it "preserves other set tokens" do
+        it "preserves other set ids" do
           perform(:set, set_id)
-          expect(post_in_both.reload.pool_string).to include("set:#{other_set_id}")
+          expect(post_in_both.reload.set_ids).not_to include(set_id)
+          expect(post_in_both.reload.set_ids).to include(other_set_id)
         end
       end
     end
 
     context "with type :pool" do
       let(:pool_id) { 42 }
-      let!(:post_in_pool) { create(:post).tap { |p| p.update_columns(pool_string: "pool:#{pool_id}") } }
+      let!(:post_in_pool) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id]) } }
       let!(:post_not_in_pool) { create(:post) }
 
       before do
@@ -49,25 +50,25 @@ RSpec.describe PostSetCleanupJob do
         User.system.update_columns(created_at: 8.days.ago)
       end
 
-      it "removes the pool token from posts belonging to the pool" do
+      it "removes the pool id from posts belonging to the pool" do
         perform(:pool, pool_id)
-        expect(post_in_pool.reload.pool_string).not_to include("pool:#{pool_id}")
+        expect(post_in_pool.reload.pool_ids).not_to include(pool_id)
       end
 
       it "does not modify posts that do not belong to the pool" do
-        original = post_not_in_pool.pool_string.dup
+        original = post_not_in_pool.pool_ids.dup
         perform(:pool, pool_id)
-        expect(post_not_in_pool.reload.pool_string).to eq(original)
+        expect(post_not_in_pool.reload.pool_ids).to eq(original)
       end
     end
 
     context "when type is passed as a string" do
       let(:set_id) { 42 }
-      let!(:post_in_set) { create(:post).tap { |p| p.update_columns(pool_string: "set:#{set_id}") } }
+      let!(:post_in_set) { create(:post).tap { |p| p.update_columns(set_ids: [set_id]) } }
 
       it "converts the string to a symbol and processes correctly" do
         perform("set", set_id)
-        expect(post_in_set.reload.pool_string).not_to include("set:#{set_id}")
+        expect(post_in_set.reload.set_ids).not_to include(set_id)
       end
     end
 
@@ -77,7 +78,7 @@ RSpec.describe PostSetCleanupJob do
       end
     end
 
-    context "when no posts contain the token" do
+    context "when no posts contain the id" do
       it "does not raise an error" do
         expect { perform(:set, 999_999) }.not_to raise_error
       end

--- a/spec/jobs/post_set_posts_sync_job_spec.rb
+++ b/spec/jobs/post_set_posts_sync_job_spec.rb
@@ -22,15 +22,15 @@ RSpec.describe PostSetPostsSyncJob do
       end
     end
 
-    context "when a post is in post_ids but missing the token" do
+    context "when a post is in post_ids but missing the set id" do
       let(:post) { create(:post) }
 
-      before { Post.where(id: post.id).update_all(pool_string: "") }
+      before { Post.where(id: post.id).update_all(set_ids: []) }
 
-      it "adds the token to pool_string" do
+      it "adds the set id to set_ids" do
         post_set.update_column(:post_ids, [post.id])
         job.perform_now(post_set.id)
-        expect(post.reload.pool_string).to include("set:#{post_set.id}")
+        expect(post.reload.set_ids).to include(post_set.id)
       end
 
       it "enqueues a BulkIndexUpdateJob for the post" do
@@ -40,15 +40,15 @@ RSpec.describe PostSetPostsSyncJob do
       end
     end
 
-    context "when a post has the token but is not in post_ids" do
+    context "when a post has the set id but is not in post_ids" do
       let(:post) { create(:post) }
 
-      before { Post.where(id: post.id).update_all(pool_string: "set:#{post_set.id}") }
+      before { Post.where(id: post.id).update_all(set_ids: [post_set.id]) }
 
-      it "removes the token from pool_string" do
+      it "removes the set id from set_ids" do
         post_set.update_column(:post_ids, [])
         job.perform_now(post_set.id)
-        expect(post.reload.pool_string).not_to include("set:#{post_set.id}")
+        expect(post.reload.set_ids).not_to include(post_set.id)
       end
 
       it "enqueues a BulkIndexUpdateJob for the post" do
@@ -58,15 +58,15 @@ RSpec.describe PostSetPostsSyncJob do
       end
     end
 
-    context "when a post is correctly in both post_ids and pool_string" do
+    context "when a post is correctly in both post_ids and set_ids" do
       let(:post) { create(:post) }
 
-      before { Post.where(id: post.id).update_all(pool_string: "set:#{post_set.id}") }
+      before { Post.where(id: post.id).update_all(set_ids: [post_set.id]) }
 
-      it "does not change pool_string" do
+      it "does not change set_ids" do
         post_set.update_column(:post_ids, [post.id])
         expect { job.perform_now(post_set.id) }
-          .not_to(change { post.reload.pool_string })
+          .not_to(change { post.reload.set_ids })
       end
 
       it "does not enqueue a BulkIndexUpdateJob" do
@@ -76,15 +76,15 @@ RSpec.describe PostSetPostsSyncJob do
       end
     end
 
-    context "when a post is correctly absent from both post_ids and pool_string" do
+    context "when a post is correctly absent from both post_ids and set_ids" do
       let(:post) { create(:post) }
 
-      before { Post.where(id: post.id).update_all(pool_string: "") }
+      before { Post.where(id: post.id).update_all(set_ids: []) }
 
-      it "does not change pool_string" do
+      it "does not change set_ids" do
         post_set.update_column(:post_ids, [])
         expect { job.perform_now(post_set.id) }
-          .not_to(change { post.reload.pool_string })
+          .not_to(change { post.reload.set_ids })
       end
 
       it "does not enqueue a BulkIndexUpdateJob" do

--- a/spec/logical/post_query_builder/pool_spec.rb
+++ b/spec/logical/post_query_builder/pool_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe PostQueryBuilder do
 
   describe "pool: metatag" do
     describe "pool:none" do
-      it "includes posts with an empty pool_string" do
+      it "includes posts with an empty pool_ids array" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
         expect(run("pool:none")).to include(post)
       end
 
       it "excludes posts that belong to a pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("pool:none")).not_to include(post)
       end
     end
@@ -27,13 +27,13 @@ RSpec.describe PostQueryBuilder do
     describe "pool:any" do
       it "includes posts that belong to at least one pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("pool:any")).to include(post)
       end
 
-      it "excludes posts with an empty pool_string" do
+      it "excludes posts with an empty pool_ids array" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
         expect(run("pool:any")).not_to include(post)
       end
     end
@@ -41,27 +41,27 @@ RSpec.describe PostQueryBuilder do
     describe "inpool:true" do
       it "includes posts that belong to at least one pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("inpool:true")).to include(post)
       end
 
-      it "excludes posts with an empty pool_string" do
+      it "excludes posts with an empty pool_ids array" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
         expect(run("inpool:true")).not_to include(post)
       end
     end
 
     describe "inpool:false" do
-      it "includes posts with an empty pool_string" do
+      it "includes posts with an empty pool_ids array" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
         expect(run("inpool:false")).to include(post)
       end
 
       it "excludes posts that belong to a pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("inpool:false")).not_to include(post)
       end
     end

--- a/spec/models/pool/creation_methods_spec.rb
+++ b/spec/models/pool/creation_methods_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe PoolsController, ".create" do
     expect(pool.post_count).to eq(posts.size)
   end
 
-  it "synchronize the posts with the pool" do
+  it "synchronizes the posts with the pool" do
     expect(pool.post_ids).to eq(posts.map(&:id))
 
     posts.each(&:reload)
-    expect(posts.map(&:pool_string)).to eq(["pool:#{pool.id}"] * posts.size)
+    expect(posts.map(&:pool_ids)).to eq([[pool.id]] * posts.size)
   end
 
   it "error when post ids are invalid" do

--- a/spec/models/post/api_methods_spec.rb
+++ b/spec/models/post/api_methods_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe Post do
     end
 
     describe "#hidden_attributes" do
-      it "always hides pool_string and fav_string" do
+      it "always hides set_ids and fav_string" do
         post = create(:post)
-        expect(post.hidden_attributes).to include(:pool_string, :fav_string)
+        expect(post.hidden_attributes).to include(:set_ids, :fav_string)
       end
 
       it "additionally hides md5 and file_ext when the post is not visible" do

--- a/spec/models/post/pool_methods_spec.rb
+++ b/spec/models/post/pool_methods_spec.rb
@@ -9,23 +9,23 @@ RSpec.describe Post do
     describe "#belongs_to_pool?" do
       it "returns truthy when the post is in the pool" do
         pool = create(:pool)
-        post = build(:post, pool_string: "pool:#{pool.id}")
+        post = build(:post, pool_ids: [pool.id])
         expect(post).to be_belongs_to_pool(pool)
       end
 
       it "returns falsy when the post is not in the pool" do
         pool = create(:pool)
-        post = build(:post, pool_string: "")
+        post = build(:post, pool_ids: [])
         expect(post).not_to be_belongs_to_pool(pool)
       end
     end
 
     describe "#add_pool!" do
-      it "appends pool:<id> to pool_string" do
+      it "adds pool id to pool_ids" do
         pool = create(:pool)
         post = create(:post)
         post.add_pool!(pool)
-        expect(post.pool_string).to include("pool:#{pool.id}")
+        expect(post.pool_ids).to include(pool.id)
       end
 
       it "does not add the pool a second time if already present" do
@@ -33,50 +33,50 @@ RSpec.describe Post do
         post = create(:post)
         post.add_pool!(pool)
         post.add_pool!(pool)
-        expect(post.pool_string.scan("pool:#{pool.id}").size).to eq(1)
+        expect(post.pool_ids.count(pool.id)).to eq(1)
       end
     end
 
     describe "#remove_pool!" do
-      it "removes pool:<id> from pool_string" do
+      it "removes pool id from pool_ids" do
         pool = create(:pool)
-        post = create(:post, pool_string: "pool:#{pool.id}")
+        post = create(:post, pool_ids: [pool.id])
         post.remove_pool!(pool)
-        expect(post.pool_string).not_to include("pool:#{pool.id}")
+        expect(post.pool_ids).not_to include(pool.id)
       end
 
-      it "does nothing when the pool is not in pool_string" do
+      it "does nothing when the pool is not in pool_ids" do
         pool = create(:pool)
-        post = create(:post, pool_string: "")
-        original = post.pool_string
+        post = create(:post, pool_ids: [])
+        original = post.pool_ids.dup
         post.remove_pool!(pool)
-        expect(post.pool_string).to eq(original)
+        expect(post.pool_ids).to eq(original)
       end
     end
 
     describe "#has_active_pools?" do
-      it "returns false when pool_string is blank" do
-        post = build(:post, pool_string: "")
+      it "returns false when pool_ids is empty" do
+        post = build(:post, pool_ids: [])
         expect(post.has_active_pools?).to be false
       end
 
-      it "returns true when pool_string contains an active pool" do
+      it "returns true when pool_ids contains an active pool" do
         pool = create(:pool, is_active: true)
-        post = create(:post, pool_string: "pool:#{pool.id}")
+        post = create(:post, pool_ids: [pool.id])
         expect(post.has_active_pools?).to be true
       end
     end
 
     describe "#pool_ids" do
-      it "returns an array of pool ids from pool_string" do
+      it "returns an array of pool ids" do
         pool1 = create(:pool)
         pool2 = create(:pool)
-        post = build(:post, pool_string: "pool:#{pool1.id} pool:#{pool2.id}")
+        post = build(:post, pool_ids: [pool1.id, pool2.id])
         expect(post.pool_ids).to include(pool1.id, pool2.id)
       end
 
-      it "returns an empty array when pool_string has no pools" do
-        post = build(:post, pool_string: "")
+      it "returns an empty array when pool_ids has no pools" do
+        post = build(:post, pool_ids: [])
         expect(post.pool_ids).to eq([])
       end
     end

--- a/spec/models/post/set_methods_spec.rb
+++ b/spec/models/post/set_methods_spec.rb
@@ -7,25 +7,25 @@ RSpec.describe Post do
 
   describe "SetMethods" do
     describe "#belongs_to_post_set" do
-      it "returns truthy when the set id is present in pool_string" do
+      it "returns truthy when the set id is present in set_ids" do
         set  = create(:post_set)
-        post = build(:post, pool_string: "set:#{set.id}")
+        post = build(:post, set_ids: [set.id])
         expect(post.belongs_to_post_set(set)).to be_truthy
       end
 
       it "returns falsy when the set id is absent" do
         set  = create(:post_set)
-        post = build(:post, pool_string: "")
+        post = build(:post, set_ids: [])
         expect(post.belongs_to_post_set(set)).to be_falsy
       end
     end
 
     describe "#add_set!" do
-      it "adds set:<id> to pool_string" do
+      it "adds set id to set_ids" do
         set  = create(:post_set)
         post = create(:post)
         post.add_set!(set)
-        expect(post.pool_string).to include("set:#{set.id}")
+        expect(post.set_ids).to include(set.id)
       end
 
       it "does not add the same set twice" do
@@ -33,29 +33,29 @@ RSpec.describe Post do
         post = create(:post)
         post.add_set!(set)
         post.add_set!(set)
-        expect(post.pool_string.scan("set:#{set.id}").size).to eq(1)
+        expect(post.set_ids.count(set.id)).to eq(1)
       end
     end
 
     describe "#remove_set!" do
-      it "removes set:<id> from pool_string" do
+      it "removes set id from set_ids" do
         set  = create(:post_set)
-        post = create(:post, pool_string: "set:#{set.id}")
+        post = create(:post, set_ids: [set.id])
         post.remove_set!(set)
-        expect(post.pool_string).not_to include("set:#{set.id}")
+        expect(post.set_ids).not_to include(set.id)
       end
     end
 
     describe "#set_ids" do
-      it "returns an array of set ids from pool_string" do
+      it "returns an array of set ids" do
         set1 = create(:post_set)
         set2 = create(:post_set)
-        post = build(:post, pool_string: "set:#{set1.id} set:#{set2.id}")
+        post = build(:post, set_ids: [set1.id, set2.id])
         expect(post.set_ids).to include(set1.id, set2.id)
       end
 
-      it "returns an empty array when no sets are in pool_string" do
-        post = build(:post, pool_string: "")
+      it "returns an empty array when no sets are in set_ids" do
+        post = build(:post, set_ids: [])
         expect(post.set_ids).to eq([])
       end
     end
@@ -63,7 +63,7 @@ RSpec.describe Post do
     describe "#give_post_sets_to_parent" do
       it "removes the post from its sets when expunged without a parent" do
         set  = create(:post_set)
-        post = create(:post, pool_string: "set:#{set.id}")
+        post = create(:post, set_ids: [set.id])
         post.expunge!
         expect(set.reload.post_ids).not_to include(post.id)
       end


### PR DESCRIPTION
# Replace `pool_string` with `pool_ids` and `set_ids` arrays

## Summary

This replaces `posts.pool_string` with separate structured membership columns:

- `posts.pool_ids integer[]`
- `posts.set_ids bigint[]`

The goal is to remove the mixed token format currently used by `pool_string`, where pool and post set memberships are stored together as text tokens such as:

```text
pool:1 pool:2 set:1 set:5
```

After this change, pool and set memberships are stored separately while preserving the existing denormalized “post knows what groups it belongs to” lookup behavior.

## Motivation

`pool_string` currently stores multiple concepts in one text field and requires token parsing for pool/set membership logic. Splitting this into structured arrays makes the data model clearer and avoids mixing public pool membership with internal post set membership.

This follows the earlier discussion about replacing the mixed `pool_string` format with structured columns while keeping the current fast lookup/cache behavior.

## Changes

- Adds `posts.pool_ids` as `integer[]`
- Adds `posts.set_ids` as `bigint[]`
- Backfills both columns from existing `pool_string` tokens and authoritative pool/post set membership arrays
- Updates pool and post set membership methods to use the new arrays
- Updates post set cleanup/sync jobs to mutate `set_ids` / `pool_ids`
- Updates `pool:any`, `pool:none`, and `inpool:*` queries to check `pool_ids`
- Removes `posts.pool_string` and its token GIN index
- Keeps `set_ids` hidden from API output
- Preserves public post JSON `pools` output

## Notes

Previously, `pool:any`, `pool:none`, and `inpool:*` checked whether `pool_string` was empty, which could include post set tokens. These checks now use `pool_ids`, so they reflect only actual pool membership.

A full OpenSearch reindex should not be required because the public/indexed pool membership values are preserved; this changes the backing storage, not the semantic value of `post.pool_ids`.

Includes a migration that adds `posts.pool_ids` and `posts.set_ids`, backfills them from existing membership data, removes the old `pool_string` token index, and drops `posts.pool_string`.

The main risk is migration cost on production-sized data, since this backfills post membership arrays across existing posts.

## Validation

- Ran focused specs for pool/set methods, post set jobs, pool query behavior, pool creation, and API hidden attributes
- Ran RuboCop on touched files
- Verified migrated schema has `pool_ids` / `set_ids` and no `pool_string`
- Verified locally that post JSON still exposes `pools` and does not expose `set_ids` or `pool_string`