### PR TITLE
[TagRelationships] Optimize database queries in alias and implication indexes

### DIFF
--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -28,7 +28,8 @@ class TagAliasesController < ApplicationController
   end
 
   def index
-    @tag_aliases = TagAlias.includes(:antecedent_tag, :consequent_tag, :approver).search(search_params).paginate(params[:page], :limit => params[:limit])
+    @tag_aliases = TagAlias.includes(:antecedent_tag, :consequent_tag, :creator, :approver).search(search_params).paginate(params[:page], :limit => params[:limit])
+    TagAlias.preload_transitives(@tag_aliases) if CurrentUser.is_member?
     respond_with(@tag_aliases)
   end
 

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -24,7 +24,7 @@ class TagImplicationsController < ApplicationController
   end
 
   def index
-    @tag_implications = TagImplication.includes(:antecedent_tag, :consequent_tag, :approver).search(search_params).paginate(params[:page], :limit => params[:limit])
+    @tag_implications = TagImplication.includes(:antecedent_tag, :consequent_tag, :creator, :approver).search(search_params).paginate(params[:page], :limit => params[:limit])
     respond_with(@tag_implications)
   end
 

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -56,10 +56,11 @@ class TagAlias < TagRelationship
                                .where(consequent_name: antecedent_names)
                                .group_by(&:consequent_name)
 
-        raw_implications = TagImplication.duplicate_relevant
-                                         .where(antecedent_name: antecedent_names)
-                                         .or(TagImplication.duplicate_relevant.where(consequent_name: antecedent_names))
-                                         .to_a
+        impl_base = TagImplication.duplicate_relevant
+        raw_implications = impl_base
+                           .where(antecedent_name: antecedent_names)
+                           .or(impl_base.where(consequent_name: antecedent_names))
+                           .to_a
 
         implications_by_name = Hash.new { |h, k| h[k] = [] }
         raw_implications.each do |ti|
@@ -88,7 +89,7 @@ class TagAlias < TagRelationship
           end
 
           record.instance_variable_set(:@transitives, transitives)
-          record.instance_variable_set(:@has_transitives, transitives.size > 0)
+          record.instance_variable_set(:@has_transitives, transitives.any?)
         end
       end
     end
@@ -114,7 +115,8 @@ class TagAlias < TagRelationship
     end
 
     def has_transitives
-      @has_transitives ||= list_transitives.size > 0
+      return @has_transitives if instance_variable_defined?(:@has_transitives)
+      @has_transitives = list_transitives.any?
     end
   end
 

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -42,6 +42,57 @@ class TagAlias < TagRelationship
   end
 
   module TransitiveChecks
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def preload_transitives(records)
+        records = records.to_a
+        return if records.empty?
+
+        antecedent_names = records.map(&:antecedent_name).uniq
+        antecedent_names_set = antecedent_names.to_set
+
+        bulk_aliases = TagAlias.duplicate_relevant
+                               .where(consequent_name: antecedent_names)
+                               .group_by(&:consequent_name)
+
+        raw_implications = TagImplication.duplicate_relevant
+                                         .where(antecedent_name: antecedent_names)
+                                         .or(TagImplication.duplicate_relevant.where(consequent_name: antecedent_names))
+                                         .to_a
+
+        implications_by_name = Hash.new { |h, k| h[k] = [] }
+        raw_implications.each do |ti|
+          implications_by_name[ti.antecedent_name] << ti if antecedent_names_set.include?(ti.antecedent_name)
+          if ti.consequent_name != ti.antecedent_name && antecedent_names_set.include?(ti.consequent_name)
+            implications_by_name[ti.consequent_name] << ti
+          end
+        end
+
+        records.each do |record|
+          next if record.instance_variable_defined?(:@transitives)
+
+          name = record.antecedent_name
+          transitives = []
+
+          (bulk_aliases[name] || []).each do |ta|
+            transitives << [:alias, ta, ta.antecedent_name, ta.consequent_name, record.consequent_name]
+          end
+
+          (implications_by_name[name] || []).each do |ti|
+            if ti.antecedent_name == name
+              transitives << [:implication, ti, ti.antecedent_name, ti.consequent_name, record.consequent_name, ti.consequent_name]
+            else
+              transitives << [:implication, ti, ti.antecedent_name, ti.consequent_name, ti.antecedent_name, record.consequent_name]
+            end
+          end
+
+          record.instance_variable_set(:@transitives, transitives)
+          record.instance_variable_set(:@has_transitives, transitives.size > 0)
+        end
+      end
+    end
+
     def list_transitives
       return @transitives if @transitives
       @transitives = []

--- a/spec/models/tag_alias/transitive_checks_spec.rb
+++ b/spec/models/tag_alias/transitive_checks_spec.rb
@@ -69,4 +69,120 @@ RSpec.describe TagAlias do
       expect(ta.has_transitives).to be true
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # .preload_transitives
+  # ---------------------------------------------------------------------------
+
+  describe ".preload_transitives" do
+    def select_query_count(&block)
+      count = 0
+      subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+        count += 1 if payload[:sql].start_with?("SELECT")
+      end
+      block.call
+      ActiveSupport::Notifications.unsubscribe(subscriber)
+      count
+    end
+
+    it "is a no-op on an empty collection" do
+      expect { TagAlias.preload_transitives([]) }.not_to raise_error
+    end
+
+    it "sets has_transitives to false when there are no chains" do
+      ta = create(:tag_alias, antecedent_name: "solo_ant", consequent_name: "solo_con")
+      TagAlias.preload_transitives([ta])
+      expect(ta.has_transitives).to be false
+    end
+
+    it "sets has_transitives to true when a transitive alias exists" do
+      create(:active_tag_alias, antecedent_name: "first_tag", consequent_name: "mid_tag")
+      ta = create(:tag_alias, antecedent_name: "mid_tag", consequent_name: "final_tag")
+      TagAlias.preload_transitives([ta])
+      expect(ta.has_transitives).to be true
+    end
+
+    it "populates the alias transitive entry with the correct tuple shape" do
+      existing = create(:active_tag_alias, antecedent_name: "chain_a", consequent_name: "chain_b")
+      ta = create(:tag_alias, antecedent_name: "chain_b", consequent_name: "chain_c")
+      TagAlias.preload_transitives([ta])
+
+      entry = ta.list_transitives.first
+      expect(entry[0]).to eq(:alias)
+      expect(entry[1]).to eq(existing)
+      expect(entry[2]).to eq("chain_a")
+      expect(entry[3]).to eq("chain_b")
+      expect(entry[4]).to eq("chain_c")
+    end
+
+    it "detects an implication where our antecedent_name matches the implication antecedent" do
+      create(:active_tag_implication, antecedent_name: "ant_tag", consequent_name: "imp_con")
+      ta = create(:tag_alias, antecedent_name: "ant_tag", consequent_name: "alias_con")
+      TagAlias.preload_transitives([ta])
+
+      entry = ta.list_transitives.first
+      expect(entry[0]).to eq(:implication)
+      expect(entry[4]).to eq("alias_con")
+    end
+
+    it "detects an implication where our antecedent_name matches the implication consequent" do
+      create(:active_tag_implication, antecedent_name: "imp_ant", consequent_name: "ant_tag")
+      ta = create(:tag_alias, antecedent_name: "ant_tag", consequent_name: "alias_con")
+      TagAlias.preload_transitives([ta])
+
+      entry = ta.list_transitives.first
+      expect(entry[0]).to eq(:implication)
+      expect(entry[5]).to eq("alias_con")
+    end
+
+    it "populates all records in the batch" do
+      create(:active_tag_alias, antecedent_name: "x", consequent_name: "a")
+      create(:active_tag_alias, antecedent_name: "y", consequent_name: "b")
+      ta_a = create(:tag_alias, antecedent_name: "a", consequent_name: "z")
+      ta_b = create(:tag_alias, antecedent_name: "b", consequent_name: "z")
+      ta_c = create(:tag_alias, antecedent_name: "c", consequent_name: "z")
+
+      TagAlias.preload_transitives([ta_a, ta_b, ta_c])
+
+      expect(ta_a.has_transitives).to be true
+      expect(ta_b.has_transitives).to be true
+      expect(ta_c.has_transitives).to be false
+    end
+
+    it "skips records that already have @transitives memoized" do
+      ta = create(:tag_alias, antecedent_name: "pre_memoized", consequent_name: "con")
+      ta.instance_variable_set(:@transitives, [:sentinel])
+      ta.instance_variable_set(:@has_transitives, true)
+
+      create(:active_tag_alias, antecedent_name: "upstream", consequent_name: "pre_memoized")
+      TagAlias.preload_transitives([ta])
+
+      expect(ta.instance_variable_get(:@transitives)).to eq([:sentinel])
+    end
+
+    it "ignores aliases and implications with deleted status" do
+      existing = create(:tag_alias, antecedent_name: "del_a", consequent_name: "del_b")
+      existing.update_columns(status: "deleted")
+      ta = create(:tag_alias, antecedent_name: "del_b", consequent_name: "del_c")
+      TagAlias.preload_transitives([ta])
+      expect(ta.has_transitives).to be false
+    end
+
+    it "fires exactly 2 SELECT queries regardless of how many records are passed" do
+      records = Array.new(3) { |i| create(:tag_alias, antecedent_name: "bulk_tag_#{i}", consequent_name: "bulk_con_#{i}") }
+
+      n = select_query_count { TagAlias.preload_transitives(records) }
+      expect(n).to eq(2)
+    end
+
+    it "fires 2 queries even when transitive matches exist across multiple records" do
+      records = Array.new(3) do |i|
+        create(:active_tag_alias, antecedent_name: "upstream_#{i}", consequent_name: "target_#{i}")
+        create(:tag_alias, antecedent_name: "target_#{i}", consequent_name: "downstream_#{i}")
+      end
+
+      n = select_query_count { TagAlias.preload_transitives(records) }
+      expect(n).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Fixed a couple N+1 query issues on both alias and implication index routes.
Neither page preloaded the tag relationship's creator.

Additionally, the tag alias index page checked each tag for transitives by running 2 extra queries per row.
This data should now be bulk-loaded instead.