### PR TITLE
[IpAddrs] Fix errors caused by broken templates and unguarded inputs

### DIFF
--- a/app/controllers/moderator/ip_addrs_controller.rb
+++ b/app/controllers/moderator/ip_addrs_controller.rb
@@ -8,13 +8,18 @@ module Moderator
     rescue_from IpAddrSearch::InvalidIpAddr, with: :render_invalid_ip_addr
 
     def index
-      search = IpAddrSearch.new(params[:search])
+      search = IpAddrSearch.new(params[:search] || {})
       @results = search.execute
       respond_with(@results)
     end
 
     def export
-      search = IpAddrSearch.new(params[:search].merge({with_history: true}))
+      unless params[:search].present? && (params[:search][:user_id].present? || params[:search][:user_name].present?)
+        render json: [], status: 200
+        return
+      end
+
+      search = IpAddrSearch.new((params[:search] || {}).merge({with_history: true}))
       @results = search.execute
       respond_with(@results) do |format|
         format.json do

--- a/app/views/moderator/ip_addrs/_ip_listing.json.erb
+++ b/app/views/moderator/ip_addrs/_ip_listing.json.erb
@@ -1,1 +1,1 @@
-<%= raw @results.map {|ip_addr, count| {ip_addr: ip_addr.to_s, count: count}}.to_json %>
+<%= raw @results.to_json %>

--- a/app/views/moderator/ip_addrs/index.json.erb
+++ b/app/views/moderator/ip_addrs/index.json.erb
@@ -1,5 +1,5 @@
 <% if params[:search][:user_id].present? || params[:search][:user_name].present? %>
-  <%= render "ip_listing.json" %>
+  <%= render "ip_listing" %>
 <% else %>
-  <%= render "user_listing.json" %>
+  <%= render "user_listing" %>
 <% end %>

--- a/app/views/moderator/ip_addrs/index.json.erb
+++ b/app/views/moderator/ip_addrs/index.json.erb
@@ -1,5 +1,7 @@
 <% if params[:search][:user_id].present? || params[:search][:user_name].present? %>
   <%= render "ip_listing" %>
-<% else %>
+<% elsif params[:search][:ip_addr].present? %>
   <%= render "user_listing" %>
+<% else %>
+  {}
 <% end %>

--- a/spec/requests/moderator/ip_addrs_controller_spec.rb
+++ b/spec/requests/moderator/ip_addrs_controller_spec.rb
@@ -32,15 +32,11 @@ RSpec.describe Moderator::IpAddrsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    # FIXME: The controller passes params[:search] directly to IpAddrSearch.new.
-    # When no search params are given, params[:search] is nil, causing
-    # nil[:user_id] to raise NoMethodError. This test is commented out until
-    # the controller guards against a nil search hash.
-    # it "returns 200 for an admin with no search params" do
-    #   sign_in_as admin
-    #   get moderator_ip_addrs_path
-    #   expect(response).to have_http_status(:ok)
-    # end
+    it "returns 200 for an admin with no search params" do
+      sign_in_as admin
+      get moderator_ip_addrs_path
+      expect(response).to have_http_status(:ok)
+    end
 
     context "as an admin" do
       before { sign_in_as admin }
@@ -51,14 +47,16 @@ RSpec.describe Moderator::IpAddrsController do
           expect(response).to have_http_status(:ok)
         end
 
-        # FIXME: The _ip_listing.json.erb partial iterates @results directly as
-        # [ip_addr, count] pairs, but search_by_user_id returns a hash
-        # {sums:, ip_addrs:}. The resulting map produces garbage and raises
-        # when rendered. Commented out until the view is corrected.
-        # it "returns 200 JSON" do
-        #   get moderator_ip_addrs_path(format: :json), params: { search: { user_name: target.name } }
-        #   expect(response).to have_http_status(:ok)
-        # end
+        it "returns 200 JSON in the correct format" do
+          create(:comment, creator: target, creator_ip_addr: "127.0.0.1")
+          get moderator_ip_addrs_path(format: :json), params: { search: { user_name: target.name } }
+          expect(response).to have_http_status(:ok)
+
+          expect(response.parsed_body).to include("sums", "ip_addrs")
+          expect(response.parsed_body["sums"]).to include("comment")
+          expect(response.parsed_body["sums"]["comment"]).to include("127.0.0.1" => 1)
+          expect(response.parsed_body["ip_addrs"]).to include("127.0.0.1")
+        end
       end
 
       context "when searching by user_id" do
@@ -66,12 +64,33 @@ RSpec.describe Moderator::IpAddrsController do
           get moderator_ip_addrs_path, params: { search: { user_id: target.id } }
           expect(response).to have_http_status(:ok)
         end
+
+        it "returns 200 JSON in the correct format" do
+          create(:comment, creator: target, creator_ip_addr: "127.0.0.1")
+          get moderator_ip_addrs_path(format: :json), params: { search: { user_id: target.id } }
+          expect(response).to have_http_status(:ok)
+
+          expect(response.parsed_body).to include("sums", "ip_addrs")
+          expect(response.parsed_body["sums"]).to include("comment")
+          expect(response.parsed_body["sums"]["comment"]).to include("127.0.0.1" => 1)
+          expect(response.parsed_body["ip_addrs"]).to include("127.0.0.1")
+        end
       end
 
       context "when searching by ip_addr" do
         it "returns 200 HTML" do
           get moderator_ip_addrs_path, params: { search: { ip_addr: "127.0.0.1" } }
           expect(response).to have_http_status(:ok)
+        end
+
+        it "returns 200 JSON in the correct format" do
+          create(:comment, creator: target, creator_ip_addr: "127.0.0.1")
+          get moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "127.0.0.1" } }
+          expect(response).to have_http_status(:ok)
+
+          expect(response.parsed_body).to include("comment")
+          expect(response.parsed_body["comment"]).to include(target.id.to_s)
+          expect(response.parsed_body["comment"][target.id.to_s]).to be >= 1
         end
 
         it "returns 422 for invalid IP address" do
@@ -109,15 +128,11 @@ RSpec.describe Moderator::IpAddrsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    # FIXME: The controller calls params[:search].merge({with_history: true}).
-    # When no search params are given, params[:search] is nil, causing
-    # NoMethodError on nil.merge. This test is commented out until the
-    # controller guards against a nil search hash.
-    # it "returns 200 for an admin with no search params" do
-    #   sign_in_as admin
-    #   get export_moderator_ip_addrs_path(format: :json)
-    #   expect(response).to have_http_status(:ok)
-    # end
+    it "returns 200 for an admin with no search params" do
+      sign_in_as admin
+      get export_moderator_ip_addrs_path(format: :json)
+      expect(response).to have_http_status(:ok)
+    end
 
     context "as an admin" do
       before { sign_in_as admin }
@@ -146,19 +161,11 @@ RSpec.describe Moderator::IpAddrsController do
         end
       end
 
-      # FIXME: When searching by ip_addr the search returns {sums:, users:},
-      # which has no :ip_addrs key. The export action then calls
-      # @results[:ip_addrs].uniq on nil, raising NoMethodError. This test is
-      # commented out until the controller handles the ip_addr search path.
       context "when searching by ip_addr" do
-        it "returns 422 for invalid IP address" do
-          get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "*dylan*dolly*" } }
-          expect(response).to have_http_status(:unprocessable_content)
-        end
-
-        it "returns 422 for invalid CIDR prefix" do
-          get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "127.0.0.1/999" } }
-          expect(response).to have_http_status(:unprocessable_content)
+        it "returns 200 and an empty array" do
+          get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "127.0.0.1" } }
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body).to eq([])
         end
       end
     end


### PR DESCRIPTION
Fixes #1944.

`/moderator/ip_addrs.json` raises `ActionView::MissingTemplate` because `index.json.erb` renders its partials by literal name with a `.json` suffix:

```erb
<%= render "ip_listing.json" %>
<%= render "user_listing.json" %>
```

Rails interprets the `.json` as part of the partial path, not a format specifier, so it looks for `_ip_listing.json` / `_user_listing.json` with request format `:json` — i.e. `_user_listing.json.json.erb` (which does not exist). The existing `_user_listing.json.erb` and `_ip_listing.json.erb` partials are never matched, and the response is a 500.

`index.html.erb` already renders these partials by their format-agnostic name (`render "user_listing"` / `render "ip_listing"`) and lets Rails resolve the right format-specific file from the request, so this change brings `index.json.erb` in line with that pattern.

### Repro

1. Log in as a moderator/admin.
2. `GET /moderator/ip_addrs.json?search[ip_addr]=<some ip>` (or `search[user_id]=...`).
3. Before this PR: 500 `Missing partial moderator/ip_addrs/_user_listing.json` (or `_ip_listing.json`).
4. After this PR: JSON body from the appropriate partial.