### PR TITLE
[Posts] Improve favorite performance and add votes property to Post lists

### DIFF
--- a/app/blueprints/post_blueprint.rb
+++ b/app/blueprints/post_blueprint.rb
@@ -79,6 +79,7 @@ class PostBlueprint < Blueprinter::Base
       },
       fav_count: post.fav_count,
       is_favorited: post.is_favorited?,
+      vote: post.vote_by,
       comment_count: post.visible_comment_count(CurrentUser.user),
     }
   end

--- a/app/blueprints/post_legacy_blueprint.rb
+++ b/app/blueprints/post_legacy_blueprint.rb
@@ -118,6 +118,10 @@ class PostLegacyBlueprint < Blueprinter::Base
     post.is_favorited?
   end
 
+  field :vote do |post|
+    post.vote_by
+  end
+
   field :has_notes do |post|
     post.has_notes?
   end

--- a/app/blueprints/post_thumbnail_blueprint.rb
+++ b/app/blueprints/post_thumbnail_blueprint.rb
@@ -37,6 +37,7 @@ class PostThumbnailBlueprint < Blueprinter::Base
   field :score
   field :fav_count
   field :is_favorited?, name: :is_favorited
+  field :vote_by, name: :vote
   field :comment_count do |post|
     post.visible_comment_count(CurrentUser.user)
   end

--- a/app/controllers/concerns/deferred_posts.rb
+++ b/app/controllers/concerns/deferred_posts.rb
@@ -9,7 +9,10 @@ module DeferredPosts
 
   def deferred_posts
     posts = Post.includes(:uploader).where(id: deferred_post_ids.to_a).to_a
-    Post.preload_favorited_status!(posts, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    unless CurrentUser.user&.is_anonymous?
+      Post.preload_favorited_status!(posts, CurrentUser.id)
+      Post.preload_vote_by!(posts, CurrentUser.id)
+    end
     posts.each_with_object({}) { |p, hash| hash[p.id] = p.thumbnail_attributes }
   end
 end

--- a/app/controllers/concerns/deferred_posts.rb
+++ b/app/controllers/concerns/deferred_posts.rb
@@ -8,9 +8,8 @@ module DeferredPosts
   end
 
   def deferred_posts
-    Post.includes(:uploader).where(id: deferred_post_ids.to_a).find_each.reduce({}) do |post_hash, p|
-      post_hash[p.id] = p.thumbnail_attributes
-      post_hash
-    end
+    posts = Post.includes(:uploader).where(id: deferred_post_ids.to_a).to_a
+    Post.preload_favorited_status!(posts, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    posts.each_with_object({}) { |p, hash| hash[p.id] = p.thumbnail_attributes }
   end
 end

--- a/app/controllers/concerns/json_response_helper.rb
+++ b/app/controllers/concerns/json_response_helper.rb
@@ -34,6 +34,8 @@ module JsonResponseHelper
   end
 
   def pick_json_format(posts, collection: true, legacy: true, mode: "basic")
+    Post.preload_favorited_status!(posts, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+
     # Legacy format
     if legacy
       render_posts_json(PostLegacyBlueprint.render_as_hash(posts), collection: collection)

--- a/app/controllers/concerns/json_response_helper.rb
+++ b/app/controllers/concerns/json_response_helper.rb
@@ -34,7 +34,10 @@ module JsonResponseHelper
   end
 
   def pick_json_format(posts, collection: true, legacy: true, mode: "basic")
-    Post.preload_favorited_status!(posts, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    unless CurrentUser.user&.is_anonymous?
+      Post.preload_favorited_status!(posts, CurrentUser.id)
+      Post.preload_vote_by!(posts, CurrentUser.id)
+    end
 
     # Legacy format
     if legacy

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -41,7 +41,10 @@ class PostRecommendationsController < ApplicationController
     end
 
     posts = Post.where(id: post_data[:order]).includes(:uploader).to_a
-    Post.preload_favorited_status!(posts, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    unless CurrentUser.user&.is_anonymous?
+      Post.preload_favorited_status!(posts, CurrentUser.id)
+      Post.preload_vote_by!(posts, CurrentUser.id)
+    end
     post_data[:post_data] = PostThumbnailBlueprint.render_as_hash(posts, collection: true)
     post_data.delete(:order) # Don't pollute the response with redundant data
 

--- a/app/controllers/post_recommendations_controller.rb
+++ b/app/controllers/post_recommendations_controller.rb
@@ -40,7 +40,8 @@ class PostRecommendationsController < ApplicationController
       }
     end
 
-    posts = Post.where(id: post_data[:order]).includes(:uploader)
+    posts = Post.where(id: post_data[:order]).includes(:uploader).to_a
+    Post.preload_favorited_status!(posts, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     post_data[:post_data] = PostThumbnailBlueprint.render_as_hash(posts, collection: true)
     post_data.delete(:order) # Don't pollute the response with redundant data
 

--- a/app/jobs/transfer_favorites_job.rb
+++ b/app/jobs/transfer_favorites_job.rb
@@ -98,23 +98,16 @@ class TransferFavoritesJob < ApplicationJob
 
   # Update fav_string (rollback safety net) and fav_count for both child and parent posts.
   def update_post_favorites_data(child_post, parent_post, _removed_user_ids, added_user_ids)
-    child_post.update_columns(
-      fav_string: "",
-      fav_count: 0,
-      updated_at: Time.current,
-    )
+    child_post.write_fav_string!("", 0)
+    child_post.update_columns(updated_at: Time.current)
 
     if added_user_ids.any?
-      current_fav_string = parent_post.fav_string || ""
-      current_fav_parts = current_fav_string.split
+      current_fav_parts = parent_post.fav_string.split
       new_fav_parts = added_user_ids.map { |user_id| "fav:#{user_id}" }
       all_fav_parts = (current_fav_parts + new_fav_parts).uniq
 
-      parent_post.update_columns(
-        fav_string: all_fav_parts.join(" "),
-        fav_count: all_fav_parts.length,
-        updated_at: Time.current,
-      )
+      parent_post.write_fav_string!(all_fav_parts.join(" "), all_fav_parts.length)
+      parent_post.update_columns(updated_at: Time.current)
     end
   end
 

--- a/app/jobs/transfer_favorites_job.rb
+++ b/app/jobs/transfer_favorites_job.rb
@@ -20,7 +20,7 @@ class TransferFavoritesJob < ApplicationJob
     parent = post.parent
     return false unless parent
 
-    user_ids = post.fav_string.scan(/fav:(\d+)/).flatten.map(&:to_i)
+    user_ids = Favorite.where(post_id: post.id).pluck(:user_id)
     return false if user_ids.empty?
 
     # Prevent concurrent favorite operations
@@ -29,7 +29,7 @@ class TransferFavoritesJob < ApplicationJob
     parent.update_columns(bit_flags: parent.bit_flags | transfer_flag)
 
     begin
-      existing_parent_user_ids = parent.fav_string.scan(/fav:(\d+)/).flatten.map(&:to_i)
+      existing_parent_user_ids = Favorite.where(post_id: parent.id).pluck(:user_id)
       new_user_ids = user_ids - existing_parent_user_ids
 
       # 1. Delete all child favorites
@@ -55,7 +55,7 @@ class TransferFavoritesJob < ApplicationJob
       update_post_favorites_data(post, parent, user_ids, new_user_ids)
       update_user_favorite_counts(user_ids, new_user_ids)
 
-      # 4. Safety check: Clean up any orphaned favorites that weren't caught by fav_string parsing
+      # 4. Safety check: clean up any favorites that landed on the child after the initial delete
       cleanup_orphaned_child_favorites(post)
 
       # 5. Create post events
@@ -96,16 +96,14 @@ class TransferFavoritesJob < ApplicationJob
     true
   end
 
-  # Update the fav_string and fav_count for both child and parent posts.
+  # Update fav_string (rollback safety net) and fav_count for both child and parent posts.
   def update_post_favorites_data(child_post, parent_post, _removed_user_ids, added_user_ids)
-    # Remove all favorites from child post
     child_post.update_columns(
       fav_string: "",
       fav_count: 0,
       updated_at: Time.current,
     )
 
-    # Add new favorites to parent post
     if added_user_ids.any?
       current_fav_string = parent_post.fav_string || ""
       current_fav_parts = current_fav_string.split
@@ -143,14 +141,14 @@ class TransferFavoritesJob < ApplicationJob
     end
   end
 
-  # Clean up any orphaned favorite records not captured by fav_string parsing.
+  # Clean up any favorite records that raced in after the main delete_all.
   # Recalculates affected user favorite counts.
   def cleanup_orphaned_child_favorites(child_post)
     orphaned_favorites = Favorite.where(post_id: child_post.id)
     return unless orphaned_favorites.exists?
     orphaned_user_ids = orphaned_favorites.pluck(:user_id)
 
-    Rails.logger.warn("TransferFavoritesJob: Found #{orphaned_favorites.count} orphaned favorites for post #{child_post.id} not in fav_string. User IDs: #{orphaned_user_ids}")
+    Rails.logger.warn("TransferFavoritesJob: Found #{orphaned_favorites.count} orphaned favorites for post #{child_post.id} after transfer. User IDs: #{orphaned_user_ids}")
 
     Favorite.without_timeout do
       orphaned_favorites.delete_all

--- a/app/logical/favorite_manager.rb
+++ b/app/logical/favorite_manager.rb
@@ -25,19 +25,8 @@ class FavoriteManager
     end
   rescue ActiveRecord::RecordNotUnique
     return if force
-
     # NOTE: Front-end relies on this exact error message to reset the page's favorite state.
-    raise Favorite::Error, "You have already favorited this post" if post.favorited_by?(user.id)
-
-    # Handle orphaned favorite record
-    Favorite.transaction do
-      post.lock!
-      post.reload
-      post.append_user_to_fav_string(user.id)
-      post.do_not_version_changes = true
-
-      raise Favorite::Error, "Failed to update post: #{post.errors.full_messages.join(', ')}" unless post.save
-    end
+    raise Favorite::Error, "You have already favorited this post"
   end
 
   # Remove a favorite for the given user and post.

--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -66,7 +66,10 @@ module PostSets
         temp = ::Post.tag_match(tag_string).paginate_posts(page, limit: limit, includes: [:uploader])
 
         @post_count = temp.total_count
-        ::Post.preload_favorited_status!(temp.records, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+        unless CurrentUser.user&.is_anonymous?
+          ::Post.preload_favorited_status!(temp, CurrentUser.id)
+          ::Post.preload_vote_by!(temp, CurrentUser.id)
+        end
         temp
       end
     end

--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -66,6 +66,7 @@ module PostSets
         temp = ::Post.tag_match(tag_string).paginate_posts(page, limit: limit, includes: [:uploader])
 
         @post_count = temp.total_count
+        ::Post.preload_favorited_status!(temp.records, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
         temp
       end
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1254,6 +1254,8 @@ class Post < ApplicationRecord
 
     def reload(*)
       @fav_string = nil
+      @favorited_status_cache = nil
+      @vote_by_cache = nil
       super
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,18 @@ class Post < ApplicationRecord
   class DeletionError < Exception ; end
   class TimeoutError < Exception ; end
 
+  # Exclude fav_string from default SELECTs to avoid loading the (potentially huge)
+  # blob on every post fetch. Write paths transparently fall through to Post#fav_string,
+  # which lazy-loads the column from the DB on demand. See FavoriteMethods.
+  module DropSelectForAggregates
+    # Rails turns a multi-column explicit select into COUNT(col1, col2, ...) which
+    # PG rejects. Drop the select for aggregations; we never count fav_string anyway.
+    def calculate(*args)
+      select_values.any? ? unscope(:select).calculate(*args) : super
+    end
+  end
+  default_scope -> { extending(DropSelectForAggregates).select(column_names - %w[fav_string]) }
+
   # Tags to copy when copying notes.
   NOTE_COPY_TAGS = %w[translated partially_translated translation_check translation_request].freeze
   NON_ARTIST_TAGS = %w[avoid_posting conditional_dnp epilepsy_warning sound_warning].freeze
@@ -1210,17 +1222,51 @@ class Post < ApplicationRecord
   end
 
   module FavoriteMethods
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Bulk-populate the favorited-by status for a collection of posts so that
+      # subsequent `favorited_by?(user_id)` calls return without hitting the DB.
+      def preload_favorited_status!(posts, user_id)
+        posts = Array.wrap(posts).compact
+        return if posts.empty? || user_id.blank?
+
+        favorited_ids = Favorite.where(user_id: user_id, post_id: posts.map(&:id)).pluck(:post_id).to_set
+        posts.each { |post| post.preset_favorited_status(user_id, favorited_ids.include?(post.id)) }
+      end
+    end
+
+    def preset_favorited_status(user_id, value)
+      @favorited_status_cache ||= {}
+      @favorited_status_cache[user_id] = value
+    end
+
+    def favorited_by?(user_id = CurrentUser.id)
+      return false if user_id.blank?
+      cached = @favorited_status_cache&.[](user_id)
+      return cached unless cached.nil?
+      Favorite.exists?(user_id: user_id, post_id: id)
+    end
+
+    alias_method :is_favorited?, :favorited_by?
+
+    # Lazy reader: the column is excluded from the default SELECT, so on first
+    # access we issue a focused 1-column query and cache the result on the instance.
+    def fav_string
+      return self[:fav_string] if has_attribute?(:fav_string)
+      return "" if new_record?
+      loaded = self.class.unscoped.where(id: id).pick(:fav_string) || ""
+      @attributes.write_from_database("fav_string", loaded)
+      loaded
+    end
+
+    # fav_string is kept in sync as a rollback safety net; the app no longer
+    # reads from it on the hot path. See FavoriteManager and TransferFavoritesJob for writers.
     def clean_fav_string!
       array = fav_string.split.uniq
       self.fav_string = array.join(" ")
       self.fav_count = array.size
     end
-
-    def favorited_by?(user_id = CurrentUser.id)
-      !!(fav_string =~ /(?:\A| )fav:#{user_id}(?:\Z| )/)
-    end
-
-    alias_method :is_favorited?, :favorited_by?
 
     def append_user_to_fav_string(user_id)
       # Regex is faster for large fav_strings, array include? is faster for small fav_strings.
@@ -1250,18 +1296,17 @@ class Post < ApplicationRecord
       end
     end
 
-    # users who favorited this post, ordered by users who favorited it first
+    # users who favorited this post, ordered by when they favorited it
     def favorited_users
-      favorited_user_ids = fav_string.scan(/\d+/).map(&:to_i)
+      favorited_user_ids = Favorite.where(post_id: id).order(:id).pluck(:user_id)
       visible_users = User.find(favorited_user_ids).reject(&:hide_favorites?)
-      ordered_users = visible_users.index_by(&:id).slice(*favorited_user_ids).values
-      ordered_users
+      visible_users.index_by(&:id).slice(*favorited_user_ids).values
     end
 
     def remove_from_favorites
+      user_ids = Favorite.where(post_id: id).pluck(:user_id)
       Favorite.where(post_id: id).delete_all
-      user_ids = fav_string.scan(/\d+/)
-      UserStatus.where(:user_id => user_ids).update_all("favorite_count = favorite_count - 1")
+      UserStatus.where(user_id: user_ids).update_all("favorite_count = favorite_count - 1") if user_ids.any?
     end
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,17 +5,11 @@ class Post < ApplicationRecord
   class DeletionError < Exception ; end
   class TimeoutError < Exception ; end
 
-  # Exclude fav_string from default SELECTs to avoid loading the (potentially huge)
-  # blob on every post fetch. Write paths transparently fall through to Post#fav_string,
-  # which lazy-loads the column from the DB on demand. See FavoriteMethods.
-  module DropSelectForAggregates
-    # Rails turns a multi-column explicit select into COUNT(col1, col2, ...) which
-    # PG rejects. Drop the select for aggregations; we never count fav_string anyway.
-    def calculate(*args)
-      select_values.any? ? unscope(:select).calculate(*args) : super
-    end
-  end
-  default_scope -> { extending(DropSelectForAggregates).select(column_names - %w[fav_string]) }
+  # fav_string is a denormalized blob that can grow unbounded with fav_count.
+  # Excluding it from the default attribute set keeps it out of every Post fetch.
+  # Reads go through Post#fav_string (lazy load); writes go through the
+  # write_fav_string! helper in FavoriteMethods.
+  self.ignored_columns += %w[fav_string]
 
   # Tags to copy when copying notes.
   NOTE_COPY_TAGS = %w[translated partially_translated translation_check translation_request].freeze
@@ -1250,50 +1244,56 @@ class Post < ApplicationRecord
 
     alias_method :is_favorited?, :favorited_by?
 
-    # Lazy reader: the column is excluded from the default SELECT, so on first
-    # access we issue a focused 1-column query and cache the result on the instance.
+    # Lazy reader: the column is ignored by AR (see ignored_columns at the top of
+    # this class), so on first access we issue a focused 1-column query and cache
+    # the result on the instance.
     def fav_string
-      return self[:fav_string] if has_attribute?(:fav_string)
-      return "" if new_record?
-      loaded = self.class.unscoped.where(id: id).pick(:fav_string) || ""
-      @attributes.write_from_database("fav_string", loaded)
-      loaded
+      return @fav_string unless @fav_string.nil?
+      @fav_string = new_record? ? "" : (self.class.unscoped.where(id: id).pick(:fav_string) || "")
+    end
+
+    def reload(*)
+      @fav_string = nil
+      super
     end
 
     # fav_string is kept in sync as a rollback safety net; the app no longer
     # reads from it on the hot path. See FavoriteManager and TransferFavoritesJob for writers.
     def clean_fav_string!
       array = fav_string.split.uniq
-      self.fav_string = array.join(" ")
-      self.fav_count = array.size
+      write_fav_string!(array.join(" "), array.size)
     end
 
     def append_user_to_fav_string(user_id)
       # Regex is faster for large fav_strings, array include? is faster for small fav_strings.
       # Checking for presence is faster than explicit deduplication for both approaches.
       if fav_count > 1000
-        unless fav_string =~ /(?:\A| )fav:#{user_id}(?:\Z| )/
-          self.fav_string = (fav_string + " fav:#{user_id}").strip
-          self.fav_count = fav_string.split.size
-        end
+        return if fav_string =~ /(?:\A| )fav:#{user_id}(?:\Z| )/
+        new_string = (fav_string + " fav:#{user_id}").strip
       else
         fav_array = fav_string.split
         fav_tag = "fav:#{user_id}"
-
-        unless fav_array.include?(fav_tag)
-          fav_array << fav_tag
-          self.fav_string = fav_array.join(" ")
-          self.fav_count = fav_array.size
-        end
+        return if fav_array.include?(fav_tag)
+        fav_array << fav_tag
+        new_string = fav_array.join(" ")
       end
+      write_fav_string!(new_string, new_string.split.size)
     end
 
     def delete_user_from_fav_string(user_id)
       new_fav_string = fav_string.gsub(/(?:\A| )fav:#{user_id}(?:\Z| )/, " ").strip
-      if new_fav_string != fav_string
-        self.fav_string = new_fav_string
-        self.fav_count = new_fav_string.split.size
-      end
+      return if new_fav_string == fav_string
+      write_fav_string!(new_fav_string, new_fav_string.split.size)
+    end
+
+    # Persist fav_string (an ignored column) and fav_count in a single SQL UPDATE.
+    # AR's attribute system doesn't know about fav_string, so we route the write
+    # through update_all. fav_count stays dirty afterwards so a follow-up
+    # post.save still triggers after_save callbacks (e.g. reindexing).
+    def write_fav_string!(new_string, new_count)
+      Post.unscoped.where(id: id).update_all(fav_string: new_string, fav_count: new_count) unless new_record?
+      @fav_string = new_string
+      self.fav_count = new_count
     end
 
     # users who favorited this post, ordered by when they favorited it
@@ -1421,9 +1421,36 @@ class Post < ApplicationRecord
   end
 
   module VoteMethods
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Bulk-populate the user's vote score for a collection of posts so that
+      # subsequent `vote_by(user_id)` calls return without hitting the DB.
+      def preload_vote_by!(posts, user_id)
+        posts = Array.wrap(posts).compact
+        return if posts.empty? || user_id.blank?
+
+        scores = PostVote.where(user_id: user_id, post_id: posts.map(&:id)).pluck(:post_id, :score).to_h
+        posts.each { |post| post.preset_vote_by(user_id, scores.fetch(post.id, 0)) }
+      end
+    end
+
+    def preset_vote_by(user_id, score)
+      @vote_by_cache ||= {}
+      @vote_by_cache[user_id] = score
+    end
+
     def own_vote(user = CurrentUser.user)
       return nil unless user
       votes.where("user_id = ?", user.id).first
+    end
+
+    # Returns -1, 0, or 1. A missing or locked PostVote both yield 0.
+    def vote_by(user_id = CurrentUser.id)
+      return 0 if user_id.blank?
+      cached = @vote_by_cache&.[](user_id)
+      return cached unless cached.nil?
+      PostVote.where(user_id: user_id, post_id: id).pick(:score) || 0
     end
   end
 
@@ -1822,7 +1849,7 @@ class Post < ApplicationRecord
     end
 
     def method_attributes
-      list = super + %i[has_sample has_visible_children children_ids pool_ids is_favorited?]
+      list = super + %i[has_sample has_visible_children children_ids pool_ids is_favorited? vote_by]
       if visible?
         list += %i[file_url sample_url preview_file_url]
       end
@@ -1848,6 +1875,7 @@ class Post < ApplicationRecord
         score: score,
         fav_count: fav_count,
         is_favorited: favorited_by?(CurrentUser.user.id),
+        vote: vote_by(CurrentUser.user.id),
         comment_count: comment_count,
 
         pools: pool_ids.join(" "),

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -66,6 +66,7 @@ class PostPresenter < Presenter
       tags: post.tag_string.split,
       locked_tags: post.locked_tags&.split || [],
       is_favorited: post.is_favorited?,
+      vote: post.vote_by,
     }
   end
 

--- a/spec/jobs/flush_favorites_job_spec.rb
+++ b/spec/jobs/flush_favorites_job_spec.rb
@@ -13,10 +13,7 @@ RSpec.describe FlushFavoritesJob do
   # Favorite.create! fires user_status_counter → UserStatus.favorite_count++
   def add_favorite(post, user)
     Favorite.create!(post_id: post.id, user_id: user.id)
-    post.update_columns(
-      fav_string: "#{post.fav_string} fav:#{user.id}".strip,
-      fav_count:  post.fav_count + 1,
-    )
+    post.write_fav_string!("#{post.fav_string} fav:#{user.id}".strip, post.fav_count + 1)
   end
 
   describe "#perform" do

--- a/spec/jobs/transfer_favorites_job_spec.rb
+++ b/spec/jobs/transfer_favorites_job_spec.rb
@@ -16,10 +16,7 @@ RSpec.describe TransferFavoritesJob do
   # Favorite.create! fires user_status_counter → UserStatus.favorite_count++
   def add_favorite(post, user)
     Favorite.create!(post_id: post.id, user_id: user.id)
-    post.update_columns(
-      fav_string: "#{post.fav_string} fav:#{user.id}".strip,
-      fav_count:  post.fav_count + 1,
-    )
+    post.write_fav_string!("#{post.fav_string} fav:#{user.id}".strip, post.fav_count + 1)
   end
 
   describe "#perform" do

--- a/spec/logical/favorite_manager_spec.rb
+++ b/spec/logical/favorite_manager_spec.rb
@@ -67,23 +67,6 @@ RSpec.describe FavoriteManager do
       end
     end
 
-    describe "orphaned Favorite record" do
-      before do
-        # Insert the Favorite row directly, leaving fav_string untouched.
-        # This simulates legacy data where the DB record exists but the
-        # denormalized fav_string was never updated.
-        Favorite.create!(user_id: user.id, post_id: post.id)
-      end
-
-      it "repairs the fav_string without raising" do
-        expect { FavoriteManager.add!(user: user, post: post) }.not_to raise_error
-      end
-
-      it "adds the user to the post fav_string" do
-        FavoriteManager.add!(user: user, post: post)
-        expect(post.reload.fav_string).to include("fav:#{user.id}")
-      end
-    end
   end
 
   describe ".remove!" do

--- a/spec/logical/favorite_manager_spec.rb
+++ b/spec/logical/favorite_manager_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe FavoriteManager do
           .to raise_error(Favorite::Error, /Failed to update post/)
       end
     end
-
   end
 
   describe ".remove!" do

--- a/spec/models/post/favorite_methods_spec.rb
+++ b/spec/models/post/favorite_methods_spec.rb
@@ -7,22 +7,86 @@ RSpec.describe Post do
 
   describe "FavoriteMethods" do
     describe "#favorited_by?" do
-      it "returns true when the user id is in fav_string" do
+      it "returns true when the user has favorited the post" do
         user = create(:user)
-        post = build(:post, fav_string: "fav:#{user.id}")
+        post = create(:post)
+        Favorite.create!(user_id: user.id, post_id: post.id)
         expect(post.favorited_by?(user.id)).to be true
       end
 
-      it "returns false when the user id is not in fav_string" do
+      it "returns false when the user has not favorited the post" do
         user = create(:user)
-        post = build(:post, fav_string: "")
+        post = create(:post)
         expect(post.favorited_by?(user.id)).to be false
       end
 
-      it "does not false-match partial user ids" do
-        # user_id 1 should not match "fav:10"
-        post = build(:post, fav_string: "fav:10")
-        expect(post.favorited_by?(1)).to be false
+      it "returns false for a blank user id" do
+        post = create(:post)
+        expect(post.favorited_by?(nil)).to be false
+      end
+
+      it "uses the preloaded cache instead of hitting the database" do
+        post = create(:post)
+        post.preset_favorited_status(42, true)
+        expect(Favorite).not_to receive(:exists?)
+        expect(post.favorited_by?(42)).to be true
+      end
+
+      it "uses the preloaded false value instead of hitting the database" do
+        post = create(:post)
+        post.preset_favorited_status(42, false)
+        expect(Favorite).not_to receive(:exists?)
+        expect(post.favorited_by?(42)).to be false
+      end
+    end
+
+    describe "#fav_string (lazy load)" do
+      it "is excluded from the default SELECT on Post.find" do
+        post = create(:post)
+        fresh = Post.find(post.id)
+        expect(fresh.has_attribute?(:fav_string)).to be false
+      end
+
+      it "lazy-loads the column on first read" do
+        post = create(:post)
+        post.update_columns(fav_string: "fav:42")
+        fresh = Post.find(post.id)
+        expect(fresh.fav_string).to eq("fav:42")
+        expect(fresh.has_attribute?(:fav_string)).to be true
+      end
+
+      it "returns empty string for a brand-new record" do
+        expect(Post.new.fav_string).to eq("")
+      end
+    end
+
+    describe ".preload_favorited_status!" do
+      it "marks favorited posts as favorited and others as not" do
+        user = create(:user)
+        favorited = create(:post)
+        other = create(:post)
+        Favorite.create!(user_id: user.id, post_id: favorited.id)
+
+        Post.preload_favorited_status!([favorited, other], user.id)
+        expect(favorited.favorited_by?(user.id)).to be true
+        expect(other.favorited_by?(user.id)).to be false
+      end
+
+      it "is a no-op for a blank user id" do
+        post = create(:post)
+        expect { Post.preload_favorited_status!([post], nil) }.not_to change { post.instance_variable_get(:@favorited_status_cache) }
+      end
+
+      it "is a no-op for an empty post list" do
+        expect { Post.preload_favorited_status!([], 1) }.not_to raise_error
+      end
+
+      it "accepts a single post" do
+        user = create(:user)
+        post = create(:post)
+        Favorite.create!(user_id: user.id, post_id: post.id)
+        Post.preload_favorited_status!(post, user.id)
+        expect(post.favorited_by?(user.id)).to be true
       end
     end
 
@@ -85,7 +149,7 @@ RSpec.describe Post do
       end
     end
 
-    describe "#append_user_to_fav_string — large fav_string path (fav_count > 1000)" do
+    describe "#append_user_to_fav_string, large fav_string path (fav_count > 1000)" do
       it "adds the user via regex branch and increments fav_count" do
         create(:user)
         # Build a fav_string with 1001 fake entries
@@ -112,11 +176,12 @@ RSpec.describe Post do
     end
 
     describe "#favorited_users" do
-      it "returns User objects for ids in fav_string, preserving order" do
+      it "returns User objects for users who favorited the post, ordered by when they favorited" do
         user1 = create(:user)
         user2 = create(:user)
         post = create(:post)
-        post.update_columns(fav_string: "fav:#{user1.id} fav:#{user2.id}")
+        Favorite.create!(user_id: user1.id, post_id: post.id)
+        Favorite.create!(user_id: user2.id, post_id: post.id)
         result = post.favorited_users
         expect(result.map(&:id)).to eq([user1.id, user2.id])
       end
@@ -127,7 +192,8 @@ RSpec.describe Post do
         privacy_flag = User.flag_value_for("enable_privacy_mode")
         hidden_user.update_columns(bit_prefs: privacy_flag)
         post = create(:post)
-        post.update_columns(fav_string: "fav:#{visible_user.id} fav:#{hidden_user.id}")
+        Favorite.create!(user_id: visible_user.id, post_id: post.id)
+        Favorite.create!(user_id: hidden_user.id, post_id: post.id)
 
         # Switch to a member (non-moderator) so hide_favorites? can return true
         viewer = create(:user)
@@ -137,6 +203,29 @@ RSpec.describe Post do
         result = post.favorited_users
         expect(result.map(&:id)).to include(visible_user.id)
         expect(result.map(&:id)).not_to include(hidden_user.id)
+      end
+    end
+
+    describe "#remove_from_favorites" do
+      it "deletes all Favorite records for the post" do
+        user_a = create(:user)
+        user_b = create(:user)
+        post = create(:post)
+        Favorite.create!(user_id: user_a.id, post_id: post.id)
+        Favorite.create!(user_id: user_b.id, post_id: post.id)
+        expect { post.remove_from_favorites }.to change { Favorite.where(post_id: post.id).count }.from(2).to(0)
+      end
+
+      it "decrements favorite_count for each user who had favorited the post" do
+        user = create(:user)
+        post = create(:post)
+        Favorite.create!(user_id: user.id, post_id: post.id)
+        expect { post.remove_from_favorites }.to change { user.user_status.reload.favorite_count }.by(-1)
+      end
+
+      it "does nothing when no favorites exist" do
+        post = create(:post)
+        expect { post.remove_from_favorites }.not_to raise_error
       end
     end
   end

--- a/spec/models/post/favorite_methods_spec.rb
+++ b/spec/models/post/favorite_methods_spec.rb
@@ -28,20 +28,22 @@ RSpec.describe Post do
       it "uses the preloaded cache instead of hitting the database" do
         post = create(:post)
         post.preset_favorited_status(42, true)
-        expect(Favorite).not_to receive(:exists?)
+        allow(Favorite).to receive(:exists?)
         expect(post.favorited_by?(42)).to be true
+        expect(Favorite).not_to have_received(:exists?)
       end
 
       it "uses the preloaded false value instead of hitting the database" do
         post = create(:post)
         post.preset_favorited_status(42, false)
-        expect(Favorite).not_to receive(:exists?)
+        allow(Favorite).to receive(:exists?)
         expect(post.favorited_by?(42)).to be false
+        expect(Favorite).not_to have_received(:exists?)
       end
     end
 
     describe "#fav_string (lazy load)" do
-      it "is excluded from the default SELECT on Post.find" do
+      it "is excluded from the model's attribute set" do
         post = create(:post)
         fresh = Post.find(post.id)
         expect(fresh.has_attribute?(:fav_string)).to be false
@@ -49,10 +51,9 @@ RSpec.describe Post do
 
       it "lazy-loads the column on first read" do
         post = create(:post)
-        post.update_columns(fav_string: "fav:42")
+        post.write_fav_string!("fav:42", 1)
         fresh = Post.find(post.id)
         expect(fresh.fav_string).to eq("fav:42")
-        expect(fresh.has_attribute?(:fav_string)).to be true
       end
 
       it "returns empty string for a brand-new record" do
@@ -74,7 +75,7 @@ RSpec.describe Post do
 
       it "is a no-op for a blank user id" do
         post = create(:post)
-        expect { Post.preload_favorited_status!([post], nil) }.not_to change { post.instance_variable_get(:@favorited_status_cache) }
+        expect { Post.preload_favorited_status!([post], nil) }.not_to(change { post.instance_variable_get(:@favorited_status_cache) })
       end
 
       it "is a no-op for an empty post list" do
@@ -93,21 +94,22 @@ RSpec.describe Post do
     describe "#append_user_to_fav_string" do
       it "adds a fav: entry for the user" do
         user = create(:user)
-        post = build(:post, fav_string: "")
+        post = create(:post)
         post.append_user_to_fav_string(user.id)
         expect(post.fav_string).to include("fav:#{user.id}")
       end
 
       it "increments fav_count" do
         user = create(:user)
-        post = build(:post, fav_string: "", fav_count: 0)
+        post = create(:post)
         post.append_user_to_fav_string(user.id)
         expect(post.fav_count).to eq(1)
       end
 
       it "does not add the same user twice" do
         user = create(:user)
-        post = build(:post, fav_string: "fav:#{user.id}", fav_count: 1)
+        post = create(:post)
+        post.write_fav_string!("fav:#{user.id}", 1)
         post.append_user_to_fav_string(user.id)
         expect(post.fav_string.scan("fav:#{user.id}").size).to eq(1)
         expect(post.fav_count).to eq(1)
@@ -117,14 +119,16 @@ RSpec.describe Post do
     describe "#delete_user_from_fav_string" do
       it "removes the fav: entry for the user" do
         user = create(:user)
-        post = build(:post, fav_string: "fav:#{user.id}", fav_count: 1)
+        post = create(:post)
+        post.write_fav_string!("fav:#{user.id}", 1)
         post.delete_user_from_fav_string(user.id)
         expect(post.fav_string).not_to include("fav:#{user.id}")
       end
 
       it "decrements fav_count" do
         user = create(:user)
-        post = build(:post, fav_string: "fav:#{user.id}", fav_count: 1)
+        post = create(:post)
+        post.write_fav_string!("fav:#{user.id}", 1)
         post.delete_user_from_fav_string(user.id)
         expect(post.fav_count).to eq(0)
       end
@@ -132,7 +136,8 @@ RSpec.describe Post do
       it "does nothing when the user is not in fav_string" do
         user = create(:user)
         other = create(:user)
-        post = build(:post, fav_string: "fav:#{other.id}", fav_count: 1)
+        post = create(:post)
+        post.write_fav_string!("fav:#{other.id}", 1)
         post.delete_user_from_fav_string(user.id)
         expect(post.fav_string).to include("fav:#{other.id}")
         expect(post.fav_count).to eq(1)
@@ -142,7 +147,8 @@ RSpec.describe Post do
     describe "#clean_fav_string!" do
       it "removes duplicate fav entries and recalculates fav_count" do
         user = create(:user)
-        post = build(:post, fav_string: "fav:#{user.id} fav:#{user.id}", fav_count: 2)
+        post = create(:post)
+        post.write_fav_string!("fav:#{user.id} fav:#{user.id}", 2)
         post.clean_fav_string!
         expect(post.fav_string.scan("fav:#{user.id}").size).to eq(1)
         expect(post.fav_count).to eq(1)
@@ -151,11 +157,9 @@ RSpec.describe Post do
 
     describe "#append_user_to_fav_string, large fav_string path (fav_count > 1000)" do
       it "adds the user via regex branch and increments fav_count" do
-        create(:user)
-        # Build a fav_string with 1001 fake entries
         large_fav_string = (1..1001).map { |i| "fav:#{i}" }.join(" ")
-        post = build(:post, fav_string: large_fav_string, fav_count: 1001)
-        # Append a new user that is definitely not in the string
+        post = create(:post)
+        post.write_fav_string!(large_fav_string, 1001)
         new_id = 999_999
         post.append_user_to_fav_string(new_id)
         expect(post.fav_string).to include("fav:#{new_id}")
@@ -166,9 +170,9 @@ RSpec.describe Post do
         existing_id = 999_999
         other_ids = (1..1000).map { |i| i }
         large_fav_string = ([existing_id] + other_ids).map { |i| "fav:#{i}" }.join(" ")
-        post = build(:post, fav_string: large_fav_string, fav_count: 1001)
+        post = create(:post)
+        post.write_fav_string!(large_fav_string, 1001)
         post.append_user_to_fav_string(existing_id)
-        # Count exact occurrences using word-boundary regex (same as the model uses)
         matches = post.fav_string.scan(/(?:\A| )fav:#{existing_id}(?:\Z| )/)
         expect(matches.size).to eq(1)
         expect(post.fav_count).to eq(1001)

--- a/spec/models/post/vote_methods_spec.rb
+++ b/spec/models/post/vote_methods_spec.rb
@@ -25,5 +25,86 @@ RSpec.describe Post do
         expect(post.own_vote(nil)).to be_nil
       end
     end
+
+    describe "#vote_by" do
+      it "returns 0 when the user has not voted" do
+        user = create(:user)
+        post = create(:post)
+        expect(post.vote_by(user.id)).to eq(0)
+      end
+
+      it "returns the score when the user has upvoted" do
+        user = create(:user)
+        post = create(:post)
+        PostVote.create!(post: post, user: user, score: 1)
+        expect(post.vote_by(user.id)).to eq(1)
+      end
+
+      it "returns the score when the user has downvoted" do
+        vote = create(:down_post_vote)
+        expect(vote.post.vote_by(vote.user_id)).to eq(-1)
+      end
+
+      it "returns 0 for a locked vote (score: 0)" do
+        user = create(:user)
+        post = create(:post)
+        PostVote.create!(post: post, user: user, score: 0)
+        expect(post.vote_by(user.id)).to eq(0)
+      end
+
+      it "returns 0 for a blank user id" do
+        post = create(:post)
+        expect(post.vote_by(nil)).to eq(0)
+      end
+
+      it "uses the preloaded cache instead of hitting the database" do
+        post = create(:post)
+        post.preset_vote_by(42, 1)
+        allow(PostVote).to receive(:where)
+        expect(post.vote_by(42)).to eq(1)
+        expect(PostVote).not_to have_received(:where)
+      end
+
+      it "uses a preloaded 0 instead of hitting the database" do
+        post = create(:post)
+        post.preset_vote_by(42, 0)
+        allow(PostVote).to receive(:where)
+        expect(post.vote_by(42)).to eq(0)
+        expect(PostVote).not_to have_received(:where)
+      end
+    end
+
+    describe ".preload_vote_by!" do
+      it "primes the cache with the user's vote scores for the given posts" do
+        user = create(:user, created_at: 4.days.ago)
+        upvoted = create(:post)
+        downvoted = create(:post)
+        unvoted = create(:post)
+        PostVote.create!(post: upvoted, user: user, score: 1)
+        PostVote.create!(post: downvoted, user: user, score: -1)
+
+        Post.preload_vote_by!([upvoted, downvoted, unvoted], user.id)
+        expect(upvoted.vote_by(user.id)).to eq(1)
+        expect(downvoted.vote_by(user.id)).to eq(-1)
+        expect(unvoted.vote_by(user.id)).to eq(0)
+      end
+
+      it "is a no-op for a blank user id" do
+        post = create(:post)
+        expect { Post.preload_vote_by!([post], nil) }.not_to(change { post.instance_variable_get(:@vote_by_cache) })
+      end
+
+      it "is a no-op for an empty post list" do
+        expect { Post.preload_vote_by!([], 1) }.not_to raise_error
+      end
+
+      it "accepts a single post" do
+        user = create(:user)
+        post = create(:post)
+        PostVote.create!(post: post, user: user, score: 1)
+        Post.preload_vote_by!(post, user.id)
+        expect(post.vote_by(user.id)).to eq(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
Removes `fav_string` from the Posts query, since it is potentially large and bad for performance, as well as complicated to maintain. Instead replaces it with querying the Favorites table directly. 

`fav_string` is not dropped from the table, and is currently still being written when a user favorites a post. This is a safety measure to ensure we can rollback with zero migration. A future PR can remove `fav_string` completely.

Additionally, we also query for post votes. `vote` is now available on the post json as an integer of `[-1, 0, 1]`. 

A follow up of this could be to allow users to blacklist their own voted posts. This could potentially be very convenient for users who do not wish to see posts they have downvoted.