### PR TITLE
[Misc] Refactor the global E621 object and deprecate old logger methods

### DIFF
--- a/app/javascript/entrypoints/application.ts
+++ b/app/javascript/entrypoints/application.ts
@@ -6,65 +6,21 @@ import Rails from "@rails/ujs";
 Rails.start();
 
 // Common imports for all controllers
-import Autocomplete from "@/components/autocomplete";
-import DTextFormatter from "@/components/DTextFormatter";
-import ThumbnailEngine from "@/components/ThumbnailEngine";
 import "@/core/analytics";
 import "@/core/AuthOverlay";
-import Blacklist from "@/core/blacklists";
 import "@/core/common";
-import DeferredPostLoader from "@/core/DeferredPostLoader";
 import "@/core/dtext_formatter_loader";
-import Hotkeys from "@/core/hotkeys";
 import "@/core/Navigation";
 import "@/core/news_updates";
 import "@/core/paginator";
 import "@/core/themes";
 import "@/core/tos_warning";
 import "@/core/user_warning"; // Realistically, should only be on specific pages
-import E621Type from "@/interfaces/E621";
-import PostCache from "@/models/PostCache";
+import { getE621Instance } from "@/interfaces/E621";
 import Logger from "@/utility/Logger";
-import ModuleRegistry from "@/utility/ModuleRegistry";
-import PerformanceTracker from "@/utility/PerformanceTracker";
-import Settings from "@/utility/Settings";
-import LStorage from "@/utility/Storage";
-import CStorage from "@/utility/StorageC";
 import ToastManager from "@/utility/Toast";
 
 Logger.log("Loading");
-
-// NOTE: When making changes to this object, ensure that the interface
-// in app/javascript/src/js/interfaces/E621.ts is updated accordingly.
-
-window["E621"] = {
-  Registry: new ModuleRegistry(),
-  Performance: new PerformanceTracker("app"),
-  Logger,
-
-  CStorage,
-  LStorage,
-  Settings,
-
-  Hotkeys,
-  Toast: ToastManager,
-
-  Autocomplete,
-  Blacklist,
-  DeferredPostLoader,
-  DTextFormatter,
-  PostCache,
-  ThumbnailEngine,
-
-  // compatibility aliases
-  error: ToastManager.alert,
-  notice: ToastManager.notice,
-  Flash: {
-    notice: ToastManager.notice,
-    error: ToastManager.alert,
-  },
-} as E621Type;
-window["Danbooru"] = window["E621"];
-
+getE621Instance();
 ToastManager.bootstrap();
 

--- a/app/javascript/src/js/interfaces/E621.ts
+++ b/app/javascript/src/js/interfaces/E621.ts
@@ -72,7 +72,7 @@ export function getE621Instance (): E621Type {
     // compatibility aliases
     // TODO: Remove after November 2026
     notice: deprecated(ToastManager.notice, "E621.notice is deprecated. Please use E621.Toast.notice instead."),
-    error: deprecated(ToastManager.alert, "E621.alert is deprecated. Please use E621.Toast.alert instead."),
+    error: deprecated(ToastManager.alert, "E621.error is deprecated. Please use E621.Toast.alert instead."),
     Flash: {
       notice: deprecated(ToastManager.notice, "E621.Flash.notice is deprecated. Please use E621.Toast.notice instead."),
       error: deprecated(ToastManager.alert, "E621.Flash.error is deprecated. Please use E621.Toast.alert instead."),
@@ -81,7 +81,7 @@ export function getE621Instance (): E621Type {
 
   window["Danbooru"] = window["E621"] = instance;
   return instance;
-};
+}
 
 /**
  * Marks a method as deprecated, logging a warning message to the console when it is called.
@@ -92,6 +92,6 @@ export function getE621Instance (): E621Type {
 function deprecated<T extends (...args: any[]) => void>(method: T, warningMessage: string): T {
   return function (this: any, ...args: any[]) {
     console.warn(warningMessage);
-    return method.apply(this, args);
+    return method(...args);
   } as unknown as T;
 }

--- a/app/javascript/src/js/interfaces/E621.ts
+++ b/app/javascript/src/js/interfaces/E621.ts
@@ -31,4 +31,67 @@ export default interface E621Type {
   DTextFormatter: typeof DTextFormatter;
   PostCache: typeof PostCache;
   ThumbnailEngine: typeof ThumbnailEngine;
+
+  // compatibility aliases
+  notice: typeof ToastManager.notice;
+  error: typeof ToastManager.alert;
+  Flash: {
+    notice: typeof ToastManager.notice;
+    error: typeof ToastManager.alert;
+  };
+}
+
+/**
+ * Bootstraps and returns the global e621 instance.
+ * Only intended to be used internally; for external usage, access the global `E621` variable directly.
+ * @returns The global E621 instance.
+ */
+export function getE621Instance (): E621Type {
+  if (window["E621"])
+    return window["E621"] as E621Type;
+
+  const instance = {
+    Registry: new ModuleRegistry(),
+    Performance: new PerformanceTracker("app"),
+    Logger,
+
+    CStorage,
+    LStorage,
+    Settings,
+
+    Hotkeys,
+    Toast: ToastManager,
+
+    Autocomplete,
+    Blacklist,
+    DeferredPostLoader,
+    DTextFormatter,
+    PostCache,
+    ThumbnailEngine,
+
+    // compatibility aliases
+    // TODO: Remove after November 2026
+    notice: deprecated(ToastManager.notice, "E621.notice is deprecated. Please use E621.Toast.notice instead."),
+    error: deprecated(ToastManager.alert, "E621.alert is deprecated. Please use E621.Toast.alert instead."),
+    Flash: {
+      notice: deprecated(ToastManager.notice, "E621.Flash.notice is deprecated. Please use E621.Toast.notice instead."),
+      error: deprecated(ToastManager.alert, "E621.Flash.error is deprecated. Please use E621.Toast.alert instead."),
+    },
+  };
+
+  window["Danbooru"] = window["E621"] = instance;
+  return instance;
+};
+
+/**
+ * Marks a method as deprecated, logging a warning message to the console when it is called.
+ * @param method The method to mark as deprecated.
+ * @param warningMessage The warning message to log when the method is called.
+ * @returns A new method that logs the warning message and then calls the original method.
+ */
+function deprecated<T extends (...args: any[]) => void>(method: T, warningMessage: string): T {
+  return function (this: any, ...args: any[]) {
+    console.warn(warningMessage);
+    return method.apply(this, args);
+  } as unknown as T;
 }


### PR DESCRIPTION
Moved the e621 object to the same file as the interface. Similar to #2043.

Deprecated the old logger methods.
The new approach is to use the `E621.Toast.notice`, `E621.Toast.alert`, `ToastManager.create`, or just instantiate a `Toast` object directly.