### PR TITLE
[AIBUR] Fix post count desync and performance issues in tag aliases and implications

### DIFF
--- a/app/controllers/tag_corrections_controller.rb
+++ b/app/controllers/tag_corrections_controller.rb
@@ -11,7 +11,12 @@ class TagCorrectionsController < ApplicationController
 
   def new
     @from_wiki = request.referer.try(:include?, "wiki_pages") || false
-    @correction = TagCorrection.new(params[:tag_id])
+
+    # Without this, calling `post_count_from_db` has a 100% chance of timing out on large tags.
+    # Since the corrections page is staff-only, we care about correctness more than performance.
+    Tag.without_timeout do
+      @correction = TagCorrection.new(params[:tag_id])
+    end
 
     if CurrentUser.is_bd_staff?
       @tag = Tag.find(params[:tag_id])

--- a/app/controllers/tag_corrections_controller.rb
+++ b/app/controllers/tag_corrections_controller.rb
@@ -21,7 +21,7 @@ class TagCorrectionsController < ApplicationController
     if CurrentUser.is_bd_staff?
       @tag = Tag.find(params[:tag_id])
 
-      @true_count = Post.tag_match("#{@tag.name} status:any", resolve_aliases: false).count_only
+      @true_count = @correction.post_count_from_db
       @aliases = TagAlias.where("(antecedent_name = ? OR consequent_name = ?) AND NOT status = ?", @tag.name, @tag.name, "deleted").count
       @implications = TagImplication.where("(antecedent_name = ? OR consequent_name = ?) AND NOT status = ?", @tag.name, @tag.name, "deleted").count
 
@@ -30,7 +30,7 @@ class TagCorrectionsController < ApplicationController
       # 2. Alias is stuck, tag counts will never be updated
       @is_aliased_away = TagAlias.where(antecedent_name: @correction.tag.name, status: %w[active processing queued]).exists?
       if @is_aliased_away && @true_count != 0
-        @true_post_ids = @true_count > 20 ? "> 20" : Post.tag_match("#{@tag.name} status:any", resolve_aliases: false).pluck(:id).join(", ")
+        @true_post_ids = @true_count > 20 ? "> 20" : Post.sql_raw_tag_match(@correction.tag.name).pluck(:id).join(", ")
       end
 
       @destroyable = @true_count == 0 && @aliases == 0 && @implications == 0

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -15,8 +15,14 @@ class TagAliasFinalizeJob < ApplicationJob
       Post.document_store.import(
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
       )
+
+      # Post counts may have drifted out of sync, or may have been inaccurate
+      # due to legacy data. Recalculate them to ensure they are correct.
       ta.antecedent_tag&.fix_post_count(from_db: true)
       ta.consequent_tag&.fix_post_count(from_db: true)
+
+      # Update the tag alias's post count with the recalculated value.
+      ta.update(status: "active", post_count: ta.consequent_tag&.post_count || 0)
     end
   end
 end

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -8,13 +8,14 @@ class TagAliasFinalizeJob < ApplicationJob
     [args[0]]
   end
 
-  def perform(alias_id, reindex_tag_name)
+  def perform(alias_id)
     ta = TagAlias.find_by(id: alias_id)
     return unless ta
+
+    post_ids = ta.tag_rel_undos.flat_map(&:undo_data).uniq
+
     Post.without_timeout do
-      Post.document_store.import(
-        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
-      )
+      Post.document_store.import(query: { id: post_ids }) if post_ids.any?
 
       # Post counts may have drifted out of sync, or may have been inaccurate
       # due to legacy data. Recalculate them to ensure they are correct.

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -15,8 +15,8 @@ class TagAliasFinalizeJob < ApplicationJob
       Post.document_store.import(
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
       )
-      ta.antecedent_tag&.fix_post_count
-      ta.consequent_tag&.fix_post_count
+      ta.antecedent_tag&.fix_post_count(from_db: true)
+      ta.consequent_tag&.fix_post_count(from_db: true)
     end
   end
 end

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -18,8 +18,8 @@ class TagAliasFinalizeJob < ApplicationJob
 
       # Post counts may have drifted out of sync, or may have been inaccurate
       # due to legacy data. Recalculate them to ensure they are correct.
-      ta.antecedent_tag&.fix_post_count(from_db: true)
-      ta.consequent_tag&.fix_post_count(from_db: true)
+      ta.antecedent_tag&.fix_post_count
+      ta.consequent_tag&.fix_post_count
 
       # Update the tag alias's post count with the recalculated value.
       ta.update(status: "active", post_count: ta.consequent_tag&.post_count || 0)

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -22,7 +22,7 @@ class TagAliasFinalizeJob < ApplicationJob
       ta.consequent_tag&.fix_post_count
 
       # Update the tag alias's post count with the recalculated value.
-      ta.update(status: "active", post_count: ta.consequent_tag&.post_count || 0)
+      ta.update(post_count: ta.consequent_tag&.post_count || 0)
     end
   end
 end

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -23,7 +23,7 @@ class TagAliasFinalizeJob < ApplicationJob
       ta.consequent_tag&.fix_post_count
 
       # Update the tag alias's post count with the recalculated value.
-      ta.update(post_count: ta.consequent_tag&.post_count || 0)
+      ta.update_columns(post_count: ta.consequent_tag&.post_count || 0)
     end
   end
 end

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -20,9 +20,6 @@ class TagImplicationFinalizeJob < ApplicationJob
       # due to legacy data. Recalculate them to ensure they are correct.
       ti.antecedent_tag&.fix_post_count
       ti.consequent_tag&.fix_post_count
-
-      # Update implication status
-      ti.update(status: "active")
     end
   end
 end

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -15,8 +15,8 @@ class TagImplicationFinalizeJob < ApplicationJob
       Post.document_store.import(
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
       )
-      ti.antecedent_tag&.fix_post_count
-      ti.consequent_tag&.fix_post_count
+      ti.antecedent_tag&.fix_post_count(from_db: true)
+      ti.consequent_tag&.fix_post_count(from_db: true)
     end
   end
 end

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -15,8 +15,14 @@ class TagImplicationFinalizeJob < ApplicationJob
       Post.document_store.import(
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
       )
+
+      # Post counts may have drifted out of sync, or may have been inaccurate
+      # due to legacy data. Recalculate them to ensure they are correct.
       ti.antecedent_tag&.fix_post_count(from_db: true)
       ti.consequent_tag&.fix_post_count(from_db: true)
+
+      # Update implication status
+      ti.update(status: "active")
     end
   end
 end

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -18,8 +18,8 @@ class TagImplicationFinalizeJob < ApplicationJob
 
       # Post counts may have drifted out of sync, or may have been inaccurate
       # due to legacy data. Recalculate them to ensure they are correct.
-      ti.antecedent_tag&.fix_post_count(from_db: true)
-      ti.consequent_tag&.fix_post_count(from_db: true)
+      ti.antecedent_tag&.fix_post_count
+      ti.consequent_tag&.fix_post_count
 
       # Update implication status
       ti.update(status: "active")

--- a/app/jobs/tag_post_count_job.rb
+++ b/app/jobs/tag_post_count_job.rb
@@ -9,7 +9,8 @@ class TagPostCountJob < ApplicationJob
   end
 
   def perform(*args)
-    tag = Tag.find(args[0])
+    tag = Tag.find_by(id: args[0])
+    return unless tag
 
     Tag.without_timeout do
       tag.fix_post_count

--- a/app/jobs/tag_post_count_job.rb
+++ b/app/jobs/tag_post_count_job.rb
@@ -11,6 +11,8 @@ class TagPostCountJob < ApplicationJob
   def perform(*args)
     tag = Tag.find(args[0])
 
-    tag.fix_post_count(from_db: true)
+    Tag.without_timeout do
+      tag.fix_post_count
+    end
   end
 end

--- a/app/jobs/tag_post_count_job.rb
+++ b/app/jobs/tag_post_count_job.rb
@@ -11,6 +11,6 @@ class TagPostCountJob < ApplicationJob
   def perform(*args)
     tag = Tag.find(args[0])
 
-    tag.fix_post_count
+    tag.fix_post_count(from_db: true)
   end
 end

--- a/app/logical/tag_correction.rb
+++ b/app/logical/tag_correction.rb
@@ -5,7 +5,7 @@ class TagCorrection
 
   attr_reader :tag
 
-  delegate :category, :post_count, :post_count_from_opensearch, :post_count_from_db, to: :tag
+  delegate :category, :post_count, :post_count_from_opensearch, to: :tag
 
   def initialize(tag_id)
     @tag = Tag.find(tag_id)
@@ -18,12 +18,15 @@ class TagCorrection
   def attributes
     {
       post_count: post_count,
-      post_count_from_opensearch: post_count_from_opensearch,
-      post_count_from_db: post_count_from_db,
+      real_post_count: post_count_from_opensearch,
       category: category,
       category_cache: category_cache,
       tag: tag,
     }
+  end
+
+  def post_count_from_db
+    @post_count_from_db ||= Tag.without_timeout { tag.post_count_from_db }
   end
 
   def category_cache

--- a/app/logical/tag_correction.rb
+++ b/app/logical/tag_correction.rb
@@ -5,7 +5,7 @@ class TagCorrection
 
   attr_reader :tag
 
-  delegate :category, :post_count, :real_post_count, to: :tag
+  delegate :category, :post_count, :post_count_from_opensearch, :post_count_from_db, to: :tag
 
   def initialize(tag_id)
     @tag = Tag.find(tag_id)
@@ -16,7 +16,14 @@ class TagCorrection
   end
 
   def attributes
-    { post_count: post_count, real_post_count: real_post_count, category: category, category_cache: category_cache, tag: tag }
+    {
+      post_count: post_count,
+      post_count_from_opensearch: post_count_from_opensearch,
+      post_count_from_db: post_count_from_db,
+      category: category,
+      category_cache: category_cache,
+      tag: tag,
+    }
   end
 
   def category_cache

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -63,16 +63,16 @@ class Tag < ApplicationRecord
       def clean_up_negative_post_counts!
         Tag.where("post_count < 0").find_each do |tag|
           tag_alias = TagAlias.where("status in ('active', 'processing') and antecedent_name = ?", tag.name).first
-          tag.fix_post_count(from_db: true)
+          tag.fix_post_count
           if tag_alias
-            tag_alias.consequent_tag.fix_post_count(from_db: true)
+            tag_alias.consequent_tag.fix_post_count
           end
         end
       end
     end
 
-    def real_post_count
-      @real_post_count ||= Post.tag_match(name, resolve_aliases: false).count_only
+    def post_count_from_opensearch
+      Post.tag_match(name, resolve_aliases: false).count_only
     end
 
     # Returns an authoritative post count from the database.
@@ -83,9 +83,8 @@ class Tag < ApplicationRecord
       Post.undeleted.sql_raw_tag_match(name).count
     end
 
-    def fix_post_count(from_db: false)
-      actual_count = from_db ? post_count_from_db : real_post_count
-      update_column(:post_count, actual_count)
+    def fix_post_count
+      update_column(:post_count, post_count_from_db)
     end
   end
 
@@ -284,8 +283,9 @@ class Tag < ApplicationRecord
 
       self.related_tags = RelatedTagCalculator.calculate_from_sample_to_array(name).join(" ")
       self.related_tags_updated_at = Time.now
-      fix_post_count if post_count > 20 && rand(post_count) <= 1
       save
+
+      TagPostCountJob.perform_later(id) if post_count > 20 && rand(post_count) <= 1
     rescue ActiveRecord::StatementInvalid
     end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -63,9 +63,9 @@ class Tag < ApplicationRecord
       def clean_up_negative_post_counts!
         Tag.where("post_count < 0").find_each do |tag|
           tag_alias = TagAlias.where("status in ('active', 'processing') and antecedent_name = ?", tag.name).first
-          tag.fix_post_count
+          tag.fix_post_count(from_db: true)
           if tag_alias
-            tag_alias.consequent_tag.fix_post_count
+            tag_alias.consequent_tag.fix_post_count(from_db: true)
           end
         end
       end
@@ -75,8 +75,17 @@ class Tag < ApplicationRecord
       @real_post_count ||= Post.tag_match(name, resolve_aliases: false).count_only
     end
 
-    def fix_post_count
-      update_column(:post_count, real_post_count)
+    # Returns an authoritative post count from the database.
+    # NOTE: this query is extraordinarily expensive. It cannot be used in anything directly
+    # user-facing. The only reasonable use case is a background job that is fixing post counts
+    # for tags that have drifted out of sync.
+    def post_count_from_db
+      Post.undeleted.sql_raw_tag_match(name).count
+    end
+
+    def fix_post_count(from_db: false)
+      actual_count = from_db ? post_count_from_db : real_post_count
+      update_column(:post_count, actual_count)
     end
   end
 

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -153,61 +153,71 @@ class TagAlias < TagRelationship
   end
 
   def process_undo!(update_topic: true)
-    unless valid?
-      raise errors.full_messages.join("; ")
-    end
+    raise NotImplementedError, "Tag aliases cannot be undone."
 
-    CurrentUser.scoped(approver) do
-      update(status: "pending")
-      update_posts_locked_tags_undo
-      update_blacklists_undo
-      update_posts_undo
-      rename_artist_undo
-      forum_updater.update(retirement_message, "UNDONE") if update_topic
-    end
-    tag_rel_undos.update_all(applied: true)
+    # unless valid?
+    #   raise errors.full_messages.join("; ")
+    # end
+    #
+    # CurrentUser.scoped(approver) do
+    #   update(status: "pending")
+    #   update_posts_locked_tags_undo
+    #   update_blacklists_undo
+    #   update_posts_undo
+    #   rename_artist_undo
+    #   forum_updater.update(retirement_message, "UNDONE") if update_topic
+    # end
+    # tag_rel_undos.update_all(applied: true)
   end
 
   def update_posts_locked_tags_undo
-    Post.without_timeout do
-      Post.where_ilike(:locked_tags, "*#{consequent_name}*").find_each(batch_size: 50) do |post|
-        fixed_tags = TagAlias.to_aliased_query(post.locked_tags, overrides: { consequent_name => antecedent_name })
-        post.update_column(:locked_tags, fixed_tags)
-      end
-    end
+    raise NotImplementedError, "Tag aliases cannot be undone."
+
+    # Post.without_timeout do
+    #   Post.where_ilike(:locked_tags, "*#{consequent_name}*").find_each(batch_size: 50) do |post|
+    #     fixed_tags = TagAlias.to_aliased_query(post.locked_tags, overrides: { consequent_name => antecedent_name })
+    #     post.update_column(:locked_tags, fixed_tags)
+    #   end
+    # end
   end
 
   def update_blacklists_undo
-    User.without_timeout do
-      User.where_ilike(:blacklisted_tags, "*#{consequent_name}*").find_each(batch_size: 50) do |user|
-        fixed_blacklist = TagAlias.to_aliased_query(user.blacklisted_tags, overrides: { consequent_name => antecedent_name }, comments: true)
-        user.update_column(:blacklisted_tags, fixed_blacklist)
-      end
-    end
+    raise NotImplementedError, "Tag aliases cannot be undone."
+
+    # User.without_timeout do
+    #   User.where_ilike(:blacklisted_tags, "*#{consequent_name}*").find_each(batch_size: 50) do |user|
+    #     fixed_blacklist = TagAlias.to_aliased_query(user.blacklisted_tags, overrides: { consequent_name => antecedent_name }, comments: true)
+    #     user.update_column(:blacklisted_tags, fixed_blacklist)
+    #   end
+    # end
   end
 
   def update_posts_undo
-    Thread.current[:skip_post_index_update] = true
-    Post.without_timeout do
-      tag_rel_undos.where(applied: false).each do |tu|
-        Post.where(id: tu.undo_data).find_each do |post|
-          post.do_not_version_changes = true
-          post.tag_string_diff = "-#{consequent_name} #{antecedent_name}"
-          post.save
-        end
-      end
-    end
-    TagAliasFinalizeJob.perform_later(id, antecedent_name)
+    raise NotImplementedError, "Tag aliases cannot be undone."
+
+    # Thread.current[:skip_post_index_update] = true
+    # Post.without_timeout do
+    #   tag_rel_undos.where(applied: false).each do |tu|
+    #     Post.where(id: tu.undo_data).find_each do |post|
+    #       post.do_not_version_changes = true
+    #       post.tag_string_diff = "-#{consequent_name} #{antecedent_name}"
+    #       post.save
+    #     end
+    #   end
+    # end
+    # TagAliasFinalizeJob.perform_later(id, antecedent_name)
   ensure
     Thread.current[:skip_post_index_update] = false
   end
 
   def rename_artist_undo
-    if consequent_tag.category == Tag.categories.artist
-      if consequent_tag.artist.present? && antecedent_tag.artist.blank?
-        consequent_tag.artist.update!(name: antecedent_name)
-      end
-    end
+    raise NotImplementedError, "Tag aliases cannot be undone."
+
+    # if consequent_tag.category == Tag.categories.artist
+    #   if consequent_tag.artist.present? && antecedent_tag.artist.blank?
+    #     consequent_tag.artist.update!(name: antecedent_name)
+    #   end
+    # end
   end
 
   def process!(update_topic: true)
@@ -225,7 +235,7 @@ class TagAlias < TagRelationship
         rename_artist
         forum_updater.update(approval_message(approver), "APPROVED") if update_topic
         update(status: "active", post_count: consequent_tag&.post_count || 0)
-        TagAliasFinalizeJob.perform_later(id, consequent_name)
+        TagAliasFinalizeJob.perform_later(id)
       end
     rescue Exception => e
       Rails.logger.error("[TA] #{e.message}\n#{e.backtrace}")

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -224,6 +224,7 @@ class TagAlias < TagRelationship
         update_posts
         rename_artist
         forum_updater.update(approval_message(approver), "APPROVED") if update_topic
+        update(status: "active", post_count: consequent_tag&.post_count || 0)
         TagAliasFinalizeJob.perform_later(id, consequent_name)
       end
     rescue Exception => e

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -224,7 +224,6 @@ class TagAlias < TagRelationship
         update_posts
         rename_artist
         forum_updater.update(approval_message(approver), "APPROVED") if update_topic
-        update(status: 'active', post_count: consequent_tag.post_count)
         TagAliasFinalizeJob.perform_later(id, consequent_name)
       end
     rescue Exception => e

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -249,6 +249,7 @@ class TagAlias < TagRelationship
         forum_updater.update(failure_message(e), "FAILED") if update_topic
         update_columns(status: "error: #{e}")
       end
+      TagAliasFinalizeJob.perform_later(id)
     end
   end
 

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -133,10 +133,9 @@ class TagImplication < TagRelationship
           update!(status: "processing")
           create_undo_information
           update_posts
-          TagImplicationFinalizeJob.perform_later(id, antecedent_name)
-          update(status: "active")
           update_descendant_names_for_parents
           forum_updater.update(approval_message(approver), "APPROVED") if update_topic
+          TagImplicationFinalizeJob.perform_later(id, antecedent_name)
         end
       rescue Exception => e
         if tries < 5 && !Rails.env.test?

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -135,6 +135,7 @@ class TagImplication < TagRelationship
           update_posts
           update_descendant_names_for_parents
           forum_updater.update(approval_message(approver), "APPROVED") if update_topic
+          update(status: "active")
           TagImplicationFinalizeJob.perform_later(id, antecedent_name)
         end
       rescue Exception => e

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -8,7 +8,6 @@
         <li><strong>Category memcache</strong>: <%= TagCategory::REVERSE_MAPPING[@correction.category_cache] || "none" %></li>
         <li><strong>Post count db cache</strong>: <%= @correction.post_count %></li>
         <li><strong>OpenSearch post count</strong>: <%= @correction.post_count_from_opensearch %></li>
-        <li><strong>Database post count</strong>: <%= @correction.post_count_from_db %></li>
       </ul>
     </div>
 

--- a/app/views/tag_corrections/new.html.erb
+++ b/app/views/tag_corrections/new.html.erb
@@ -7,7 +7,8 @@
         <li><strong>Category actual</strong>: <%= TagCategory::REVERSE_MAPPING[@correction.category] %></li>
         <li><strong>Category memcache</strong>: <%= TagCategory::REVERSE_MAPPING[@correction.category_cache] || "none" %></li>
         <li><strong>Post count db cache</strong>: <%= @correction.post_count %></li>
-        <li><strong>Post count actual:</strong> <%= @correction.real_post_count %></li>
+        <li><strong>OpenSearch post count</strong>: <%= @correction.post_count_from_opensearch %></li>
+        <li><strong>Database post count</strong>: <%= @correction.post_count_from_db %></li>
       </ul>
     </div>
 

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -7,39 +7,44 @@ RSpec.describe TagAliasFinalizeJob do
 
   describe "#perform" do
     let(:ta) { create(:tag_alias) }
+    let(:post_ids) { [101, 102, 103] }
 
     before do
       ta.update_columns(status: "active", approver_id: create(:admin_user).id)
+      ta.tag_rel_undos.create!(undo_data: post_ids)
       allow(Post.document_store).to receive(:import)
       allow(ta.antecedent_tag).to receive(:fix_post_count)
       allow(ta.consequent_tag).to receive(:fix_post_count) { ta.consequent_tag.post_count = 42 }
       allow(TagAlias).to receive(:find_by).with(id: ta.id).and_return(ta)
     end
 
-    it "bulk-reindexes posts matching the given tag name" do
-      described_class.perform_now(ta.id, ta.consequent_name)
-      expect(Post.document_store).to have_received(:import).with(
-        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ta.consequent_name],
-      )
+    it "reindexes only the posts captured in the undo data" do
+      described_class.perform_now(ta.id)
+      expect(Post.document_store).to have_received(:import).with(query: { id: post_ids })
+    end
+
+    it "unions undo data across multiple tag_rel_undos and de-duplicates" do
+      ta.tag_rel_undos.create!(undo_data: [103, 104])
+      described_class.perform_now(ta.id)
+      expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102, 103, 104] })
+    end
+
+    it "skips the bulk reindex when no posts were affected" do
+      ta.tag_rel_undos.destroy_all
+      described_class.perform_now(ta.id)
+      expect(Post.document_store).not_to have_received(:import)
     end
 
     it "fixes post counts on both tags after reindexing" do
-      described_class.perform_now(ta.id, ta.consequent_name)
+      described_class.perform_now(ta.id)
       expect(ta.antecedent_tag).to have_received(:fix_post_count)
       expect(ta.consequent_tag).to have_received(:fix_post_count)
-    end
-
-    it "uses antecedent_name as the reindex target when called for an undo" do
-      described_class.perform_now(ta.id, ta.antecedent_name)
-      expect(Post.document_store).to have_received(:import).with(
-        query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ta.antecedent_name],
-      )
     end
 
     it "updates the post count of the tag alias after reindexing" do
       allow(ta).to receive(:update).and_call_original
 
-      described_class.perform_now(ta.id, ta.consequent_name)
+      described_class.perform_now(ta.id)
       expect(ta).to have_received(:update).with(post_count: 42)
     end
   end

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe TagAliasFinalizeJob do
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ta.antecedent_name],
       )
     end
+
+    it "updates the tag alias's status to active and recalculates its post count" do
+      ta.update_column(:status, "processing")
+      allow(ta).to receive(:update).and_call_original
+
+      described_class.perform_now(ta.id, ta.consequent_name)
+      expect(ta).to have_received(:update).with(status: "active", post_count: ta.consequent_tag.post_count)
+    end
   end
 end

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe TagAliasFinalizeJob do
     end
 
     it "updates the post count of the tag alias after reindexing" do
-      allow(ta).to receive(:update).and_call_original
+      allow(ta).to receive(:update_columns).and_call_original
 
       described_class.perform_now(ta.id)
-      expect(ta).to have_received(:update).with(post_count: 42)
+      expect(ta).to have_received(:update_columns).with(post_count: 42)
     end
   end
 end

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe TagAliasFinalizeJob do
       )
     end
 
-    it "updates the tag alias's status to active and recalculates its post count" do
+    it "updates the post count of the tag alias after reindexing" do
       ta.update_column(:status, "processing")
       allow(ta).to receive(:update).and_call_original
 
       described_class.perform_now(ta.id, ta.consequent_name)
-      expect(ta).to have_received(:update).with(status: "active", post_count: ta.consequent_tag.post_count)
+      expect(ta).to have_received(:update).with(post_count: ta.consequent_tag.post_count)
     end
   end
 end

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TagAliasFinalizeJob do
       ta.update_columns(status: "active", approver_id: create(:admin_user).id)
       allow(Post.document_store).to receive(:import)
       allow(ta.antecedent_tag).to receive(:fix_post_count)
-      allow(ta.consequent_tag).to receive(:fix_post_count)
+      allow(ta.consequent_tag).to receive(:fix_post_count) { ta.consequent_tag.post_count = 42 }
       allow(TagAlias).to receive(:find_by).with(id: ta.id).and_return(ta)
     end
 
@@ -37,11 +37,10 @@ RSpec.describe TagAliasFinalizeJob do
     end
 
     it "updates the post count of the tag alias after reindexing" do
-      ta.update_column(:status, "processing")
       allow(ta).to receive(:update).and_call_original
 
       described_class.perform_now(ta.id, ta.consequent_name)
-      expect(ta).to have_received(:update).with(post_count: ta.consequent_tag.post_count)
+      expect(ta).to have_received(:update).with(post_count: 42)
     end
   end
 end

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -35,13 +35,5 @@ RSpec.describe TagImplicationFinalizeJob do
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ti.antecedent_name],
       )
     end
-
-    it "updates the tag implication's status to active" do
-      ti.update_column(:status, "processing")
-      allow(ti).to receive(:update).and_call_original
-
-      described_class.perform_now(ti.id, ti.consequent_name)
-      expect(ti).to have_received(:update).with(status: "active")
-    end
   end
 end

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -35,5 +35,13 @@ RSpec.describe TagImplicationFinalizeJob do
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ti.antecedent_name],
       )
     end
+
+    it "updates the tag implication's status to active" do
+      ti.update_column(:status, "processing")
+      allow(ti).to receive(:update).and_call_original
+
+      described_class.perform_now(ti.id, ti.consequent_name)
+      expect(ti).to have_received(:update).with(status: "active")
+    end
   end
 end

--- a/spec/jobs/tag_post_count_job_spec.rb
+++ b/spec/jobs/tag_post_count_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TagPostCountJob do
     let(:tag) { create(:tag) }
 
     it "calls fix_post_count on the tag" do
-      allow(Tag).to receive(:find).with(tag.id).and_return(tag)
+      allow(Tag).to receive(:find_by).with(id: tag.id).and_return(tag)
       allow(tag).to receive(:fix_post_count)
       described_class.perform_now(tag.id)
       expect(tag).to have_received(:fix_post_count)

--- a/spec/models/tag/count_methods_spec.rb
+++ b/spec/models/tag/count_methods_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Tag do
   # #fix_post_count
   # -------------------------------------------------------------------------
   describe "#fix_post_count" do
-    it "updates post_count to the value returned by real_post_count" do
+    it "updates post_count to the value returned by post_count_from_db" do
       tag = create(:tag, name: "fix_count_tag", post_count: 99)
-      allow(tag).to receive(:real_post_count).and_return(42)
+      allow(tag).to receive(:post_count_from_db).and_return(42)
       tag.fix_post_count
       expect(tag.reload.post_count).to eq(42)
     end

--- a/spec/models/tag_alias/instance_methods_spec.rb
+++ b/spec/models/tag_alias/instance_methods_spec.rb
@@ -128,72 +128,72 @@ RSpec.describe TagAlias do
   # #update_posts_locked_tags_undo
   # ---------------------------------------------------------------------------
 
-  describe "#update_posts_locked_tags_undo" do
-    it "replaces the consequent tag with the antecedent tag in post locked_tags" do
-      ta = create(:active_tag_alias,
-                  antecedent_name: "lock_undo_ant_#{SecureRandom.hex(4)}",
-                  consequent_name: "lock_undo_con_#{SecureRandom.hex(4)}")
-
-      post = create(:post)
-      post.update_column(:locked_tags, ta.consequent_name)
-
-      ta.update_posts_locked_tags_undo
-
-      expect(post.reload.locked_tags).to include(ta.antecedent_name)
-      expect(post.reload.locked_tags).not_to include(ta.consequent_name)
-    end
-  end
+  # describe "#update_posts_locked_tags_undo" do
+  #   it "replaces the consequent tag with the antecedent tag in post locked_tags" do
+  #     ta = create(:active_tag_alias,
+  #                 antecedent_name: "lock_undo_ant_#{SecureRandom.hex(4)}",
+  #                 consequent_name: "lock_undo_con_#{SecureRandom.hex(4)}")
+  #
+  #     post = create(:post)
+  #     post.update_column(:locked_tags, ta.consequent_name)
+  #
+  #     ta.update_posts_locked_tags_undo
+  #
+  #     expect(post.reload.locked_tags).to include(ta.antecedent_name)
+  #     expect(post.reload.locked_tags).not_to include(ta.consequent_name)
+  #   end
+  # end
 
   # ---------------------------------------------------------------------------
   # #update_blacklists_undo
   # ---------------------------------------------------------------------------
 
-  describe "#update_blacklists_undo" do
-    it "replaces the consequent tag with the antecedent tag in user blacklists" do
-      ta = create(:active_tag_alias,
-                  antecedent_name: "bl_undo_ant_#{SecureRandom.hex(4)}",
-                  consequent_name: "bl_undo_con_#{SecureRandom.hex(4)}")
-
-      user = create(:user)
-      user.update_column(:blacklisted_tags, ta.consequent_name)
-
-      ta.update_blacklists_undo
-
-      expect(user.reload.blacklisted_tags).to include(ta.antecedent_name)
-      expect(user.reload.blacklisted_tags).not_to include(ta.consequent_name)
-    end
-  end
+  # describe "#update_blacklists_undo" do
+  #   it "replaces the consequent tag with the antecedent tag in user blacklists" do
+  #     ta = create(:active_tag_alias,
+  #                 antecedent_name: "bl_undo_ant_#{SecureRandom.hex(4)}",
+  #                 consequent_name: "bl_undo_con_#{SecureRandom.hex(4)}")
+  #
+  #     user = create(:user)
+  #     user.update_column(:blacklisted_tags, ta.consequent_name)
+  #
+  #     ta.update_blacklists_undo
+  #
+  #     expect(user.reload.blacklisted_tags).to include(ta.antecedent_name)
+  #     expect(user.reload.blacklisted_tags).not_to include(ta.consequent_name)
+  #   end
+  # end
 
   # ---------------------------------------------------------------------------
   # #update_posts_undo
   # ---------------------------------------------------------------------------
 
-  describe "#update_posts_undo" do
-    it "applies tag diffs from unapplied TagRelUndo records to matching posts" do
-      ta = create(:active_tag_alias,
-                  antecedent_name: "undo_post_ant_#{SecureRandom.hex(4)}",
-                  consequent_name: "undo_post_con_#{SecureRandom.hex(4)}")
-      # Set to pending so normalize_tags doesn't re-alias the antecedent back to the
-      # consequent during the post save (mirrors what process_undo! does before calling this).
-      ta.update_columns(status: "pending")
-
-      post = create(:post)
-      post.update_column(:tag_string, "#{ta.consequent_name} other_tag")
-      ta.tag_rel_undos.create!(undo_data: [post.id])
-
-      ta.update_posts_undo
-
-      expect(post.reload.tag_string).to include(ta.antecedent_name)
-    end
-
-    it "enqueues TagAliasFinalizeJob with antecedent_name" do
-      ta = create(:active_tag_alias)
-      ta.tag_rel_undos.create!(undo_data: [])
-
-      expect { ta.update_posts_undo }
-        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.antecedent_name)
-    end
-  end
+  # describe "#update_posts_undo" do
+  #   it "applies tag diffs from unapplied TagRelUndo records to matching posts" do
+  #     ta = create(:active_tag_alias,
+  #                 antecedent_name: "undo_post_ant_#{SecureRandom.hex(4)}",
+  #                 consequent_name: "undo_post_con_#{SecureRandom.hex(4)}")
+  #     # Set to pending so normalize_tags doesn't re-alias the antecedent back to the
+  #     # consequent during the post save (mirrors what process_undo! does before calling this).
+  #     ta.update_columns(status: "pending")
+  #
+  #     post = create(:post)
+  #     post.update_column(:tag_string, "#{ta.consequent_name} other_tag")
+  #     ta.tag_rel_undos.create!(undo_data: [post.id])
+  #
+  #     ta.update_posts_undo
+  #
+  #     expect(post.reload.tag_string).to include(ta.antecedent_name)
+  #   end
+  #
+  #   it "enqueues TagAliasFinalizeJob with antecedent_name" do
+  #     ta = create(:active_tag_alias)
+  #     ta.tag_rel_undos.create!(undo_data: [])
+  #
+  #     expect { ta.update_posts_undo }
+  #       .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.antecedent_name)
+  #   end
+  # end
 
   # ---------------------------------------------------------------------------
   # #rename_artist
@@ -241,29 +241,29 @@ RSpec.describe TagAlias do
   # #rename_artist_undo
   # ---------------------------------------------------------------------------
 
-  describe "#rename_artist_undo" do
-    it "renames the consequent artist back to the antecedent name" do
-      ta = create(:active_tag_alias,
-                  antecedent_name: "art_undo_ant_#{SecureRandom.hex(4)}",
-                  consequent_name: "art_undo_con_#{SecureRandom.hex(4)}")
-      ta.consequent_tag.update_columns(category: 1)
-      create(:artist, name: ta.consequent_name)
-
-      ta.rename_artist_undo
-
-      expect(Artist.find_by(name: ta.antecedent_name)).to be_present
-    end
-
-    it "does nothing when the consequent tag is not in the artist category" do
-      ta = create(:active_tag_alias,
-                  antecedent_name: "gen_undo_ant_#{SecureRandom.hex(4)}",
-                  consequent_name: "gen_undo_con_#{SecureRandom.hex(4)}")
-      ta.consequent_tag.update_columns(category: Tag.categories.general)
-      create(:artist, name: ta.consequent_name)
-
-      expect { ta.rename_artist_undo }.not_to(change(Artist, :count))
-    end
-  end
+  # describe "#rename_artist_undo" do
+  #   it "renames the consequent artist back to the antecedent name" do
+  #     ta = create(:active_tag_alias,
+  #                 antecedent_name: "art_undo_ant_#{SecureRandom.hex(4)}",
+  #                 consequent_name: "art_undo_con_#{SecureRandom.hex(4)}")
+  #     ta.consequent_tag.update_columns(category: 1)
+  #     create(:artist, name: ta.consequent_name)
+  #
+  #     ta.rename_artist_undo
+  #
+  #     expect(Artist.find_by(name: ta.antecedent_name)).to be_present
+  #   end
+  #
+  #   it "does nothing when the consequent tag is not in the artist category" do
+  #     ta = create(:active_tag_alias,
+  #                 antecedent_name: "gen_undo_ant_#{SecureRandom.hex(4)}",
+  #                 consequent_name: "gen_undo_con_#{SecureRandom.hex(4)}")
+  #     ta.consequent_tag.update_columns(category: Tag.categories.general)
+  #     create(:artist, name: ta.consequent_name)
+  #
+  #     expect { ta.rename_artist_undo }.not_to(change(Artist, :count))
+  #   end
+  # end
 
   # ---------------------------------------------------------------------------
   # #move_aliases_and_implications

--- a/spec/models/tag_alias/process_methods_spec.rb
+++ b/spec/models/tag_alias/process_methods_spec.rb
@@ -10,13 +10,14 @@ RSpec.describe TagAlias do
   # ---------------------------------------------------------------------------
 
   describe "#process!" do
-    it "sets status to active after successful processing" do
+    it "sets status to processing before finalizing" do
       ta = create(:tag_alias)
       ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
 
       ta.process!(update_topic: false)
 
-      expect(ta.reload.status).to eq("active")
+      # Status gets set to "active" in the TagAliasFinalizeJob
+      expect(ta.reload.status).to eq("processing")
     end
 
     it "sets status to error when processing raises an exception" do
@@ -27,16 +28,6 @@ RSpec.describe TagAlias do
       ta.process!(update_topic: false)
 
       expect(ta.reload.status).to start_with("error:")
-    end
-
-    it "sets post_count to the consequent tag post_count on success" do
-      ta = create(:tag_alias)
-      ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
-      ta.consequent_tag.update_columns(post_count: 7)
-
-      ta.process!(update_topic: false)
-
-      expect(ta.reload.post_count).to eq(7)
     end
 
     it "enqueues TagAliasFinalizeJob with consequent_name on success" do

--- a/spec/models/tag_alias/process_methods_spec.rb
+++ b/spec/models/tag_alias/process_methods_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe TagAlias do
         .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
     end
 
+    it "enqueues TagAliasFinalizeJob even when processing fails so partially-modified posts get reindexed" do
+      ta = create(:tag_alias)
+      ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
+      allow(ta).to receive(:update_posts).and_raise(RuntimeError, "simulated failure")
+
+      expect { ta.process!(update_topic: false) }
+        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
+      expect(ta.reload.status).to start_with("error:")
+    end
+
     it "does not call fix_post_count directly" do
       ta = create(:tag_alias)
       ta.update_columns(status: "queued", approver_id: create(:admin_user).id)

--- a/spec/models/tag_alias/process_methods_spec.rb
+++ b/spec/models/tag_alias/process_methods_spec.rb
@@ -10,14 +10,13 @@ RSpec.describe TagAlias do
   # ---------------------------------------------------------------------------
 
   describe "#process!" do
-    it "sets status to processing before finalizing" do
+    it "sets status to active after processing" do
       ta = create(:tag_alias)
       ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
 
       ta.process!(update_topic: false)
 
-      # Status gets set to "active" in the TagAliasFinalizeJob
-      expect(ta.reload.status).to eq("processing")
+      expect(ta.reload.status).to eq("active")
     end
 
     it "sets status to error when processing raises an exception" do

--- a/spec/models/tag_alias/process_methods_spec.rb
+++ b/spec/models/tag_alias/process_methods_spec.rb
@@ -29,12 +29,12 @@ RSpec.describe TagAlias do
       expect(ta.reload.status).to start_with("error:")
     end
 
-    it "enqueues TagAliasFinalizeJob with consequent_name on success" do
+    it "enqueues TagAliasFinalizeJob on success" do
       ta = create(:tag_alias)
       ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
 
       expect { ta.process!(update_topic: false) }
-        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.consequent_name)
+        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
     end
 
     it "does not call fix_post_count directly" do
@@ -54,55 +54,55 @@ RSpec.describe TagAlias do
   # #process_undo!
   # ---------------------------------------------------------------------------
 
-  describe "#process_undo!" do
-    it "resets status to pending" do
-      ta = create(:active_tag_alias)
-      ta.update_columns(approver_id: create(:admin_user).id)
-
-      ta.process_undo!(update_topic: false)
-
-      expect(ta.reload.status).to eq("pending")
-    end
-
-    it "marks all tag_rel_undos as applied" do
-      ta = create(:active_tag_alias)
-      ta.update_columns(approver_id: create(:admin_user).id)
-      ta.tag_rel_undos.create!(undo_data: [])
-
-      ta.process_undo!(update_topic: false)
-
-      expect(ta.tag_rel_undos.where(applied: false).count).to eq(0)
-    end
-
-    it "raises when the alias is invalid" do
-      ta = create(:active_tag_alias)
-      ta.update_columns(approver_id: create(:admin_user).id)
-      allow(ta).to receive_messages(
-        valid?: false,
-        errors: instance_double(ActiveModel::Errors, full_messages: ["something is wrong"]),
-      )
-
-      expect { ta.process_undo!(update_topic: false) }.to raise_error(RuntimeError, /something is wrong/)
-    end
-
-    it "enqueues TagAliasFinalizeJob with antecedent_name" do
-      ta = create(:active_tag_alias)
-      ta.update_columns(approver_id: create(:admin_user).id)
-
-      expect { ta.process_undo!(update_topic: false) }
-        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.antecedent_name)
-    end
-
-    it "does not call fix_post_count directly" do
-      ta = create(:active_tag_alias)
-      ta.update_columns(approver_id: create(:admin_user).id)
-      allow(ta.antecedent_tag).to receive(:fix_post_count)
-      allow(ta.consequent_tag).to receive(:fix_post_count)
-
-      ta.process_undo!(update_topic: false)
-
-      expect(ta.antecedent_tag).not_to have_received(:fix_post_count)
-      expect(ta.consequent_tag).not_to have_received(:fix_post_count)
-    end
-  end
+  # describe "#process_undo!" do
+  #   it "resets status to pending" do
+  #     ta = create(:active_tag_alias)
+  #     ta.update_columns(approver_id: create(:admin_user).id)
+  #
+  #     ta.process_undo!(update_topic: false)
+  #
+  #     expect(ta.reload.status).to eq("pending")
+  #   end
+  #
+  #   it "marks all tag_rel_undos as applied" do
+  #     ta = create(:active_tag_alias)
+  #     ta.update_columns(approver_id: create(:admin_user).id)
+  #     ta.tag_rel_undos.create!(undo_data: [])
+  #
+  #     ta.process_undo!(update_topic: false)
+  #
+  #     expect(ta.tag_rel_undos.where(applied: false).count).to eq(0)
+  #   end
+  #
+  #   it "raises when the alias is invalid" do
+  #     ta = create(:active_tag_alias)
+  #     ta.update_columns(approver_id: create(:admin_user).id)
+  #     allow(ta).to receive_messages(
+  #       valid?: false,
+  #       errors: instance_double(ActiveModel::Errors, full_messages: ["something is wrong"]),
+  #     )
+  #
+  #     expect { ta.process_undo!(update_topic: false) }.to raise_error(RuntimeError, /something is wrong/)
+  #   end
+  #
+  #   it "enqueues TagAliasFinalizeJob with antecedent_name" do
+  #     ta = create(:active_tag_alias)
+  #     ta.update_columns(approver_id: create(:admin_user).id)
+  #
+  #     expect { ta.process_undo!(update_topic: false) }
+  #       .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id, ta.antecedent_name)
+  #   end
+  #
+  #   it "does not call fix_post_count directly" do
+  #     ta = create(:active_tag_alias)
+  #     ta.update_columns(approver_id: create(:admin_user).id)
+  #     allow(ta.antecedent_tag).to receive(:fix_post_count)
+  #     allow(ta.consequent_tag).to receive(:fix_post_count)
+  #
+  #     ta.process_undo!(update_topic: false)
+  #
+  #     expect(ta.antecedent_tag).not_to have_received(:fix_post_count)
+  #     expect(ta.consequent_tag).not_to have_received(:fix_post_count)
+  #   end
+  # end
 end

--- a/spec/models/tag_implication/approval_methods_spec.rb
+++ b/spec/models/tag_implication/approval_methods_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe TagImplication do
   # #process!
   # ---------------------------------------------------------------------------
   describe "#process!" do
-    it "sets status to processing before finalizing" do
+    it "sets status to active after processing" do
       ti = create(:tag_implication)
       ti.update_columns(status: "queued", approver_id: create(:admin_user).id)
       allow(ti).to receive_messages(
@@ -58,8 +58,7 @@ RSpec.describe TagImplication do
 
       ti.process!(update_topic: false)
 
-      # Status gets set to "active" in the TagImplicationFinalizeJob
-      expect(ti.reload.status).to eq("processing")
+      expect(ti.reload.status).to eq("active")
     end
 
     it "sets status to error when processing raises an exception" do

--- a/spec/models/tag_implication/approval_methods_spec.rb
+++ b/spec/models/tag_implication/approval_methods_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe TagImplication do
   # #process!
   # ---------------------------------------------------------------------------
   describe "#process!" do
-    it "sets status to active after successful processing" do
+    it "sets status to processing before finalizing" do
       ti = create(:tag_implication)
       ti.update_columns(status: "queued", approver_id: create(:admin_user).id)
       allow(ti).to receive_messages(
@@ -58,7 +58,8 @@ RSpec.describe TagImplication do
 
       ti.process!(update_topic: false)
 
-      expect(ti.reload.status).to eq("active")
+      # Status gets set to "active" in the TagImplicationFinalizeJob
+      expect(ti.reload.status).to eq("processing")
     end
 
     it "sets status to error when processing raises an exception" do

--- a/spec/requests/tag_corrections_controller_spec.rb
+++ b/spec/requests/tag_corrections_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TagCorrectionsController do
       it "returns JSON with correction attributes" do
         get tag_correction_path(tag_id: tag.id, format: :json)
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body).to include("post_count", "real_post_count", "category")
+        expect(response.parsed_body).to include("post_count", "post_count_from_opensearch", "post_count_from_db", "category")
       end
     end
 

--- a/spec/requests/tag_corrections_controller_spec.rb
+++ b/spec/requests/tag_corrections_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TagCorrectionsController do
       it "returns JSON with correction attributes" do
         get tag_correction_path(tag_id: tag.id, format: :json)
         expect(response).to have_http_status(:ok)
-        expect(response.parsed_body).to include("post_count", "post_count_from_opensearch", "post_count_from_db", "category")
+        expect(response.parsed_body).to include("post_count", "real_post_count", "category")
       end
     end
 
@@ -82,14 +82,11 @@ RSpec.describe TagCorrectionsController do
       end
 
       context "when the tag is aliased away and has more than 20 posts" do
-        let(:high_count_query) { instance_double(DocumentStore::Response, count_only: 25) }
-
-        before do
-          CurrentUser.scoped(bd_janitor) { create(:active_tag_alias, antecedent_name: tag.name) }
-          allow(Post).to receive(:tag_match).and_return(high_count_query)
-        end
-
         it "returns 200 and sets @true_post_ids to \"> 20\"" do
+          CurrentUser.scoped(bd_janitor) { create(:active_tag_alias, antecedent_name: tag.name) }
+          allow(Tag).to receive(:find).with(tag.id.to_s).and_return(tag)
+          allow(tag).to receive(:post_count_from_db).and_return(25)
+
           get new_tag_correction_path(tag_id: tag.id)
           expect(response).to have_http_status(:ok)
           expect(controller.instance_variable_get(:@true_post_ids)).to eq("> 20")


### PR DESCRIPTION
Aliases and implications would fail to update their tag counts - most prominently on antecedents.
In addition to that, tag aliases would update the OpenSearch index for every post with the consequent tag. This is entirely pointless, and would take hours.
Both issues should now be fixed.

Commented out all the undo logic for the tag aliases.
It's unfinished, buggy, and has no UI. Fixing/reworking it will need to be its own project.