### PR TITLE
[Appeals] Nicer error handling when a flag can't be appealed

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -23,6 +23,11 @@ class AppealsController < ApplicationController
 
   def new
     @appeal = Appeal.new(qtype: params[:qtype], disp_id: params[:disp_id])
+    unless @appeal.can_create_for?(CurrentUser.user)
+      redirect_to appeals_path, alert: "This deletion can't be appealed or has already been resolved."
+      return
+    end
+
     @existing_similar = Appeal
                         .visible(CurrentUser.user)
                         .where({
@@ -33,8 +38,6 @@ class AppealsController < ApplicationController
                         })
                         .order(created_at: :desc)
                         .limit(5)
-
-    check_new_permission(@appeal)
   end
 
   def create

--- a/spec/requests/appeals_controller_spec.rb
+++ b/spec/requests/appeals_controller_spec.rb
@@ -94,10 +94,11 @@ RSpec.describe AppealsController do
       expect(response).to redirect_to(new_session_path(url: new_appeal_path))
     end
 
-    it "returns 403 for a member who is not the post uploader" do
+    it "redirects to the appeals index for a member who is not the post uploader" do
       sign_in_as other_member
       get new_appeal_path(qtype: "flag", disp_id: post_flag.id)
-      expect(response).to have_http_status(:forbidden)
+      expect(response).to redirect_to(appeals_path)
+      expect(flash[:alert]).to eq("This deletion can't be appealed or has already been resolved.")
     end
 
     it "returns 200 for the post uploader" do


### PR DESCRIPTION
Instead of a "Access Denied" page, give an alert and return the user to the appeal index.

<img width="1430" height="164" alt="image" src="https://github.com/user-attachments/assets/d224012e-5959-48e8-8e69-a700c5d917e0" />

This is most likely to happen when clicking an appeal link in a deletion DMail, when the deletion has already been resolved.