### PR TITLE
[Users] Fix an N+1 query issues on the profile page

### DIFF
--- a/app/logical/post_sets/favorites.rb
+++ b/app/logical/post_sets/favorites.rb
@@ -4,11 +4,12 @@ module PostSets
   class Favorites < PostSets::Base
     attr_reader :page, :limit
 
-    def initialize(user, page, limit:)
+    def initialize(user, page, limit:, post_count: nil)
       super()
       @user = user
       @page = page
       @limit = limit
+      @post_count = post_count
     end
 
     def tag_string

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -67,7 +67,7 @@ class UserPresenter
   end
 
   def uploads
-    Post.tag_match("user:#{user.name}").limit(8)
+    PostSets::Post.new("user:#{user.name}", 1, limit: 8).posts
   end
 
   def has_uploads?
@@ -75,8 +75,7 @@ class UserPresenter
   end
 
   def favorites
-    ids = Favorite.where(user_id: user.id).order(created_at: :desc).limit(8).pluck(:post_id)
-    Post.where(id: ids).sort_by { |post| ids.index(post.id) }
+    PostSets::Favorites.new(@user, 1, limit: 8).posts
   end
 
   def has_favorites?
@@ -87,7 +86,7 @@ class UserPresenter
     # Almost all verified artists only have one artist tag.
     # If this changes, we may need to come up with a way to bulk search for posts with any of the artist's tags.
     @artist_posts_cache ||= {}
-    @artist_posts_cache[artist.id] ||= Post.tag_match(artist.name).limit(8)
+    @artist_posts_cache[artist.id] ||= PostSets::Post.new(artist.name, 1, limit: 8).posts
   end
 
   def upload_count(template)

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -75,7 +75,7 @@ class UserPresenter
   end
 
   def favorites
-    PostSets::Favorites.new(@user, 1, limit: 8).posts
+    PostSets::Favorites.new(user, 1, limit: 8, post_count: user.favorite_count).posts
   end
 
   def has_favorites?


### PR DESCRIPTION
The post summary section was fetching uploader data in separate queries for some reason.