### PR TITLE
[PostVersions] Improve readability

### DIFF
--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -7,6 +7,7 @@ class PostVersionsController < ApplicationController
 
   def index
     @post_versions = PostVersion.search(search_params).paginate(params[:page], limit: params[:limit], max_count: 10_000, search_count: params[:search], includes: [:updater, { post: [:versions] }])
+    PostVersion.preload_tag_categories!(@post_versions)
     if CurrentUser.is_staff?
       ids = @post_versions&.map(&:id)
       @latest = request.params.merge(page: "b#{ids[0] + 1}") if ids.present?

--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -186,7 +186,7 @@ module LinkHelper
 
   def decorated_link_to(text, path, **)
     link_to(path, class: "decorated", **) do
-      favicon_for_link(path) + text
+      favicon_for_link(path) + tag.span(text)
     end
   end
 

--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -18,7 +18,7 @@ module PostVersionsHelper
       changes << tag.div(tag.del(diff_source_link("-", source)))
     end
 
-    tag.span(safe_join(changes, " "), class: "diff-list")
+    tag.div(safe_join(changes, " "), class: "diff-list")
   end
 
   def diff_source_link(sign, source)

--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -3,16 +3,19 @@
 module PostVersionsHelper
   def post_source_diff(post_version)
     diff = post_version.diff_sources(post_version.previous)
-    changes = []
+    new_sources = post_version.source.to_s.split("\n")
+    added = diff[:added_sources].to_set
 
-    diff[:added_sources].each do |source|
-      changes << tag.div(tag.ins(diff_source_link("+", source)))
+    changes = new_sources.map do |source|
+      if added.include?(source)
+        tag.div(tag.ins(diff_source_link("+", source)))
+      else
+        tag.div(post_source_tag(source))
+      end
     end
+
     diff[:removed_sources].each do |source|
       changes << tag.div(tag.del(diff_source_link("-", source)))
-    end
-    diff[:unchanged_sources].each do |source|
-      changes << tag.div(post_source_tag(source))
     end
 
     tag.span(safe_join(changes, " "), class: "diff-list")

--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -12,27 +12,14 @@ module PostVersionsHelper
       changes << tag.div(tag.del(diff_source_link("-", source)))
     end
     diff[:unchanged_sources].each do |source|
-      changes << tag.div(source_link(source))
+      changes << tag.div(post_source_tag(source))
     end
 
     tag.span(safe_join(changes, " "), class: "diff-list")
   end
 
-  def wordbreak_source(string)
-    lines = string.scan(/.{1,10}/)
-    safe_join(lines, tag.wbr)
-  end
-
-  def source_link(source)
-    if source =~ %r!\Ahttps?://!i
-      link_to(wordbreak_source(source), source, rel: "nofollow")
-    else
-      wordbreak_source(source)
-    end
-  end
-
   def diff_source_link(sign, source)
-    safe_join([tag.span(sign, class: "diff-sign"), source_link(source)])
+    safe_join([tag.span(sign, class: "diff-sign"), post_source_tag(source)])
   end
 
   def post_version_diff(post_version)

--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -28,7 +28,7 @@ module PostVersionsHelper
   def post_version_diff(post_version)
     diff = post_version.diff(post_version.previous)
     all_names = (diff[:added_tags] + diff[:removed_tags] + diff[:unchanged_tags]).sort
-    categories = Tag.categories_for(all_names)
+    categories = post_version.tag_categories
     added = diff[:added_tags].to_set
     removed = diff[:removed_tags].to_set
     obsolete_added = diff[:obsolete_added_tags].to_set
@@ -52,8 +52,7 @@ module PostVersionsHelper
   def post_version_locked_diff(post_version)
     diff = post_version.diff(post_version.previous)
     all_names = (diff[:added_locked_tags] + diff[:removed_locked_tags] + diff[:unchanged_locked_tags]).sort
-    lookup_names = all_names.map { |t| trim_leading_minus(t) }
-    categories = Tag.categories_for(lookup_names)
+    categories = post_version.tag_categories
     added = diff[:added_locked_tags].to_set
     removed = diff[:removed_locked_tags].to_set
 

--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -6,13 +6,13 @@ module PostVersionsHelper
     changes = []
 
     diff[:added_sources].each do |source|
-      changes << tag.div(tag.ins(wordbreak_source("+#{source}")))
+      changes << tag.div(tag.ins(diff_source_link("+", source)))
     end
     diff[:removed_sources].each do |source|
-      changes << tag.div(tag.del(wordbreak_source("-#{source}")))
+      changes << tag.div(tag.del(diff_source_link("-", source)))
     end
     diff[:unchanged_sources].each do |source|
-      changes << tag.div(wordbreak_source(source))
+      changes << tag.div(source_link(source))
     end
 
     tag.span(safe_join(changes, " "), class: "diff-list")
@@ -23,20 +23,37 @@ module PostVersionsHelper
     safe_join(lines, tag.wbr)
   end
 
+  def source_link(source)
+    if source =~ %r!\Ahttps?://!i
+      link_to(wordbreak_source(source), source, rel: "nofollow")
+    else
+      wordbreak_source(source)
+    end
+  end
+
+  def diff_source_link(sign, source)
+    safe_join([tag.span(sign, class: "diff-sign"), source_link(source)])
+  end
+
   def post_version_diff(post_version)
     diff = post_version.diff(post_version.previous)
-    changes = []
+    all_names = (diff[:added_tags] + diff[:removed_tags] + diff[:unchanged_tags]).sort
+    categories = Tag.categories_for(all_names)
+    added = diff[:added_tags].to_set
+    removed = diff[:removed_tags].to_set
+    obsolete_added = diff[:obsolete_added_tags].to_set
+    obsolete_removed = diff[:obsolete_removed_tags].to_set
 
-    diff[:added_tags].each do |tag_name|
-      classes = diff[:obsolete_added_tags].include?(tag_name) ? "obsolete" : ""
-      changes << tag.ins(link_to_wiki_or_new("+#{tag_name}", tag_name), class: classes)
-    end
-    diff[:removed_tags].each do |tag_name|
-      classes = diff[:obsolete_removed_tags].include?(tag_name) ? "obsolete" : ""
-      changes << tag.del(link_to_wiki_or_new("-#{tag_name}", tag_name), class: classes)
-    end
-    diff[:unchanged_tags].each do |tag_name|
-      changes << tag.span(link_to_wiki_or_new(tag_name))
+    changes = all_names.map do |tag_name|
+      if added.include?(tag_name)
+        classes = obsolete_added.include?(tag_name) ? "obsolete" : nil
+        tag.ins(diff_tag_link("+", tag_name, tag_name, categories), class: classes)
+      elsif removed.include?(tag_name)
+        classes = obsolete_removed.include?(tag_name) ? "obsolete" : nil
+        tag.del(diff_tag_link("-", tag_name, tag_name, categories), class: classes)
+      else
+        tag.span(category_tag_link(tag_name, tag_name, categories))
+      end
     end
 
     tag.span(safe_join(changes, " "), class: "diff-list")
@@ -44,22 +61,36 @@ module PostVersionsHelper
 
   def post_version_locked_diff(post_version)
     diff = post_version.diff(post_version.previous)
-    changes = []
+    all_names = (diff[:added_locked_tags] + diff[:removed_locked_tags] + diff[:unchanged_locked_tags]).sort
+    lookup_names = all_names.map { |t| trim_leading_minus(t) }
+    categories = Tag.categories_for(lookup_names)
+    added = diff[:added_locked_tags].to_set
+    removed = diff[:removed_locked_tags].to_set
 
-    diff[:added_locked_tags].each do |tag_name|
-      changes << tag.ins(link_to_wiki_or_new("+#{tag_name}", trim_leading_minus(tag_name)))
-    end
-    diff[:removed_locked_tags].each do |tag_name|
-      changes << tag.del(link_to_wiki_or_new("-#{tag_name}", trim_leading_minus(tag_name)))
-    end
-    diff[:unchanged_locked_tags].each do |tag_name|
-      changes << tag.span(link_to_wiki_or_new(tag_name, trim_leading_minus(tag_name)))
+    changes = all_names.map do |tag_name|
+      lookup = trim_leading_minus(tag_name)
+      if added.include?(tag_name)
+        tag.ins(diff_tag_link("+", tag_name, lookup, categories))
+      elsif removed.include?(tag_name)
+        tag.del(diff_tag_link("-", tag_name, lookup, categories))
+      else
+        tag.span(category_tag_link(tag_name, lookup, categories))
+      end
     end
 
     tag.span(safe_join(changes, " "), class: "diff-list")
   end
 
   private
+
+  def diff_tag_link(sign, display_name, lookup_name, categories)
+    safe_join([tag.span(sign, class: "diff-sign"), category_tag_link(display_name, lookup_name, categories)])
+  end
+
+  def category_tag_link(text, tag_name, categories)
+    category = categories[tag_name] || 0
+    link_to(text, show_or_new_wiki_pages_path(title: tag_name), class: "tag-type-#{category}")
+  end
 
   def trim_leading_minus(str)
     str.start_with?("-") ? str[1..] : str

--- a/app/javascript/src/styles/common/diffs.scss
+++ b/app/javascript/src/styles/common/diffs.scss
@@ -25,27 +25,49 @@
 }
 
 .diff-list {
-  ins, ins a {
+  ins, del {
+    text-decoration: none;
+    margin-right: 0.25em;
+    padding: 0 0.2em;
+    border-radius: 0.15em;
+  }
+
+  ins {
+    background-color: rgba(46, 160, 67, 0.32);
+  }
+
+  del {
+    background-color: rgba(248, 81, 73, 0.32);
+  }
+
+  .diff-sign {
+    margin-right: 0.15em;
+    font-weight: bold;
+  }
+
+  ins .diff-sign {
     color: $diff-tag-added-color;
-    text-decoration: none;
-    margin-right: 0.5em;
   }
 
-  del, del a {
+  del .diff-sign {
     color: $diff-tag-removed-color;
-    text-decoration: none;
-    margin-right: 0.5em;
   }
 
-  ins.obsolete, ins.obsolete a {
-    text-decoration: line-through;
-    color: $diff-tag-added-obsolete-color;
+  ins.obsolete {
+    background-color: rgba(110, 130, 70, 0.4);
   }
 
-  del.obsolete, del.obsolete a {
+  del.obsolete {
+    background-color: rgba(150, 80, 80, 0.4);
+  }
+
+  ins.obsolete, del.obsolete {
+    opacity: 0.75;
+  }
+
+  ins.obsolete a, del.obsolete a {
     text-decoration: line-through;
-    color: $diff-tag-removed-obsolete-color;
-  }  
+  }
 }
 
 // diffy

--- a/app/javascript/src/styles/common/diffs.scss
+++ b/app/javascript/src/styles/common/diffs.scss
@@ -25,9 +25,12 @@
 }
 
 .diff-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.125rem 0.5rem;
+
   ins, del {
     text-decoration: none;
-    margin-right: 0.25em;
     padding: 0 0.2em;
     border-radius: 0.15em;
   }

--- a/app/javascript/src/styles/specific/post_versions.scss
+++ b/app/javascript/src/styles/specific/post_versions.scss
@@ -157,6 +157,10 @@ div#c-post-versions {
       grid-row: 4;
       @include grid-col(10, 14);
       overflow-wrap: anywhere;
+
+      .diff-list {
+        display: block;
+      }
     }
 
     .pv-actions {

--- a/app/javascript/src/styles/specific/post_versions.scss
+++ b/app/javascript/src/styles/specific/post_versions.scss
@@ -159,7 +159,19 @@ div#c-post-versions {
       overflow-wrap: anywhere;
 
       .diff-list {
-        display: block;
+        display: flex;
+        flex-flow: column;
+
+        ins, del {
+          white-space: nowrap;
+        }
+
+        a.decorated {
+          white-space: nowrap;
+          span { white-space: normal; }
+          .link-decoration { margin: -0.2em 4px -0.2em 0; }
+        }
+        s { white-space: normal }
       }
     }
 

--- a/app/javascript/src/styles/specific/post_versions.scss
+++ b/app/javascript/src/styles/specific/post_versions.scss
@@ -156,6 +156,7 @@ div#c-post-versions {
     .pv-sources {
       grid-row: 4;
       @include grid-col(10, 14);
+      overflow-wrap: anywhere;
     }
 
     .pv-actions {

--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -79,6 +79,31 @@ class PostVersion < ApplicationRecord
     (locked_tags || "").split
   end
 
+  # Bulk-populate tag category lookups for a collection of post versions so
+  # subsequent #tag_categories calls reuse one round-trip instead of one per version.
+  def self.preload_tag_categories!(versions)
+    versions = Array.wrap(versions).compact
+    return if versions.empty?
+
+    names = versions.flat_map(&:diff_tag_names).uniq
+    categories = Tag.categories_for(names)
+    versions.each { |pv| pv.preset_tag_categories(categories) }
+  end
+
+  def preset_tag_categories(categories)
+    @tag_categories = categories
+  end
+
+  def tag_categories
+    @tag_categories ||= Tag.categories_for(diff_tag_names)
+  end
+
+  def diff_tag_names
+    d = diff(previous)
+    d[:added_tags] + d[:removed_tags] + d[:unchanged_tags] +
+      (d[:added_locked_tags] + d[:removed_locked_tags] + d[:unchanged_locked_tags]).map { |t| t.start_with?("-") ? t[1..] : t }
+  end
+
   def presenter
     PostVersionPresenter.new(self)
   end

--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -100,8 +100,8 @@ class PostVersion < ApplicationRecord
 
   def diff_tag_names
     d = diff(previous)
-    d[:added_tags] + d[:removed_tags] + d[:unchanged_tags] +
-      (d[:added_locked_tags] + d[:removed_locked_tags] + d[:unchanged_locked_tags]).map { |t| t.start_with?("-") ? t[1..] : t }
+    (d[:added_tags] + d[:removed_tags] + d[:unchanged_tags] +
+      (d[:added_locked_tags] + d[:removed_locked_tags] + d[:unchanged_locked_tags]).map { |t| t.start_with?("-") ? t[1..] : t }).uniq
   end
 
   def presenter

--- a/spec/models/post_version/class_methods_spec.rb
+++ b/spec/models/post_version/class_methods_spec.rb
@@ -97,13 +97,15 @@ RSpec.describe PostVersion do
 
   describe ".preload_tag_categories!" do
     it "does nothing when given an empty collection" do
-      expect(Tag).not_to receive(:categories_for)
+      allow(Tag).to receive(:categories_for)
       PostVersion.preload_tag_categories!([])
+      expect(Tag).not_to have_received(:categories_for)
     end
 
     it "compacts nils from the given collection" do
-      expect(Tag).not_to receive(:categories_for)
+      allow(Tag).to receive(:categories_for)
       PostVersion.preload_tag_categories!([nil, nil])
+      expect(Tag).not_to have_received(:categories_for)
     end
 
     it "makes a single Tag.categories_for call covering tag names from all versions" do
@@ -113,8 +115,9 @@ RSpec.describe PostVersion do
       v2 = create(:post_version, post: post, tags: "alpha beta")
       v3 = create(:post_version, post: post, tags: "beta gamma")
 
-      expect(Tag).to receive(:categories_for).once.and_call_original
+      allow(Tag).to receive(:categories_for).and_call_original
       PostVersion.preload_tag_categories!([v2, v3])
+      expect(Tag).to have_received(:categories_for).once
     end
 
     it "presets the resolved categories on each version" do

--- a/spec/models/post_version/class_methods_spec.rb
+++ b/spec/models/post_version/class_methods_spec.rb
@@ -90,4 +90,43 @@ RSpec.describe PostVersion do
       expect(pv.updater_ip_addr.to_s).to eq(CurrentUser.ip_addr)
     end
   end
+
+  # ------------------------------------------------------------------ #
+  # .preload_tag_categories!                                             #
+  # ------------------------------------------------------------------ #
+
+  describe ".preload_tag_categories!" do
+    it "does nothing when given an empty collection" do
+      expect(Tag).not_to receive(:categories_for)
+      PostVersion.preload_tag_categories!([])
+    end
+
+    it "compacts nils from the given collection" do
+      expect(Tag).not_to receive(:categories_for)
+      PostVersion.preload_tag_categories!([nil, nil])
+    end
+
+    it "makes a single Tag.categories_for call covering tag names from all versions" do
+      post = create(:post)
+      v1 = post.versions.first
+      v1.update_columns(tags: "alpha")
+      v2 = create(:post_version, post: post, tags: "alpha beta")
+      v3 = create(:post_version, post: post, tags: "beta gamma")
+
+      expect(Tag).to receive(:categories_for).once.and_call_original
+      PostVersion.preload_tag_categories!([v2, v3])
+    end
+
+    it "presets the resolved categories on each version" do
+      post = create(:post)
+      v1 = post.versions.first
+      v1.update_columns(tags: "alpha")
+      v2 = create(:post_version, post: post, tags: "alpha beta")
+
+      resolved = { "alpha" => 1, "beta" => 4 }
+      allow(Tag).to receive(:categories_for).and_return(resolved)
+      PostVersion.preload_tag_categories!([v2])
+      expect(v2.tag_categories).to eq(resolved)
+    end
+  end
 end

--- a/spec/models/post_version/instance_methods_spec.rb
+++ b/spec/models/post_version/instance_methods_spec.rb
@@ -173,8 +173,9 @@ RSpec.describe PostVersion do
     it "returns the preset hash without hitting Tag.categories_for" do
       pv = build(:post_version)
       pv.preset_tag_categories({ "alpha" => 1 })
-      expect(Tag).not_to receive(:categories_for)
+      allow(Tag).to receive(:categories_for)
       expect(pv.tag_categories).to eq({ "alpha" => 1 })
+      expect(Tag).not_to have_received(:categories_for)
     end
 
     it "falls back to Tag.categories_for(diff_tag_names) when not preset" do

--- a/spec/models/post_version/instance_methods_spec.rb
+++ b/spec/models/post_version/instance_methods_spec.rb
@@ -139,4 +139,49 @@ RSpec.describe PostVersion do
   #     expect(pv.presenter).to be_a(PostVersionPresenter)
   #   end
   # end
+
+  # ------------------------------------------------------------------ #
+  # #diff_tag_names                                                      #
+  # ------------------------------------------------------------------ #
+
+  describe "#diff_tag_names" do
+    it "includes added, removed, and unchanged tags from the diff" do
+      post = create(:post)
+      v1   = post.versions.first
+      v1.update_columns(tags: "alpha beta")
+      v2 = create(:post_version, post: post, tags: "alpha gamma")
+      expect(v2.diff_tag_names).to include("alpha", "beta", "gamma")
+    end
+
+    # Locked tags use a "-name" prefix to mean "lock this tag OFF" (see Post#normalize_tags).
+    # The category lookup needs the real tag name, so the leading minus is stripped.
+    it "strips a leading minus from locked tag names" do
+      post = create(:post)
+      v1   = post.versions.first
+      v1.update_columns(locked_tags: "-cub")
+      v2 = create(:post_version, post: post, locked_tags: "")
+      expect(v2.diff_tag_names).to include("cub")
+      expect(v2.diff_tag_names).not_to include("-cub")
+    end
+  end
+
+  # ------------------------------------------------------------------ #
+  # #tag_categories                                                      #
+  # ------------------------------------------------------------------ #
+
+  describe "#tag_categories" do
+    it "returns the preset hash without hitting Tag.categories_for" do
+      pv = build(:post_version)
+      pv.preset_tag_categories({ "alpha" => 1 })
+      expect(Tag).not_to receive(:categories_for)
+      expect(pv.tag_categories).to eq({ "alpha" => 1 })
+    end
+
+    it "falls back to Tag.categories_for(diff_tag_names) when not preset" do
+      pv = build(:post_version)
+      allow(pv).to receive(:diff_tag_names).and_return(%w[alpha beta])
+      allow(Tag).to receive(:categories_for).with(%w[alpha beta]).and_return({ "alpha" => 1, "beta" => 4 })
+      expect(pv.tag_categories).to eq({ "alpha" => 1, "beta" => 4 })
+    end
+  end
 end


### PR DESCRIPTION
Post versions are very hard to read, and very hard to moderate. 

To make this easier, and surface important moderation information (such as, does this meet our tagging standards), we add category colors.
Since tags are now easier to distinguish, we retain them in their alphabetical order, to help users anchor their view. 
Categories are loaded once per page. The increase in page loading time is minimal. 
We also update the look of URLs to match what is displayed on the post detail page.

<img width="2515" height="1227" alt="image" src="https://github.com/user-attachments/assets/f947f326-eb55-485a-b0d9-ad9b01aa3afd" />
