### PR TITLE
[WikiPages] Fix N+1 query problem in "recent changes" list

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -14,7 +14,7 @@ class WikiPage < ApplicationRecord
   after_destroy :clear_recent_changes_cache
   after_save :create_version
   after_save :update_help_page, if: :saved_change_to_title?
-  after_save :clear_recent_changes_cache, if: :wiki_page_changed?
+  after_save :clear_recent_changes_cache
 
   normalizes :body, with: ->(body) { body.gsub("\r\n", "\n") }
 

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -58,8 +58,10 @@ class WikiPage < ApplicationRecord
       where("is_deleted = false")
     end
 
-    def recent
-      order("updated_at DESC").limit(25)
+    def recent_changes
+      Cache.fetch("wiki_page:recent_changes", expires_in: 1.hour) do
+        order(updated_at: :desc).includes(:tag).limit(25).to_a
+      end
     end
 
     def other_names_include(name)

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -11,8 +11,10 @@ class WikiPage < ApplicationRecord
   before_create :create_tag
   before_destroy :validate_not_used_as_help_page
   before_destroy :log_destroy
+  after_destroy :clear_recent_changes_cache
   after_save :create_version
   after_save :update_help_page, if: :saved_change_to_title?
+  after_save :clear_recent_changes_cache, if: :wiki_page_changed?
 
   normalizes :body, with: ->(body) { body.gsub("\r\n", "\n") }
 
@@ -59,7 +61,7 @@ class WikiPage < ApplicationRecord
     end
 
     def recent_changes
-      Cache.fetch("wiki_page:recent_changes", expires_in: 1.hour) do
+      Cache.fetch("wiki_page:recent_changes", expires_in: 15.minutes) do
         order(updated_at: :desc).includes(:tag).limit(25).to_a
       end
     end
@@ -371,5 +373,9 @@ class WikiPage < ApplicationRecord
         match
       end
     end.map { |x| x.downcase.tr(" ", "_").to_s }.uniq
+  end
+
+  def clear_recent_changes_cache
+    Cache.delete("wiki_page:recent_changes")
   end
 end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -62,7 +62,7 @@ class WikiPage < ApplicationRecord
 
     def recent_changes
       Cache.fetch("wiki_page:recent_changes", expires_in: 15.minutes) do
-        order(updated_at: :desc).includes(:tag).limit(25).to_a
+        select(:id, :title, :updated_at).order(updated_at: :desc).includes(:tag).limit(25).to_a
       end
     end
 

--- a/app/views/wiki_pages/_recent_changes.html.erb
+++ b/app/views/wiki_pages/_recent_changes.html.erb
@@ -1,7 +1,7 @@
 <section>
   <h1>Recent Changes (<%= link_to "all", wiki_pages_path(:order => "time") %>)</h1>
   <ul>
-    <% WikiPage.recent.each do |page| %>
+    <% WikiPage.recent_changes.each do |page| %>
       <li class="category-<%= page.category_id %>"><%= link_to page.pretty_title, wiki_page_path(page) %></li>
     <% end %>
   </ul>

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -368,8 +368,7 @@ CREATE TABLE public.bans (
     banner_id integer NOT NULL,
     expires_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    force_logout boolean DEFAULT false NOT NULL
+    updated_at timestamp without time zone NOT NULL
 );
 
 
@@ -5336,7 +5335,6 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260519151649'),
-('20260517202346'),
 ('20260505163626'),
 ('20260503072727'),
 ('20260501134813'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -368,7 +368,8 @@ CREATE TABLE public.bans (
     banner_id integer NOT NULL,
     expires_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    force_logout boolean DEFAULT false NOT NULL
 );
 
 
@@ -5335,6 +5336,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260519151649'),
+('20260517202346'),
 ('20260505163626'),
 ('20260503072727'),
 ('20260501134813'),

--- a/spec/models/wiki_page/class_methods_spec.rb
+++ b/spec/models/wiki_page/class_methods_spec.rb
@@ -88,21 +88,30 @@ RSpec.describe WikiPage do
   end
 
   # -------------------------------------------------------------------------
-  # .recent
+  # .recent_changes
   # -------------------------------------------------------------------------
-  describe ".recent" do
+  describe ".recent_changes" do
+    after { Cache.delete("wiki_page:recent_changes") }
+
     it "returns at most 25 records" do
       26.times { create(:wiki_page) }
-      expect(WikiPage.recent.count).to eq(25)
+      expect(WikiPage.recent_changes.count).to eq(25)
     end
 
     it "orders results by updated_at descending" do
       older = create(:wiki_page)
       newer = create(:wiki_page)
       newer.update_columns(updated_at: 1.minute.from_now)
-      results = WikiPage.recent
+      results = WikiPage.recent_changes
       expect(results.first).to eq(newer)
       expect(results).to include(older)
+    end
+
+    it "includes associated tags to avoid N+1 queries" do
+      tag = create(:high_post_count_tag)
+      page = create(:wiki_page, title: tag.name)
+      expect(WikiPage.recent_changes).to include(page)
+      expect(page.association(:tag)).to be_loaded
     end
   end
 

--- a/spec/models/wiki_page/class_methods_spec.rb
+++ b/spec/models/wiki_page/class_methods_spec.rb
@@ -111,7 +111,18 @@ RSpec.describe WikiPage do
       tag = create(:high_post_count_tag)
       page = create(:wiki_page, title: tag.name)
       expect(WikiPage.recent_changes).to include(page)
-      expect(page.association(:tag)).to be_loaded
+
+      result = WikiPage.recent_changes.find { |p| p == page }
+      expect(result.association(:tag)).to be_loaded
+    end
+
+    it "ensures that cache is properly invalidated when a wiki page is updated" do
+      page = create(:wiki_page)
+      expect(WikiPage.recent_changes).to include(page)
+
+      other = create(:wiki_page)
+      expect(WikiPage.recent_changes).to include(other)
+      expect(WikiPage.recent_changes).to include(page)
     end
   end
 


### PR DESCRIPTION
Wiki page links required the tag's category to be fetched.
It was fetching those categories one tag at a time.

Also slapped some basic caching onto it, for good measure.