### PR TITLE
[Posts] Tweaks to image sampler parameters

### DIFF
--- a/app/logical/image_sampler.rb
+++ b/app/logical/image_sampler.rb
@@ -215,8 +215,24 @@ module ImageSampler
     jpg_image = Tempfile.new(["image-thumb", ".jpg"], binmode: true)
     webp_image = Tempfile.new(["image-thumb", ".webp"], binmode: true)
 
-    result.jpegsave(jpg_image.path, Q: 90, background: calc_background_color(background), strip: true, interlace: true, optimize_coding: true)
-    result.webpsave(webp_image.path, Q: 90, min_size: true)
+    result.jpegsave(
+      jpg_image.path,
+      Q: 90,
+      background: calc_background_color(background),
+      strip: true,
+      interlace: true,
+      optimize_coding: true,
+      optimize_scans: true,
+      trellis_quant: true,
+      quant_table: 3,
+    )
+    result.webpsave(
+      webp_image.path,
+      Q: 90,
+      effort: 6,
+      alpha_q: 90,
+      smart_subsample: true,
+    )
 
     {
       jpg: jpg_image,

--- a/app/logical/image_sampler.rb
+++ b/app/logical/image_sampler.rb
@@ -44,8 +44,23 @@ module ImageSampler
     jpg = Tempfile.new(["avatar", ".jpg"], binmode: true)
     webp = Tempfile.new(["avatar", ".webp"], binmode: true)
 
-    resized.jpegsave(jpg.path, Q: 90, strip: true, interlace: true, optimize_coding: true)
-    resized.webpsave(webp.path, Q: 90, min_size: true)
+    resized.jpegsave(
+      jpg.path,
+      Q: 90,
+      strip: true,
+      interlace: true,
+      optimize_coding: true,
+      optimize_scans: true,
+      trellis_quant: true,
+      quant_table: 3,
+    )
+    resized.webpsave(
+      webp.path,
+      Q: 90,
+      effort: 6,
+      alpha_q: 90,
+      smart_subsample: true,
+    )
 
     sm.store_avatar(jpg, user_id, "jpg")
     sm.store_avatar(webp, user_id, "webp")


### PR DESCRIPTION
Tweaked some parameters passed on to libvips, based on the [suggestions from the forums](https://e621.net/forum_topics/64410).

Did not disable interlacing for thumbnails – that would add complexity to the image sampler that I did not want to deal with. The overhead for 256px samples should be fairly minimal regardless.