### PR TITLE
[PostReplacements] Fix a crash on the new replacement page

### DIFF
--- a/app/javascript/src/js/components/autocompletable_input.vue
+++ b/app/javascript/src/js/components/autocompletable_input.vue
@@ -26,14 +26,14 @@ export default {
   },
   methods: {
     currentEntries() {
-      return LStorage.getObject(`autocomplete-${this.listId}`) || [];
+      return LStorage.Raw.getObject(`autocomplete-${this.listId}`) || [];
     },
   },
   watch: {
     addToList(value) {
       const maxEntries = 50;
       const entries = new Set([value.trim(), ...this.currentEntries()]);
-      LStorage.putObject(`autocomplete-${this.listId}`, [...entries].slice(0, maxEntries));
+      LStorage.Raw.putObject(`autocomplete-${this.listId}`, [...entries].slice(0, maxEntries));
     }
   },
 }

--- a/app/javascript/src/js/utility/Storage.ts
+++ b/app/javascript/src/js/utility/Storage.ts
@@ -57,6 +57,26 @@ export default class LStorage {
     StaffStats: false,
     StaffNotes: false,
   };
+
+  /** Backwards compatibility layer for AutocompleteInput */
+  static Raw = {
+    getObject: function (name: string) {
+      if (!L2Utils.isAvailable) return null;
+      const value = localStorage[name];
+      if (!value) return null;
+
+      try {
+        return JSON.parse(value);
+      } catch (error) {
+        console.error(`Failed to parse localStorage key "${name}" with value "${value}" as JSON.`, error);
+        return null;
+      }
+    },
+    putObject: function (name: string, value: any) {
+      if (!L2Utils.isAvailable) return;
+      localStorage[name] = JSON.stringify(value);
+    },
+  };
 }
 
 // Corresponding storage keys and configuration for L2Storage.
@@ -114,6 +134,8 @@ const StorageKeys: StorageConfig = {
     StaffStats: "e6.users.staffstats",
     StaffNotes: "e6.users.staffnotes",
   },
+
+  "Raw": null, // Custom getObject and putObject functions that bypass the proxies
 };
 
 


### PR DESCRIPTION
The new LStorage implementation lacked a couple backwards compatibility methods, which caused Vue to enter an infinite loop while unable to mount.