### PR TITLE
[Favorites] Handle the "already favorited" error more gracefully

### DIFF
--- a/app/javascript/src/js/models/Favorite.js
+++ b/app/javascript/src/js/models/Favorite.js
@@ -32,7 +32,10 @@ export default class Favorite {
         try {
           const errorData = await response.json();
           backendErrorMessage = errorData.message || "Unknown error";
-          $(window).trigger("danbooru:error", "Error: " + backendErrorMessage);
+
+          // NOTE: the PostShowToolbar relies on this error message to reset the page's favorite state.
+          if (backendErrorMessage !== "You have already favorited this post")
+            $(window).trigger("danbooru:error", "Error: " + backendErrorMessage);
         } catch (_error) {
           $(window).trigger("danbooru:error", "Error: " + (response.status + " " + response.statusText));
         }

--- a/app/javascript/src/js/models/Favorite.js
+++ b/app/javascript/src/js/models/Favorite.js
@@ -28,13 +28,15 @@ export default class Favorite {
     }, { name: `Post.favorite.${post_id}`, unique: true, delay: delay }).then(async (response) => {
       if (!response.ok) {
         console.log("Response not OK:", response.status, response.statusText);
+        let backendErrorMessage = null;
         try {
           const errorData = await response.json();
-          $(window).trigger("danbooru:error", "Error: " + (errorData.message || "Unknown error"));
+          backendErrorMessage = errorData.message || "Unknown error";
+          $(window).trigger("danbooru:error", "Error: " + backendErrorMessage);
         } catch (_error) {
           $(window).trigger("danbooru:error", "Error: " + (response.status + " " + response.statusText));
         }
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`, { cause: backendErrorMessage });
       }
 
       try {
@@ -78,13 +80,15 @@ export default class Favorite {
     }, { name: `Post.favorite.${post_id}`, unique: true, delay: delay }).then(async (response) => {
       if (!response.ok) {
         console.log("Response not OK:", response.status, response.statusText);
+        let backendErrorMessage = null;
         try {
           const errorData = await response.json();
-          $(window).trigger("danbooru:error", "Error: " + (errorData.message || "Unknown error"));
+          backendErrorMessage = errorData.message || "Unknown error";
+          $(window).trigger("danbooru:error", "Error: " + backendErrorMessage);
         } catch (_error) {
           $(window).trigger("danbooru:error", "Error: " + (response.status + " " + response.statusText));
         }
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`, { cause: backendErrorMessage });
       }
 
       try {
@@ -103,5 +107,3 @@ export default class Favorite {
     });
   }
 }
-
-

--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -204,10 +204,18 @@ export default class PostsShowToolbar {
 
   static async addFavorite () {
     return Favorite.create(PostsShowToolbar.currentPost.id, 500)
-      .then(() => {
-        $(".ptbr-favorite-button").attr("favorited", "true");
-        $("#image-container").attr("data-is-favorited", "true");
-      });
+      .then(
+        () => {
+          $(".ptbr-favorite-button").attr("favorited", "true");
+          $("#image-container").attr("data-is-favorited", "true");
+        },
+        (error) => {
+          if (error.cause !== "You have already favorited this post") return;
+          $(".ptbr-favorite-button").attr("favorited", "true");
+          $("#image-container").attr("data-is-favorited", "true");
+          return;
+        },
+      );
   }
 
   static async deleteFavorite () {

--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -210,10 +210,9 @@ export default class PostsShowToolbar {
           $("#image-container").attr("data-is-favorited", "true");
         },
         (error) => {
-          if (error.cause !== "You have already favorited this post") return;
+          if (error.cause !== "You have already favorited this post") throw error;
           $(".ptbr-favorite-button").attr("favorited", "true");
           $("#image-container").attr("data-is-favorited", "true");
-          return;
         },
       );
   }

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -25,6 +25,8 @@ class FavoriteManager
     end
   rescue ActiveRecord::RecordNotUnique
     return if force
+
+    # NOTE: Front-end relies on this exact error message to reset the page's favorite state.
     raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)
 
     # Handle orphaned favorite record


### PR DESCRIPTION
Fixes #2022.
Resets the page into the "favorited" state if a favorite already exists.

No similar fix is needed for the situation where a user tries to unfavorite a post they have not favorited, since the back-end never even checks for that.