### PR TITLE
[Comments] Fix an error on posts with hidden comments

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,12 +77,7 @@ class PostsController < ApplicationController
     @has_samples = @post.is_image? || @post.video_sample_list[:has]
 
     if request.format.html? && @post.comment_count > 0
-      if !CurrentUser.user.is_staff? && @post.is_comment_disabled?
-        @comments = @post.comments.stickied
-      else
-        @comments = @post.comments.above_threshold
-      end
-      @comments = @comments.includes(:creator, :updater).to_a
+      @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
       Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     else
       @comments = Comment.none
@@ -109,12 +104,7 @@ class PostsController < ApplicationController
     @children_post_set = PostSets::PostRelationship.new(@post.id, include_deleted: include_deleted, want_parent: false)
 
     if request.format.html? && @post.comment_count > 0
-      if !CurrentUser.user.is_staff? && @post.is_comment_disabled?
-        @comments = @post.comments.stickied
-      else
-        @comments = @post.comments.above_threshold
-      end
-      @comments = @comments.includes(:creator, :updater).to_a
+      @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
       Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     else
       @comments = Comment.none

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,7 +77,7 @@ class PostsController < ApplicationController
     @has_samples = @post.is_image? || @post.video_sample_list[:has]
 
     if request.format.html? && @post.comment_count > 0
-      if !CurrentUser.user.is_moderator? && @post.is_comment_disabled?
+      if !CurrentUser.user.is_staff? && @post.is_comment_disabled?
         @comments = @post.comments.stickied
       else
         @comments = @post.comments.above_threshold
@@ -109,7 +109,12 @@ class PostsController < ApplicationController
     @children_post_set = PostSets::PostRelationship.new(@post.id, include_deleted: include_deleted, want_parent: false)
 
     if request.format.html? && @post.comment_count > 0
-      @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
+      if !CurrentUser.user.is_staff? && @post.is_comment_disabled?
+        @comments = @post.comments.stickied
+      else
+        @comments = @post.comments.above_threshold
+      end
+      @comments = @comments.includes(:creator, :updater).to_a
       Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     else
       @comments = Comment.none

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,7 +77,12 @@ class PostsController < ApplicationController
     @has_samples = @post.is_image? || @post.video_sample_list[:has]
 
     if request.format.html? && @post.comment_count > 0
-      @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
+      if !CurrentUser.user.is_moderator? && @post.is_comment_disabled?
+        @comments = @post.comments.stickied
+      else
+        @comments = @post.comments.above_threshold
+      end
+      @comments = @comments.includes(:creator, :updater).to_a
       Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
     else
       @comments = Comment.none

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -66,7 +66,7 @@ class Comment < ApplicationRecord
       unless user.is_staff?
         disabled_post_ids = SearchMethods.comment_disabled_post_ids
         unless disabled_post_ids.empty?
-          conditions << "comments.post_id NOT IN (?)"
+          conditions << "(comments.post_id NOT IN (?) OR comments.is_sticky = true)"
           arguments << disabled_post_ids
         end
       end

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -11,7 +11,6 @@
         <%= render "posts/partials/common/inline_blacklist" %>
       </span>
     </div>
-    <% comments = comments.stickied %>
     <div class="list-of-comments">
       <% if comments.any? %>
         <%= render partial: "comments/partials/show/comment", collection: comments, locals: { post: post } %>

--- a/spec/models/comment/search_spec.rb
+++ b/spec/models/comment/search_spec.rb
@@ -207,6 +207,16 @@ RSpec.describe Comment do
       expect(result).not_to include(on_disabled)
     end
 
+    it "includes stickied comments on disabled posts for non-staff" do
+      post        = create(:post)
+      on_disabled = CurrentUser.scoped(create(:user), "127.0.0.1") { make_comment(post: post, is_sticky: true) }
+      post.update_columns(is_comment_disabled: true)
+      Comment::SearchMethods.clear_comment_disabled_cache
+      member = create(:user)
+      result = Comment.accessible(member)
+      expect(result).to include(on_disabled)
+    end
+
     it "includes comments on disabled posts for staff" do
       post        = create(:post)
       on_disabled = CurrentUser.scoped(create(:user), "127.0.0.1") { make_comment(post: post) }


### PR DESCRIPTION
The comments partial was trying to narrow down the comments list to just sticked comments.
Also fixed an unrelated bug that was causing stickied posts to now show up on posts with hidden comments.