### PR TITLE
[Appeals] Only allow appeals on unresolved deletions

### DIFF
--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -44,6 +44,7 @@ class PostFlag < ApplicationRecord
   module AccessMethods
     def can_appeal?(user = CurrentUser.user)
       return false unless is_deletion?
+      return false if is_resolved?
       return true if post.linked_users.include?(user.id) # Verified artists can appeal deletions of their own posts
       return false if reason =~ /takedown #\d+/i
       return true if post.uploader_id == user.id # Uploaders can appeal anything except for takedowns

--- a/spec/models/post_flag/permissions_spec.rb
+++ b/spec/models/post_flag/permissions_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe PostFlag do
   describe "#can_appeal?" do
     let(:post) { create(:post) }
     let(:flag) { create(:post_flag, post: post) }
+    let(:resolved_flag) { create(:deletion_post_flag, post: post, is_resolved: true) }
     let(:deletion) { create(:deletion_post_flag, post: post) }
 
     context "when the flag is not a deletion flag" do
@@ -118,6 +119,10 @@ RSpec.describe PostFlag do
     end
 
     context "when the flag is a deletion flag" do
+      it "returns false if the flag is resolved" do
+        expect(resolved_flag.can_appeal?(create(:user))).to be(false)
+      end
+
       it "returns true for linked users" do
         user = create(:user)
         artist = create(:artist, name: "linked_artist", linked_user_id: user.id)

--- a/spec/requests/appeals_controller_spec.rb
+++ b/spec/requests/appeals_controller_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe AppealsController do
   let(:janitor)      { create(:janitor_user) }
   let(:admin)        { create(:admin_user) }
   # uploader must be passed explicitly — the :post factory always creates its own uploader user.
-  let(:flagged_post) { create(:post, uploader: uploader) }
-  let(:post_flag)    { CurrentUser.scoped(other_member) { create(:deletion_post_flag, post: flagged_post) } }
-  let(:appeal)       { CurrentUser.scoped(uploader) { create(:appeal, post_flag: post_flag) } }
+  let(:flagged_post)       { create(:post, uploader: uploader) }
+  let(:post_flag)          { CurrentUser.scoped(other_member) { create(:deletion_post_flag, post: flagged_post) } }
+  let(:post_flag_resolved) { CurrentUser.scoped(other_member) { create(:deletion_post_flag, post: flagged_post, is_resolved: true) } }
+  let(:appeal)             { CurrentUser.scoped(uploader) { create(:appeal, post_flag: post_flag) } }
 
   # ---------------------------------------------------------------------------
   # GET /appeals — index
@@ -112,6 +113,7 @@ RSpec.describe AppealsController do
 
   describe "POST /appeals" do
     let(:valid_params) { { appeal: { qtype: "flag", disp_id: post_flag.id, reason: "The flag is wrong." } } }
+    let(:valid_params_resolved) { { appeal: { qtype: "flag", disp_id: post_flag_resolved.id, reason: "The flag is wrong." } } }
 
     context "as anonymous" do
       it "redirects HTML to the login page" do
@@ -133,6 +135,11 @@ RSpec.describe AppealsController do
 
     context "as the post uploader" do
       before { sign_in_as uploader }
+
+      it "returns 403 for a resolved flag" do
+        post appeals_path, params: valid_params_resolved
+        expect(response).to have_http_status(:forbidden)
+      end
 
       it "creates an appeal and redirects to the appeal page" do
         expect { post appeals_path, params: valid_params }.to change(Appeal, :count).by(1)


### PR DESCRIPTION
If a post is deleted, undeleted, then flagged or deleted again, you get multiple buttons. Noticed it when testing the DB flag reasons PR.

<img width="1000" height="908" alt="image" src="https://github.com/user-attachments/assets/2e6a7b2e-68c8-458d-8875-671709234674" />
