### PR TITLE
[Misc] Add HTML metatags to hint palette changing tools to not alter site colors

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,7 +7,8 @@
 <% unless disable_mobile_mode? %>
   <meta name="viewport" content="width=device-width,initial-scale=1">
 <% end %>
-
+<meta name="darkreader-lock">
+<meta name="color-scheme" content="light dark">
 <meta name="current-user-name" content="<%= CurrentUser.name %>">
 <meta name="current-user-id" content="<%= CurrentUser.id %>">
 <meta name="current-user-can-approve-posts" content="<%= CurrentUser.can_approve_posts? %>">

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
 <% end %>
 <meta name="darkreader-lock">
-<meta name="color-scheme" content="light dark">
+<meta name="color-scheme" content="dark light">
 <meta name="current-user-name" content="<%= CurrentUser.name %>">
 <meta name="current-user-id" content="<%= CurrentUser.id %>">
 <meta name="current-user-can-approve-posts" content="<%= CurrentUser.can_approve_posts? %>">


### PR DESCRIPTION
- Adds the [darkreader extension metatag](https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-statically) to inform the site should not have it's colors changed automatically.
- Adds the [`colors-scheme` metatag](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/color-scheme) which should prevent other browsers from automatically changing the colors (for some reason). I set the value to `dark light`, since with the site themes, users can already enjoy darker and lighter palettes.