### PR TITLE
[Misc] Remove the usage of :unprocessable_entity

### DIFF
--- a/app/controllers/api_keys_controller.rb
+++ b/app/controllers/api_keys_controller.rb
@@ -48,7 +48,7 @@ class ApiKeysController < ApplicationController
 
   def regenerate
     unless @api_key.expired?
-      render_expected_error(:unprocessable_entity, "Only expired API keys can be regenerated")
+      render_expected_error(:unprocessable_content, "Only expired API keys can be regenerated")
       return
     end
 

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -64,7 +64,7 @@ class PostReplacementsController < ApplicationController
       # Both Approve and Reset To submit to this endpoint; reset-to passes penalize_current_uploader=false.
       action_name = is_reset_to ? "reset to" : "approve"
       flash.now[:notice] = "Error: Cannot #{action_name} replacement for deleted target post"
-      render plain: flash[:notice], status: :unprocessable_entity
+      render plain: flash[:notice], status: 422
       return
     end
 

--- a/spec/requests/comments_controller_spec.rb
+++ b/spec/requests/comments_controller_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe CommentsController do
     describe "created_at search param" do
       it "returns 422 for invalid created_at value in HTML format" do
         get comments_path(search: { created_at: "999999999999999999999" })
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "returns 422 for invalid created_at value in JSON format" do
         get comments_path(format: :json, search: { created_at: "999999999999999999999" })
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/requests/moderator/ip_addrs_controller_spec.rb
+++ b/spec/requests/moderator/ip_addrs_controller_spec.rb
@@ -76,12 +76,12 @@ RSpec.describe Moderator::IpAddrsController do
 
         it "returns 422 for invalid IP address" do
           get moderator_ip_addrs_path, params: { search: { ip_addr: "*dylan*dolly*" } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "returns 422 for invalid CIDR prefix" do
           get moderator_ip_addrs_path, params: { search: { ip_addr: "127.0.0.1/999" } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end
@@ -153,12 +153,12 @@ RSpec.describe Moderator::IpAddrsController do
       context "when searching by ip_addr" do
         it "returns 422 for invalid IP address" do
           get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "*dylan*dolly*" } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
 
         it "returns 422 for invalid CIDR prefix" do
           get export_moderator_ip_addrs_path(format: :json), params: { search: { ip_addr: "127.0.0.1/999" } }
-          expect(response).to have_http_status(:unprocessable_entity)
+          expect(response).to have_http_status(:unprocessable_content)
         end
       end
     end

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -99,12 +99,12 @@ RSpec.describe PostsController do
 
       it "returns 422 for HTML" do
         get posts_path
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
 
       it "returns 422 for JSON" do
         get posts_path(format: :json)
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end


### PR DESCRIPTION
It is deprecated, and slated to be removed.
Plus, RSpec complains.