### PR TITLE
[Recommended] Address performance issues with the "Similar" mode

### DIFF
--- a/app/logical/elastic_query_builder.rb
+++ b/app/logical/elastic_query_builder.rb
@@ -41,7 +41,11 @@ class ElasticQueryBuilder
       },
     }
 
-    query[:bool][:minimum_should_match] = 1 if should.any?
+    if @minimum_should_match.present?
+      query[:bool][:minimum_should_match] = @minimum_should_match
+    elsif should.any?
+      query[:bool][:minimum_should_match] = 1
+    end
 
     if @function_score.present?
       @function_score[:query] = query

--- a/app/logical/elastic_query_builder.rb
+++ b/app/logical/elastic_query_builder.rb
@@ -4,12 +4,6 @@ class ElasticQueryBuilder
   attr_accessor :q, :must, :must_not, :should, :order
   attr_reader :has_invalid_input
 
-  protected
-
-  attr_writer :minimum_should_match
-
-  public
-
   def initialize(query)
     @q = query
     # These terms are ANDed together

--- a/app/logical/elastic_query_builder.rb
+++ b/app/logical/elastic_query_builder.rb
@@ -4,6 +4,12 @@ class ElasticQueryBuilder
   attr_accessor :q, :must, :must_not, :should, :order
   attr_reader :has_invalid_input
 
+  protected
+
+  attr_writer :minimum_should_match
+
+  public
+
   def initialize(query)
     @q = query
     # These terms are ANDed together

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -73,7 +73,7 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
                          .min_by(MAX_TAGS, &:post_count)
 
     should.concat(selected_tags.map { |tag| { term: { tags: tag.name } } })
-    @minimum_should_match = selected_tags.size >= 4 ? "30%" : 1
+    @minimum_should_match = selected_tags.size >= 7 ? "30%" : 1
 
     functions = [{ random_score: { seed: @post.id, field: "id" } }]
     selected_tags.each do |tag|

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -64,8 +64,10 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
     pool_ids = @post.pool_ids
     must_not.push({ terms: { pools: pool_ids } }) if pool_ids.any?
 
-    # Pick the rarest tags first — common tags (solo, mammal) are poor discriminators
     selected_tags = @post.categorized_tags.values.flatten.min_by(MAX_TAGS, &:post_count)
+
+    should.concat(selected_tags.map { |tag| { term: { tags: tag.name } } })
+    @minimum_should_match = (selected_tags.size * 0.3).floor >= 1 ? "30%" : 1
 
     functions = [{ random_score: { seed: @post.id, field: "id" } }]
     selected_tags.each do |tag|

--- a/app/logical/recommended_query_builder.rb
+++ b/app/logical/recommended_query_builder.rb
@@ -53,21 +53,27 @@ class RecommendedQueryBuilder < ElasticPostQueryBuilder
 
   MAX_TAGS = 50
   WEIGHTS_FOR_TAGS = {
-    artist: 0.0,
     character: 1.25,
-    copyright: 0.0, # shared publisher tags are basically meaningless
     species: 1.25,
     general: 1.0,
   }.freeze
+  IGNORED_CATEGORIES = %w[artist copyright].freeze
 
   def build_for_tags
     pool_ids = @post.pool_ids
     must_not.push({ terms: { pools: pool_ids } }) if pool_ids.any?
 
-    selected_tags = @post.categorized_tags.values.flatten.min_by(MAX_TAGS, &:post_count)
+    # Pick the least common tags to use as constraints.
+    # - artist tags are ignored because those are served better by the :artist mode
+    # - copyright tags are ignored because they are often too broad to be useful
+    selected_tags = @post.categorized_tags
+                         .except(*IGNORED_CATEGORIES)
+                         .values
+                         .flatten
+                         .min_by(MAX_TAGS, &:post_count)
 
     should.concat(selected_tags.map { |tag| { term: { tags: tag.name } } })
-    @minimum_should_match = (selected_tags.size * 0.3).floor >= 1 ? "30%" : 1
+    @minimum_should_match = selected_tags.size >= 4 ? "30%" : 1
 
     functions = [{ random_score: { seed: @post.id, field: "id" } }]
     selected_tags.each do |tag|

--- a/spec/logical/recommended_query_builder_spec.rb
+++ b/spec/logical/recommended_query_builder_spec.rb
@@ -244,22 +244,10 @@ RSpec.describe RecommendedQueryBuilder do
     end
 
     describe "per-category tag weights" do
-      it "assigns the artist weight to artist tags" do
-        post = make_post(all_tags: { "artist" => [["artist_a", 50]] })
-        fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "artist_a" }
-        expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:artist])
-      end
-
       it "assigns the character weight to character tags" do
         post = make_post(all_tags: { "character" => [["char_a", 10]] })
         fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "char_a" }
         expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:character])
-      end
-
-      it "assigns the copyright weight to copyright tags" do
-        post = make_post(all_tags: { "copyright" => [["copy_a", 10]] })
-        fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "copy_a" }
-        expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:copyright])
       end
 
       it "assigns the species weight to species tags" do
@@ -272,6 +260,14 @@ RSpec.describe RecommendedQueryBuilder do
         post = make_post(all_tags: { "general" => [["tag_a", 100]] })
         fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "tag_a" }
         expect(fn[:weight]).to eq(described_class::WEIGHTS_FOR_TAGS[:general])
+      end
+
+      it "does not assign weights to artist or copyright tags" do
+        post = make_post(all_tags: { "artist" => [["artist_a", 10]], "copyright" => [["copy_a", 10]] })
+        artist_fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "artist_a" }
+        copy_fn = tags_function_score(post)[:functions].find { |f| f.dig(:filter, :term, :tags) == "copy_a" }
+        expect(artist_fn).to be_nil
+        expect(copy_fn).to be_nil
       end
     end
 
@@ -318,6 +314,21 @@ RSpec.describe RecommendedQueryBuilder do
         post = make_post(known_artists: %w[some_artist], all_tags: { "artist" => [["some_artist", 50]] })
         builder = build_for(post, mode: :tags)
         expect(builder.should).to be_empty
+      end
+    end
+
+    describe "no minimum_should_match" do
+      it "sets minimum_should_match to 1 when there are should clauses but no explicit minimum" do
+        post = make_post(all_tags: { "general" => [["tag_a", 10]] })
+        builder = build_for(post, mode: :tags)
+        expect(builder.instance_variable_get(:@minimum_should_match)).to eq(1)
+      end
+
+      it "respects an explicitly set minimum_should_match value" do
+        post = make_post(all_tags: { "general" => [["tag_a", 10], ["tag_b", 20], ["tag_c", 30]] })
+        builder = build_for(post, mode: :tags)
+        builder.instance_variable_set(:@minimum_should_match, "50%")
+        expect(builder.instance_variable_get(:@minimum_should_match)).to eq("50%")
       end
     end
   end

--- a/spec/logical/recommended_query_builder_spec.rb
+++ b/spec/logical/recommended_query_builder_spec.rb
@@ -325,10 +325,9 @@ RSpec.describe RecommendedQueryBuilder do
       end
 
       it "respects an explicitly set minimum_should_match value" do
-        post = make_post(all_tags: { "general" => [["tag_a", 10], ["tag_b", 20], ["tag_c", 30]] })
+        post = make_post(all_tags: { "general" => [["tag_a", 10], ["tag_b", 20], ["tag_c", 30], ["tag_d", 30], ["tag_e", 30], ["tag_f", 30], ["tag_g", 30]] })
         builder = build_for(post, mode: :tags)
-        builder.instance_variable_set(:@minimum_should_match, "50%")
-        expect(builder.instance_variable_get(:@minimum_should_match)).to eq("50%")
+        expect(builder.instance_variable_get(:@minimum_should_match)).to eq("30%")
       end
     end
   end

--- a/spec/logical/recommended_query_builder_spec.rb
+++ b/spec/logical/recommended_query_builder_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe RecommendedQueryBuilder do
         expect(builder.instance_variable_get(:@minimum_should_match)).to eq(1)
       end
 
-      it "respects an explicitly set minimum_should_match value" do
+      it "sets minimum_should_match to 30% when there are 7+ should clauses" do
         post = make_post(all_tags: { "general" => [["tag_a", 10], ["tag_b", 20], ["tag_c", 30], ["tag_d", 30], ["tag_e", 30], ["tag_f", 30], ["tag_g", 30]] })
         builder = build_for(post, mode: :tags)
         expect(builder.instance_variable_get(:@minimum_should_match)).to eq("30%")


### PR DESCRIPTION
Previous approach caused OpenSearch to score every post on the site in order to determine the most similar ones.
This implementation instructs it to match at least 30% of the selected tags, narrowing down the scope considerably.

The trade-off is that if a post has a lot of tags with low post counts, the "similar" results will be sparse.