### PR TITLE
[Posts] Fix exception in post editor for anonymous users

### DIFF
--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -578,7 +578,7 @@ Post.initialize_post_sections = function () {
     return urls.every(url => isUrlValid(url, ignoreUrls));
   };
 
-  const splitUrls = urls => urls.split(/\r?\n/);
+  const splitUrls = urls => urls?.split(/\r?\n/) || [];
 
   const oldSources = splitUrls($("input[name='post[old_source]']").val());
   const invalidOldSources = oldSources.filter(url => !isUrlValid(url));

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -1,5 +1,6 @@
 import Hotkeys from "@/core/hotkeys";
 import PostVote from "@/models/PostVote";
+import User from "@/models/User";
 import Page from "@/utility/Page";
 import LStorage from "@/utility/storage";
 import SVGIcon from "@/utility/SVGIcon";
@@ -538,6 +539,8 @@ Post.initialize_change_resize_mode_link = function () {
 
 Post._isEditing = false;
 Post.initialize_post_sections = function () {
+  if (User.is.anonymous) return;
+
   $("#side-edit-link, #post-edit-link, #menu-post-edit-link, #post-edit-close").on("click.danbooru", (event) => {
     event.preventDefault(); // Only one of these is a link
     Post._isEditing = !Post._isEditing;


### PR DESCRIPTION
The editor form fields don't exist for anonymous users, which causes an exception.

`$("input[name='post[old_source]']").val()` returns `undefined`, which causes an exception in `splitUrls()`.