### PR TITLE
[Posts] Fix an error raised if the source has an ambiguous path

### DIFF
--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -23,6 +23,10 @@ module PostsHelper
     # This will do a better job at handling technically invalid URLs like
     # http:example.com, http:/example.com or just example.com
     url = Addressable::URI.heuristic_parse(source)
+
+    # Ensure the URL can be re-assembled and is valid
+    return nil if url.omit(:scheme).to_s.empty?
+
     # Only allow http:// and https:// links. Disallow javascript: links.
     if %w[http https].include?(url.scheme)
       url

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -69,6 +69,24 @@ RSpec.describe PostsHelper do
 
       it { is_expected.to be_nil }
     end
+
+    context "when the url only contains a protocol" do
+      let(:path) { "http:" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the url contains multiple protocols" do
+      let(:path) { "http:http://example.com" }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when it contains malformed a protocol" do
+      let(:path) { "https:://example.com/" }
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe "#post_source_tag" do

--- a/spec/helpers/posts_helper_spec.rb
+++ b/spec/helpers/posts_helper_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe PostsHelper do
       it { is_expected.to be_nil }
     end
 
-    context "when it contains malformed a protocol" do
+    context "when it contains a malformed protocol" do
       let(:path) { "https:://example.com/" }
 
       it { is_expected.to be_nil }


### PR DESCRIPTION
Fixes crashes on some legacy malformed sources. Examples:
`https:https://www.furaffinity.net/view/59537722/` more than one protocol
`https:://www.newgrounds.com/art/view/elvche/hotdogs-p58` malformed protocol
`http:` only the protocol