### PR TITLE
[Users] Refactor user levels

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -234,14 +234,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  %i[logged_in logged_out restricted approver].each do |role|
+  %i[approver].each do |role|
     define_method("#{role}_only") do
       user_access_check("is_#{role}?")
     end
   end
 
   def logged_in_only
-    if CurrentUser.user.is_logged_out?
+    if CurrentUser.user.is_logged_out? || IpBan.is_banned?(CurrentUser.ip_addr)
       access_denied("Must be logged in")
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,7 +64,7 @@ class ApplicationController < ActionController::Base
   end
 
   def api_check
-    if !CurrentUser.is_anonymous? && !request.get? && !request.head?
+    if CurrentUser.user.is_logged_in? && !request.get? && !request.head?
       throttled = CurrentUser.user.token_bucket.throttled?
       headers["X-Api-Limit"] = CurrentUser.user.token_bucket.cached_count.to_s
 
@@ -172,7 +172,7 @@ class ApplicationController < ActionController::Base
 
     respond_to do |fmt|
       fmt.html do
-        if CurrentUser.is_anonymous?
+        if CurrentUser.user.is_logged_out?
           if request.get?
             redirect_to new_session_path(url: previous_url), notice: @message
           else
@@ -206,7 +206,7 @@ class ApplicationController < ActionController::Base
   end
 
   def requires_reauthentication
-    return redirect_to(new_session_path(url: request.fullpath)) if CurrentUser.user.is_anonymous?
+    return redirect_to(new_session_path(url: request.fullpath)) if CurrentUser.user.is_logged_out?
     last_authenticated_at = session[:last_authenticated_at]
     if last_authenticated_at.blank? || Time.zone.parse(last_authenticated_at) < 1.hour.ago
       redirect_to(confirm_password_session_path(url: request.fullpath))
@@ -219,7 +219,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  User::Roles.each do |role|
+  UserLevel::ROLES.each do |role|
     define_method("#{role}_only") do
       user_access_check("is_#{role}?")
     end
@@ -231,8 +231,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  %i[logged_in logged_out restricted approver].each do |role|
+    define_method("#{role}_only") do
+      user_access_check("is_#{role}?")
+    end
+  end
+
   def logged_in_only
-    if CurrentUser.is_anonymous?
+    if CurrentUser.user.is_logged_out?
       access_denied("Must be logged in")
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -219,6 +219,9 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # These method names are misleading.
+  # For example, `janitor_only` does not mean "only janitors can access this", it means "janitors and above can access this".
+  # This is a legacy naming convention that would require a large refactor to change, so we are stuck with it.
   UserLevel::ROLES.each do |role|
     define_method("#{role}_only") do
       user_access_check("is_#{role}?")

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,7 +21,7 @@ class CommentsController < ApplicationController
   def show
     @comment = Comment.find(params[:id])
     check_accessible(@comment, bypass_user_settings: true)
-    Comment.preload_vote_by!(@comment, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    Comment.preload_vote_by!(@comment, CurrentUser.id) unless CurrentUser.user&.is_logged_out?
     respond_with_comment(@comment)
   end
 
@@ -31,7 +31,7 @@ class CommentsController < ApplicationController
   def for_post
     @post = Post.find(params[:id])
     @comments = @post.comments.includes(:creator, :updater).to_a
-    Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_logged_out?
     comment_html = render_to_string partial: "comments/partials/show/comment", collection: @comments, locals: { post: @post }, formats: [:html]
     respond_with do |format|
       format.json do
@@ -95,7 +95,7 @@ class CommentsController < ApplicationController
     else
       @comment.user_warned!(params[:record_type], CurrentUser.user)
     end
-    Comment.preload_vote_by!(@comment, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    Comment.preload_vote_by!(@comment, CurrentUser.id) unless CurrentUser.user&.is_logged_out?
     html = render_to_string partial: "comments/partials/show/comment", locals: { comment: @comment, post: nil }, formats: [:html]
     render json: { html: html, posts: deferred_posts }
   end
@@ -107,7 +107,7 @@ class CommentsController < ApplicationController
     @posts = Post.includes(:uploader).includes(comments: %i[creator updater]).tag_match("#{tags} order:comment_bumped").paginate(params[:page], limit: 5, search_count: params[:search])
 
     @comments = @posts.to_h { |post| [post.id, post.comments.above_threshold.includes(:creator, :updater).recent.reverse] }
-    Comment.preload_vote_by!(@comments.values.flatten, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    Comment.preload_vote_by!(@comments.values.flatten, CurrentUser.id) unless CurrentUser.user&.is_logged_out?
     Post.preload_stats!(@posts)
     respond_with(@posts)
   end
@@ -127,7 +127,7 @@ class CommentsController < ApplicationController
     @comments = @comments.above_threshold unless search_params[:id]
     @comments = @comments.paginate(params[:page], limit: params[:limit], search_count: search_params_for_count)
 
-    Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+    Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_logged_out?
     Post.preload_stats!(@comments.map(&:post))
 
     if CurrentUser.is_staff?

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -4,7 +4,7 @@ class EmailsController < ApplicationController
   respond_to :html
 
   def resend_confirmation
-    if IpBan.is_banned? CurrentUser.user.ip_addr
+    if IpBan.is_banned? CurrentUser.ip_addr
       redirect_to home_users_path, notice: "An error occurred trying to send an activation email"
       return
     end
@@ -23,7 +23,7 @@ class EmailsController < ApplicationController
   end
 
   def activate_user
-    if IpBan.is_banned? CurrentUser.user.ip_addr
+    if IpBan.is_banned? CurrentUser.ip_addr
       redirect_to home_users_path, notice: 'An error occurred trying to activate your account'
       return
     end

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -4,18 +4,18 @@ class EmailsController < ApplicationController
   respond_to :html
 
   def resend_confirmation
-    if IpBan.is_banned? CurrentUser.ip_addr
+    if IpBan.is_banned? CurrentUser.user.ip_addr
       redirect_to home_users_path, notice: "An error occurred trying to send an activation email"
       return
     end
 
-    raise User::PrivilegeError.new("Must be logged in to resend verification email.") if CurrentUser.is_logged_out?
-    raise User::PrivilegeError.new("Account already active.") if CurrentUser.is_verified?
+    raise User::PrivilegeError.new("Must be logged in to resend verification email.") if CurrentUser.user.is_logged_out?
+    raise User::PrivilegeError.new("Account already active.") if CurrentUser.user.is_verified?
     raise User::PrivilegeError.new('Cannot send confirmation because the email is not allowed.') if EmailBlacklist.is_banned?(CurrentUser.user.email)
-    if RateLimiter.check_limit("emailconfirm:#{CurrentUser.id}", 1, 12.hours)
+    if RateLimiter.check_limit("emailconfirm:#{CurrentUser.user.id}", 1, 12.hours)
       raise User::PrivilegeError.new("Confirmation email sent too recently. Please wait at least 12 hours between sends.")
     end
-    RateLimiter.hit("emailconfirm:#{CurrentUser.id}", 12.hours)
+    RateLimiter.hit("emailconfirm:#{CurrentUser.user.id}", 12.hours)
 
 
     Maintenance::User::EmailConfirmationMailer.confirmation(CurrentUser.user).deliver_now
@@ -23,7 +23,7 @@ class EmailsController < ApplicationController
   end
 
   def activate_user
-    if IpBan.is_banned? CurrentUser.ip_addr
+    if IpBan.is_banned? CurrentUser.user.ip_addr
       redirect_to home_users_path, notice: 'An error occurred trying to activate your account'
       return
     end

--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -9,7 +9,7 @@ class EmailsController < ApplicationController
       return
     end
 
-    raise User::PrivilegeError.new("Must be logged in to resend verification email.") if CurrentUser.is_anonymous?
+    raise User::PrivilegeError.new("Must be logged in to resend verification email.") if CurrentUser.is_logged_out?
     raise User::PrivilegeError.new("Account already active.") if CurrentUser.is_verified?
     raise User::PrivilegeError.new('Cannot send confirmation because the email is not allowed.') if EmailBlacklist.is_banned?(CurrentUser.user.email)
     if RateLimiter.check_limit("emailconfirm:#{CurrentUser.id}", 1, 12.hours)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -78,7 +78,7 @@ class PostsController < ApplicationController
 
     if request.format.html? && @post.comment_count > 0
       @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
-      Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+      Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_logged_out?
     else
       @comments = Comment.none
     end
@@ -105,7 +105,7 @@ class PostsController < ApplicationController
 
     if request.format.html? && @post.comment_count > 0
       @comments = @post.comments.above_threshold.includes(:creator, :updater).to_a
-      Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_anonymous?
+      Comment.preload_vote_by!(@comments, CurrentUser.id) unless CurrentUser.user&.is_logged_out?
     else
       @comments = Comment.none
     end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -73,7 +73,7 @@ class StaticController < ApplicationController
   end
 
   def disable_mobile_mode
-    if CurrentUser.is_logged_out?
+    if CurrentUser.user.is_logged_out?
       if cookies[:nmm]
         cookies.delete(:nmm)
       else

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -73,7 +73,7 @@ class StaticController < ApplicationController
   end
 
   def disable_mobile_mode
-    if CurrentUser.is_anonymous?
+    if CurrentUser.is_logged_out?
       if cookies[:nmm]
         cookies.delete(:nmm)
       else
@@ -210,9 +210,9 @@ class StaticController < ApplicationController
 
     add_link[:tools, "DB Export", Danbooru.config.db_export_path] if Danbooru.config.db_export_path.present?
     add_link[:tools, "Discord", discord_post_path] if CurrentUser.can_discord?
-    add_link[:users, "Signup", new_user_path] if CurrentUser.is_anonymous?
+    add_link[:users, "Signup", new_user_path] if CurrentUser.user.is_logged_out?
 
-    unless CurrentUser.is_anonymous?
+    unless CurrentUser.user.is_logged_out?
       add_link[:users, "User Home", home_users_path]
       add_link[:users, "Profile", user_path(CurrentUser.user)]
       add_link[:users, "Settings", settings_users_path]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,7 @@ class UsersController < ApplicationController
   end
 
   def new
-    unless CurrentUser.is_anonymous?
+    unless CurrentUser.user.is_logged_out?
       return access_denied("You are already signed in") unless request.format.html?
       redirect_back_or_to(posts_path, notice: "You are already signed in")
       return
@@ -56,7 +56,7 @@ class UsersController < ApplicationController
     user = CurrentUser.user
     respond_with(user, methods: user.full_attributes) do |format|
       format.html do
-        next render_404 if user.is_anonymous?
+        next render_404 if user.is_logged_out?
         redirect_to(user_path(user))
       end
     end
@@ -145,7 +145,7 @@ class UsersController < ApplicationController
   end
 
   def create
-    raise User::PrivilegeError, "Already signed in" unless CurrentUser.is_anonymous?
+    raise User::PrivilegeError, "Already signed in" unless CurrentUser.user.is_logged_out?
     raise User::PrivilegeError, "Signups are disabled" unless Danbooru.config.enable_signups?
     User.transaction do
       @user = User.new(user_params(:create).merge({ last_ip_addr: request.remote_ip }))

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -2,7 +2,7 @@
 
 module Admin::UsersHelper
   def user_level_select(object, field)
-    options = Danbooru.config.levels.map { |x,y| [x,y] }
+    options = UserLevel::ASSIGNABLE_LEVELS.map { |x,y| [x,y] }
     select(object, field, options)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   def disable_mobile_mode?
-    if CurrentUser.user.blank? || CurrentUser.is_anonymous?
+    if CurrentUser.user.blank? || CurrentUser.user.is_logged_out?
       return cookies[:nmm].present?
     end
 
@@ -132,7 +132,7 @@ module ApplicationHelper
     user_class = user.level_css_class
     user_class += " user-post-approver" if user.can_approve_posts?
     user_class += " user-post-uploader" if user.can_upload_free?
-    user_class += " user-banned" if user.is_blocked?
+    user_class += " user-banned" if user.is_restricted?
     user_class += " with-style" if CurrentUser.user.style_usernames?
     html = link_to(user.pretty_name.presence || "<blank>", user_path(user), class: user_class, rel: "nofollow")
     html << " (Unactivated)" if include_activation && !user.is_verified?
@@ -141,7 +141,8 @@ module ApplicationHelper
 
   def body_attributes(user = CurrentUser.user)
     attributes = %i[id name level level_string can_approve_posts? can_upload_free? per_page]
-    attributes += User::Roles.map { |role| :"is_#{role}?" }
+    attributes += UserLevel::BODY_ATTRIBUTE_ROLES.map { |role| :"is_#{role}?" }
+    attributes += %i[is_anonymous? is_restricted?]
 
     controller_param = params[:controller].parameterize.dasherize
     action_param = params[:action].parameterize.dasherize

--- a/app/helpers/ticket_helper.rb
+++ b/app/helpers/ticket_helper.rb
@@ -14,7 +14,7 @@ module TicketHelper
 
   def generate_content_warnings(message)
     warnings = []
-    if message.creator&.is_blocked? && message.creator&.recent_ban&.expires_at.nil?
+    if message.creator&.is_restricted? && message.creator&.recent_ban&.expires_at.nil?
       warnings << "The creator of this message is already permanently banned."
     end
     warnings << "The creator of this message already received a #{message.warning_type} for its contents." if message.warning_type

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -31,7 +31,7 @@ module UsersHelper
 
   def user_banned_badge(user)
     return if user.nil?
-    return unless user.is_blocked?
+    return unless user.is_restricted?
     return unless user.recent_ban&.prevent_login?
 
     tag.span(class: "level-badge user-blocked", title: "This user had been forcibly logged out.") do

--- a/app/logical/danbooru_logger.rb
+++ b/app/logical/danbooru_logger.rb
@@ -13,7 +13,7 @@ class DanbooruLogger
   end
 
   def self.initialize(user)
-    add_attributes("user.id" => user.id) unless user.is_anonymous?
+    add_attributes("user.id" => user.id) unless user.is_logged_out?
   end
 
   def self.add_attributes(**)

--- a/app/logical/moderator/dashboard/report.rb
+++ b/app/logical/moderator/dashboard/report.rb
@@ -7,7 +7,7 @@ module Moderator
 
       def initialize(min_date, max_level)
         @min_date = min_date.present? ? min_date.to_date : 1.week.ago
-        @max_level = max_level.present? ? max_level.to_i : User::Levels::MEMBER
+        @max_level = max_level.present? ? max_level.to_i : UserLevel::MEMBER
       end
 
       def artists

--- a/app/logical/session_creator.rb
+++ b/app/logical/session_creator.rb
@@ -19,7 +19,7 @@ class SessionCreator
       session[:user_id] = user.id
       session[:last_authenticated_at] = Time.now.utc.to_s
       session[:ph] = user.password_token
-      user.update_column(:last_ip_addr, request.remote_ip) unless user.is_blocked?
+      user.update_column(:last_ip_addr, request.remote_ip) unless user.is_restricted?
 
       if remember
         verifier = ActiveSupport::MessageVerifier.new(Danbooru.config.remember_key, serializer: JSON, digest: "SHA256")

--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -30,7 +30,7 @@ class SessionLoader
     end
 
     CurrentUser.user.unban! if CurrentUser.user.ban_expired?
-    if CurrentUser.user.is_blocked?
+    if CurrentUser.user.is_restricted?
       recent_ban = CurrentUser.user.recent_ban
       if recent_ban.nil? || recent_ban.prevent_login?
         ban_message = "Account is banned: forever"
@@ -75,7 +75,7 @@ class SessionLoader
   end
 
   def refresh_old_remember_token
-    if cookies.encrypted[:remember] && !CurrentUser.is_anonymous?
+    if cookies.encrypted[:remember] && !CurrentUser.user.is_logged_out?
       cookies.encrypted[:remember] = {value: @remember_validator.generate("#{CurrentUser.id}:#{CurrentUser.password_token}", purpose: "rbr", expires_in: 14.days), expires: Time.now + 14.days, httponly: true, same_site: :lax, secure: Rails.env.production?}
     end
   end
@@ -143,7 +143,7 @@ class SessionLoader
   end
 
   def update_user_login_tracking
-    return if CurrentUser.is_anonymous?
+    return if CurrentUser.user.is_logged_out?
 
     cache_key = if CurrentUser.api_key
                   "user_login_tracking:api_key:#{CurrentUser.api_key.id}"
@@ -179,7 +179,7 @@ class SessionLoader
   # This should normally happen when the user reads their last unread dmail.
   def refresh_unread_dmails
     return if skip_cookies?
-    return if CurrentUser.is_anonymous?
+    return if CurrentUser.user.is_logged_out?
     return if cookies[:hide_dmail_notice].blank?
 
     if !CurrentUser.user.has_mail? && cookies[:hide_dmail_notice] == "1"

--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -44,7 +44,7 @@ class StatsUpdater
     ### Users ###
 
     stats[:total_users] = User.count
-    Danbooru.config.levels.each do |name, level|
+    UserLevel::MAPPING.each do |name, level|
       stats[:"#{name.downcase}_users"] = User.where(level: level).count
     end
     stats[:unactivated_users] = User.where.not(email_verification_key: nil).count

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1394,7 +1394,7 @@ class TagQuery
       when "fav", "-fav", "~fav", "favoritedby", "-favoritedby", "~favoritedby"
         add_to_query(type, :fav_ids) do
           if g2.downcase == "me"
-            favuser = CurrentUser.is_authenticated? ? CurrentUser.user : nil
+            favuser = CurrentUser.user.is_logged_in? ? CurrentUser.user : nil
           else
             favuser = User.find_by_name_or_id(g2) # rubocop:disable Rails/DynamicFindBy
           end
@@ -1681,7 +1681,7 @@ class TagQuery
 
   def user_id_or_invalid(val)
     if val.is_a?(String) && val.casecmp?("me")
-      return CurrentUser.is_authenticated? ? CurrentUser.id : -1
+      return CurrentUser.user.is_logged_in? ? CurrentUser.id : -1
     end
     User.name_or_id_to_id(val).presence || -1
   end
@@ -1690,7 +1690,7 @@ class TagQuery
     if CurrentUser.user.is_moderator?
       return CurrentUser.id if val.is_a?(String) && val.casecmp?("me")
       User.name_or_id_to_id(val).presence
-    elsif CurrentUser.user.is_authenticated?
+    elsif CurrentUser.user.is_logged_in?
       CurrentUser.id.presence
     end || -1
   end

--- a/app/logical/user_deletion.rb
+++ b/app/logical/user_deletion.rb
@@ -58,7 +58,7 @@ class UserDeletion
       profile_about: "",
       profile_artinfo: "",
       custom_style: "",
-      level: User::Levels::MEMBER,
+      level: UserLevel::MEMBER,
     )
     AvatarCleanupJob.perform_later(user.id, force: true)
   end
@@ -89,7 +89,7 @@ class UserDeletion
   end
 
   def validate
-    if user.is_blocked? && user.recent_ban&.prevent_login? && !admin_deletion
+    if user.is_restricted? && user.recent_ban&.prevent_login? && !admin_deletion
       raise ValidationError, "Banned users cannot delete their own accounts (request deletion at #{Danbooru.config.contact_email})"
     end
 
@@ -101,12 +101,12 @@ class UserDeletion
       raise ValidationError, "Password is incorrect"
     end
 
-    if user.level >= User::Levels::ADMIN
+    if user.level >= UserLevel::ADMIN
       raise ValidationError, "Admins cannot delete their account"
     end
 
     # Prevent deletion of staff accounts via admin deletion
-    if admin_deletion && user.level >= User::Levels::JANITOR
+    if admin_deletion && user.level >= UserLevel::JANITOR
       raise ValidationError, "Staff accounts cannot be deleted via admin deletion"
     end
   end

--- a/app/logical/user_email_change.rb
+++ b/app/logical/user_email_change.rb
@@ -10,7 +10,7 @@ class UserEmailChange
   end
 
   def process
-    if user.is_blocked?
+    if user.is_restricted?
       raise ::User::PrivilegeError.new("Cannot change email while banned")
     end
 

--- a/app/logical/user_level.rb
+++ b/app/logical/user_level.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UserLevel
+module UserLevel
   MAPPING = {
     "Anonymous" => 0,
     "Blocked" => 10,

--- a/app/logical/user_level.rb
+++ b/app/logical/user_level.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class UserLevel
+  MAPPING = {
+    "Anonymous" => 0,
+    "Blocked" => 10,
+    "Member" => 20,
+    "Privileged" => 30,
+    "Former Staff" => 34,
+    "Janitor" => 35,
+    "Moderator" => 40,
+    "Admin" => 50,
+  }.freeze
+  REVERSE_MAPPING = MAPPING.invert.freeze
+
+  def self.normalize(name)
+    name.downcase.tr(" ", "_")
+  end
+
+  MAPPING.each do |name, level|
+    const_set(name.upcase.tr(" ", "_"), level)
+  end
+
+  # Normalized role names.
+  # Used primarily to create helper methods (`#is_admin?`) and access gates (`#admin_only`).
+  ROLES = MAPPING.keys.map { |n| normalize(n) }.freeze
+
+  # Levels that can be manually assigned to users.
+  # Existing user account cannot be made Anonymous - things will break in unexpected ways.
+  # Users should not be manually blocked - a permanent ban should be created instead.
+  ASSIGNABLE_LEVELS = MAPPING.except("Anonymous", "Blocked").freeze
+
+  # Normalized roles that are exported as data attributes in the body tag.
+  BODY_ATTRIBUTE_ROLES = ASSIGNABLE_LEVELS.keys.map { |n| normalize(n) }.freeze
+end

--- a/app/logical/user_promotion.rb
+++ b/app/logical/user_promotion.rb
@@ -74,6 +74,6 @@ class UserPromotion
 
   def validate
     raise User::PrivilegeError, "Can't demote BD staff" if user.is_bd_staff? && !promoter.is_bd_staff?
-    raise User::PrivilegeError, "Only BD staff can promote to admin" if new_level.to_i >= User::Levels::ADMIN && !promoter.is_bd_staff?
+    raise User::PrivilegeError, "Only BD staff can promote to admin" if new_level.to_i >= UserLevel::ADMIN && !promoter.is_bd_staff?
   end
 end

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -87,18 +87,18 @@ class Ban < ApplicationRecord
   end
 
   def update_user_on_create
-    user.level = User::Levels::BLOCKED
+    user.level = UserLevel::BLOCKED
     # Don't validate in order for deleted users to be bannable
     user.save(validate: false)
   end
 
   def update_user_on_update
-    user.level = User::Levels::BLOCKED
+    user.level = UserLevel::BLOCKED
     user.save(validate: false)
   end
 
   def update_user_on_destroy
-    user.level = User::Levels::MEMBER
+    user.level = UserLevel::MEMBER
     user.save(validate: false)
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -53,7 +53,7 @@ class Comment < ApplicationRecord
       arguments = []
 
       # 1. Visibility: not hidden or created by the user themselves
-      if user.is_anonymous? || !(user.show_hidden_comments? || bypass_user_settings)
+      if user.is_logged_out? || !(user.show_hidden_comments? || bypass_user_settings)
         conditions << "comments.is_hidden = false"
       elsif !user.is_staff?
         conditions << "(comments.is_hidden = false OR comments.creator_id = ?)"
@@ -204,7 +204,7 @@ class Comment < ApplicationRecord
     # Authorization check: user has permission to see this comment
     def is_accessible?(user = CurrentUser.user, bypass_user_settings: false)
       # 1. Visibility: not hidden or created by the user themselves
-      if user.is_anonymous? || !(user.show_hidden_comments? || bypass_user_settings)
+      if user.is_logged_out? || !(user.show_hidden_comments? || bypass_user_settings)
         return false if is_hidden?
       elsif !user.is_staff?
         return false if is_hidden? && creator_id != user.id

--- a/app/models/dmail_filter.rb
+++ b/app/models/dmail_filter.rb
@@ -13,7 +13,7 @@ class DmailFilter < ApplicationRecord
   end
 
   def filtered?(dmail)
-    dmail.from.level < User::Levels::MODERATOR && has_filter? && (dmail.body =~ regexp || dmail.title =~ regexp || dmail.from.name =~ regexp)
+    dmail.from.level < UserLevel::MODERATOR && has_filter? && (dmail.body =~ regexp || dmail.title =~ regexp || dmail.from.name =~ regexp)
   end
 
   def has_filter?

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -184,7 +184,7 @@ class ForumTopic < ApplicationRecord
     end
 
     def mark_as_read!(user = CurrentUser.user)
-      return if user.is_anonymous?
+      return if user.is_logged_out?
 
       match = ForumTopicVisit.where(:user_id => user.id, :forum_topic_id => id).first
       if match

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1231,7 +1231,7 @@ class Post < ApplicationRecord
       # that rendering thumbnails doesn't issue a query per post. Skips anonymous
       # users, who never have favorites or votes.
       def preload_stats!(posts, user = CurrentUser.user)
-        return if user.nil? || user.is_anonymous?
+        return if user.nil? || user.is_logged_out?
         preload_favorited_status!(posts, user.id)
         preload_vote_by!(posts, user.id)
       end
@@ -2158,7 +2158,7 @@ class Post < ApplicationRecord
   end
 
   def loginblocked?
-    CurrentUser.is_anonymous? && (hide_from_anonymous? || Danbooru.config.user_needs_login_for_post?(self))
+    CurrentUser.user.is_logged_out? && (hide_from_anonymous? || Danbooru.config.user_needs_login_for_post?(self))
   end
 
   def visible?

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -268,7 +268,7 @@ class PostFlag < ApplicationRecord
     when :all, "all", FLAG_REASON_VISIBILITY_LEVEL_MAP[:all]
       true
     when :users, "users", FLAG_REASON_VISIBILITY_LEVEL_MAP[:users]
-      !user.is_anonymous?
+      !user.is_logged_out?
     when :uploader, "uploader", FLAG_REASON_VISIBILITY_LEVEL_MAP[:uploader]
       post.uploader_id == user.id
     else

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -414,7 +414,7 @@ class PostReplacement < ApplicationRecord
       end
 
       def visible(user)
-        return where.not(status: "rejected") if user.is_anonymous?
+        return where.not(status: "rejected") if user.is_logged_out?
         return all if user.is_janitor?
         where("creator_id = ? or status != ?", user.id, "rejected")
       end

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -172,7 +172,7 @@ class PostSet < ApplicationRecord
     end
 
     def is_maintainer?(user)
-      return false if user.is_blocked?
+      return false if user.is_restricted?
       if association(:post_set_maintainers).loaded?
         post_set_maintainers.any? { |m| m.user_id == user.id && m.status == "approved" }
       else
@@ -197,7 +197,7 @@ class PostSet < ApplicationRecord
     end
 
     def is_owner?(user)
-      return false if user.is_blocked?
+      return false if user.is_restricted?
       creator_id == user.id
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -17,7 +17,7 @@ class Setting < RailsSettings::Base
   end
 
   scope :limits do
-    field :uploads_min_level,       type: :integer, default: User::Levels::MEMBER, validates: { presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 } }
+    field :uploads_min_level,       type: :integer, default: UserLevel::MEMBER, validates: { presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 } }
     field :hide_pending_posts_for,  type: :integer, default: 0, validates: { presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 } }
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,7 +328,7 @@ class User < ApplicationRecord
     end
 
     # Convenience methods for checking user levels
-    # Note that these method names are misleading. "is_janitor?" meand "janitor and above can access this".
+    # Note that these method names are misleading. "is_janitor?" means "janitor and above can access this".
     # This is a naming convention that would require a large refactor to change, so we are stuck with it.
     UserLevel::MAPPING.each do |name, value|
       normalized_name = UserLevel.normalize(name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -328,6 +328,8 @@ class User < ApplicationRecord
     end
 
     # Convenience methods for checking user levels
+    # Note that these method names are misleading. "is_janitor?" meand "janitor and above can access this".
+    # This is a naming convention that would require a large refactor to change, so we are stuck with it.
     UserLevel::MAPPING.each do |name, value|
       normalized_name = UserLevel.normalize(name)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,17 +14,6 @@ class User < ApplicationRecord
     end
   end
 
-  module Levels
-    Danbooru.config.levels.each do |name, level|
-      const_set(name.upcase.tr(" ", "_"), level)
-    end
-  end
-
-  # Used for `before_action :<role>_only`. Must have a corresponding `is_<role>?` method.
-  Roles = Levels.constants.map(&:downcase) + [
-    :approver,
-  ]
-
   # ================================================================================================#
   # UNDER NO CIRCUMSTANCES should new boolean attributes be added or removed from the middle of the #
   # list. Deprecated / unused bitflags should be prefixed with an underscore, and left in place.    #
@@ -163,7 +152,7 @@ class User < ApplicationRecord
     end
 
     def ban_expired?
-      is_blocked? && recent_ban&.expired?
+      is_restricted? && recent_ban&.expired?
     end
   end
 
@@ -324,19 +313,50 @@ class User < ApplicationRecord
 
       def anonymous
         user = User.new(name: "Anonymous", created_at: Time.now)
-        user.level = Levels::ANONYMOUS
+        user.level = UserLevel::ANONYMOUS
         user.freeze.readonly!
         user
       end
 
       def level_hash
-        Danbooru.config.levels
+        UserLevel::MAPPING
       end
 
       def level_string(value)
-        Danbooru.config.levels.invert[value] || ""
+        UserLevel::REVERSE_MAPPING[value] || ""
       end
     end
+
+    # Convenience methods for checking user levels
+    UserLevel::MAPPING.each do |name, value|
+      normalized_name = UserLevel.normalize(name)
+
+      define_method("is_#{normalized_name}?") do
+        is_verified? && level >= value && id.present?
+      end
+    end
+
+    # Additional access check levels
+
+    def is_logged_in?
+      level > UserLevel::ANONYMOUS
+    end
+
+    def is_logged_out?
+      level == UserLevel::ANONYMOUS
+    end
+    alias is_anonymous? is_logged_out? # Otherwise it will return true for logged in users
+
+    def is_restricted?
+      level == UserLevel::BLOCKED
+    end
+    alias is_banned is_restricted? # Required for API backwards compatibility
+
+    def is_approver?
+      can_approve_posts?
+    end
+
+    ### Other ###
 
     def promote_to!(new_level, options = {})
       UserPromotion.new(self, CurrentUser.user, new_level, options).promote!
@@ -350,45 +370,12 @@ class User < ApplicationRecord
       User.level_string(value || level)
     end
 
-    def is_anonymous?
-      level == Levels::ANONYMOUS
-    end
-
-    def is_blocked?
-      level == Levels::BLOCKED
-    end
-
-    def is_banned?
-      is_blocked?
-    end
-    alias is_banned is_banned?
-
-    # Defines various convenience methods for finding out the user's level
-    Danbooru.config.levels.each do |name, value|
-      # TODO: HACK: Remove this and make the below logic better to work with the new setup.
-      next if [0, 10].include?(value)
-      normalized_name = name.downcase.tr(" ", "_")
-
-      # Changed from e6 to match new Danbooru semantics.
-      define_method("is_#{normalized_name}?") do
-        is_verified? && level >= value && id.present?
-      end
-    end
-
-    def is_authenticated?
-      level > Levels::ANONYMOUS
-    end
-
     def is_bd_staff?
       is_bd_staff
     end
 
     def is_staff?
       is_janitor?
-    end
-
-    def is_approver?
-      can_approve_posts?
     end
 
     def is_artist?
@@ -483,7 +470,7 @@ class User < ApplicationRecord
 
   module ForumMethods
     def has_forum_been_updated?
-      return false unless is_authenticated? && forum_notification_dot
+      return false unless is_logged_in? && forum_notification_dot
       max_updated_at = ForumTopic.visible(self).order(updated_at: :desc).first&.updated_at
       return false if max_updated_at.nil?
       return true if last_forum_read_at.nil?
@@ -972,7 +959,7 @@ class User < ApplicationRecord
 
   module SearchMethods
     def admins
-      where("level = ?", Levels::ADMIN)
+      where("level = ?", UserLevel::ADMIN)
     end
 
     def with_email(email)
@@ -1101,7 +1088,7 @@ class User < ApplicationRecord
   def hide_favorites?
     return false if CurrentUser.is_moderator?
     return false if CurrentUser.user.id == id
-    return true if is_blocked?
+    return true if is_restricted?
     enable_privacy_mode?
   end
 

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -16,7 +16,7 @@ class UserPresenter
   end
 
   def ban_reason
-    if user.is_blocked? && user.recent_ban.present?
+    if user.is_restricted? && user.recent_ban.present?
       text = "#{user.recent_ban.reason}\n\n"
       if user.recent_ban.expires_at.nil?
         text << "Expires never (#{user.bans.count} bans total)"

--- a/app/views/appeals/_secondary_links.html.erb
+++ b/app/views/appeals/_secondary_links.html.erb
@@ -1,9 +1,9 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "List", appeals_path %>
-  <% unless CurrentUser.is_anonymous? %>
-    <%= subnav_link_to "Mine", appeals_path(search: { creator_id: CurrentUser.id }) %>
+  <% if CurrentUser.user.is_logged_in? %>
+    <%= subnav_link_to "Mine", appeals_path(search: { creator_id: CurrentUser.user.id }) %>
   <% end %>
-  <% if CurrentUser.is_janitor? %>
-  <%= subnav_link_to "Claimed", appeals_path(search: { claimant_id: CurrentUser.id }) %>
+  <% if CurrentUser.user.is_janitor? %>
+  <%= subnav_link_to "Claimed", appeals_path(search: { claimant_id: CurrentUser.user.id }) %>
   <% end %>
 <% end %>

--- a/app/views/blips/show.html.erb
+++ b/app/views/blips/show.html.erb
@@ -13,7 +13,7 @@
       <% end %>
     </div>
 
-    <% if CurrentUser.is_anonymous? %>
+    <% if CurrentUser.user.is_logged_out? %>
         <h5 id="respond-link"><%= link_to "Login to respond »", new_session_path %></h5>
     <% else %>
         <%= render "form", blip: @blip.responses.new %>

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -41,16 +41,16 @@
     </div>
   <% end %>
 
-  <% if (post.is_comment_locked? || post.is_comment_disabled?) && !CurrentUser.is_moderator? %>
+  <% if (post.is_comment_locked? || post.is_comment_disabled?) && !CurrentUser.user.is_moderator? %>
   <% elsif CurrentUser.user.is_member? %>
     <div class="new-comment">
-      <% if !CurrentUser.is_anonymous? && !CurrentUser.user.is_janitor? %>
+      <% if CurrentUser.user.is_logged_in? && !CurrentUser.user.is_janitor? %>
         <h2>Before commenting, read the <%= link_to "how to comment guide", wiki_pages_path(:search => {:title => "howto:comment"}) %>.</h2>
       <% end %>
       <p><%= link_to "Post comment", new_comment_path(comment: { post_id: post.id }), :class => "expand-comment-response" %></p>
       <%= render "comments/form", comment: post.comments.new, hidden: true %>
     </div>
-  <% elsif CurrentUser.user.is_anonymous? %>
+  <% elsif CurrentUser.user.is_logged_out? %>
     <h5 id="respond-link"><%= link_to "Login to respond »", new_session_path %></h5>
   <% end %>
 </div>

--- a/app/views/forum_topics/show.html.erb
+++ b/app/views/forum_topics/show.html.erb
@@ -26,7 +26,7 @@
           <%= render "forum_posts/partials/new/form", :forum_post => ForumPost.new(:topic_id => @forum_topic.id) %>
         </div>
       <% end %>
-    <% elsif CurrentUser.user.is_anonymous? && !@forum_topic.is_locked? %>
+    <% elsif CurrentUser.user.is_logged_out? && !@forum_topic.is_locked? %>
       <h5 id="respond-link"><%= link_to "Login to respond »", new_session_path %></h5>
     <% end %>
 

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -15,11 +15,11 @@
   <div id="page" role="main">
     <%= render "news_updates/notice", news_update: NewsUpdate.recent %>
 
-    <% if CurrentUser.user.is_blocked? && CurrentUser.user.recent_ban&.prevent_login? %>
+    <% if CurrentUser.user.is_restricted? && CurrentUser.user.recent_ban&.prevent_login? %>
       <%= render "users/ban_notice" %>
     <% end %>
 
-    <% if !CurrentUser.is_anonymous? && !CurrentUser.is_verified? %>
+    <% if CurrentUser.user.is_logged_in? && !CurrentUser.is_verified? %>
       <%= render "users/validation_notice" %>
     <% end %>
 

--- a/app/views/layouts/navigation/_main_links.html.erb
+++ b/app/views/layouts/navigation/_main_links.html.erb
@@ -1,4 +1,4 @@
-<% if CurrentUser.is_anonymous? %>
+<% if CurrentUser.user.is_logged_out? %>
   <%= decorated_nav_link_to("Log In", :log_in, new_session_path, class: "nav-hidden") %>
 <% else %>
   <%= decorated_nav_link_to("Profile", :user, user_path(CurrentUser.user), class: "nav-hidden") %>

--- a/app/views/layouts/navigation/_navigation.html.erb
+++ b/app/views/layouts/navigation/_navigation.html.erb
@@ -18,7 +18,7 @@
         <%= svg_icon(:times, class: "on") %>
       </span>
     </a>
-    <% if CurrentUser.is_anonymous? %>
+    <% if CurrentUser.user.is_logged_out? %>
       <a href="<%= new_session_path(url: request.fullpath) %>" class="simple-login nav-controls-profile collapse-2 auth-login-link">
         <span class="login-name">
           Sign In
@@ -32,17 +32,17 @@
     <% end %>
   </menu>
 
-  <menu class="nav-tools desktop <%= CurrentUser.is_anonymous? ? "anonymous" : "" %>">
+  <menu class="nav-tools desktop <%= CurrentUser.user.is_logged_out? ? "anonymous" : "" %>">
     <%= decorated_nav_link_to("Themes", :swatch, theme_path, class: "nav-tools-themes", title: "Site Themes", aria: { label: "Themes" }) %>
-    <% unless CurrentUser.is_anonymous? %>
+    <% unless CurrentUser.user.is_logged_out? %>
       <%= decorated_nav_link_to("Settings", :settings, settings_users_path, class: "nav-tools-settings", title: "User Settings", aria: { label: "Settings" }) %>
     <% end %>
   </menu>
 
-  <menu class="nav-help desktop <%= CurrentUser.is_anonymous? ? "anonymous" : "" %>">
+  <menu class="nav-help desktop <%= CurrentUser.user.is_logged_out? ? "anonymous" : "" %>">
     <%= nav_link_to("Wiki", wiki_pages_path(title: "help:home"), class: "nav-help-wiki") %>
     <%= nav_link_to("Help", help_pages_path, class: "nav-help-help") %>
-    <% unless CurrentUser.is_anonymous? %>
+    <% unless CurrentUser.user.is_logged_out? %>
       <%= custom_image_nav_link_to("Discord", "images/favicons/discord.com.png", discord_get_path, class: "nav-help-discord collapse-1") %>
     <% end %>
     <%= nav_link_to("More", site_map_path, class: "nav-help-map") %>

--- a/app/views/posts/partials/common/_blacklist_editor.html.erb
+++ b/app/views/posts/partials/common/_blacklist_editor.html.erb
@@ -1,4 +1,4 @@
-<div id="blacklist-edit-dialog" data-title="<% if CurrentUser.is_anonymous? %> Anonymous <% end %>Blacklist">
+<div id="blacklist-edit-dialog" data-title="<% if CurrentUser.user.is_logged_out? %> Anonymous <% end %>Blacklist">
   <h4>Tag Blacklist</h4>
   <p><%= link_to "Blacklist Help", help_page_path(id: "blacklist") %></p>
   <textarea id="blacklist-edit" rows="8" cols="30"></textarea>

--- a/app/views/posts/partials/common/_secondary_links.html.erb
+++ b/app/views/posts/partials/common/_secondary_links.html.erb
@@ -3,7 +3,7 @@
   <%= subnav_link_to "Upload", new_upload_path if CurrentUser.user.is_member? %>
   <%= subnav_link_to "Hot", posts_path(tags: "order:hot", d: "1") %>
   <%= subnav_link_to("Popular", popular_index_path) %>
-  <%= subnav_link_to "Favorites", favorites_path if CurrentUser.user.is_authenticated? %>
+  <%= subnav_link_to "Favorites", favorites_path if CurrentUser.user.is_logged_in? %>
   <%= subnav_link_to "Changes", post_versions_path %>
   <li><a href="#" id="blacklist-edit-link">Blacklist</a></li>
   <%= subnav_link_to "Help", help_page_path(id: "posts") %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -20,14 +20,14 @@
         <%= render "posts/partials/show/sidebar/information", :post => @post %>
       </section>
 
-      <% if CurrentUser.is_member? %>
+      <% if CurrentUser.user.is_member? %>
         <section id="post-options">
           <h3>Options</h3>
           <%= render "posts/partials/show/sidebar/options", :post => @post %>
         </section>
       <% end %>
 
-      <% if CurrentUser.is_authenticated? %>
+      <% if CurrentUser.user.is_logged_in? %>
         <section id="post-history">
           <h3>History</h3>
           <%= render "posts/partials/show/sidebar/history", :post => @post %>

--- a/app/views/security/dashboard/index.html.erb
+++ b/app/views/security/dashboard/index.html.erb
@@ -32,7 +32,7 @@
       <h2>Uploads</h2>
       Uploads are currently permitted for <b><%= User.level_string(Security::Lockdown.uploads_min_level) %></b> and up.
       <%= custom_form_for(:uploads_min_level, url: uploads_min_level_security_lockdown_index_path, method: :put) do |f| %>
-        <%= f.input :min_level, collection: User.level_hash.select { |_k, v| v >= User::Levels::MEMBER }.to_a, selected: Security::Lockdown.uploads_min_level %>
+        <%= f.input :min_level, collection: User.level_hash.select { |_k, v| v >= UserLevel::MEMBER }.to_a, selected: Security::Lockdown.uploads_min_level %>
         <%= f.button :submit, value: "Submit" %>
       <% end %>
 

--- a/app/views/tickets/_secondary_links.html.erb
+++ b/app/views/tickets/_secondary_links.html.erb
@@ -1,12 +1,12 @@
 <% content_for(:secondary_links) do %>
   <%= subnav_link_to "List", tickets_path %>
-  <% unless CurrentUser.is_anonymous? %>
-    <%= subnav_link_to "Mine", tickets_path(search: { creator_id: CurrentUser.id }) %>
+  <% if CurrentUser.user.is_logged_in? %>
+    <%= subnav_link_to "Mine", tickets_path(search: { creator_id: CurrentUser.user.id }) %>
   <% end %>
-  <% if CurrentUser.is_moderator? %>
-  <%= subnav_link_to "Claimed", tickets_path(search: { claimant_id: CurrentUser.id }) %>
+  <% if CurrentUser.user.is_moderator? %>
+  <%= subnav_link_to "Claimed", tickets_path(search: { claimant_id: CurrentUser.user.id }) %>
   <% end %>
-  <% if CurrentUser.is_admin? %>
+  <% if CurrentUser.user.is_admin? %>
     <li class="divider"></li>
     <%= subnav_link_to "AutoMod Rules", admin_automod_rules_path %>
   <% end %>

--- a/app/views/user_name_change_requests/new.html.erb
+++ b/app/views/user_name_change_requests/new.html.erb
@@ -1,6 +1,6 @@
 <div id="c-user-name-change-requests">
   <div id="a-new">
-    <% if CurrentUser.is_authenticated? && (name_error = CurrentUser.user.name_error) %>
+    <% if CurrentUser.user.is_logged_in? && (name_error = CurrentUser.user.name_error) %>
       <div class="ui-state-highlight site-notice">
         <p>Your current username '<%= CurrentUser.user.pretty_name %>' is invalid. You must change it to continue using the site.</p>
         Error: <%= name_error %>

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -3,11 +3,11 @@
   <%= subnav_link_to "Listing", users_path %>
   <%= subnav_link_to "Search", search_users_path %>
 
-  <% if CurrentUser.user.is_anonymous? %>
+  <% if CurrentUser.user.is_logged_out? %>
     <%= subnav_link_to "Sign up", new_user_path %>
   <% end %>
 
-  <% if @user && !@user.new_record? && !CurrentUser.user.is_anonymous? %>
+  <% if @user && !@user.new_record? && !CurrentUser.user.is_logged_out? %>
     <li class="divider"></li>
     <% if @user.id == CurrentUser.user.id %>
       <%= subnav_link_to "Settings", settings_users_path %>
@@ -18,15 +18,15 @@
       <%= subnav_link_to "Report/Commend", new_ticket_path(disp_id: @user.id, qtype: "user") %>
     <% end %>
 
-    <% if CurrentUser.is_admin? %>
-      <% if CurrentUser.is_bd_staff? %>
+    <% if CurrentUser.user.is_admin? %>
+      <% if CurrentUser.user.is_bd_staff? %>
         <%= subnav_link_to "Reset Password", request_password_reset_admin_user_path(@user) %>
       <% end %>
       <%= subnav_link_to "Edit Blacklist", edit_blacklist_admin_user_path(@user) %>
       <%= subnav_link_to "Edit User", edit_admin_user_path(@user) %>
     <% end %>
-    <% if CurrentUser.is_moderator? %>
-      <% if @user.is_blocked? && @user.recent_ban.present? %>
+    <% if CurrentUser.user.is_moderator? %>
+      <% if @user.is_restricted? && @user.recent_ban.present? %>
         <%= subnav_link_to "Unban", ban_path(@user.recent_ban) %>
       <% else %>
         <%= subnav_link_to "Ban", new_ban_path(ban: { user_id: @user.id }) %>

--- a/app/views/users/home.html.erb
+++ b/app/views/users/home.html.erb
@@ -1,4 +1,4 @@
-<% if CurrentUser.is_anonymous? %>
+<% if CurrentUser.user.is_logged_out? %>
   <h2>You are not logged in.</h2>
 
   <div class="section" style="width:450px;">

--- a/app/views/users/partials/show/_ban_banner.html.erb
+++ b/app/views/users/partials/show/_ban_banner.html.erb
@@ -1,4 +1,4 @@
-<% if user.is_blocked? && user.recent_ban %>
+<% if user.is_restricted? && user.recent_ban %>
   <div class="profile-ban dtext-container">
     <%= format_text presenter.ban_reason %>
   </div>

--- a/app/views/users/partials/show/_post_summary.html.erb
+++ b/app/views/users/partials/show/_post_summary.html.erb
@@ -55,7 +55,7 @@
 
     <div class="profile-sample-links">
       <%= link_to(sanitize("<b>#{user.favorite_count}</b> total"), favorites_path(user_id: user.id)) %>
-      <% if user.enable_privacy_mode? || user.is_blocked? %>
+      <% if user.enable_privacy_mode? || user.is_restricted? %>
         <span>[hidden]</span>
       <% end %>
     </div>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -70,19 +70,6 @@ module Danbooru
       "/db_export/"
     end
 
-    def levels
-      {
-        "Anonymous" => 0,
-        "Blocked" => 10,
-        "Member" => 20,
-        "Privileged" => 30,
-        "Former Staff" => 34,
-        "Janitor" => 35,
-        "Moderator" => 40,
-        "Admin" => 50,
-      }
-    end
-
     # Prevent new users from going above 80k while allowing those currently above
     # it to continue adding new favorites with the old limit.
     # { 123 => 200_000 }
@@ -640,7 +627,7 @@ module Danbooru
     # ```ruby
     # {
     #     title: "Post #%POST_ID% has been deleted",
-    #     body: "Post #%POST_ID% has been automatically deleted, as it has not been approved within #{unapproved_post_deletion_window.inspect}.\n\nThis is a courtesy notification; you don't need to take further action if you don't want to. If you would like to request this post to be reviewed, you can ask one of \"our janitors\":[/users?commit=Search&search%5Blevel%5D=#{Danbooru.config.levels['Janitor']}].\n\nYou can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOADER_ID%]; you can access this at any time by going to \"your profile page\":[/users/%UPLOADER_ID%] & selecting the `deleted` tab on the `Upload` pane, or you can search {{user:!%UPLOADER_ID% status:deleted}}.",
+    #     body: "Post #%POST_ID% has been automatically deleted, as it has not been approved within #{unapproved_post_deletion_window.inspect}.\n\nThis is a courtesy notification; you don't need to take further action if you don't want to. If you would like to request this post to be reviewed, you can ask one of \"our janitors\":[/users?commit=Search&search%5Blevel%5D=#{UserLevel::JANITOR}].\n\nYou can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOADER_ID%]; you can access this at any time by going to \"your profile page\":[/users/%UPLOADER_ID%] & selecting the `deleted` tab on the `Upload` pane, or you can search {{user:!%UPLOADER_ID% status:deleted}}.",
     #   }
     # ```
     def post_pruned_dmail_template

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,7 @@ admin = User.find_or_create_by!(name: "admin") do |user|
   user.email = "admin@e621.local"
   user.can_upload_free = true
   user.can_approve_posts = true
-  user.level = User::Levels::ADMIN
+  user.level = UserLevel::ADMIN
 
   user.is_bd_staff = true
   user.is_bd_auditor = true
@@ -28,7 +28,7 @@ User.find_or_create_by!(name: Danbooru.config.system_user) do |user|
   user.email = "system@e621.local"
   user.can_upload_free = true
   user.can_approve_posts = true
-  user.level = User::Levels::JANITOR
+  user.level = UserLevel::JANITOR
 end
 
 ForumCategory.find_or_create_by!(name: "Tag Alias and Implication Suggestions") do |category|

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -5,7 +5,7 @@ require "faker"
 FactoryBot.define do
   factory :user, aliases: [:member_user] do
     name { generate_username }
-    level { User::Levels::MEMBER }
+    level { UserLevel::MEMBER }
     created_at { Time.now - 2.weeks }
     email { "#{(name || '').downcase}@example.com" }
     password { "hexerade" }
@@ -30,58 +30,58 @@ FactoryBot.define do
 
     factory :anonymous_user do
       name { "Anonymous" }
-      level { User::Levels::ANONYMOUS }
+      level { UserLevel::ANONYMOUS }
     end
 
     factory :banned_user do
-      level { User::Levels::BLOCKED }
+      level { UserLevel::BLOCKED }
     end
 
     factory :privileged_user do
-      level { User::Levels::PRIVILEGED }
+      level { UserLevel::PRIVILEGED }
     end
 
     factory :former_staff_user do
-      level { User::Levels::FORMER_STAFF }
+      level { UserLevel::FORMER_STAFF }
     end
 
     factory :janitor_user do
-      level { User::Levels::JANITOR }
+      level { UserLevel::JANITOR }
     end
 
     factory :moderator_user do
-      level { User::Levels::MODERATOR }
+      level { UserLevel::MODERATOR }
     end
 
     factory :admin_user do
-      level { User::Levels::ADMIN }
+      level { UserLevel::ADMIN }
     end
 
     # Legacy option
     factory(:bd_staff_user) do
       is_bd_staff { true }
-      level { User::Levels::ADMIN }
+      level { UserLevel::ADMIN }
       can_approve_posts { true }
     end
 
     factory(:bd_member_user) do
       is_bd_staff { true }
-      level { User::Levels::MEMBER }
+      level { UserLevel::MEMBER }
     end
 
     factory(:bd_janitor_user) do
       is_bd_staff { true }
-      level { User::Levels::JANITOR }
+      level { UserLevel::JANITOR }
     end
 
     factory(:bd_moderator_user) do
       is_bd_staff { true }
-      level { User::Levels::MODERATOR }
+      level { UserLevel::MODERATOR }
     end
 
     factory(:bd_admin_user) do
       is_bd_staff { true }
-      level { User::Levels::ADMIN }
+      level { UserLevel::ADMIN }
     end
 
     #########################

--- a/spec/logical/session_loader_spec.rb
+++ b/spec/logical/session_loader_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe SessionLoader do
 
     it "sets CurrentUser.user to User.anonymous when no credentials are present" do
       loader.load
-      expect(CurrentUser.level).to be 0
+      expect(CurrentUser.user.is_logged_out?).to be true
     end
   end
 
@@ -117,7 +117,7 @@ RSpec.describe SessionLoader do
 
       it "leaves CurrentUser as anonymous" do
         loader.load
-        expect(CurrentUser.level).to be 0
+        expect(CurrentUser.user.is_logged_out?).to be true
       end
     end
 
@@ -282,7 +282,7 @@ RSpec.describe SessionLoader do
 
       it "leaves CurrentUser as anonymous without raising" do
         expect { loader.load }.not_to raise_error
-        expect(CurrentUser.level).to be 0
+        expect(CurrentUser.user.is_logged_out?).to be true
       end
     end
 
@@ -291,7 +291,7 @@ RSpec.describe SessionLoader do
 
       it "leaves CurrentUser as anonymous" do
         loader.load
-        expect(CurrentUser.level).to be 0
+        expect(CurrentUser.user.is_logged_out?).to be true
       end
     end
   end

--- a/spec/logical/session_loader_spec.rb
+++ b/spec/logical/session_loader_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe SessionLoader do
 
     it "sets CurrentUser.user to User.anonymous when no credentials are present" do
       loader.load
-      expect(CurrentUser.is_anonymous?).to be true
+      expect(CurrentUser.level).to be 0
     end
   end
 
@@ -117,7 +117,7 @@ RSpec.describe SessionLoader do
 
       it "leaves CurrentUser as anonymous" do
         loader.load
-        expect(CurrentUser.is_anonymous?).to be true
+        expect(CurrentUser.level).to be 0
       end
     end
 
@@ -282,7 +282,7 @@ RSpec.describe SessionLoader do
 
       it "leaves CurrentUser as anonymous without raising" do
         expect { loader.load }.not_to raise_error
-        expect(CurrentUser.is_anonymous?).to be true
+        expect(CurrentUser.level).to be 0
       end
     end
 
@@ -291,7 +291,7 @@ RSpec.describe SessionLoader do
 
       it "leaves CurrentUser as anonymous" do
         loader.load
-        expect(CurrentUser.is_anonymous?).to be true
+        expect(CurrentUser.level).to be 0
       end
     end
   end
@@ -330,7 +330,7 @@ RSpec.describe SessionLoader do
 
       it "unbans the user and does not raise" do
         expect { loader.load }.not_to raise_error
-        expect(user.reload.is_blocked?).to be false
+        expect(user.reload.is_restricted?).to be false
       end
     end
 

--- a/spec/logical/user_deletion_spec.rb
+++ b/spec/logical/user_deletion_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe UserDeletion do
         expect(user.profile_about).to eq("")
         expect(user.profile_artinfo).to eq("")
         expect(user.custom_style).to eq("")
-        expect(user.level).to eq(User::Levels::MEMBER)
+        expect(user.level).to eq(UserLevel::MEMBER)
       end
 
       it "invalidates the password hash" do

--- a/spec/models/ban/callbacks_spec.rb
+++ b/spec/models/ban/callbacks_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Ban do
       it "sets the user level to BLOCKED" do
         expect do
           create(:ban, user: subject_user, banner: moderator)
-        end.to change { subject_user.reload.level }.to(User::Levels::BLOCKED)
+        end.to change { subject_user.reload.level }.to(UserLevel::BLOCKED)
       end
     end
 
@@ -63,7 +63,7 @@ RSpec.describe Ban do
         expect do
           ban.update!(prevent_login: "1")
         end.not_to(change { subject_user.reload.level })
-        expect(subject_user.reload.level).to eq(User::Levels::BLOCKED)
+        expect(subject_user.reload.level).to eq(UserLevel::BLOCKED)
       end
 
       it "keeps the user level at BLOCKED when switching from hard to soft ban" do
@@ -71,7 +71,7 @@ RSpec.describe Ban do
         expect do
           ban.update!(prevent_login: "0")
         end.not_to(change { subject_user.reload.level })
-        expect(subject_user.reload.level).to eq(User::Levels::BLOCKED)
+        expect(subject_user.reload.level).to eq(UserLevel::BLOCKED)
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe Ban do
         ban = create(:ban, user: subject_user, banner: moderator, prevent_login: "1")
         expect do
           ban.destroy!
-        end.to change { subject_user.reload.level }.to(User::Levels::MEMBER)
+        end.to change { subject_user.reload.level }.to(UserLevel::MEMBER)
       end
     end
   end

--- a/spec/models/ban/class_methods_spec.rb
+++ b/spec/models/ban/class_methods_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Ban do
         Ban.prune!
 
         expect(subject_user.reload.is_banned).to be(false)
-        expect(subject_user.reload.level).to eq(User::Levels::MEMBER)
+        expect(subject_user.reload.level).to eq(UserLevel::MEMBER)
       end
 
       it "does not unban a user whose ban is still active" do

--- a/spec/models/forum_category_spec.rb
+++ b/spec/models/forum_category_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe ForumCategory do
       moderator = create(:moderator_user)
       admin = create(:admin_user)
 
-      member_category = create(:forum_category, name: "Member Category", can_view: User::Levels::MEMBER)
-      janitor_category = create(:forum_category, name: "Janitor Category", can_view: User::Levels::JANITOR)
-      moderator_category = create(:forum_category, name: "Moderator Category", can_view: User::Levels::MODERATOR)
-      admin_category = create(:forum_category, name: "Admin Category", can_view: User::Levels::ADMIN)
+      member_category = create(:forum_category, name: "Member Category", can_view: UserLevel::MEMBER)
+      janitor_category = create(:forum_category, name: "Janitor Category", can_view: UserLevel::JANITOR)
+      moderator_category = create(:forum_category, name: "Moderator Category", can_view: UserLevel::MODERATOR)
+      admin_category = create(:forum_category, name: "Admin Category", can_view: UserLevel::ADMIN)
 
       expect(ForumCategory.visible(member)).to eq([category0, member_category])
       expect(ForumCategory.visible(janitor)).to eq([category0, member_category, janitor_category])
@@ -75,10 +75,10 @@ RSpec.describe ForumCategory do
       moderator = create(:moderator_user)
       admin = create(:admin_user)
 
-      member_category = create(:forum_category, can_view: User::Levels::MEMBER)
-      janitor_category = create(:forum_category, can_view: User::Levels::JANITOR)
-      moderator_category = create(:forum_category, can_view: User::Levels::MODERATOR)
-      admin_category = create(:forum_category, can_view: User::Levels::ADMIN)
+      member_category = create(:forum_category, can_view: UserLevel::MEMBER)
+      janitor_category = create(:forum_category, can_view: UserLevel::JANITOR)
+      moderator_category = create(:forum_category, can_view: UserLevel::MODERATOR)
+      admin_category = create(:forum_category, can_view: UserLevel::ADMIN)
 
       expect(member_category.can_access?(member)).to be true
       expect(member_category.can_access?(janitor)).to be true
@@ -107,10 +107,10 @@ RSpec.describe ForumCategory do
       moderator = create(:moderator_user)
       admin = create(:admin_user)
 
-      member_category = create(:forum_category, can_create: User::Levels::MEMBER)
-      janitor_category = create(:forum_category, can_create: User::Levels::JANITOR)
-      moderator_category = create(:forum_category, can_create: User::Levels::MODERATOR)
-      admin_category = create(:forum_category, can_create: User::Levels::ADMIN)
+      member_category = create(:forum_category, can_create: UserLevel::MEMBER)
+      janitor_category = create(:forum_category, can_create: UserLevel::JANITOR)
+      moderator_category = create(:forum_category, can_create: UserLevel::MODERATOR)
+      admin_category = create(:forum_category, can_create: UserLevel::ADMIN)
 
       expect(member_category.can_create?(member)).to be true
       expect(member_category.can_create?(janitor)).to be true
@@ -139,10 +139,10 @@ RSpec.describe ForumCategory do
       moderator = create(:moderator_user)
       admin = create(:admin_user)
 
-      member_category = create(:forum_category, can_reply: User::Levels::MEMBER)
-      janitor_category = create(:forum_category, can_reply: User::Levels::JANITOR)
-      moderator_category = create(:forum_category, can_reply: User::Levels::MODERATOR)
-      admin_category = create(:forum_category, can_reply: User::Levels::ADMIN)
+      member_category = create(:forum_category, can_reply: UserLevel::MEMBER)
+      janitor_category = create(:forum_category, can_reply: UserLevel::JANITOR)
+      moderator_category = create(:forum_category, can_reply: UserLevel::MODERATOR)
+      admin_category = create(:forum_category, can_reply: UserLevel::ADMIN)
 
       expect(member_category.can_reply?(member)).to be true
       expect(member_category.can_reply?(janitor)).to be true

--- a/spec/models/forum_post/instance_methods_spec.rb
+++ b/spec/models/forum_post/instance_methods_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ForumPost do
   let(:other)           { create(:user) }
   let(:unverified)      { create(:unverified_user) }
   let(:category)        { create(:forum_category) }
-  let(:admin_category)  { create(:forum_category, can_view: User::Levels::ADMIN) }
+  let(:admin_category)  { create(:forum_category, can_view: UserLevel::ADMIN) }
   let(:topic)           { CurrentUser.scoped(member) { create(:forum_topic, category_id: category.id) } }
 
   before do

--- a/spec/models/forum_post/scopes_spec.rb
+++ b/spec/models/forum_post/scopes_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ForumPost do
   # .permitted
   # -------------------------------------------------------------------------
   describe ".permitted" do
-    let(:restricted_category) { create(:forum_category, can_view: User::Levels::MODERATOR) }
+    let(:restricted_category) { create(:forum_category, can_view: UserLevel::MODERATOR) }
     let(:restricted_topic) do
       CurrentUser.scoped(moderator) { create(:forum_topic, category_id: restricted_category.id) }
     end

--- a/spec/models/forum_post/validations_spec.rb
+++ b/spec/models/forum_post/validations_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ForumPost do
     end
 
     it "is invalid on create when the topic's category requires a higher view level" do
-      restricted = create(:forum_category, can_view: User::Levels::MODERATOR)
+      restricted = create(:forum_category, can_view: UserLevel::MODERATOR)
       restricted_topic = CurrentUser.scoped(create(:moderator_user)) { create(:forum_topic, category_id: restricted.id) }
       record = build(:forum_post, topic_id: restricted_topic.id)
       expect(record).not_to be_valid
@@ -68,7 +68,7 @@ RSpec.describe ForumPost do
     end
 
     it "is invalid on create when the topic's category does not allow replies at the user's level" do
-      restricted = create(:forum_category, can_reply: User::Levels::MODERATOR)
+      restricted = create(:forum_category, can_reply: UserLevel::MODERATOR)
       restricted_topic = CurrentUser.scoped(create(:moderator_user)) { create(:forum_topic, category_id: restricted.id) }
       record = build(:forum_post, topic_id: restricted_topic.id)
       expect(record).not_to be_valid

--- a/spec/models/forum_topic/instance_methods_spec.rb
+++ b/spec/models/forum_topic/instance_methods_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ForumTopic do
   let(:other)           { create(:user) }
   let(:unverified)      { create(:unverified_user) }
   let(:category)        { create(:forum_category) }
-  let(:admin_category)  { create(:forum_category, can_view: User::Levels::ADMIN) }
+  let(:admin_category)  { create(:forum_category, can_view: UserLevel::ADMIN) }
 
   before do
     CurrentUser.user = member
@@ -78,7 +78,7 @@ RSpec.describe ForumTopic do
     end
 
     it "is not visible to a member when category requires a higher level" do
-      restricted = create(:forum_category, can_view: User::Levels::MODERATOR)
+      restricted = create(:forum_category, can_view: UserLevel::MODERATOR)
       topic = create(:forum_topic)
       topic.update_columns(category_id: restricted.id)
       expect(topic.can_access?(member)).to be false
@@ -135,7 +135,7 @@ RSpec.describe ForumTopic do
     end
 
     it "returns false when user level is below the category requirement" do
-      restricted = create(:forum_category, can_reply: User::Levels::MODERATOR)
+      restricted = create(:forum_category, can_reply: UserLevel::MODERATOR)
       topic = create(:forum_topic)
       topic.update_columns(category_id: restricted.id)
       expect(topic.can_reply?(member)).to be false
@@ -193,7 +193,7 @@ RSpec.describe ForumTopic do
     end
 
     it "denies the creator if the topic category changed to a restricted one" do
-      restricted = create(:forum_category, can_view: User::Levels::MODERATOR)
+      restricted = create(:forum_category, can_view: UserLevel::MODERATOR)
       topic = make_topic
       topic.update_columns(creator_id: member.id, category_id: restricted.id)
       expect(topic.can_hide?(member)).to be false

--- a/spec/models/forum_topic/scopes_spec.rb
+++ b/spec/models/forum_topic/scopes_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe ForumTopic do
   # .visible
   # -------------------------------------------------------------------------
   describe ".visible" do
-    let(:public_category)     { create(:forum_category, can_view: User::Levels::ANONYMOUS) }
-    let(:moderator_category)  { create(:forum_category, can_view: User::Levels::MODERATOR) }
+    let(:public_category)     { create(:forum_category, can_view: UserLevel::ANONYMOUS) }
+    let(:moderator_category)  { create(:forum_category, can_view: UserLevel::MODERATOR) }
 
     it "includes topics in categories the user has access to" do
       topic = make_topic(category_id: public_category.id)

--- a/spec/models/forum_topic/validations_spec.rb
+++ b/spec/models/forum_topic/validations_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ForumTopic do
   # category_allows_creation (create-only)
   # -------------------------------------------------------------------------
   describe "category_allows_creation" do
-    let(:restricted_category) { create(:forum_category, can_create: User::Levels::ADMIN) }
+    let(:restricted_category) { create(:forum_category, can_create: UserLevel::ADMIN) }
 
     it "is invalid when creating in a category that does not allow the user's level" do
       record = build(:forum_topic, category_id: restricted_category.id)

--- a/spec/models/setting/defaults_spec.rb
+++ b/spec/models/setting/defaults_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Setting do
     # limits
     # -------------------------------------------------------------------------
     describe "limits" do
-      it { expect(Setting.uploads_min_level).to eq(User::Levels::MEMBER) }
+      it { expect(Setting.uploads_min_level).to eq(UserLevel::MEMBER) }
       it { expect(Setting.hide_pending_posts_for).to eq(0) }
     end
 

--- a/spec/models/user/level_methods_spec.rb
+++ b/spec/models/user/level_methods_spec.rb
@@ -9,21 +9,12 @@ require "rails_helper"
 RSpec.describe User do
   describe "level methods" do
     # -------------------------------------------------------------------------
-    # .level_hash
-    # -------------------------------------------------------------------------
-    describe ".level_hash" do
-      it "returns the levels hash from config" do
-        expect(User.level_hash).to eq(Danbooru.config.levels)
-      end
-    end
-
-    # -------------------------------------------------------------------------
     # .level_string
     # -------------------------------------------------------------------------
     describe ".level_string" do
       it "returns the level name for a known value" do
-        expect(User.level_string(User::Levels::MEMBER)).to eq("Member")
-        expect(User.level_string(User::Levels::ADMIN)).to eq("Admin")
+        expect(User.level_string(UserLevel::MEMBER)).to eq("Member")
+        expect(User.level_string(UserLevel::ADMIN)).to eq("Admin")
       end
 
       it "returns an empty string for an unknown value" do
@@ -38,7 +29,7 @@ RSpec.describe User do
       subject(:anon) { User.anonymous }
 
       it "has the anonymous level" do
-        expect(anon.level).to eq(User::Levels::ANONYMOUS)
+        expect(anon.level).to eq(UserLevel::ANONYMOUS)
       end
 
       it "is named Anonymous" do
@@ -69,13 +60,13 @@ RSpec.describe User do
     # -------------------------------------------------------------------------
     describe "#level_string" do
       it "returns the level name for the user's current level" do
-        user = build(:user, level: User::Levels::MEMBER)
+        user = build(:user, level: UserLevel::MEMBER)
         expect(user.level_string).to eq("Member")
       end
 
       it "returns the level name for a given value, ignoring the user's level" do
-        user = build(:user, level: User::Levels::MEMBER)
-        expect(user.level_string(User::Levels::ADMIN)).to eq("Admin")
+        user = build(:user, level: UserLevel::MEMBER)
+        expect(user.level_string(UserLevel::ADMIN)).to eq("Admin")
       end
     end
 
@@ -84,45 +75,69 @@ RSpec.describe User do
     # -------------------------------------------------------------------------
     describe "#level_string_was" do
       it "returns the previous level name after a level change" do
-        user = create(:user, level: User::Levels::MEMBER)
-        user.level = User::Levels::JANITOR
+        user = create(:user, level: UserLevel::MEMBER)
+        user.level = UserLevel::JANITOR
         expect(user.level_string_was).to eq("Member")
       end
     end
 
     # -------------------------------------------------------------------------
-    # #is_anonymous?
+    # #is_logged_in?
     # -------------------------------------------------------------------------
-    describe "#is_anonymous?" do
-      it "returns true for an anonymous user" do
-        expect(User.anonymous.is_anonymous?).to be(true)
+    describe "#is_logged_in?" do
+      it "returns false for an anonymous user" do
+        expect(User.anonymous.is_logged_in?).to be(false)
       end
 
-      it "returns false for a regular member" do
+      it "returns true for a regular member" do
         user = build(:user)
-        expect(user.is_anonymous?).to be(false)
+        expect(user.is_logged_in?).to be(true)
+      end
+
+      it "returns true for a blocked user" do
+        user = build(:user, level: UserLevel::BLOCKED)
+        expect(user.is_logged_in?).to be(true)
+      end
+
+      it "returns true for a staff member" do
+        user = build(:admin_user)
+        expect(user.is_logged_in?).to be(true)
       end
     end
 
     # -------------------------------------------------------------------------
-    # #is_blocked?
+    # #is_logged_out?
     # -------------------------------------------------------------------------
-    describe "#is_blocked?" do
-      it "returns true for a hard-banned user" do
-        user = build(:user, level: User::Levels::BLOCKED)
-        build(:ban, user: user, prevent_login: true)
-        expect(user.is_blocked?).to be(true)
-      end
-
-      it "returns true for a soft-banned user" do
-        user = build(:user, level: User::Levels::BLOCKED)
-        build(:ban, user: user, prevent_login: false)
-        expect(user.is_blocked?).to be(true)
+    describe "#is_logged_out?" do
+      it "returns true for an anonymous user" do
+        expect(User.anonymous.is_logged_out?).to be(true)
       end
 
       it "returns false for a regular member" do
         user = build(:user)
-        expect(user.is_blocked?).to be(false)
+        expect(user.is_logged_out?).to be(false)
+      end
+    end
+
+    # -------------------------------------------------------------------------
+    # #is_restricted?
+    # -------------------------------------------------------------------------
+    describe "#is_restricted?" do
+      it "returns true for a hard-banned user" do
+        user = build(:user, level: UserLevel::BLOCKED)
+        build(:ban, user: user, prevent_login: true)
+        expect(user.is_restricted?).to be(true)
+      end
+
+      it "returns true for a soft-banned user" do
+        user = build(:user, level: UserLevel::BLOCKED)
+        build(:ban, user: user, prevent_login: false)
+        expect(user.is_restricted?).to be(true)
+      end
+
+      it "returns false for a regular member" do
+        user = build(:user)
+        expect(user.is_restricted?).to be(false)
       end
     end
 
@@ -187,12 +202,12 @@ RSpec.describe User do
     # -------------------------------------------------------------------------
     describe "#level_css_class" do
       it "returns the parameterized level name prefixed with 'user-'" do
-        expect(build(:user, level: User::Levels::MEMBER).level_css_class).to eq("user-member")
-        expect(build(:user, level: User::Levels::ADMIN).level_css_class).to eq("user-admin")
+        expect(build(:user, level: UserLevel::MEMBER).level_css_class).to eq("user-member")
+        expect(build(:user, level: UserLevel::ADMIN).level_css_class).to eq("user-admin")
       end
 
       it "hyphenates multi-word level names" do
-        expect(build(:user, level: User::Levels::FORMER_STAFF).level_css_class).to eq("user-former-staff")
+        expect(build(:user, level: UserLevel::FORMER_STAFF).level_css_class).to eq("user-former-staff")
       end
     end
   end

--- a/spec/models/user_feedback/validations_spec.rb
+++ b/spec/models/user_feedback/validations_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe UserFeedback do
       it "does not re-run on update" do
         feedback = create(:user_feedback, user: subject_user, creator: moderator)
         # Demote the creator to member — creator_is_moderator should not re-fire
-        moderator.update_columns(level: User::Levels::MEMBER)
+        moderator.update_columns(level: UserLevel::MEMBER)
         moderator.reload
         feedback.body = "updated body"
         expect(feedback).to be_valid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,7 +94,7 @@ RSpec.configure do |config|
       user.email = "admin@e621.local"
       user.can_upload_free = true
       user.can_approve_posts = true
-      user.level = User::Levels::ADMIN
+      user.level = UserLevel::ADMIN
 
       user.is_bd_staff = true
       user.is_bd_auditor = true
@@ -107,7 +107,7 @@ RSpec.configure do |config|
       user.email = "system@e621.local"
       user.can_upload_free = true
       user.can_approve_posts = true
-      user.level = User::Levels::JANITOR
+      user.level = UserLevel::JANITOR
     end
 
     ForumCategory.find_or_create_by!(name: "Tag Alias and Implication Suggestions") do |category|

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -216,8 +216,8 @@ RSpec.describe Admin::UsersController do
       end
 
       it "promotes a user to a new level" do
-        patch admin_user_path(user), params: { user: { profile_about: "x", level: User::Levels::PRIVILEGED } }
-        expect(user.reload.level).to eq(User::Levels::PRIVILEGED)
+        patch admin_user_path(user), params: { user: { profile_about: "x", level: UserLevel::PRIVILEGED } }
+        expect(user.reload.level).to eq(UserLevel::PRIVILEGED)
       end
     end
   end

--- a/spec/requests/bans_controller_spec.rb
+++ b/spec/requests/bans_controller_spec.rb
@@ -170,13 +170,13 @@ RSpec.describe BansController do
       it "creates a soft ban (level BLOCKED, login allowed) when prevent_login is not set" do
         post bans_path, params: { ban: { user_id: ban_target.id, reason: "Violation.", duration: 7 } }
         expect(Ban.last.prevent_login?).to be(false)
-        expect(ban_target.reload.level).to eq(User::Levels::BLOCKED)
+        expect(ban_target.reload.level).to eq(UserLevel::BLOCKED)
       end
 
       it "creates a hard ban (level set to BLOCKED) when prevent_login is '1'" do
         post bans_path, params: { ban: { user_id: ban_target.id, reason: "Violation.", duration: 7, prevent_login: "1" } }
         expect(Ban.last.prevent_login?).to be(true)
-        expect(ban_target.reload.level).to eq(User::Levels::BLOCKED)
+        expect(ban_target.reload.level).to eq(UserLevel::BLOCKED)
       end
     end
   end

--- a/spec/requests/dmails_controller_spec.rb
+++ b/spec/requests/dmails_controller_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe DmailsController do
         former_moderator = create(:moderator_user)
         dmail_from_former_moderator = create(:dmail, from: former_moderator, to: recipient, owner_id: recipient.id)
         key = dmail_from_former_moderator.generate_key
-        former_moderator.update_columns(level: User::Levels::MEMBER)
+        former_moderator.update_columns(level: UserLevel::MEMBER)
 
         sign_in_as janitor
         get dmail_path(dmail_from_former_moderator), params: { key: key }

--- a/spec/requests/forum_topics_controller_spec.rb
+++ b/spec/requests/forum_topics_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ForumTopicsController do
     end
 
     it "excludes topics in categories above the user's view level" do
-      hidden_category = create(:forum_category, can_view: User::Levels::MODERATOR)
+      hidden_category = create(:forum_category, can_view: UserLevel::MODERATOR)
       hidden_topic = CurrentUser.scoped(mod) { create(:forum_topic, category: hidden_category) }
 
       sign_in_as user

--- a/spec/requests/maintenance/user/email_changes_controller_spec.rb
+++ b/spec/requests/maintenance/user/email_changes_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Maintenance::User::EmailChangesController do
       end
 
       context "when the user is banned" do
-        before { allow(user).to receive(:is_blocked?).and_return(true) }
+        before { allow(user).to receive(:is_restricted?).and_return(true) }
 
         it "returns 403" do
           post maintenance_user_email_change_path, params: { email_change: { email: "new@example.com", password: "hexerade" } }

--- a/spec/requests/security/lockdown_controller_spec.rb
+++ b/spec/requests/security/lockdown_controller_spec.rb
@@ -172,14 +172,14 @@ RSpec.describe Security::LockdownController do
   describe "PUT /security/lockdown/uploads_min_level" do
     it "redirects anonymous to the login page" do
       put uploads_min_level_security_lockdown_index_path,
-          params: { uploads_min_level: { min_level: User::Levels::MEMBER } }
+          params: { uploads_min_level: { min_level: UserLevel::MEMBER } }
       expect(response).to redirect_to(new_session_path)
     end
 
     it "returns 403 for a regular member" do
       sign_in_as user
       put uploads_min_level_security_lockdown_index_path,
-          params: { uploads_min_level: { min_level: User::Levels::MEMBER } }
+          params: { uploads_min_level: { min_level: UserLevel::MEMBER } }
       expect(response).to have_http_status(:forbidden)
     end
 
@@ -188,21 +188,21 @@ RSpec.describe Security::LockdownController do
 
       it "redirects to the security dashboard" do
         put uploads_min_level_security_lockdown_index_path,
-            params: { uploads_min_level: { min_level: User::Levels::MEMBER } }
+            params: { uploads_min_level: { min_level: UserLevel::MEMBER } }
         expect(response).to redirect_to(security_root_path)
       end
 
       it "updates the minimum upload level when a valid level is given" do
         put uploads_min_level_security_lockdown_index_path,
-            params: { uploads_min_level: { min_level: User::Levels::PRIVILEGED } }
-        expect(Security::Lockdown.uploads_min_level).to eq(User::Levels::PRIVILEGED)
+            params: { uploads_min_level: { min_level: UserLevel::PRIVILEGED } }
+        expect(Security::Lockdown.uploads_min_level).to eq(UserLevel::PRIVILEGED)
       end
 
       it "logs a min_upload_level StaffAuditLog entry when the level changes" do
         # Seed a known starting value; rails-settings-cached caches values in memory and
         # DB transaction rollback alone does not clear the cache between examples.
-        Security::Lockdown.uploads_min_level = User::Levels::MEMBER
-        new_level = User::Levels::PRIVILEGED
+        Security::Lockdown.uploads_min_level = UserLevel::MEMBER
+        new_level = UserLevel::PRIVILEGED
 
         expect do
           put uploads_min_level_security_lockdown_index_path,

--- a/spec/requests/uploads_controller_spec.rb
+++ b/spec/requests/uploads_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe UploadsController do
     end
 
     context "when the uploads min level is set above member" do
-      before { allow(Security::Lockdown).to receive(:uploads_min_level).and_return(User::Levels::JANITOR) }
+      before { allow(Security::Lockdown).to receive(:uploads_min_level).and_return(UserLevel::JANITOR) }
 
       it "returns 403 for a member" do
         sign_in_as member
@@ -209,7 +209,7 @@ RSpec.describe UploadsController do
     end
 
     context "when the uploads min level is set above member" do
-      before { allow(Security::Lockdown).to receive(:uploads_min_level).and_return(User::Levels::JANITOR) }
+      before { allow(Security::Lockdown).to receive(:uploads_min_level).and_return(UserLevel::JANITOR) }
 
       it "returns 403 for a member" do
         sign_in_as member


### PR DESCRIPTION
Previously, the user levels were defined in the config file.
That made very little sense. User levels are deeply ingrained in the app through the use of `is_{level_string}?` methods and `only_{level_string}` access gates.

The level definitions now live in the `UserLevels` class, alongside some other helpful constants.