### PR TITLE
[Comments] Add vote to comment payloads

### DIFF
--- a/app/blueprints/comment_blueprint.rb
+++ b/app/blueprints/comment_blueprint.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Rubocop does not understand the Blueprinter block syntax
+# rubocop:disable Style/SymbolProc
+
+class CommentBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :created_at, :updated_at, :post_id, :creator_id, :body, :score,
+         :updater_id, :do_not_bump_post, :is_hidden, :is_sticky,
+         :warning_type, :warning_user_id
+
+  field :creator_name do |comment|
+    comment.creator_name
+  end
+
+  field :updater_name do |comment|
+    comment.updater_name
+  end
+
+  field :vote do |comment|
+    comment.vote_by
+  end
+end
+
+# rubocop:enable Style/SymbolProc

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,8 +21,8 @@ class CommentsController < ApplicationController
   def show
     @comment = Comment.find(params[:id])
     check_accessible(@comment, bypass_user_settings: true)
-    @comment_votes = CommentVote.for_comments_and_user([@comment.id], CurrentUser.id)
-    respond_with(@comment)
+    Comment.preload_vote_by!(@comment, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    respond_with_comment(@comment)
   end
 
   def search
@@ -30,8 +30,8 @@ class CommentsController < ApplicationController
 
   def for_post
     @post = Post.find(params[:id])
-    @comments = @post.comments.includes(:creator, :updater)
-    @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
+    @comments = @post.comments.includes(:creator, :updater).to_a
+    Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     comment_html = render_to_string partial: "comments/partials/show/comment", collection: @comments, locals: { post: @post }, formats: [:html]
     respond_with do |format|
       format.json do
@@ -42,19 +42,19 @@ class CommentsController < ApplicationController
 
   def new
     @comment = Comment.new(comment_params(:create))
-    respond_with(@comment)
+    respond_with_comment(@comment)
   end
 
   def edit
     @comment = Comment.find(params[:id])
     check_editable(@comment)
-    respond_with(@comment)
+    respond_with_comment(@comment)
   end
 
   def create
     @comment = Comment.create(comment_params(:create))
     flash[:notice] = @comment.valid? ? "Comment posted" : @comment.errors.full_messages.join("; ")
-    respond_with(@comment) do |format|
+    respond_with_comment(@comment) do |format|
       format.html do
         redirect_back fallback_location: @comment.post || comments_path
       end
@@ -65,27 +65,27 @@ class CommentsController < ApplicationController
     @comment = Comment.find(params[:id])
     check_editable(@comment)
     @comment.update(comment_params(:update))
-    respond_with(@comment, location: post_path(@comment.post_id))
+    respond_with_comment(@comment, location: post_path(@comment.post_id))
   end
 
   def destroy
     @comment = Comment.find(params[:id])
     @comment.destroy
-    respond_with(@comment)
+    respond_with_comment(@comment)
   end
 
   def hide
     @comment = Comment.find(params[:id])
     check_hidable(@comment)
     @comment.hide!
-    respond_with(@comment)
+    respond_with_comment(@comment)
   end
 
   def unhide
     @comment = Comment.find(params[:id])
     check_hidable(@comment)
     @comment.unhide!
-    respond_with(@comment)
+    respond_with_comment(@comment)
   end
 
   def warning
@@ -95,7 +95,7 @@ class CommentsController < ApplicationController
     else
       @comment.user_warned!(params[:record_type], CurrentUser.user)
     end
-    @comment_votes = CommentVote.for_comments_and_user([@comment.id], CurrentUser.id)
+    Comment.preload_vote_by!(@comment, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     html = render_to_string partial: "comments/partials/show/comment", locals: { comment: @comment, post: nil }, formats: [:html]
     render json: { html: html, posts: deferred_posts }
   end
@@ -107,7 +107,7 @@ class CommentsController < ApplicationController
     @posts = Post.includes(:uploader).includes(comments: %i[creator updater]).tag_match("#{tags} order:comment_bumped").paginate(params[:page], limit: 5, search_count: params[:search])
 
     @comments = @posts.to_h { |post| [post.id, post.comments.above_threshold.includes(:creator, :updater).recent.reverse] }
-    @comment_votes = CommentVote.for_comments_and_user(CurrentUser.id ? @comments.values.flatten.map(&:id) : [], CurrentUser.id)
+    Comment.preload_vote_by!(@comments.values.flatten, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     respond_with(@posts)
   end
 
@@ -126,14 +126,23 @@ class CommentsController < ApplicationController
     @comments = @comments.above_threshold unless search_params[:id]
     @comments = @comments.paginate(params[:page], limit: params[:limit], search_count: search_params_for_count)
 
-    @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
+    Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
 
     if CurrentUser.is_staff?
       ids = @comments&.map(&:id)
       @latest = request.params.merge(page: "b#{ids[0] + 1}") if ids.present?
     end
 
-    respond_with(@comments)
+    respond_with(@comments) do |format|
+      format.json { render json: CommentBlueprint.render_as_hash(@comments, collection: true) }
+    end
+  end
+
+  def respond_with_comment(record, **opts, &block)
+    respond_with(record, **opts) do |format|
+      format.json { render json: CommentBlueprint.render_as_hash(record) }
+      block&.call(format)
+    end
   end
 
   def check_accessible(comment, bypass_user_settings: false)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,11 +77,10 @@ class PostsController < ApplicationController
     @has_samples = @post.is_image? || @post.video_sample_list[:has]
 
     if request.format.html? && @post.comment_count > 0
-      @comments = @post.comments.above_threshold.includes(:creator, :updater)
-      @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
+      @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
+      Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     else
       @comments = Comment.none
-      @comment_votes = CommentVote.none
     end
 
     respond_with(@post) do |format|
@@ -105,11 +104,10 @@ class PostsController < ApplicationController
     @children_post_set = PostSets::PostRelationship.new(@post.id, include_deleted: include_deleted, want_parent: false)
 
     if request.format.html? && @post.comment_count > 0
-      @comments = @post.comments.above_threshold.includes(:creator, :updater)
-      @comment_votes = CommentVote.for_comments_and_user(@comments.map(&:id), CurrentUser.id)
+      @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
+      Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     else
       @comments = Comment.none
-      @comment_votes = CommentVote.none
     end
 
     @fixup_post_url = true

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 module CommentsHelper
-  def comment_vote_block(comment, vote)
+  def comment_vote_block(comment)
     return if comment.is_sticky
 
-    voted = !vote.nil?
-    vote_score = voted ? vote.score : 0
+    vote_score = comment.vote_by
     score_tag = tag.li(comment.score, class: "comment-score #{score_class(comment.score)}", id: "comment-score-#{comment.id}")
 
     if CurrentUser.is_member?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -249,8 +249,38 @@ class Comment < ApplicationRecord
     end
   end
 
+  module VoteMethods
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      # Bulk-populate the user's vote score for a collection of comments so that
+      # subsequent `vote_by(user_id)` calls return without hitting the DB.
+      def preload_vote_by!(comments, user_id)
+        comments = Array.wrap(comments).compact
+        return if comments.empty? || user_id.blank?
+
+        scores = CommentVote.where(user_id: user_id, comment_id: comments.map(&:id)).pluck(:comment_id, :score).to_h
+        comments.each { |comment| comment.preset_vote_by(user_id, scores.fetch(comment.id, 0)) }
+      end
+    end
+
+    def preset_vote_by(user_id, score)
+      @vote_by_cache ||= {}
+      @vote_by_cache[user_id] = score
+    end
+
+    # Returns -1, 0, or 1. A missing or locked CommentVote both yield 0.
+    def vote_by(user_id = CurrentUser.id)
+      return 0 if user_id.blank?
+      cached = @vote_by_cache&.[](user_id)
+      return cached unless cached.nil?
+      CommentVote.where(user_id: user_id, comment_id: id).pick(:score) || 0
+    end
+  end
+
   extend SearchMethods
   include AccessMethods
+  include VoteMethods
 
   def validate_post_exists
     errors.add(:post, "must exist") unless Post.exists?(post_id)
@@ -305,7 +335,7 @@ class Comment < ApplicationRecord
   end
 
   def method_attributes
-    super + %i[creator_name updater_name]
+    super + %i[creator_name updater_name vote_by]
   end
 
   def hide!

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -335,7 +335,7 @@ class Comment < ApplicationRecord
   end
 
   def method_attributes
-    super + %i[creator_name updater_name vote_by]
+    super + %i[creator_name updater_name]
   end
 
   def hide!

--- a/app/models/comment_vote.rb
+++ b/app/models/comment_vote.rb
@@ -4,11 +4,6 @@ class CommentVote < UserVote
   validate :validate_user_can_vote
   validate :validate_comment_can_be_voted
 
-  def self.for_comments_and_user(comment_ids, user_id)
-    return {} unless user_id
-    CommentVote.where(comment_id: comment_ids, user_id: user_id).index_by(&:comment_id)
-  end
-
   def self.model_creator_column
     :creator
   end

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -45,7 +45,7 @@
             <li><%= tag.a "Delete", href: '#', class: 'comment-delete-link' %></li>
           <% end %>
           <li>|</li>
-          <%= comment_vote_block(comment, @comment_votes[comment.id]) %>
+          <%= comment_vote_block(comment) %>
           <% if CurrentUser.is_moderator? %>
             <li><%= link_to "(List)", controller: 'comment_votes', search: { comment_id: comment.id } %></li>
           <% end %>

--- a/spec/models/comment/vote_methods_spec.rb
+++ b/spec/models/comment/vote_methods_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Comment do
+  include_context "as admin"
+
+  describe "VoteMethods" do
+    describe "#vote_by" do
+      it "returns 0 when the user has not voted" do
+        user    = create(:user)
+        comment = create(:comment)
+        expect(comment.vote_by(user.id)).to eq(0)
+      end
+
+      it "returns the score when the user has upvoted" do
+        vote = create(:comment_vote)
+        expect(vote.comment.vote_by(vote.user_id)).to eq(1)
+      end
+
+      it "returns the score when the user has downvoted" do
+        vote = create(:down_comment_vote)
+        expect(vote.comment.vote_by(vote.user_id)).to eq(-1)
+      end
+
+      it "returns 0 for a locked vote (score: 0)" do
+        vote = create(:locked_comment_vote)
+        expect(vote.comment.vote_by(vote.user_id)).to eq(0)
+      end
+
+      it "returns 0 for a blank user id" do
+        comment = create(:comment)
+        expect(comment.vote_by(nil)).to eq(0)
+      end
+
+      it "uses the preloaded cache instead of hitting the database" do
+        comment = create(:comment)
+        comment.preset_vote_by(42, 1)
+        allow(CommentVote).to receive(:where)
+        expect(comment.vote_by(42)).to eq(1)
+        expect(CommentVote).not_to have_received(:where)
+      end
+
+      it "uses a preloaded 0 instead of hitting the database" do
+        comment = create(:comment)
+        comment.preset_vote_by(42, 0)
+        allow(CommentVote).to receive(:where)
+        expect(comment.vote_by(42)).to eq(0)
+        expect(CommentVote).not_to have_received(:where)
+      end
+    end
+
+    describe ".preload_vote_by!" do
+      it "primes the cache with the user's vote scores for the given comments" do
+        upvote     = create(:comment_vote)
+        downvote   = create(:down_comment_vote, user: upvote.user)
+        unvoted    = create(:comment)
+
+        Comment.preload_vote_by!([upvote.comment, downvote.comment, unvoted], upvote.user_id)
+        expect(upvote.comment.vote_by(upvote.user_id)).to eq(1)
+        expect(downvote.comment.vote_by(upvote.user_id)).to eq(-1)
+        expect(unvoted.vote_by(upvote.user_id)).to eq(0)
+      end
+
+      it "is a no-op for a blank user id" do
+        comment = create(:comment)
+        expect { Comment.preload_vote_by!([comment], nil) }.not_to(change { comment.instance_variable_get(:@vote_by_cache) })
+      end
+
+      it "is a no-op for an empty comment list" do
+        expect { Comment.preload_vote_by!([], 1) }.not_to raise_error
+      end
+
+      it "accepts a single comment" do
+        vote = create(:comment_vote)
+        Comment.preload_vote_by!(vote.comment, vote.user_id)
+        expect(vote.comment.vote_by(vote.user_id)).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/models/comment_vote/instance_methods_spec.rb
+++ b/spec/models/comment_vote/instance_methods_spec.rb
@@ -22,40 +22,4 @@ RSpec.describe CommentVote do
       expect(CommentVote.model_creator_column).to eq(:creator)
     end
   end
-
-  describe ".for_comments_and_user" do
-    it "returns a hash keyed by comment_id for the given user" do
-      voter   = create(:user)
-      vote_a  = create(:comment_vote, user: voter)
-      vote_b  = create(:comment_vote, user: voter)
-
-      result = CommentVote.for_comments_and_user([vote_a.comment_id, vote_b.comment_id], voter.id)
-
-      expect(result).to be_a(Hash)
-      expect(result[vote_a.comment_id]).to eq(vote_a)
-      expect(result[vote_b.comment_id]).to eq(vote_b)
-    end
-
-    it "excludes votes from other users" do
-      voter       = create(:user)
-      other_voter = create(:user)
-      vote        = create(:comment_vote, user: voter)
-      _other      = create(:comment_vote, user: other_voter, comment: vote.comment)
-
-      result = CommentVote.for_comments_and_user([vote.comment_id], voter.id)
-      expect(result[vote.comment_id]).to eq(vote)
-    end
-
-    it "returns an empty hash when user_id is nil" do
-      vote   = create(:comment_vote)
-      result = CommentVote.for_comments_and_user([vote.comment_id], nil)
-      expect(result).to eq({})
-    end
-
-    it "returns an empty hash when the comment list is empty" do
-      voter  = create(:user)
-      result = CommentVote.for_comments_and_user([], voter.id)
-      expect(result).to eq({})
-    end
-  end
 end

--- a/spec/requests/comments_controller_spec.rb
+++ b/spec/requests/comments_controller_spec.rb
@@ -134,6 +134,21 @@ RSpec.describe CommentsController do
       get comment_path(-1)
       expect(response).to have_http_status(:not_found)
     end
+
+    it "includes the current user's vote in the JSON payload" do
+      voter = create(:user)
+      CurrentUser.scoped(voter) { create(:comment_vote, comment: comment, user: voter, score: 1) }
+      sign_in_as voter
+      get comment_path(comment, format: :json)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body["vote"]).to eq(1)
+    end
+
+    it "returns 0 for the vote field when the current user has not voted" do
+      sign_in_as other_member
+      get comment_path(comment, format: :json)
+      expect(response.parsed_body["vote"]).to eq(0)
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a `vote` integer to the comment json, which the query already paid for.
To call this field "vote", we also introduce a real blueprint for comments. 