### PR TITLE
[PostFlags] Fix bugs regarding resolved/unresolved and deletion flags

### DIFF
--- a/app/controllers/deleted_posts_controller.rb
+++ b/app/controllers/deleted_posts_controller.rb
@@ -8,7 +8,7 @@ class DeletedPostsController < ApplicationController
       @user = User.find(params[:user_id])
       @posts = Post.where(is_deleted: true)
       @posts = @posts.where(uploader_id: @user.id)
-      @posts = @posts.includes(:uploader).includes(:flags).where.not(post_flags: { id: nil }).order(Arel.sql("post_flags.created_at DESC")).paginate(params[:page])
+      @posts = @posts.includes(:uploader).includes(:flags).where.not(post_flags: { id: nil }).order(post_flags: { created_at: :desc }).paginate(params[:page])
     else
       post_flags = PostFlag.where(is_deletion: true, is_resolved: false).includes(post: %i[uploader flags]).order(id: :desc).paginate(params[:page])
       new_opts = { pagination_mode: :numbered, records_per_page: post_flags.records_per_page, total_count: post_flags.total_count, current_page: post_flags.current_page }

--- a/app/controllers/deleted_posts_controller.rb
+++ b/app/controllers/deleted_posts_controller.rb
@@ -8,9 +8,9 @@ class DeletedPostsController < ApplicationController
       @user = User.find(params[:user_id])
       @posts = Post.where(is_deleted: true)
       @posts = @posts.where(uploader_id: @user.id)
-      @posts = @posts.includes(:uploader).includes(:flags).where("post_flags.id IS NOT NULL").order(Arel.sql("post_flags.created_at DESC")).paginate(params[:page])
+      @posts = @posts.includes(:uploader).includes(:flags).where.not(post_flags: { id: nil }).order(Arel.sql("post_flags.created_at DESC")).paginate(params[:page])
     else
-      post_flags = PostFlag.where(is_deletion: true).includes(post: [:uploader, :flags]).order(id: :desc).paginate(params[:page])
+      post_flags = PostFlag.where(is_deletion: true, is_resolved: false).includes(post: %i[uploader flags]).order(id: :desc).paginate(params[:page])
       new_opts = { pagination_mode: :numbered, records_per_page: post_flags.records_per_page, total_count: post_flags.total_count, current_page: post_flags.current_page }
       @posts = ::Danbooru::Paginator::PaginatedArray.new(post_flags.map(&:post), new_opts)
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1663,11 +1663,11 @@ class Post < ApplicationRecord
     end
 
     def deletion_flag
-      flags.order(id: :desc).first
+      flags.unresolved.where(is_deletion: true).order(id: :desc).first
     end
 
     def pending_flag
-      flags.unresolved.order(id: :desc).first
+      flags.unresolved.where(is_deletion: false).order(id: :desc).first
     end
 
     def substitute_deletion_dmail_template(text, reason = nil)

--- a/spec/models/post/deletion_methods_spec.rb
+++ b/spec/models/post/deletion_methods_spec.rb
@@ -124,21 +124,53 @@ RSpec.describe Post do
     end
 
     describe "#deletion_flag" do
-      it "returns nil when no flags exist" do
+      it "returns nil when no deletion flags exist" do
         post = create(:post)
         expect(post.deletion_flag).to be_nil
       end
 
-      it "returns the most recent PostFlag" do
+      it "returns nil when only non-deletion flags exist" do
+        post = create(:post)
+        create(:post_flag, post: post)
+        expect(post.deletion_flag).to be_nil
+      end
+
+      it "returns nil when only resolved deletion flags exist" do
         post = create(:post)
         post.delete!("First reason")
-        expect(post.deletion_flag).to be_a(PostFlag)
+        post.undelete!
+        create(:post_flag, post: post)
+        expect(post.deletion_flag).to be_nil
+      end
+
+      it "returns the deletion PostFlag" do
+        post = create(:post)
+        post.delete!("First reason")
+        deletion = post.deletion_flag
+        expect(deletion).to be_a(PostFlag)
+        expect(deletion&.reason).to eq("First reason")
+      end
+
+      it "returns the most recent deletion PostFlag" do
+        post = create(:post)
+        post.delete!("First reason")
+        post.undelete!
+        post.delete!("Second reason")
+        deletion = post.deletion_flag
+        expect(deletion).to be_a(PostFlag)
+        expect(deletion&.reason).to eq("Second reason")
       end
     end
 
     describe "#pending_flag" do
       it "returns nil when no unresolved flags exist" do
         post = create(:post)
+        expect(post.pending_flag).to be_nil
+      end
+
+      it "returns nil for a deletion flag" do
+        post = create(:post)
+        post.delete!("Reason")
         expect(post.pending_flag).to be_nil
       end
 
@@ -207,6 +239,18 @@ RSpec.describe Post do
         post.delete!("bogus")
         result = post.substitute_deletion_dmail_template("Post #%FLAG_ID%")
         expect(result).to include(post.deletion_flag.id.to_s)
+      end
+
+      it "substitutes %FLAG_ID% with the latest deletion flag id" do
+        post = create(:post)
+        post.delete!("bogus")
+        first_id = post.deletion_flag.id.to_s
+        post.undelete!
+        post.delete!("bogus2")
+        second_id = post.deletion_flag.id.to_s
+        result = post.substitute_deletion_dmail_template("Post #%FLAG_ID%")
+        expect(result).not_to include(first_id)
+        expect(result).to include(second_id)
       end
 
       it "substitutes %REASON% when a reason is provided" do


### PR DESCRIPTION
Basically `deletion_flag` and `pending_flag` would return irrelevant flags in some cases, so fix those and add tests.

These fixes broke the deleted post index, so I had a look at that. Turns out the deleted post index repeats posts for every deletion flag, resolved or not, so fix the query so it only shows a post once for the most recent (unresolved) deletion. This also makes it so undeleted posts no longer show up in the deleted index. I assume that's OK?