### PR TITLE
[DMails] Allow all staff to see DMails from the automoderator

### DIFF
--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -240,8 +240,8 @@ class Dmail < ApplicationRecord
   end
 
   def visible_to?(user)
-    return true if user.is_janitor? && to_id == User.system.id
-    return true if user.is_moderator? && (from_id == User.system.id || Ticket.where(qtype: "dmail", disp_id: id).exists?)
+    return true if user.is_janitor? && (from_id == User.system.id || to_id == User.system.id)
+    return true if user.is_moderator? && Ticket.where(qtype: "dmail", disp_id: id).exists?
     return true if user.is_admin? && (to.is_admin? || from.is_admin?)
     owner_id == user.id
   end

--- a/spec/models/dmail/permissions_spec.rb
+++ b/spec/models/dmail/permissions_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Dmail do
   let(:sender)    { create(:user) }
   let(:recipient) { create(:user) }
   let(:other)     { create(:user) }
+  let(:janitor) { create(:janitor_user) }
   let(:moderator) { create(:moderator_user) }
   let(:admin)     { create(:admin_user) }
 
@@ -48,15 +49,31 @@ RSpec.describe Dmail do
     end
 
     # -------------------------------------------------------------------------
+    # Janitor special access
+    # -------------------------------------------------------------------------
+    describe "janitor access" do
+      it "is visible to a janitor when the dmail is from the system user" do
+        dmail = create(:dmail, from: User.system, to: recipient, owner: recipient,
+                               bypass_limits: true, no_email_notification: true)
+        expect(dmail.visible_to?(janitor)).to be true
+      end
+
+      it "is visible to a janitor when the dmail is to the system user" do
+        dmail = create(:dmail, from: sender, to: User.system, owner: User.system,
+                               bypass_limits: true, no_email_notification: true)
+        expect(dmail.visible_to?(janitor)).to be true
+      end
+
+      it "is not visible to a janitor for a regular user-to-user dmail they do not own" do
+        dmail = make_dmail
+        expect(dmail.visible_to?(janitor)).to be false
+      end
+    end
+
+    # -------------------------------------------------------------------------
     # Moderator special access
     # -------------------------------------------------------------------------
     describe "moderator access" do
-      it "is visible to a moderator when the dmail is from the system user" do
-        dmail = create(:dmail, from: User.system, to: recipient, owner: recipient,
-                               bypass_limits: true, no_email_notification: true)
-        expect(dmail.visible_to?(moderator)).to be true
-      end
-
       it "is not visible to a moderator for a regular user-to-user dmail they do not own" do
         dmail = make_dmail
         expect(dmail.visible_to?(moderator)).to be false


### PR DESCRIPTION
I think this makes sense for a few reasons:
- If you can see replies to the auto moderator DMails, then you can almost always see the original sent message, so this asymmetry is kind of weird to begin with.
- As far as I can tell, automod DMails don't contain sensitive information (user replies to the automod are more likely to do so).
- The auto moderator sends DMails in behalf of janitors (deletion DMails), so it makes to allow them to be able to see those.
- Simpler logic.

Anecdotally, I've had a user asking for help on Discord send me a link to their deletion DMail. It would've been practical to have had access to it.