### PR TITLE
[DbExport] Add public database export page and job

### DIFF
--- a/app/controllers/db_exports_controller.rb
+++ b/app/controllers/db_exports_controller.rb
@@ -2,7 +2,6 @@
 
 class DbExportsController < ApplicationController
   before_action :validate_exports_enabled
-  before_action :member_only, only: %i[favorites votes]
 
   def index
     @exports = DbExport.order(:name)
@@ -13,37 +12,7 @@ class DbExportsController < ApplicationController
     end
   end
 
-  def favorites
-    user = CurrentUser.user
-    stream_personal_csv(
-      "SELECT id, post_id, created_at FROM favorites WHERE user_id = #{user.id} ORDER BY id DESC",
-      "favorites-#{user.name}-#{Date.current}.csv",
-    )
-  end
-
-  def votes
-    user = CurrentUser.user
-    stream_personal_csv(
-      "SELECT id, post_id, score, created_at FROM post_votes WHERE user_id = #{user.id} ORDER BY id DESC",
-      "votes-#{user.name}-#{Date.current}.csv",
-    )
-  end
-
   private
-
-  def stream_personal_csv(query, filename)
-    headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format(disposition: "attachment", filename: filename)
-    headers["Content-Type"] = "text/csv"
-
-    conn = ActiveRecord::Base.connection.raw_connection
-    self.response_body = Enumerator.new do |yielder|
-      conn.copy_data("COPY (#{query}) TO STDOUT WITH CSV HEADER") do
-        while (row = conn.get_copy_data)
-          yielder << row
-        end
-      end
-    end
-  end
 
   def export_json(export)
     {

--- a/app/controllers/db_exports_controller.rb
+++ b/app/controllers/db_exports_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class DbExportsController < ApplicationController
+  before_action :validate_exports_enabled
+  before_action :member_only, only: %i[favorites votes]
+
+  def index
+    @exports = DbExport.order(:name)
+
+    respond_to do |format|
+      format.html
+      format.json { render json: @exports.map { |export| export_json(export) } }
+    end
+  end
+
+  def favorites
+    user = CurrentUser.user
+    stream_personal_csv(
+      "SELECT id, post_id, created_at FROM favorites WHERE user_id = #{user.id} ORDER BY id DESC",
+      "favorites-#{user.name}-#{Date.current}.csv",
+    )
+  end
+
+  def votes
+    user = CurrentUser.user
+    stream_personal_csv(
+      "SELECT id, post_id, score, created_at FROM post_votes WHERE user_id = #{user.id} ORDER BY id DESC",
+      "votes-#{user.name}-#{Date.current}.csv",
+    )
+  end
+
+  private
+
+  def stream_personal_csv(query, filename)
+    headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format(disposition: "attachment", filename: filename)
+    headers["Content-Type"] = "text/csv"
+
+    conn = ActiveRecord::Base.connection.raw_connection
+    self.response_body = Enumerator.new do |yielder|
+      conn.copy_data("COPY (#{query}) TO STDOUT WITH CSV HEADER") do
+        while (row = conn.get_copy_data)
+          yielder << row
+        end
+      end
+    end
+  end
+
+  def export_json(export)
+    {
+      name: export.name,
+      file_name: export.file_name,
+      file_size: export.file_size,
+      updated_at: export.updated_at,
+      url: export.url,
+    }
+  end
+
+  def validate_exports_enabled
+    raise ActiveRecord::RecordNotFound unless Danbooru.config.db_export_enabled?
+  end
+end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -208,7 +208,7 @@ class StaticController < ApplicationController
     add_link[:staff, "Tickets", tickets_path]
     add_link[:staff, "Appeals", appeals_path]
 
-    add_link[:tools, "DB Export", Danbooru.config.db_export_path] if Danbooru.config.db_export_path.present?
+    add_link[:tools, "DB Export", db_exports_path] if Danbooru.config.db_export_enabled?
     add_link[:tools, "Discord", discord_post_path] if CurrentUser.can_discord?
     add_link[:users, "Signup", new_user_path] if CurrentUser.user.is_logged_out?
 

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -70,6 +70,7 @@
 @import "specific/bans.scss";
 @import "specific/blips.scss";
 @import "specific/comments.scss";
+@import "specific/db_exports.scss";
 @import "specific/destroyed_posts.scss";
 @import "specific/dmails.scss";
 @import "specific/edit_history.scss";

--- a/app/javascript/src/styles/specific/db_exports.scss
+++ b/app/javascript/src/styles/specific/db_exports.scss
@@ -1,0 +1,119 @@
+body.c-db-exports.a-index {
+  .exports-description {
+    margin-bottom: 1.5rem;
+    max-width: 50rem;
+
+    p {
+      margin-bottom: 0.5em;
+    }
+  }
+
+  h2 {
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .exports-list {
+    display: grid;
+    grid-template-columns: 1fr 0.75fr 1fr auto;
+    margin-bottom: 1rem;
+
+    .header {
+      font-weight: bold;
+      padding: $padding-050 $padding-025;
+      background-color: var(--color-section-darken-5);
+      border-bottom: 1px solid var(--color-foreground);
+      color: var(--color-text-table-header);
+    }
+
+    .cell {
+      padding: $padding-050 $padding-025;
+      background-color: var(--color-section);
+      border-bottom: 1px solid var(--color-table-border);
+      display: flex;
+      align-items: center;
+    }
+
+    .row {
+      display: contents;
+
+      &:last-child .cell {
+        border-bottom: none;
+      }
+
+      @media (min-width: 801px) {
+        &:hover .cell {
+          background-color: var(--color-section-lighten-10);
+        }
+      }
+    }
+
+    @media (max-width: 800px) {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+
+      .header {
+        display: none;
+      }
+
+      .row {
+        display: grid;
+        grid-template-columns: 1fr;
+        background: var(--color-section);
+        border-radius: 4px;
+        overflow: hidden;
+
+        .cell {
+          padding: 0.75rem 1rem;
+          border-bottom: 1px solid var(--color-table-border);
+          display: flex;
+          justify-content: space-between;
+          align-items: start;
+          gap: 1rem;
+
+          &:first-child {
+            background-color: var(--color-section-darken-5);
+            font-size: 1.1rem;
+            justify-content: flex-start;
+
+            &::before {
+              display: none;
+            }
+          }
+
+          &:last-child {
+            border-bottom: none;
+          }
+
+          &::before {
+            content: attr(data-label);
+            font-weight: bold;
+            flex-shrink: 0;
+          }
+        }
+      }
+    }
+  }
+
+  .export-download-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    white-space: nowrap;
+  }
+
+  .exports-personal-section {
+    background: var(--color-section);
+    padding: 1rem;
+    border-radius: 4px;
+    max-width: 30rem;
+
+    p {
+      margin-bottom: 0.75rem;
+    }
+
+    .export-download-link {
+      margin-right: 1rem;
+    }
+  }
+}

--- a/app/javascript/src/styles/specific/db_exports.scss
+++ b/app/javascript/src/styles/specific/db_exports.scss
@@ -101,19 +101,4 @@ body.c-db-exports.a-index {
     gap: 0.25rem;
     white-space: nowrap;
   }
-
-  .exports-personal-section {
-    background: var(--color-section);
-    padding: 1rem;
-    border-radius: 4px;
-    max-width: 30rem;
-
-    p {
-      margin-bottom: 0.75rem;
-    }
-
-    .export-download-link {
-      margin-right: 1rem;
-    }
-  }
 }

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -112,6 +112,7 @@ class DbExportJob < ApplicationJob
       end
     end
   ensure
+    conn&.exec("RESET statement_timeout")
     gz&.finish
   end
 

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -68,9 +68,8 @@ class DbExportJob < ApplicationJob
     "pools" => {
       query: -> { "SELECT id, name, created_at, updated_at, creator_id, description, is_active, category, post_ids FROM pools ORDER BY id" },
     },
-    # Deleted pages are filtered out because they are not visible to regular users.
     "wiki_pages" => {
-      query: -> { "SELECT id, created_at, updated_at, title, body, creator_id, updater_id, is_locked FROM wiki_pages WHERE is_deleted = false ORDER BY id" },
+      query: -> { "SELECT id, created_at, updated_at, title, body, creator_id, updater_id, is_locked FROM wiki_pages ORDER BY id" },
     },
   }.freeze
 

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -3,7 +3,7 @@
 # Each export is public: the SELECT projection lists only publicly visible
 # columns, and hidden/deleted rows are filtered out.
 class DbExportJob < ApplicationJob
-  queue_as :default
+  queue_as :low_prio
 
   EXPORTS = {
     "posts" => {

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+# Each export is public: the SELECT projection lists only publicly visible
+# columns, and hidden/deleted rows are filtered out.
+class DbExportJob < ApplicationJob
+  queue_as :default
+
+  EXPORTS = {
+    "posts" => {
+      query: -> {
+        <<~SQL.squish
+          SELECT id, uploader_id, created_at, md5, source, rating, image_width, image_height,
+                 tag_string, locked_tags, fav_count, file_ext, parent_id, change_seq, approver_id,
+                 file_size, comment_count, description, duration, updated_at, is_deleted, is_pending,
+                 is_flagged, score, up_score, down_score, is_rating_locked, is_status_locked, is_note_locked
+          FROM posts ORDER BY id
+        SQL
+      },
+    },
+    # Hidden versions are filtered out because they contain changes
+    # that are not visible to regular users.
+    "post_versions" => {
+      query: -> {
+        <<~SQL.squish
+          SELECT id, post_id, version, tags, added_tags, removed_tags, locked_tags,
+                 added_locked_tags, removed_locked_tags, rating, rating_changed, parent_id,
+                 parent_changed, source, source_changed, description, description_changed,
+                 updater_id, updated_at, reason
+          FROM post_versions WHERE is_hidden = false ORDER BY id
+        SQL
+      },
+    },
+    # Pending and rejected replacements are filtered out because they are not visible to regular users.
+    "post_replacements" => {
+      query: -> {
+        <<~SQL.squish
+          SELECT id, post_id, creator_id, approver_id, file_ext, file_size, image_height, image_width,
+                 md5, source, file_name, status, reason, created_at, updated_at
+          FROM post_replacements2
+          WHERE status IN ('approved', 'original') ORDER BY id
+        SQL
+      },
+    },
+    "tags" => {
+      query: -> { "SELECT id, name, category, post_count FROM tags ORDER BY id" },
+    },
+    "tag_aliases" => {
+      query: -> { "SELECT id, antecedent_name, consequent_name, created_at, status FROM tag_aliases ORDER BY id" },
+    },
+    "tag_implications" => {
+      query: -> { "SELECT id, antecedent_name, consequent_name, created_at, status FROM tag_implications ORDER BY id" },
+    },
+    "bulk_update_requests" => {
+      query: -> { "SELECT id, user_id, forum_topic_id, forum_post_id, script, status, approver_id, title, created_at, updated_at FROM bulk_update_requests ORDER BY id" },
+    },
+    "artists" => {
+      query: -> {
+        <<~SQL.squish
+          SELECT a.id, a.name, a.other_names, a.group_name, a.linked_user_id,
+                 a.is_active, a.is_locked, a.creator_id, a.created_at, a.updated_at,
+                 array_to_string(array_agg(au.url ORDER BY au.id) FILTER (WHERE au.url IS NOT NULL), ' ') AS urls
+          FROM artists a
+          LEFT JOIN artist_urls au ON au.artist_id = a.id AND au.is_active = true
+          GROUP BY a.id ORDER BY a.id
+        SQL
+      },
+    },
+    "pools" => {
+      query: -> { "SELECT id, name, created_at, updated_at, creator_id, description, is_active, category, post_ids FROM pools ORDER BY id" },
+    },
+    # Deleted pages are filtered out because they are not visible to regular users.
+    "wiki_pages" => {
+      query: -> { "SELECT id, created_at, updated_at, title, body, creator_id, updater_id, is_locked FROM wiki_pages WHERE is_deleted = false ORDER BY id" },
+    },
+  }.freeze
+
+  def perform
+    return unless Danbooru.config.db_export_enabled?
+
+    EXPORTS.each do |name, config|
+      generate_export(name, config)
+    end
+  end
+
+  private
+
+  def generate_export(name, config)
+    Rails.logger.info("DbExportJob: Generating #{name} export")
+
+    file = Tempfile.new(["#{name}-export", ".csv.gz"], binmode: true)
+    write_csv_gz(config[:query].call, file)
+    file.rewind
+
+    Danbooru.config.storage_manager.store_db_export(file, "#{name}.csv.gz")
+    record_export(name, file.size)
+
+    Rails.logger.info("DbExportJob: Finished #{name} export (#{ActiveSupport::NumberHelper.number_to_human_size(file.size)})")
+  rescue StandardError => e
+    Rails.logger.error("DbExportJob: Failed to generate #{name} export: #{e.message}")
+    ActiveRecord::Base.connection.reconnect!
+  ensure
+    file&.close!
+  end
+
+  def write_csv_gz(query, file)
+    gz = Zlib::GzipWriter.new(file)
+    conn = ActiveRecord::Base.connection.raw_connection
+    conn.exec("SET statement_timeout = 0")
+    conn.copy_data("COPY (#{query}) TO STDOUT WITH CSV HEADER") do
+      while (row = conn.get_copy_data)
+        gz.write(row)
+      end
+    end
+  ensure
+    gz&.finish
+  end
+
+  def record_export(name, file_size)
+    export = DbExport.find_or_initialize_by(name: name)
+    export.update!(file_size: file_size, updated_at: Time.current)
+  end
+end

--- a/app/logical/storage_manager.rb
+++ b/app/logical/storage_manager.rb
@@ -7,6 +7,7 @@ class StorageManager
   IMAGE_TYPES = %i[preview_jpg preview_webp sample_jpg sample_webp original].freeze
   MASCOT_PREFIX = "mascots"
   AVATAR_PREFIX = "avatars"
+  DB_EXPORT_PREFIX = "db_export"
 
   attr_reader :base_url, :base_dir, :hierarchical, :large_image_prefix, :protected_prefix, :base_path, :replacement_prefix
 
@@ -183,6 +184,22 @@ class StorageManager
 
   def furids_url
     "#{base_url}#{base_path}/furid/"
+  end
+
+  def db_export_path(file_name)
+    "#{base_dir}/#{DB_EXPORT_PREFIX}/#{file_name}"
+  end
+
+  def db_export_url(file_name)
+    "#{base_url}#{base_path}/#{DB_EXPORT_PREFIX}/#{file_name}"
+  end
+
+  def store_db_export(io, file_name)
+    store(io, db_export_path(file_name))
+  end
+
+  def delete_db_export(file_name)
+    delete(db_export_path(file_name))
   end
 
   #########################

--- a/app/models/db_export.rb
+++ b/app/models/db_export.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DbExport < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+
+  def file_name
+    "#{name}.csv.gz"
+  end
+
+  def url
+    Danbooru.config.storage_manager.db_export_url(file_name)
+  end
+end

--- a/app/views/db_exports/index.html.erb
+++ b/app/views/db_exports/index.html.erb
@@ -30,20 +30,6 @@
     <% else %>
       <p>No exports are currently available.</p>
     <% end %>
-
-    <% unless CurrentUser.is_anonymous? %>
-      <h2>Personal data</h2>
-
-      <div class="exports-personal-section">
-        <p>Export your own data as CSV files.</p>
-        <%= link_to favorites_db_exports_path, class: "export-download-link" do %>
-          <%= svg_icon(:download, width: 16, height: 16) %> Favorites
-        <% end %>
-        <%= link_to votes_db_exports_path, class: "export-download-link" do %>
-          <%= svg_icon(:download, width: 16, height: 16) %> Votes
-        <% end %>
-      </div>
-    <% end %>
   </div>
 </div>
 

--- a/app/views/db_exports/index.html.erb
+++ b/app/views/db_exports/index.html.erb
@@ -1,0 +1,52 @@
+<div id="c-db-exports">
+  <div id="a-index">
+    <h1>Database Exports</h1>
+
+    <div class="exports-description">
+      <p>Database exports in gzipped CSV format, updated daily.</p>
+      <p>For programmatic access, use the <%= link_to "JSON endpoint", db_exports_path(format: :json) %>.</p>
+    </div>
+
+    <% if @exports.any? %>
+      <div class="exports-list">
+        <div class="header">Name</div>
+        <div class="header">Size</div>
+        <div class="header">Updated</div>
+        <div class="header"></div>
+
+        <% @exports.each do |export| %>
+          <div class="row">
+            <div class="cell" data-label="Name"><strong><%= export.name %></strong></div>
+            <div class="cell" data-label="Size"><%= number_to_human_size(export.file_size) %></div>
+            <div class="cell" data-label="Updated"><%= time_ago_in_words_tagged(export.updated_at) %></div>
+            <div class="cell" data-label="Actions">
+              <%= link_to export.url, class: "export-download-link" do %>
+                <%= svg_icon(:download, width: 16, height: 16) %> Download
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p>No exports are currently available.</p>
+    <% end %>
+
+    <% unless CurrentUser.is_anonymous? %>
+      <h2>Personal data</h2>
+
+      <div class="exports-personal-section">
+        <p>Export your own data as CSV files.</p>
+        <%= link_to favorites_db_exports_path, class: "export-download-link" do %>
+          <%= svg_icon(:download, width: 16, height: 16) %> Favorites
+        <% end %>
+        <%= link_to votes_db_exports_path, class: "export-download-link" do %>
+          <%= svg_icon(:download, width: 16, height: 16) %> Votes
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<% content_for(:page_title) do %>
+  Database Exports
+<% end %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -65,9 +65,9 @@ module Danbooru
       "Anonymous"
     end
 
-    # The path of the daily DB exports. Hidden from the site map if `nil`.
-    def db_export_path
-      "/db_export/"
+    # Whether the daily database exports are enabled. Hidden from the site map if false.
+    def db_export_enabled?
+      true
     end
 
     # Prevent new users from going above 80k while allowing those currently above

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -67,7 +67,7 @@ module Danbooru
 
     # Whether the daily database exports are enabled. Hidden from the site map if false.
     def db_export_enabled?
-      true
+      false
     end
 
     # Prevent new users from going above 80k while allowing those currently above

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -35,6 +35,11 @@ Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
       "class" => "SitemapGeneratorJob",
       "description" => "Generate the sitemap.xml file for search engines",
     },
+    "DbExportJob" => {
+      "cron" => "0 4 * * *", # Every day at 4:00 AM
+      "class" => "DbExportJob",
+      "description" => "Generate the daily public database exports",
+    },
   }
 
   Sidekiq::Cron::Job.load_from_hash schedule

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,6 +204,12 @@ Rails.application.routes.draw do
     end
   end
   resource :dtext_preview, only: %i[create]
+  resources :db_exports, only: %i[index] do
+    collection do
+      get :favorites
+      get :votes
+    end
+  end
   resources :favorites, only: %i[index create destroy]
   resources :forum_posts do
     resource :votes, controller: "forum_post_votes"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,12 +204,7 @@ Rails.application.routes.draw do
     end
   end
   resource :dtext_preview, only: %i[create]
-  resources :db_exports, only: %i[index] do
-    collection do
-      get :favorites
-      get :votes
-    end
-  end
+  resources :db_exports, only: %i[index]
   resources :favorites, only: %i[index create destroy]
   resources :forum_posts do
     resource :votes, controller: "forum_post_votes"

--- a/db/migrate/20260530165214_create_db_exports.rb
+++ b/db/migrate/20260530165214_create_db_exports.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateDbExports < ActiveRecord::Migration[8.1]
+  def change
+    create_table :db_exports do |t|
+      t.string :name, null: false
+      t.bigint :file_size, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :db_exports, :name, unique: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -549,6 +549,38 @@ ALTER SEQUENCE public.comments_id_seq OWNED BY public.comments.id;
 
 
 --
+-- Name: db_exports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.db_exports (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    file_size bigint DEFAULT 0 NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: db_exports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.db_exports_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: db_exports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.db_exports_id_seq OWNED BY public.db_exports.id;
+
+
+--
 -- Name: destroyed_posts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2812,6 +2844,13 @@ ALTER TABLE ONLY public.comments ALTER COLUMN id SET DEFAULT nextval('public.com
 
 
 --
+-- Name: db_exports id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.db_exports ALTER COLUMN id SET DEFAULT nextval('public.db_exports_id_seq'::regclass);
+
+
+--
 -- Name: destroyed_posts id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3313,6 +3352,14 @@ ALTER TABLE ONLY public.comment_votes
 
 ALTER TABLE ONLY public.comments
     ADD CONSTRAINT comments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: db_exports db_exports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.db_exports
+    ADD CONSTRAINT db_exports_pkey PRIMARY KEY (id);
 
 
 --
@@ -4114,6 +4161,13 @@ CREATE INDEX index_comments_on_post_id ON public.comments USING btree (post_id);
 --
 
 CREATE INDEX index_comments_on_to_tsvector_english_body ON public.comments USING gin (to_tsvector('english'::regconfig, body));
+
+
+--
+-- Name: index_db_exports_on_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_db_exports_on_name ON public.db_exports USING btree (name);
 
 
 --
@@ -5406,6 +5460,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260530165214'),
 ('20260530162738'),
 ('20260526234030'),
 ('20260520175932'),

--- a/spec/jobs/db_export_job_spec.rb
+++ b/spec/jobs/db_export_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DbExportJob do
 
     # Pin a single real storage manager (config builds a new one per call) and
     # intercept only store_db_export, so post creation can still resolve file paths.
-    allow(Danbooru.config.custom_configuration).to receive(:storage_manager).and_return(storage)
+    allow(Danbooru.config.custom_configuration).to receive_messages(db_export_enabled?: true, storage_manager: storage)
     allow(storage).to receive(:store_db_export) do |io, file_name|
       io.rewind
       stored[file_name] = Zlib::GzipReader.new(io).read

--- a/spec/jobs/db_export_job_spec.rb
+++ b/spec/jobs/db_export_job_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DbExportJob do
+  let(:user) { create(:user) }
+  let(:storage) { Danbooru.config.storage_manager }
+  # Captures the gzipped CSV handed to the storage manager, keyed by file name,
+  # so contents can be asserted without touching the filesystem.
+  let(:stored) { {} }
+
+  before do
+    CurrentUser.user = user
+    CurrentUser.ip_addr = "127.0.0.1"
+
+    # Pin a single real storage manager (config builds a new one per call) and
+    # intercept only store_db_export, so post creation can still resolve file paths.
+    allow(Danbooru.config.custom_configuration).to receive(:storage_manager).and_return(storage)
+    allow(storage).to receive(:store_db_export) do |io, file_name|
+      io.rewind
+      stored[file_name] = Zlib::GzipReader.new(io).read
+    end
+  end
+
+  after do
+    CurrentUser.user = nil
+    CurrentUser.ip_addr = nil
+  end
+
+  def perform
+    described_class.perform_now
+  end
+
+  def export_csv(name)
+    perform
+    stored["#{name}.csv.gz"]
+  end
+
+  describe "#perform" do
+    it "stores a gzipped CSV for every configured export" do
+      perform
+      DbExportJob::EXPORTS.each_key do |name|
+        expect(stored).to have_key("#{name}.csv.gz")
+      end
+    end
+
+    it "records a DbExport row for each export" do
+      expect { perform }.to change(DbExport, :count).by(DbExportJob::EXPORTS.size)
+    end
+
+    it "records the file size and generation time" do
+      perform
+      export = DbExport.find_by(name: "tags")
+      expect(export.file_size).to be_positive
+      expect(export.updated_at).to be_present
+    end
+
+    it "reuses the existing row on a subsequent run" do
+      perform
+      expect { perform }.not_to change(DbExport, :count)
+    end
+
+    it "does nothing when exports are disabled" do
+      allow(Danbooru.config.custom_configuration).to receive(:db_export_enabled?).and_return(false)
+      expect { perform }.not_to change(DbExport, :count)
+      expect(stored).to be_empty
+    end
+
+    it "continues when an individual export fails" do
+      allow(ActiveRecord::Base.connection).to receive(:reconnect!)
+      call_count = 0
+      allow(storage).to receive(:store_db_export) do |_io, file_name|
+        call_count += 1
+        raise StandardError, "boom" if file_name == "posts.csv.gz"
+      end
+
+      perform
+
+      expect(call_count).to eq(DbExportJob::EXPORTS.size)
+      expect(DbExport.where(name: "posts").exists?).to be false
+      expect(DbExport.where(name: "tags").exists?).to be true
+    end
+
+    context "with exported contents" do
+      it "exports posts" do
+        post = create(:post)
+        expect(export_csv("posts")).to include(post.md5)
+      end
+
+      it "exports tags" do
+        create(:tag, name: "test_export_tag")
+        expect(export_csv("tags")).to include("test_export_tag")
+      end
+
+      it "exports pools" do
+        create(:pool, name: "test_export_pool")
+        expect(export_csv("pools")).to include("test_export_pool")
+      end
+
+      it "exports wiki pages" do
+        create(:wiki_page, title: "test_export_wiki")
+        expect(export_csv("wiki_pages")).to include("test_export_wiki")
+      end
+
+      it "exports artists" do
+        create(:artist, name: "test_export_artist")
+        expect(export_csv("artists")).to include("test_export_artist")
+      end
+
+      it "exports post versions for visible changes" do
+        post = create(:post)
+        post.update!(tag_string: "new_export_tag")
+        expect(export_csv("post_versions")).to include("new_export_tag")
+      end
+
+      it "exports approved and original replacements but not pending, rejected, or promoted ones" do
+        post = create(:post)
+        approved = create(:approved_post_replacement, post: post)
+        original = create(:original_post_replacement, post: post)
+        pending = create(:post_replacement, post: post)
+        rejected = create(:rejected_post_replacement, post: post)
+        promoted = create(:promoted_post_replacement, post: post)
+
+        csv = export_csv("post_replacements")
+        expect(csv).to include(approved.md5, original.md5)
+        expect(csv).not_to include(pending.md5, rejected.md5, promoted.md5)
+      end
+    end
+  end
+end

--- a/spec/models/db_export_spec.rb
+++ b/spec/models/db_export_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DbExport do
+  describe "validations" do
+    it "requires a name" do
+      expect(described_class.new(name: nil)).not_to be_valid
+    end
+
+    it "requires a unique name" do
+      described_class.create!(name: "posts", file_size: 0)
+      expect(described_class.new(name: "posts", file_size: 0)).not_to be_valid
+    end
+  end
+
+  describe "#file_name" do
+    it "appends the gzipped csv extension to the name" do
+      expect(described_class.new(name: "posts").file_name).to eq("posts.csv.gz")
+    end
+  end
+
+  describe "#url" do
+    it "delegates to the storage manager with the file name" do
+      export = described_class.new(name: "posts")
+      # config builds a new storage manager per call, so pin one to stub against.
+      storage = Danbooru.config.storage_manager
+      allow(Danbooru.config.custom_configuration).to receive(:storage_manager).and_return(storage)
+      allow(storage).to receive(:db_export_url).with("posts.csv.gz").and_return("https://example.com/posts.csv.gz")
+      expect(export.url).to eq("https://example.com/posts.csv.gz")
+    end
+  end
+end

--- a/spec/requests/db_exports_controller_spec.rb
+++ b/spec/requests/db_exports_controller_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 RSpec.describe DbExportsController do
-  include_context "as admin"
-
-  let(:member) { create(:user) }
-
   before do
     DbExport.create!(name: "posts", file_size: 2048)
     DbExport.create!(name: "tags", file_size: 512)
@@ -38,44 +34,6 @@ RSpec.describe DbExportsController do
       entry = body.find { |export| export["name"] == "posts" }
       expect(entry).to include("file_name" => "posts.csv.gz", "file_size" => 2048)
       expect(entry["url"]).to be_present
-    end
-  end
-
-  describe "GET /db_exports/favorites" do
-    it "rejects anonymous users" do
-      get favorites_db_exports_path
-      expect(response).to have_http_status(:found)
-    end
-
-    it "streams the favorites of a logged-in user as CSV" do
-      post_record = create(:post)
-      FavoriteManager.add!(user: member, post: post_record)
-
-      sign_in_as(member)
-      get favorites_db_exports_path
-
-      expect(response).to have_http_status(:ok)
-      expect(response.media_type).to eq("text/csv")
-      expect(response.body).to include(post_record.id.to_s)
-    end
-  end
-
-  describe "GET /db_exports/votes" do
-    it "rejects anonymous users" do
-      get votes_db_exports_path
-      expect(response).to have_http_status(:found)
-    end
-
-    it "streams the post votes of a logged-in user as CSV" do
-      post_record = create(:post)
-      create(:post_vote, user: member, post: post_record, score: 1)
-
-      sign_in_as(member)
-      get votes_db_exports_path
-
-      expect(response).to have_http_status(:ok)
-      expect(response.media_type).to eq("text/csv")
-      expect(response.body).to include(post_record.id.to_s)
     end
   end
 end

--- a/spec/requests/db_exports_controller_spec.rb
+++ b/spec/requests/db_exports_controller_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe DbExportsController do
   before do
+    allow(Danbooru.config.custom_configuration).to receive(:db_export_enabled?).and_return(true)
     DbExport.create!(name: "posts", file_size: 2048)
     DbExport.create!(name: "tags", file_size: 512)
   end

--- a/spec/requests/db_exports_controller_spec.rb
+++ b/spec/requests/db_exports_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DbExportsController do
+  include_context "as admin"
+
+  let(:member) { create(:user) }
+
+  before do
+    DbExport.create!(name: "posts", file_size: 2048)
+    DbExport.create!(name: "tags", file_size: 512)
+  end
+
+  describe "GET /db_exports" do
+    it "renders for anonymous users" do
+      get db_exports_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "lists the available exports" do
+      get db_exports_path
+      expect(response.body).to include("posts")
+      expect(response.body).to include("tags")
+    end
+
+    it "returns 404 when exports are disabled" do
+      allow(Danbooru.config.custom_configuration).to receive(:db_export_enabled?).and_return(false)
+      get db_exports_path
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "renders a JSON array with export metadata" do
+      get db_exports_path(format: :json)
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+      expect(body).to be_an(Array)
+      entry = body.find { |export| export["name"] == "posts" }
+      expect(entry).to include("file_name" => "posts.csv.gz", "file_size" => 2048)
+      expect(entry["url"]).to be_present
+    end
+  end
+
+  describe "GET /db_exports/favorites" do
+    it "rejects anonymous users" do
+      get favorites_db_exports_path
+      expect(response).to have_http_status(:found)
+    end
+
+    it "streams the favorites of a logged-in user as CSV" do
+      post_record = create(:post)
+      FavoriteManager.add!(user: member, post: post_record)
+
+      sign_in_as(member)
+      get favorites_db_exports_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/csv")
+      expect(response.body).to include(post_record.id.to_s)
+    end
+  end
+
+  describe "GET /db_exports/votes" do
+    it "rejects anonymous users" do
+      get votes_db_exports_path
+      expect(response).to have_http_status(:found)
+    end
+
+    it "streams the post votes of a logged-in user as CSV" do
+      post_record = create(:post)
+      create(:post_vote, user: member, post: post_record, score: 1)
+
+      sign_in_as(member)
+      get votes_db_exports_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq("text/csv")
+      expect(response.body).to include(post_record.id.to_s)
+    end
+  end
+end

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -205,14 +205,21 @@ RSpec.describe StaticController do
       end
     end
 
-    context "when db_export_path is configured" do
-      before do
-        allow(Danbooru.config.custom_configuration).to receive(:db_export_path).and_return("/db_export/")
-      end
-
+    context "when database exports are enabled" do
       it "shows the DB Export link" do
         get site_map_path
         expect(response.body).to include("DB Export")
+      end
+    end
+
+    context "when database exports are disabled" do
+      before do
+        allow(Danbooru.config.custom_configuration).to receive(:db_export_enabled?).and_return(false)
+      end
+
+      it "hides the DB Export link" do
+        get site_map_path
+        expect(response.body).not_to include("DB Export")
       end
     end
   end

--- a/spec/requests/static_controller_spec.rb
+++ b/spec/requests/static_controller_spec.rb
@@ -206,6 +206,10 @@ RSpec.describe StaticController do
     end
 
     context "when database exports are enabled" do
+      before do
+        allow(Danbooru.config.custom_configuration).to receive(:db_export_enabled?).and_return(true)
+      end
+
       it "shows the DB Export link" do
         get site_map_path
         expect(response.body).to include("DB Export")


### PR DESCRIPTION
New Db Export Page. A second attempt at #1772.

Uses Sidekiq to run a job daily for the export. Files are stored on the CDN, overwritten on update. Only the last export is available.
Data is sanitized before being exported in accordance with the table below.

### All exports

| Model | Content |
| ----- | ----- |
| posts | |
| post_versions | Excludes hidden versions |
| post_replacements | Excludes pending/rejected |
| tags | |
| tag_aliases | |
| tag_implications | |
| bulk_update_requests | |
| artists | |
| pools | |
| wiki_pages | |


### Api Stuff

The page comes with a JSON API that returns an array of

```json
{"name":"posts","file_name":"posts-2026-04-06.csv.gz","file_size":36547,"updated_at":"2026-04-06T18:56:23.844+00:00"},
```

### Screenshots

**Desktop**

<img width="2518" height="954" alt="image" src="https://github.com/user-attachments/assets/497a6974-636a-4df7-ae4e-ebcba2d3d1a2" />

**Mobile**

<img width="553" height="977" alt="image" src="https://github.com/user-attachments/assets/02f72027-bbbe-4e44-a28a-c05a852fb8a3" />


