### PR TITLE
[PostVersions] [UI] Fix overflowing source links

### DIFF
--- a/app/javascript/src/styles/specific/post_versions.scss
+++ b/app/javascript/src/styles/specific/post_versions.scss
@@ -157,6 +157,7 @@ div#c-post-versions {
       grid-row: 4;
       @include grid-col(10, 14);
       overflow-wrap: anywhere;
+      overflow-y: scroll;
 
       .diff-list {
         display: flex;


### PR DESCRIPTION
Fixes [this](https://discord.com/channels/431908090883997698/1509183518775709736/1509222187813441576).
<img width="1176" height="244" alt="image" src="https://github.com/user-attachments/assets/7d406532-e55c-4867-be00-8e91c8457a03" />