### PR TITLE
[Posts] Rework the janitor toolbar toggle to use a cookie

### DIFF
--- a/app/javascript/src/js/pages/posts/show/mod_queue.js
+++ b/app/javascript/src/js/pages/posts/show/mod_queue.js
@@ -1,6 +1,6 @@
 import Post from "@/pages/posts/posts";
-import LStorage from "@/utility/Storage";
 import Dialog from "@/utility/dialog";
+import CStorage from "@/utility/StorageC";
 
 let ModQueue = {};
 
@@ -88,25 +88,23 @@ ModQueue.delete_with_reason_dialog = function (event) {
 };
 
 $(function () {
-  if (!$("body").data("user-is-approver")) return;
+  if (!$("body").data("user-can-approve-posts")) return;
 
   // Toolbar visibility
-  let toolbarVisible = LStorage.Posts.JanitorToolbar;
+  let toolbarVisible = CStorage.janitorToolbarVisible;
   const toolbar = $("#pending-approval-notice");
-  if (toolbarVisible) toolbar.addClass("enabled");
 
   const toolbarToggle = $("#janitor-toolbar-toggle")
     .on("click", (event) => {
       event.preventDefault();
       toolbarVisible = !toolbarVisible;
-      LStorage.Posts.JanitorToolbar = toolbarVisible;
+      CStorage.janitorToolbarVisible = toolbarVisible;
 
       toolbar.toggleClass("enabled");
       toolbarToggle.text(toolbarVisible ? "Approvals: On" : "Approvals: Off");
 
       return false;
-    })
-    .text(toolbarVisible ? "Approvals: On" : "Approvals: Off");
+    });
 
   // Toolbar buttons
   $(document).on("click.danbooru", ".quick-mod .detailed-rejection-link", ModQueue.detailed_rejection_dialog);

--- a/app/javascript/src/js/utility/Storage.ts
+++ b/app/javascript/src/js/utility/Storage.ts
@@ -28,7 +28,6 @@ export default class LStorage {
   static Posts = {
     Mode: "view", // Too many to list
     ShowPostChildren: false,
-    JanitorToolbar: false,
     Set: 0,
     WikiExcerpt: 1 as 0 | 1 | 2,
     Fullscreen: false,
@@ -105,7 +104,6 @@ const StorageKeys: StorageConfig = {
   "Posts": {
     Mode: "mode", // legacy
     ShowPostChildren: "show-relationship-previews", // legacy
-    JanitorToolbar: "jtb", // legacy
     Set: "set", // legacy
     WikiExcerpt: "e6.posts.wiki",
     Fullscreen: "e6.posts.fusk",

--- a/app/javascript/src/js/utility/StorageC.ts
+++ b/app/javascript/src/js/utility/StorageC.ts
@@ -53,6 +53,17 @@ export default class CStorage {
     if (value > 0) CookieJar.set("mascot", value.toString(), "/");
     else CookieJar.delete("mascot");
   }
+
+
+  /** @returns true if the janitor toolbar is visible, otherwise false */
+  static get janitorToolbarVisible (): boolean {
+    return CookieJar.getBool("janitor_toolbar");
+  }
+
+  static set janitorToolbarVisible (value: boolean) {
+    if (value) CookieJar.setBool("janitor_toolbar", true);
+    else CookieJar.delete("janitor_toolbar");
+  }
 }
 
 /**

--- a/app/views/posts/partials/common/_secondary_links.html.erb
+++ b/app/views/posts/partials/common/_secondary_links.html.erb
@@ -7,9 +7,9 @@
   <%= subnav_link_to "Changes", post_versions_path %>
   <li><a href="#" id="blacklist-edit-link">Blacklist</a></li>
   <%= subnav_link_to "Help", help_page_path(id: "posts") %>
-  <% if CurrentUser.can_approve_posts? %>
+  <% if CurrentUser.can_approve_posts? && @post.present? && @post.is_pending? %>
     <li class="divider"></li>
-    <li><a href="#" id="janitor-toolbar-toggle">Approvals: Off</a></li>
+    <li><a href="#" id="janitor-toolbar-toggle">Approvals: <%= cookies[:janitor_toolbar] == "1" ? "On" : "Off" %></a></li>
   <% end %>
 <% end %>
 

--- a/app/views/posts/partials/show/content/notices/_notices.html.erb
+++ b/app/views/posts/partials/show/content/notices/_notices.html.erb
@@ -48,7 +48,7 @@
 <% end %>
 
 <% if post.is_pending? %>
-  <div class="notice notice-pending" id="pending-approval-notice">
+  <div class="notice notice-pending <%= "enabled" if cookies[:janitor_toolbar] == "1" %>" id="pending-approval-notice">
     <div class="notice-pending-status">
       This post is pending approval. (<%= link_to "learn more", wiki_pages_path(title: "about:mod_queue") %>)
     </div>


### PR DESCRIPTION
Previously, the janitor toolbar was relying on a value stored in LocalStorage, and thus would only be toggled once the page is loaded.
That caused a page reflow and annoyance from the janitors.