### PR TITLE
[UI] Optimize navbar avatar loading

### DIFF
--- a/app/javascript/src/js/core/DeferredPostLoader.ts
+++ b/app/javascript/src/js/core/DeferredPostLoader.ts
@@ -42,39 +42,6 @@ export default class DeferredPostLoader {
     window.___deferred_posts = {};
   }
 
-  public static renderNavbarAvatar () {
-    const avatars = $(".savm-profile-icon.placeholder");
-    if (!avatars.length) return;
-    avatars.removeClass("placeholder");
-
-    // Determine avatar data from the first placeholder
-    const avatar = $(avatars[0]);
-    const postID = avatar.data("id");
-    if (!postID) return;
-    const post = PostCache.get(postID);
-    if (!post || !post.preview_url) return;
-
-    let path = post.preview_url;
-    if (!post.isDeleted && avatar.data("has-cropped-avatar")) {
-      const userID = avatar.data("user-id") || "0",
-        userHash = avatar.data("user-hash") || "0";
-      if (userID) path = post.preview_url.replace(/\/data\/.*$/, `/data/avatars/${userID}.jpg?t=${userHash}`);
-    }
-
-    // Avatars are rendered without accounting for blacklist.
-    // If someone blacklists their own avatar, it's their problem.
-
-    for (const placeholder of avatars) {
-      const $placeholder = $(placeholder);
-      $("<img>")
-        .attr({
-          "src": path,
-          "alt": "User avatar",
-        })
-        .appendTo($placeholder);
-    }
-  }
-
   public static renderDTextThumbnails () {
     let counter = 0;
     for (const placeholder of $(".thumb-placeholder-link")) {
@@ -139,7 +106,6 @@ export default class DeferredPostLoader {
 
 $(() => {
   DeferredPostLoader.loadPostData();
-  DeferredPostLoader.renderNavbarAvatar();
   DeferredPostLoader.renderDTextThumbnails();
   DeferredPostLoader.renderUserAvatars();
 

--- a/app/javascript/src/styles/views/application/_avatar.scss
+++ b/app/javascript/src/styles/views/application/_avatar.scss
@@ -12,11 +12,15 @@ nav.navigation .simple-avatar {
     overflow: hidden;
     position: relative;
 
+    picture {
+      position: absolute;
+      inset: 0;
+    }
+
     img {
       width: 2.5rem;
       height: 2.5rem;
       object-fit: cover;
-      position: absolute;
     }
 
     &::before {
@@ -268,12 +272,15 @@ div.savm-profile {
       @include st-radius;
       background: themed("color-section-darken-5");
 
+      picture {
+        position: absolute;
+        inset: 0;
+      }
+
       img {
         width: 2rem;
         height: 2rem;
         object-fit: cover;
-        position: absolute;
-        inset: 0;
       }
 
       &::before {

--- a/app/jobs/avatar_crop_job.rb
+++ b/app/jobs/avatar_crop_job.rb
@@ -13,6 +13,7 @@ class AvatarCropJob < ApplicationJob
     flag = User.flag_value_for("has_cropped_avatar")
     user.update_columns(bit_prefs: user.bit_prefs | flag)
     user.touch # otherwise, the old avatar may still be cached for a while
+    UserAvatarUrlCache.invalidate(user_id)
   rescue ActiveRecord::RecordNotFound
     nil
   end

--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -79,6 +79,9 @@ class UploadService
           UserStatus.for_user(previous_uploader).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count + 1")
         end
 
+        # Invalidate avatar cache
+        User.where(avatar_id: post.id).pluck(:id).each { |uid| UserAvatarUrlCache.invalidate(uid) }
+
         # Everything went through correctly, the old files can now be removed
         if md5_changed
           Post.delete_files(post.id, previous_md5, previous_file_ext, force: true)

--- a/app/logical/user_avatar_url_cache.rb
+++ b/app/logical/user_avatar_url_cache.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module UserAvatarUrlCache
+  CACHE_TTL = 15.minutes
+
+  def self.key(user_id)
+    "user_avatar_url:#{user_id}"
+  end
+
+  # Returns the JPEG URL for the navbar avatar, or nil if unavailable.
+  # For cropped avatars, computes inline with no query. For uncropped avatars,
+  # caches the post's preview URL to avoid loading the full post on every request.
+  def self.get(user)
+    return nil if user.avatar_id.blank?
+
+    if user.has_cropped_avatar?
+      "/data/avatars/#{user.id}.jpg?t=#{user.updated_at.to_i}"
+    else
+      Cache.fetch(key(user.id), expires_in: CACHE_TTL) do
+        post = Post.find_by(id: user.avatar_id)
+        post && !post.is_deleted? ? post.preview_file_url : nil
+      end
+    end
+  end
+
+  def self.invalidate(user_id)
+    Cache.delete(key(user_id))
+  end
+end

--- a/app/logical/user_avatar_url_cache.rb
+++ b/app/logical/user_avatar_url_cache.rb
@@ -11,13 +11,15 @@ module UserAvatarUrlCache
   # For cropped avatars, computes inline with no query. For uncropped avatars,
   # caches the post's preview URL to avoid loading the full post on every request.
   def self.get(user)
-    return nil if user.avatar_id.blank?
+    return nil if user.blank? || user.avatar_id.blank?
 
     if user.has_cropped_avatar?
       "/data/avatars/#{user.id}.jpg?t=#{user.updated_at.to_i}"
     else
       Cache.fetch(key(user.id), expires_in: CACHE_TTL) do
         post = Post.find_by(id: user.avatar_id)
+        # NOTE: For deleted posts, this will cache nil, which is what we want.
+        # Deleted posts cannot be used as avatars, and this will prevent repeated lookups.
         post && !post.is_deleted? ? post.preview_file_url : nil
       end
     end

--- a/app/logical/user_avatar_url_cache.rb
+++ b/app/logical/user_avatar_url_cache.rb
@@ -14,13 +14,16 @@ module UserAvatarUrlCache
     return nil if user.blank? || user.avatar_id.blank?
 
     if user.has_cropped_avatar?
-      "/data/avatars/#{user.id}.jpg?t=#{user.updated_at.to_i}"
+      [
+        "/data/avatars/#{user.id}.webp?t=#{user.updated_at.to_i}",
+        "/data/avatars/#{user.id}.jpg?t=#{user.updated_at.to_i}",
+      ]
     else
       Cache.fetch(key(user.id), expires_in: CACHE_TTL) do
         post = Post.find_by(id: user.avatar_id)
         # NOTE: For deleted posts, this will cache nil, which is what we want.
         # Deleted posts cannot be used as avatars, and this will prevent repeated lookups.
-        post && !post.is_deleted? ? post.preview_file_url : nil
+        post && !post.is_deleted? ? post.preview_file_url_pair : nil
       end
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -89,6 +89,7 @@ class Post < ApplicationRecord
     def delete_avatar_crops
       User.where(avatar_id: id).pluck(:id).each do |user_id|
         AvatarCleanupJob.perform_later(user_id, force: true)
+        UserAvatarUrlCache.invalidate(user_id)
       end
     end
 
@@ -1712,6 +1713,7 @@ class Post < ApplicationRecord
         PostEvent.add(id, CurrentUser.user, :undeleted)
       end
       move_files_on_undelete
+      User.where(avatar_id: id).pluck(:id).each { |uid| UserAvatarUrlCache.invalidate(uid) }
       UserStatus.for_user(uploader_id).update_all("post_deleted_count = post_deleted_count - 1")
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -392,6 +392,9 @@ class User < ApplicationRecord
 
     def clear_cropped_avatar_on_avatar_change
       return unless saved_change_to_avatar_id?
+
+      UserAvatarUrlCache.invalidate(id)
+
       return unless has_cropped_avatar?
 
       flag = User.flag_value_for("has_cropped_avatar")

--- a/app/views/layouts/navigation/_avatar_menu.html.erb
+++ b/app/views/layouts/navigation/_avatar_menu.html.erb
@@ -15,8 +15,8 @@
   >
   <% if avatar_url %>
     <picture>
-      <source srcset="<%= avatar_url[1] %>" type="image/webp">
-      <%= image_tag(avatar_url[0], alt: "User avatar") %>
+      <source srcset="<%= avatar_url[0] %>" type="image/webp">
+      <%= image_tag(avatar_url[1], alt: "User avatar") %>
     </picture>
   <% end %>
   </span>
@@ -35,8 +35,8 @@
       >
       <% if avatar_url %>
         <picture>
-          <source srcset="<%= avatar_url[1] %>" type="image/webp">
-          <%= image_tag(avatar_url[0], alt: "User avatar") %>
+          <source srcset="<%= avatar_url[0] %>" type="image/webp">
+          <%= image_tag(avatar_url[1], alt: "User avatar") %>
         </picture>
       <% end %>
       </span>

--- a/app/views/layouts/navigation/_avatar_menu.html.erb
+++ b/app/views/layouts/navigation/_avatar_menu.html.erb
@@ -12,7 +12,14 @@
   <span
     class="avatar-image savm-profile-icon"
     data-name="<%= (user.name.presence || "?")[0].capitalize %>"
-  ><%= image_tag(avatar_url, alt: "User avatar") if avatar_url %></span>
+  >
+  <% if avatar_url %>
+    <picture>
+      <source srcset="<%= avatar_url[1] %>" type="image/webp">
+      <%= image_tag(avatar_url[0], alt: "User avatar") %>
+    </picture>
+  <% end %>
+  </span>
   <span class="avatar-more"><%= svg_icon(:chevron_down) %></span>
 </a>
 
@@ -25,7 +32,14 @@
     <a href="<%= user_path(user) %>" class="savm-profile-link">
       <span class="savm-profile-icon"
         data-name="<%= (user.name.presence || "?")[0].capitalize %>"
-      ><%= image_tag(avatar_url, alt: "User avatar") if avatar_url %></span>
+      >
+      <% if avatar_url %>
+        <picture>
+          <source srcset="<%= avatar_url[1] %>" type="image/webp">
+          <%= image_tag(avatar_url[0], alt: "User avatar") %>
+        </picture>
+      <% end %>
+      </span>
       <span class="savm-profile-name"><%= user.pretty_name.presence || "<blank>" %></span>
       <span class="savm-profile-title"><%= user_level_plain(user) %></span>
     </a>

--- a/app/views/layouts/navigation/_avatar_menu.html.erb
+++ b/app/views/layouts/navigation/_avatar_menu.html.erb
@@ -1,25 +1,18 @@
-<%# locals: (user: CurrentUser.user, avatar_id: CurrentUser.user&.avatar_id.presence, has_mail: CurrentUser.has_mail?) %>
+<%# locals: (user: CurrentUser.user, has_mail: CurrentUser.has_mail?) %>
 
-<% deferred_post_ids.add(avatar_id) if avatar_id %>
+<% avatar_url = UserAvatarUrlCache.get(user) %>
 <a
   href="<%= user_path(user) %>"
   class="simple-avatar nav-controls-profile collapse-2"
   data-user-id="<%= user.id %>"
-  data-user-hash="<%= user.updated_at.to_i %>"
-  data-has-cropped-avatar="<%= user.has_cropped_avatar? %>"
-  data-id="<%= avatar_id %>"
   data-name="<%= user.name.presence || "<blank>" %>"
   data-has-mail="<%= has_mail %>"
 >
   <span class="avatar-name"><%= user.pretty_name.presence || "<blank>" %></span>
   <span
-    class="avatar-image savm-profile-icon placeholder"
-    data-id="<%= avatar_id %>"
-    data-user-id="<%= user.id %>"
-    data-has-cropped-avatar="<%= user.has_cropped_avatar? %>"
-    data-user-hash="<%= user.updated_at.to_i %>"
+    class="avatar-image savm-profile-icon"
     data-name="<%= (user.name.presence || "?")[0].capitalize %>"
-  ></span>
+  ><%= image_tag(avatar_url, alt: "User avatar") if avatar_url %></span>
   <span class="avatar-more"><%= svg_icon(:chevron_down) %></span>
 </a>
 
@@ -30,13 +23,9 @@
   <%# Profile Strip %>
   <div class="savm-profile">
     <a href="<%= user_path(user) %>" class="savm-profile-link">
-      <span class="savm-profile-icon placeholder"
-        data-id="<%= avatar_id %>"
-        data-user-id="<%= user.id %>"
-        data-has-cropped-avatar="<%= user.has_cropped_avatar? %>"
-        data-user-hash="<%= user.updated_at.to_i %>"
+      <span class="savm-profile-icon"
         data-name="<%= (user.name.presence || "?")[0].capitalize %>"
-      ></span>
+      ><%= image_tag(avatar_url, alt: "User avatar") if avatar_url %></span>
       <span class="savm-profile-name"><%= user.pretty_name.presence || "<blank>" %></span>
       <span class="savm-profile-title"><%= user_level_plain(user) %></span>
     </a>

--- a/spec/logical/user_avatar_url_cache_spec.rb
+++ b/spec/logical/user_avatar_url_cache_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserAvatarUrlCache do
+  describe "#key" do
+    it "generates a cache key based on the user ID" do
+      expect(UserAvatarUrlCache.key(123)).to eq("user_avatar_url:123")
+    end
+  end
+
+  describe "#get" do
+    include_context "as member"
+
+    let(:post) { create(:post) }
+    let(:deleted_post) { create(:deleted_post) }
+
+    it "returns nil if the user is blank" do
+      expect(UserAvatarUrlCache.get(nil)).to be_nil
+    end
+
+    it "returns nil if the user has no avatar" do
+      user = build(:user)
+      expect(UserAvatarUrlCache.get(user)).to be_nil
+    end
+
+    it "returns the correct URLs for a cropped avatar" do
+      user = build(:user, avatar_id: 10, bit_prefs: User.flag_value_for("has_cropped_avatar"), updated_at: Time.at(1_000_000))
+      expect(UserAvatarUrlCache.get(user)).to eq([
+        "/data/avatars/#{user.id}.webp?t=1000000",
+        "/data/avatars/#{user.id}.jpg?t=1000000",
+      ])
+    end
+
+    it "caches the preview URL for an uncropped avatar" do
+      user = create(:user, avatar_id: post.id)
+
+      expect(UserAvatarUrlCache.get(user)).to eq(post.preview_file_url_pair)
+      expect(Cache.fetch(UserAvatarUrlCache.key(user.id))).to eq(post.preview_file_url_pair)
+    end
+
+    it "caches nil for a deleted avatar post" do
+      user = create(:user, avatar_id: deleted_post.id)
+
+      expect(UserAvatarUrlCache.get(user)).to be_nil
+      expect(Cache.fetch(UserAvatarUrlCache.key(user.id))).to be_nil
+    end
+  end
+
+  describe "#invalidate" do
+    it "deletes the cache entry for the given user ID" do
+      user = create(:user, avatar_id: 10)
+      Cache.write(UserAvatarUrlCache.key(user.id), "cached value")
+      UserAvatarUrlCache.invalidate(user.id)
+      expect(Cache.fetch(UserAvatarUrlCache.key(user.id))).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Previously, the user's avatar in the navbar was using DeferredPosts to determine which image to display.
On pages with a lot of other thumbnails loaded via DeferredPosts, that is not a big deal. However, most pages don't have any other thumbnails – resulting in 3 extra DB queries on each page load. This includes favorite and post vote data.

What made this especially pointless is the fact that we don't even need most of this data to load these avatars.
It's just an image - no blacklisting is done here.

As such, we can dramatically optimize this.
Users with cropped avatars don't even need a DB query of any kind: their avatar image URL can be reconstructed directly.
For everyone else, we cache the thumbnail image URL. Rather than 3 queries for each page load, it's 1 query every 15 minutes.