### PR TITLE
[Posts] Silence OpenSearch timeout errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -115,7 +115,7 @@ class ApplicationController < ActionController::Base
       render_expected_error(400, "You must reset your password.")
     when OpenSearch::Transport::Transport::Errors::InternalServerError
       if exception.message.include?("time_exceeded_exception")
-        render_expected_error(503, "The search timed out. Try using fewer or simpler tags.")
+        render_expected_error(422, "The search timed out. Try using fewer or simpler tags.")
       else
         render_error_page(500, exception)
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -113,6 +113,12 @@ class ApplicationController < ActionController::Base
       render_expected_error(400, exception.message)
     when BCrypt::Errors::InvalidHash
       render_expected_error(400, "You must reset your password.")
+    when OpenSearch::Transport::Transport::Errors::InternalServerError
+      if exception.message.include?("time_exceeded_exception")
+        render_expected_error(503, "The search timed out. Try using fewer or simpler tags.")
+      else
+        render_error_page(500, exception)
+      end
     else
       render_error_page(500, exception)
     end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -93,6 +93,20 @@ RSpec.describe PostsController do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context "when the search is too complex" do
+      before { allow(Post).to receive(:tag_match).and_raise(OpenSearch::Transport::Transport::Errors::InternalServerError.new("time_exceeded_exception")) }
+
+      it "returns 422 for HTML" do
+        get posts_path
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns 422 for JSON" do
+        get posts_path(format: :json)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
These errors are not terribly common, but they happen.
Typically caused by the user adding too many wildcards, especially in sources.

No practical way of us to determine ahead of time whether the search will time out.
At the very least, we can prevent it from creating ExceptionLog entries.