### PR TITLE
[Search] Allow 'me' shortcut to be used across metatags

### DIFF
--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1645,6 +1645,7 @@ class TagQuery
 
   def privileged_user_id_or_invalid(val)
     if CurrentUser.user.is_moderator?
+      return CurrentUser.id if val.is_a?(String) && val.casecmp?("me")
       User.name_or_id_to_id(val).presence
     elsif CurrentUser.user.is_authenticated?
       CurrentUser.id.presence

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1366,6 +1366,9 @@ class TagQuery
           post_set_id
         end
 
+      # NOTE: The favorite case is the only case where `user_id_or_invalid` isn't used, because it needs to check for the `hide_favorites` user setting.
+      # As a result, to avoid an extra lookup in the common case of a valid user, the logic is duplicated here instead of using `user_id_or_invalid` with an `invalid_user_id` of `-1` and then checking for that in the caller.
+      # In future permissions changes, the situation may change, either allowing for `user_id_or_invalid` to be used here or necessitating similar logic in other cases, so this should be kept in mind.
       when "fav", "-fav", "~fav", "favoritedby", "-favoritedby", "~favoritedby"
         add_to_query(type, :fav_ids) do
           if g2.downcase == "me"
@@ -1634,6 +1637,9 @@ class TagQuery
   end
 
   def user_id_or_invalid(val)
+    if val.respond_to?(:downcase) && val.downcase == "me"
+      return CurrentUser.is_authenticated? ? CurrentUser.id : -1
+    end
     User.name_or_id_to_id(val).presence || -1
   end
 

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1637,7 +1637,7 @@ class TagQuery
   end
 
   def user_id_or_invalid(val)
-    if val.respond_to?(:downcase) && val.downcase == "me"
+    if val.is_a?(String) && val.casecmp?("me")
       return CurrentUser.is_authenticated? ? CurrentUser.id : -1
     end
     User.name_or_id_to_id(val).presence || -1

--- a/spec/logical/tag_query/content_metatags_spec.rb
+++ b/spec/logical/tag_query/content_metatags_spec.rb
@@ -190,5 +190,10 @@ RSpec.describe TagQuery, type: :model do
       tq = TagQuery.new("deletedby:#{moderator.name}")
       expect(tq[:status]).to eq("any")
     end
+
+    it "stores the current user's ID for deletedby:me" do
+      tq = TagQuery.new("deletedby:me")
+      expect(tq[:deleter]).to include(CurrentUser.id)
+    end
   end
 end

--- a/spec/logical/tag_query/user_metatags_spec.rb
+++ b/spec/logical/tag_query/user_metatags_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe TagQuery, type: :model do
     end
 
     it "skips for user:me on an anonymous session" do
-      CurrentUser.user.level = User::Levels::ANONYMOUS
+      CurrentUser.user = User.anonymous
       tq = TagQuery.new("user:me")
       expect(tq[:uploader_ids]).to include(-1)
     end

--- a/spec/logical/tag_query/user_metatags_spec.rb
+++ b/spec/logical/tag_query/user_metatags_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe TagQuery, type: :model do
       tq = TagQuery.new("~user:#{target_user.name}")
       expect(tq[:uploader_ids_should]).to include(target_user.id)
     end
+
+    it "stores the current user's ID for user:me" do
+      tq = TagQuery.new("user:me")
+      expect(tq[:uploader_ids]).to include(CurrentUser.id)
+    end
+
+    it "skips for user:me on an anonymous session" do
+      CurrentUser.user.level = User::Levels::ANONYMOUS
+      tq = TagQuery.new("user:me")
+      expect(tq[:uploader_ids]).to include(-1)
+    end
   end
 
   describe "approver: metatag" do
@@ -61,6 +72,11 @@ RSpec.describe TagQuery, type: :model do
       tq = TagQuery.new("-approver:any")
       expect(tq[:approver]).to eq("none")
     end
+
+    it "stores the current user's ID for approver:me" do
+      tq = TagQuery.new("approver:me")
+      expect(tq[:approver_ids]).to include(CurrentUser.id)
+    end
   end
 
   describe "commenter: metatag and comm: alias" do
@@ -79,6 +95,11 @@ RSpec.describe TagQuery, type: :model do
       tq = TagQuery.new("commenter:any")
       expect(tq[:commenter]).to eq("any")
     end
+
+    it "stores the current user's ID for commenter:me" do
+      tq = TagQuery.new("commenter:me")
+      expect(tq[:commenter_ids]).to include(CurrentUser.id)
+    end
   end
 
   describe "noter: metatag" do
@@ -90,6 +111,11 @@ RSpec.describe TagQuery, type: :model do
     it "handles noter:any" do
       tq = TagQuery.new("noter:any")
       expect(tq[:noter]).to eq("any")
+    end
+
+    it "stores the current user's ID for noter:me" do
+      tq = TagQuery.new("noter:me")
+      expect(tq[:noter_ids]).to include(CurrentUser.id)
     end
   end
 

--- a/spec/logical/tag_query/user_metatags_spec.rb
+++ b/spec/logical/tag_query/user_metatags_spec.rb
@@ -129,6 +129,11 @@ RSpec.describe TagQuery, type: :model do
       tq = TagQuery.new("noteupdater:nobody_here_zzz")
       expect(tq[:note_updater_ids]).to include(-1)
     end
+
+    it "stores the current user's ID for noteupdater:me" do
+      tq = TagQuery.new("noteupdater:me")
+      expect(tq[:note_updater_ids]).to include(CurrentUser.id)
+    end
   end
 
   describe "fav: metatag and favoritedby: alias" do
@@ -186,6 +191,11 @@ RSpec.describe TagQuery, type: :model do
       it "voted: resolves the user and stores ID in voted array" do
         tq = TagQuery.new("voted:#{target_user.name}")
         expect(tq[:voted]).to include(target_user.id)
+      end
+
+      it "upvote:me stores the moderator's own ID" do
+        tq = TagQuery.new("upvote:Me") # test case-insensitivity
+        expect(tq[:upvote]).to include(CurrentUser.id)
       end
     end
 


### PR DESCRIPTION
Notes
* Added test for metatags even though they should all be the same
* Added test to ensure safe behavior from anonymous users
* Added guard to prevent 'downcase' from throwing if a non-string somehow gets passed