### PR TITLE
[Popular] Better date validation

### DIFF
--- a/app/logical/post_sets/popular.rb
+++ b/app/logical/post_sets/popular.rb
@@ -9,7 +9,11 @@ module PostSets
       @date = if date.blank?
                 Time.zone.now
               else
-                parsed = Time.zone.parse(date)
+                begin
+                  parsed = Time.zone.parse(date)
+                rescue TypeError, ArgumentError
+                  raise ParseValue::InvalidDateError, "Invalid date: #{date}"
+                end
                 raise ParseValue::InvalidDateError, "Invalid date: #{date}" if parsed.nil? || parsed.year > 9999 || parsed.year < 1
                 parsed
               end

--- a/spec/requests/popular_controller_spec.rb
+++ b/spec/requests/popular_controller_spec.rb
@@ -100,6 +100,11 @@ RSpec.describe PopularController do
         get popular_index_path(format: :json, date: "not-a-date")
         expect(response).to have_http_status(:unprocessable_content)
       end
+
+      it "returns 422 when date is an invalid nested hash param" do
+        get popular_index_path(date: { foo: "bar" })
+        expect(response).to have_http_status(:unprocessable_content)
+      end
     end
   end
 end


### PR DESCRIPTION
Just wrapped date parsing in a begin-rescue block to avoid writing to the exception log.