### PR TITLE
[Posts] Make "similar" recommendation tab public again

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -112,8 +112,8 @@
       <% end %>
 
       <%# Determine which recommender tabs to show %>
-      <% artist_tab_available = @post.known_artist_tags.any? %>
-      <% tags_tab_available = @post.tags_for_category("general").size > 1 && CurrentUser.user.is_staff? %>
+      <% artist_tab_available = @post.known_artist_tags.any? && Danbooru.config.post_recommendations_enabled?[:artist] %>
+      <% tags_tab_available = @post.tags_for_category("general").size > 1 && Danbooru.config.post_recommendations_enabled?[:tags] %>
 
       <% if artist_tab_available || tags_tab_available %>
         <div

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -885,6 +885,13 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
     def aibur_stats_discord_webhook_url
       nil
     end
+
+    def post_recommendations_enabled?
+      {
+        artist: true,
+        tags: true,
+      }
+    end
   end
 
   class EnvironmentConfiguration


### PR DESCRIPTION
Added override toggles to the config file, so that we can easily turn individual recommendations mode if need be.