### PR TITLE
[Uploads] Add AVIF support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm ci
 
 FROM ruby:3.3.1-alpine3.20
 
-RUN apk --no-cache add ffmpeg vips \
+RUN apk --no-cache add ffmpeg vips libheif \
   postgresql15-client \
   git jemalloc tzdata \
   sudo gcompat ragel build-base \

--- a/app/javascript/src/js/components/autocomplete.js
+++ b/app/javascript/src/js/components/autocomplete.js
@@ -13,8 +13,8 @@ const Autocomplete = {
       locked: ["rating", "note", "status"],
       child: ["any", "none"],
       parent: ["any", "none"],
-      filetype: ["jpg", "png", "gif", "swf", "webm", "mp4", "webp"],
-      type: ["jpg", "png", "gif", "swf", "webm", "mp4", "webp"],
+      filetype: ["jpg", "png", "gif", "swf", "webm", "mp4", "webp", "avif"],
+      type: ["jpg", "png", "gif", "swf", "webm", "mp4", "webp", "avif"],
     };
   },
 

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -105,7 +105,7 @@ module FileMethods
   end
 
   def is_animated_avif?(file_path)
-    # TODO
+    # TODO!AVIF
     # old way:
     # # Try to load the second frame/page. If it exists, it's animated.
     #     begin
@@ -172,6 +172,7 @@ module FileMethods
   # Verify whether the file at the provided path is corrupt.
   # * Regular images: attempt to load the image with libvips.
   # * GIFs: attempt to load each frame with libvips.
+  # * AVIF: # TODO!AVIF
   # * APNG: not implemented, could defer to ffmpeg if needed.
   # * Other file types: assumed to be non-corrupt.
   def is_corrupt?(file_path)

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -9,6 +9,7 @@ module FileMethods
     webm: "webm",
     mp4: "mp4",
     webp: "webp",
+    avif: "avif",
   }.freeze
 
   def is_of_type?(type)
@@ -16,7 +17,7 @@ module FileMethods
   end
 
   def is_image?
-    is_png? || is_jpg? || is_gif? || is_webp?
+    is_png? || is_jpg? || is_gif? || is_webp? || is_avif?
   end
 
   def is_png?
@@ -45,6 +46,10 @@ module FileMethods
 
   def is_webp?
     is_of_type?(:webp)
+  end
+
+  def is_avif?
+    is_of_type?(:avif)
   end
 
   def is_video?
@@ -99,6 +104,17 @@ module FileMethods
     false
   end
 
+  def is_animated_avif?(file_path)
+    # TODO
+    # old way:
+    # # Try to load the second frame/page. If it exists, it's animated.
+    #     begin
+    #       result = Vips::Image.new_from_file(file_path, page: 1)
+    #     rescue Vips::Error => e
+    #       result = e
+    #     end
+  end
+
   def file_header_to_file_ext(file_path)
     File.open file_path do |bin|
       mime_type = Marcel::MimeType.for(bin)
@@ -115,6 +131,8 @@ module FileMethods
         "mp4"
       when "image/webp"
         "webp"
+      when "image/avif"
+        "avif"
       else
         mime_type
       end

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -105,7 +105,8 @@ module FileMethods
   end
 
   def is_animated_avif?(file_path)
-    # TODO!AVIF
+    false # Placeholder implementation; proper AVIF animation detection would require parsing the file structure for 'av01' tracks, which is non-trivial and not currently implemented.
+    # TODO!AVIF - check for `avis` (avif image sequence) box, mif1miaf?
     # old way:
     # # Try to load the second frame/page. If it exists, it's animated.
     #     begin

--- a/app/logical/image_sampler.rb
+++ b/app/logical/image_sampler.rb
@@ -22,7 +22,7 @@ module ImageSampler
     # Generate samples
     # Animated GIFs, APNGs, and WEBPs are not needed, Flash files are not supported.
     # All video files need samples to be used as a poster in the player.
-    return if post.is_gif? || post.is_animated_png?(post.file_path) || post.is_animated_webp?(post.file_path)
+    return if post.is_gif? || post.is_animated_png?(post.file_path) || post.is_animated_webp?(post.file_path) || post.is_animated_avif?(post.file_path)
     return unless post.is_video? || dimensions.min > Danbooru.config.large_image_width || dimensions.max > Danbooru.config.large_image_width * 2
     sample(image, dimensions, background: post.bg_color).each do |ext, file|
       path = sm.post_file_path(post, :"sample_#{ext}")

--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -30,13 +30,9 @@ class StatsUpdater
     stats[:safe_posts] = Post.tag_match("rating:s", always_show_deleted: true).count_only
     stats[:questionable_posts] = Post.tag_match("rating:q", always_show_deleted: true).count_only
     stats[:explicit_posts] = Post.tag_match("rating:e", always_show_deleted: true).count_only
-    stats[:jpg_posts] = Post.tag_match("type:jpg", always_show_deleted: true).count_only
-    stats[:png_posts] = Post.tag_match("type:png", always_show_deleted: true).count_only
-    stats[:webp_posts] = Post.tag_match("type:webp", always_show_deleted: true).count_only
-    stats[:gif_posts] = Post.tag_match("type:gif", always_show_deleted: true).count_only
-    stats[:swf_posts] = Post.tag_match("type:swf", always_show_deleted: true).count_only
-    stats[:webm_posts] = Post.tag_match("type:webm", always_show_deleted: true).count_only
-    stats[:mp4_posts] = Post.tag_match("type:mp4", always_show_deleted: true).count_only
+    FileMethods::FILE_TYPE.each_key do |ext|
+      stats[:"#{ext}_posts"] = Post.tag_match("type:#{ext}", always_show_deleted: true).count_only
+    end
     stats[:average_file_size] = Post.average("file_size")
     stats[:total_file_size] = Post.sum("file_size")
     stats[:average_posts_per_day] = daily_average.call(stats[:total_posts])

--- a/app/logical/upload_service/utils.rb
+++ b/app/logical/upload_service/utils.rb
@@ -44,6 +44,8 @@ class UploadService
       upload.image_height = height
 
       upload.validate!(:file)
+      # TODO!AVIF - validate things animated avif is a `video/quicktime`
+      # BUG: rails/marcel#150
 
       # Combine existing tags with automatic tags and deduplicate
       # Mostly needed for promoted replacements, which copy tags from the original post

--- a/app/logical/upload_service/utils.rb
+++ b/app/logical/upload_service/utils.rb
@@ -66,6 +66,7 @@ class UploadService
       tags += %w[animated_gif animated] if upload.is_animated_gif?(file.path)
       tags += %w[animated_png animated] if upload.is_animated_png?(file.path)
       tags += %w[animated_webp animated] if upload.is_animated_webp?(file.path)
+      tags += %w[animated_avif animated] if upload.is_animated_avif?(file.path)
       tags += ["animated"] if upload.is_webm? || upload.is_mp4?
       # tags += ["ai_generated"] if upload.is_ai_generated?(file.path)[:score] >= 50
       tags.join(" ")

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -426,7 +426,7 @@ class Post < ApplicationRecord
       @has_sample ||= begin
         if is_video?
           true
-        elsif is_gif? || is_flash? || has_tag?("animated_gif", "animated_png", "animated_webp")
+        elsif is_gif? || is_flash? || has_tag?("animated_gif", "animated_png", "animated_webp", "animated_avif")
           false
         elsif is_image? && image_width.present?
           dims = [image_width, image_height].compact
@@ -875,6 +875,7 @@ class Post < ApplicationRecord
       tags -= ["animated_gif"] unless is_gif?
       tags -= ["animated_png"] unless is_png?
       tags -= ["animated_webp"] unless is_webp?
+      tags -= ["animated_avif"] unless is_avif?
 
       tags << "long_playtime" if duration.present? && (is_video? || tags.include?("animated_gif")) && duration >= 30
       tags << "short_playtime" if duration.present? && (is_video? || tags.include?("animated_gif")) && duration < 30

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -410,6 +410,7 @@ module Danbooru
         "webm" => 100.megabytes,
         "mp4" => 100.megabytes,
         "webp" => 100.megabytes,
+        "avif" => 100.megabytes,
       }
     end
 

--- a/spec/logical/file_methods/animation_detection_spec.rb
+++ b/spec/logical/file_methods/animation_detection_spec.rb
@@ -10,6 +10,7 @@ require "rails_helper"
 #   - is_animated_png?(file_path)
 #   - is_animated_gif?(file_path)
 #   - is_animated_webp?(file_path)
+#   - is_animated_avif?(file_path)  # TODO
 #
 # Each method guards on `file_ext` before touching the file, so the falsy
 # "wrong extension" case needs no real file. Real fixture files are used for
@@ -105,5 +106,9 @@ RSpec.describe FileMethods, type: :model do
         expect(upload.is_animated_webp?("/nonexistent/path.webp")).to be false
       end
     end
+  end
+
+  describe "#is_animated_avif?" do
+    # TODO
   end
 end

--- a/spec/logical/file_methods/animation_detection_spec.rb
+++ b/spec/logical/file_methods/animation_detection_spec.rb
@@ -10,7 +10,7 @@ require "rails_helper"
 #   - is_animated_png?(file_path)
 #   - is_animated_gif?(file_path)
 #   - is_animated_webp?(file_path)
-#   - is_animated_avif?(file_path)  # TODO
+#   - is_animated_avif?(file_path)  # TODO!AVIF
 #
 # Each method guards on `file_ext` before touching the file, so the falsy
 # "wrong extension" case needs no real file. Real fixture files are used for
@@ -109,6 +109,6 @@ RSpec.describe FileMethods, type: :model do
   end
 
   describe "#is_animated_avif?" do
-    # TODO
+    # TODO!AVIF
   end
 end

--- a/spec/logical/file_methods/corruption_detection_spec.rb
+++ b/spec/logical/file_methods/corruption_detection_spec.rb
@@ -68,8 +68,12 @@ RSpec.describe FileMethods, type: :model do
       end
     end
 
-    context "with a corrupt AVIF fixture" do
-      # TODO
+    context "with a valid AVIF fixture" do
+      it "returns false" do
+        upload = build(:upload, file_ext: "avif")
+        path = file_fixture("sample.avif").to_s
+        expect(upload.is_corrupt?(path)).to be false
+      end
     end
 
     context "with a valid animated GIF" do

--- a/spec/logical/file_methods/corruption_detection_spec.rb
+++ b/spec/logical/file_methods/corruption_detection_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe FileMethods, type: :model do
       end
     end
 
+    context "with a corrupt AVIF fixture" do
+      # TODO
+    end
+
     context "with a valid animated GIF" do
       it "returns false" do
         upload = build(:upload, file_ext: "gif")

--- a/spec/logical/file_methods/file_utilities_spec.rb
+++ b/spec/logical/file_methods/file_utilities_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe FileMethods, type: :model do
       "gif"  => "animated.gif",
       "webm" => "animated.webm",
       "mp4"  => "animated.mp4",
+      "avif" => "sample.avif", # TODO
     }.each do |expected_ext, fixture_name|
       it "returns '#{expected_ext}' for a #{expected_ext.upcase} file" do
         upload = build(:upload)
@@ -57,6 +58,10 @@ RSpec.describe FileMethods, type: :model do
         path = file_fixture("sample.webp").to_s
         expect(upload.calculate_dimensions(path)).to eq([256, 256])
       end
+    end
+
+    context "with an AVIF image" do
+      # TODO
     end
 
     context "with an MP4 video" do

--- a/spec/logical/file_methods/file_utilities_spec.rb
+++ b/spec/logical/file_methods/file_utilities_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe FileMethods, type: :model do
       "gif"  => "animated.gif",
       "webm" => "animated.webm",
       "mp4"  => "animated.mp4",
-      "avif" => "sample.avif", # TODO
+      "avif" => "sample.avif", # TODO!AVIF
     }.each do |expected_ext, fixture_name|
       it "returns '#{expected_ext}' for a #{expected_ext.upcase} file" do
         upload = build(:upload)
@@ -61,7 +61,11 @@ RSpec.describe FileMethods, type: :model do
     end
 
     context "with an AVIF image" do
-      # TODO
+      it "returns the correct [width, height]" do
+        upload = build(:upload, file_ext: "avif")
+        path = file_fixture("sample.avif").to_s
+        expect(upload.calculate_dimensions(path)).to eq([256, 256])
+      end
     end
 
     context "with an MP4 video" do

--- a/spec/logical/file_methods/type_detection_spec.rb
+++ b/spec/logical/file_methods/type_detection_spec.rb
@@ -118,7 +118,15 @@ RSpec.describe FileMethods do
 
   # ----------------------------------------------------------------------- #
   describe "#is_avif?" do
-    # TODO
+    it "returns true when file_ext is 'avif'" do
+      host.file_ext = "avif"
+      expect(host.is_avif?).to be true
+    end
+
+    it "returns false for other extensions" do
+      host.file_ext = "webp"
+      expect(host.is_avif?).to be false
+    end
   end
 
   # ----------------------------------------------------------------------- #

--- a/spec/logical/file_methods/type_detection_spec.rb
+++ b/spec/logical/file_methods/type_detection_spec.rb
@@ -7,8 +7,8 @@ require "rails_helper"
 # --------------------------------------------------------------------------- #
 #
 # Covers:
-#   - is_png?, is_jpg?, is_gif?, is_flash?, is_webm?, is_mp4?, is_webp?
-#   - is_image?  (png | jpg | gif | webp)
+#   - is_png?, is_jpg?, is_gif?, is_flash?, is_webm?, is_mp4?, is_webp?, is_avif?
+#   - is_image?  (png | jpg | gif | webp | avif)
 #   - is_video?  (webm | mp4)
 #
 # These methods only inspect the `file_ext` attribute, so an anonymous class
@@ -117,8 +117,13 @@ RSpec.describe FileMethods do
   end
 
   # ----------------------------------------------------------------------- #
+  describe "#is_avif?" do
+    # TODO
+  end
+
+  # ----------------------------------------------------------------------- #
   describe "#is_image?" do
-    %w[png jpg gif webp].each do |ext|
+    %w[png jpg gif webp avif].each do |ext|
       it "returns true for '#{ext}'" do
         host.file_ext = ext
         expect(host.is_image?).to be true

--- a/spec/logical/image_sampler/orchestration_spec.rb
+++ b/spec/logical/image_sampler/orchestration_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe ImageSampler do
         is_gif?:           false,
         is_animated_png?:  false,
         is_animated_webp?: false,
+        is_animated_avif?: false,
         image_width:       256,
         image_height:      256,
         bg_color:          "000000",
@@ -104,6 +105,10 @@ RSpec.describe ImageSampler do
       end
     end
 
+    context "when post is an animated AVID" do
+      # TODO!AVIF
+    end
+
     context "when the image is too small for a sample (256x256, large_image_width=850)" do
       # dimensions.min=256 is not > 850, dimensions.max=256 is not > 1700
       it "stores exactly 2 thumbnail files and no sample files" do
@@ -127,6 +132,7 @@ RSpec.describe ImageSampler do
           is_gif?:           false,
           is_animated_png?:  false,
           is_animated_webp?: false,
+          is_animated_avif?: false,
           image_width:       1000,
           image_height:      1000,
           bg_color:          "000000",
@@ -154,6 +160,7 @@ RSpec.describe ImageSampler do
           is_gif?:           false,
           is_animated_png?:  false,
           is_animated_webp?: false,
+          is_animated_avif?: false,
           image_width:       256,
           image_height:      256,
           bg_color:          "000000",

--- a/spec/models/post/image_methods_spec.rb
+++ b/spec/models/post/image_methods_spec.rb
@@ -116,6 +116,11 @@ RSpec.describe Post do
         expect(build(:post, file_ext: "gif").is_gif?).to be true
       end
 
+      it "recognizes avif as an image" do
+        expect(build(:post, file_ext: "avif").is_image?).to be true
+        expect(build(:post, file_ext: "avif").is_avif?).to be true
+      end
+
       it "recognizes webm as a video" do
         expect(build(:post, file_ext: "webm").is_video?).to be true
         expect(build(:post, file_ext: "webm").is_webm?).to be true


### PR DESCRIPTION
Closes e621ng/e621ng#2118

TODO: 
- Source:
  - Implement animation detection. Not sure if we need `vips-tools` for this.
  - Find places where file types are listed manually and add `avif`
    - perhaps replace that list with an automatic list
  - Fix `upload.validate!(:file)` thinking animated avif is `video/quicktime`
    - This is a bug in marcel - it doesn't have the magic for `avis` in it's definitions. 
    - Bug is fixed in [`e86302c`](https://github.com/rails/marcel/commit/e86302c8b4db3aaa5079104ae8451677f1400aaf), waiting for next version release of `marcel` to update to
- Tests:
  - Address `TODO!AVIF` items in spec
  - Add avif test fixtures

<details><summary>Notes to self</summary>
My previous implementation of this stuff: https://github.com/e621ng/e621ng/compare/master...Catt0s-Projects:e999ng:development

<!-- I dream of the day i can do this with jpegxl -->
</details> 


Unfortunately, we do need to add `libheif` to make this work... Looking into `libavif` since we don't need all of heif