### PR TITLE
[Posts] Rework the "Download" button logic

### DIFF
--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -242,7 +242,7 @@ export default class PostsShowToolbar {
       toggle.attr("aria-expanded", !offclickHandler.disabled);
     });
 
-    $(".ptbr-etc-pool, .ptbr-etc-set, .ptbr-share-button").on("click", () => {
+    $(".ptbr-etc-download, .ptbr-etc-pool, .ptbr-etc-set, .ptbr-share-button").on("click", () => {
       offclickHandler.disabled = true;
       menu.addClass("hidden");
     });

--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -242,37 +242,6 @@ export default class PostsShowToolbar {
       toggle.attr("aria-expanded", !offclickHandler.disabled);
     });
 
-    const button = $(".ptbr-etc-download").on("click.e6.prepare", (event) => {
-      event.preventDefault();
-
-      if (button.attr("pending") == "true") return;
-      button.attr("pending", "true");
-
-      const url = PostsShowToolbar.currentPost.file.url;
-
-      fetch(url, {
-        mode: "cors",
-      })
-        .then(response => {
-          if (!response.ok) throw new Error(`HTTP ${response.status}`);
-          return response.blob();
-        })
-        .then(blob => {
-          const blobUrl = window.URL.createObjectURL(blob);
-          PostsShowToolbar.generateDownloadLink(blobUrl, button.attr("download"));
-          button.attr("pending", "false");
-          setTimeout(() => window.URL.revokeObjectURL(blobUrl), 0);
-        })
-        .catch(e => {
-          E621.Toast.alert("Failed to download post file: " + e.message, e);
-          button.attr("pending", "false");
-        })
-        .finally(() => {
-          offclickHandler.disabled = true;
-          menu.addClass("hidden");
-        });
-    });
-
     $(".ptbr-etc-pool, .ptbr-etc-set, .ptbr-share-button").on("click", () => {
       offclickHandler.disabled = true;
       menu.addClass("hidden");

--- a/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
+++ b/app/javascript/src/js/pages/posts/show/PostsShowToolbar.js
@@ -247,16 +247,6 @@ export default class PostsShowToolbar {
       menu.addClass("hidden");
     });
   }
-
-  static generateDownloadLink (blobUrl, fileName) {
-    // I will take a download link... and CLICK IT!!!
-    const downloadLink = document.createElement("a");
-    downloadLink.href = blobUrl;
-    downloadLink.setAttribute("download", fileName);
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    downloadLink.remove();
-  }
 }
 
 $(() => {

--- a/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_post_toolbar.scss
@@ -246,27 +246,6 @@
 #ptbr-wrapper .ptbr-etc-download {
   min-width: 6rem;
   align-items: center;
-
-  svg {
-    display: none;
-    height: 1rem;
-    width: 1rem;
-    animation: spin-animation ease-in-out 1s infinite;
-  }
-
-  span {
-    text-align: center;
-  }
-
-  &[pending="true"] {
-    svg { display: inline; }
-    span { display: none; }
-  }
-  
-  @keyframes spin-animation {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-  }
 }
 
 

--- a/app/logical/storage_manager.rb
+++ b/app/logical/storage_manager.rb
@@ -209,17 +209,17 @@ class StorageManager
     end
   end
 
-  def download_url(md5, file_ext)
-    path = file_path_base(md5, file_ext, :original)
-    "#{base_url}#{base_path}/download#{path}"
-  end
-
   def post_file_url(post, type = :original, ext: nil, scale: nil)
     if %i[preview preview_jpg preview_webp].include?(type) && !post.has_preview?
       return "/images/download-preview.png"
     end
     ext ||= post.file_ext
     file_url(post.md5, ext, type, protect: post.protect_file?, scale: scale)
+  end
+
+  def download_url(md5, file_ext)
+    path = file_path_base(md5, file_ext, :original)
+    "#{base_url}#{base_path}/download#{path}"
   end
 
   def post_download_url(post)

--- a/app/logical/storage_manager.rb
+++ b/app/logical/storage_manager.rb
@@ -209,12 +209,22 @@ class StorageManager
     end
   end
 
+  def download_url(md5, file_ext)
+    path = file_path_base(md5, file_ext, :original)
+    "#{base_url}#{base_path}/download#{path}"
+  end
+
   def post_file_url(post, type = :original, ext: nil, scale: nil)
     if %i[preview preview_jpg preview_webp].include?(type) && !post.has_preview?
       return "/images/download-preview.png"
     end
     ext ||= post.file_ext
     file_url(post.md5, ext, type, protect: post.protect_file?, scale: scale)
+  end
+
+  def post_download_url(post)
+    return nil if post.is_deleted?
+    download_url(post.md5, post.file_ext)
   end
 
   def file_path_base(md5, file_ext, type = :original, protect: false, scale: nil)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -122,6 +122,10 @@ class Post < ApplicationRecord
       storage_manager.post_file_url(self)
     end
 
+    def download_url
+      storage_manager.post_download_url(self)
+    end
+
     # TODO: Deprecate this method
     def file_url_ext(ext)
       storage_manager.post_file_url(self, ext: ext)

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -136,16 +136,18 @@
       <%= svg_icon(:ellipsis_v) %>
     </button>
     <div class="ptbr-etc-menu hidden" id="ptbr-etc-menu" role="menu">
-      <a
-        href="<%= @post.file_url %>"
-        class="st-button ptbr-etc-download"
-        download="<%= @post.md5 %>.<%= @post.file_ext %>"
-        pending="false"
-        data-hotkey="download"
-      >
-        <%= svg_icon(:hexagon) %>
-        <span>Download</span>
-      </a>
+      <% unless @post.is_deleted? %>
+        <a
+          href="<%= @post.download_url %>"
+          class="st-button ptbr-etc-download"
+          download="<%= @post.md5 %>.<%= @post.file_ext %>"
+          pending="false"
+          data-hotkey="download"
+        >
+          <%= svg_icon(:hexagon) %>
+          <span>Download</span>
+        </a>
+      <% end %>
       <button class="st-button ptbr-share-button" data-hotkey="share">Share</button>
       <% if CurrentUser.is_member? %>
         <button class="st-button ptbr-etc-pool add-to-pool" data-hotkey="add-to-pool">Add to Pool</button>

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -140,7 +140,6 @@
         <a
           href="<%= @post.download_url %>"
           class="st-button ptbr-etc-download"
-          download="<%= @post.md5 %>.<%= @post.file_ext %>"
           data-hotkey="download"
         >
           Download

--- a/app/views/posts/partials/show/content/_toolbar.html.erb
+++ b/app/views/posts/partials/show/content/_toolbar.html.erb
@@ -141,11 +141,9 @@
           href="<%= @post.download_url %>"
           class="st-button ptbr-etc-download"
           download="<%= @post.md5 %>.<%= @post.file_ext %>"
-          pending="false"
           data-hotkey="download"
         >
-          <%= svg_icon(:hexagon) %>
-          <span>Download</span>
+          Download
         </a>
       <% end %>
       <button class="st-button ptbr-share-button" data-hotkey="share">Share</button>

--- a/app/views/posts/partials/show/content/embedded/_video.html.erb
+++ b/app/views/posts/partials/show/content/embedded/_video.html.erb
@@ -1,4 +1,4 @@
-<%= tag.video(id: "image", class: post.display_class_for, loop: "true", controls: "controls") do %>
+<%= tag.video(id: "image", class: post.display_class_for, loop: "true", controls: "controls", controlslist: "nodownload") do %>
   <% post.initial_video_urls.each do |video| %>
     <%= tag.source(src: video[:url], type: video[:codec]) %>
   <% end %>

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -23,7 +23,7 @@ server {
 
   location /data/download/ {
     alias /app/public/data/;
-    add_header Content-Disposition "attachment";
+    add_header Content-Disposition "attachment"; filename="$arg_filename"';
     expires max;
   }
 

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -13,6 +13,20 @@ server {
     break;
   }
 
+  location /data/download/deleted/ {
+    return 403;
+  }
+
+  location /data/download/replacements/ {
+    return 403;
+  }
+
+  location /data/download/ {
+    alias /app/public/data/;
+    add_header Content-Disposition "attachment";
+    expires max;
+  }
+
   location /data/deleted/ {
     add_header Cache-Control "private";
     secure_link $arg_auth,$arg_expires;

--- a/docker/default.conf.template
+++ b/docker/default.conf.template
@@ -23,7 +23,7 @@ server {
 
   location /data/download/ {
     alias /app/public/data/;
-    add_header Content-Disposition "attachment"; filename="$arg_filename"';
+    add_header Content-Disposition 'attachment; filename="$arg_filename"';
     expires max;
   }
 

--- a/spec/logical/storage_manager/url_generation_spec.rb
+++ b/spec/logical/storage_manager/url_generation_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe StorageManager do
 
     it "returns nil for a deleted post" do
       post = instance_double(Post, md5: md5, file_ext: "jpg", is_deleted?: true)
-      expect(manager.post_download_url(post)).to eq(nil)
+      expect(manager.post_download_url(post)).to be_nil
     end
   end
 end

--- a/spec/logical/storage_manager/url_generation_spec.rb
+++ b/spec/logical/storage_manager/url_generation_spec.rb
@@ -114,4 +114,28 @@ RSpec.describe StorageManager do
       end
     end
   end
+
+  # -------------------------------------------------------------------------
+  # #download_url
+  # -------------------------------------------------------------------------
+  describe "#download_url" do
+    it "returns the download URL for the given md5 and extension" do
+      expect(manager.download_url(md5, "jpg")).to eq("http://example.com/data/download/#{md5}.jpg")
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #post_download_url
+  # -------------------------------------------------------------------------
+  describe "#post_download_url" do
+    it "returns the download URL for a non-deleted post" do
+      post = instance_double(Post, md5: md5, file_ext: "jpg", is_deleted?: false)
+      expect(manager.post_download_url(post)).to eq("http://example.com/data/download/#{md5}.jpg")
+    end
+
+    it "returns nil for a deleted post" do
+      post = instance_double(Post, md5: md5, file_ext: "jpg", is_deleted?: true)
+      expect(manager.post_download_url(post)).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
The "Download" button proved to be surprisingly challenging because in production, we serve static content from a different domain: `static1.e621.net` vs `e621.net`. This means that simply adding the `download` attribute does not work: modern browsers block cross-origin downloads like this.

Previous solution to this involved downloading the file into memory, creating a blob, and then downloading it.
A better solution implemented here involves adding another route to the static server that returns the same content as `/data/`, but with a `Content-Disposition "attachment"` header.

Currently, this approach does not work with deleted files.
But that is an edge case - almost all users will never have access to them anyways.