### PR TITLE
[Mailers] Prevent crash for accounts with legacy invalid email addresses

### DIFF
--- a/app/logical/email_address_validator.rb
+++ b/app/logical/email_address_validator.rb
@@ -7,88 +7,105 @@ class EmailAddressValidator < ActiveModel::EachValidator
     email = value.to_s.strip
     return if email.blank?
 
+    # The normalize_email_address before_validation callback sets
+    # @email_had_display_name when the raw input carried a display name.
+    # Coerce to a boolean so a never-set ivar (nil) is treated as "no display
+    # name", matching the original validate_each behavior.
+    had_display_name = !!rec.instance_variable_get(:@email_had_display_name)
+    error = self.class.validation_error(email, had_display_name: had_display_name)
+    rec.errors.add(attr, error) if error
+  end
+
+  # Class-level predicate so non-ActiveModel callers (e.g. mailers) can ask
+  # "is this string a deliverable address?" without building a record. Shares
+  # the exact structural checks performed by validate_each so the two paths
+  # cannot drift.
+  #
+  # Unlike the instance validator, this is meant to gate sending mail to a
+  # value taken verbatim from the database, so it is stricter:
+  #   * the raw value must already be trimmed (leading/trailing whitespace or
+  #     CR/LF would survive into the recipient header and make the mail gem
+  #     raise at format time, so such values are rejected), and
+  #   * any parser failure (not just Mail::Field::ParseError) is treated as
+  #     invalid rather than propagated, so the caller can never crash.
+  def self.valid?(email)
+    raw = email.to_s
+    value = raw.strip
+    return false if value.blank?
+    return false if raw != value
+
+    validation_error(value).nil?
+  rescue StandardError
+    false
+  end
+
+  # Returns an error message (String) describing the first structural problem
+  # with +email+, or nil when the address is acceptable. +email+ must already
+  # be stripped and non-blank.
+  #
+  # +had_display_name+ lets the instance validator pass the result of the
+  # normalize_email_address callback. When nil (the class-level caller), a
+  # display name is detected directly by comparing the parsed address against
+  # the input.
+  def self.validation_error(email, had_display_name: nil)
     # Parse with Mail::Address
     begin
       parsed = Mail::Address.new(email)
       address = parsed.address
     rescue Mail::Field::ParseError
-      rec.errors.add(attr, "is invalid")
-      return
+      return "is invalid"
     end
+
+    return "is invalid" if address.nil?
 
     # No display names, comments, etc.
-    # Check if normalization detected display names in original input
-    if address.nil? || rec.instance_variable_get(:@email_had_display_name)
-      rec.errors.add(attr, "is invalid")
-      return
-    end
+    display_name = had_display_name.nil? ? (address != email) : had_display_name
+    return "is invalid" if display_name
 
     local, domain = address.split("@", 2)
-    if local.nil? || domain.nil?
-      rec.errors.add(attr, "is invalid")
-      return
-    end
+    return "is invalid" if local.nil? || domain.nil?
 
     # ===== Validating Local Parts ===== #
 
     # Local-part validations
     if local.start_with?(".") || local.end_with?(".")
-      rec.errors.add(attr, "cannot have dots at the beginning or end of the local part")
-      return
+      return "cannot have dots at the beginning or end of the local part"
     end
 
-    if local.include?("..")
-      rec.errors.add(attr, "cannot have consecutive dots in the local part")
-      return
-    end
+    return "cannot have consecutive dots in the local part" if local.include?("..")
 
-    if local.length > 64
-      rec.errors.add(attr, "local part is too long (maximum 64 characters)")
-      return
-    end
+    return "local part is too long (maximum 64 characters)" if local.length > 64
 
     # ===== Validating Domain Parts ===== #
 
-    if domain.length > 253
-      rec.errors.add(attr, "domain is too long (maximum 253 characters)")
-      return
-    end
+    return "domain is too long (maximum 253 characters)" if domain.length > 253
 
     # Reject IP literals and require at least one dot (standard domain format)
     if domain.start_with?("[") || domain.exclude?(".")
-      rec.errors.add(attr, "must use a standard domain format")
-      return
+      return "must use a standard domain format"
     end
 
     # Check domain labels
     labels = domain.split(".")
     labels.each do |label|
-      if label.empty?
-        rec.errors.add(attr, "has an invalid domain structure")
-        break
-      end
+      return "has an invalid domain structure" if label.empty?
 
-      if label.length > 63
-        rec.errors.add(attr, "has a domain label that is too long")
-        break
-      end
+      return "has a domain label that is too long" if label.length > 63
 
       if label.start_with?("-") || label.end_with?("-")
-        rec.errors.add(attr, "has a domain label that starts or ends with a hyphen")
-        break
+        return "has a domain label that starts or ends with a hyphen"
       end
 
       # Require labels to be alphanumeric + hyphens only (no underscores, etc.)
-      unless label =~ /\A[a-zA-Z0-9-]+\z/
-        rec.errors.add(attr, "has invalid characters in the domain")
-        break
-      end
+      return "has invalid characters in the domain" unless label =~ /\A[a-zA-Z0-9-]+\z/
     end
 
     # TLD should be at least 2 characters and all letters
     tld = labels.last
     if tld.nil? || tld.length < 2 || tld !~ /\A[a-zA-Z]+\z/
-      rec.errors.add(attr, "has an invalid top-level domain")
+      return "has an invalid top-level domain"
     end
+
+    nil
   end
 end

--- a/app/logical/email_address_validator.rb
+++ b/app/logical/email_address_validator.rb
@@ -11,7 +11,7 @@ class EmailAddressValidator < ActiveModel::EachValidator
     # @email_had_display_name when the raw input carried a display name.
     # Coerce to a boolean so a never-set ivar (nil) is treated as "no display
     # name", matching the original validate_each behavior.
-    had_display_name = !!rec.instance_variable_get(:@email_had_display_name)
+    had_display_name = rec.instance_variable_get(:@email_had_display_name) == true
     error = self.class.validation_error(email, had_display_name: had_display_name)
     rec.errors.add(attr, error) if error
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -11,18 +11,10 @@ class ApplicationMailer < ActionMailer::Base
 
   protected
 
-  # True when +user+ has an address the mail gem can turn into a recipient.
-  #
-  # Concrete mailers call this in place of the former `user.email.blank?` guard
-  # so the action short-circuits for any undeliverable address, not just an
-  # empty one. Legacy accounts may hold a malformed value (e.g.
-  # "Email- Something-Weird-Comes@hotmail.com") that the mail gem cannot parse,
-  # raising Mail::Field::IncompleteParseError and 500-ing the mailer. Bailing at
-  # the action level (rather than only nil-ing the recipient) is required: a
-  # Mail::Message with no destination raises "SMTP To address may not be blank"
-  # at delivery time. EmailAddressValidator.valid? also returns false for a
-  # blank value, so this stays a strict superset of the old guard. See issue
-  # #1712.
+  # Guards against the mail gem raising on legacy malformed addresses:
+  # https://github.com/e621ng/e621ng/issues/1712
+  # EmailAddressValidator.valid? already returns false for blank, so this is a
+  # strict superset of the former `user.email.blank?` check.
   def deliverable_email?(user)
     EmailAddressValidator.valid?(user.email)
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -8,4 +8,22 @@ class ApplicationMailer < ActionMailer::Base
   def user_email(user)
     email_address_with_name(user.email, user.name)
   end
+
+  protected
+
+  # True when +user+ has an address the mail gem can turn into a recipient.
+  #
+  # Concrete mailers call this in place of the former `user.email.blank?` guard
+  # so the action short-circuits for any undeliverable address, not just an
+  # empty one. Legacy accounts may hold a malformed value (e.g.
+  # "Email- Something-Weird-Comes@hotmail.com") that the mail gem cannot parse,
+  # raising Mail::Field::IncompleteParseError and 500-ing the mailer. Bailing at
+  # the action level (rather than only nil-ing the recipient) is required: a
+  # Mail::Message with no destination raises "SMTP To address may not be blank"
+  # at delivery time. EmailAddressValidator.valid? also returns false for a
+  # blank value, so this stays a strict superset of the old guard. See issue
+  # #1712.
+  def deliverable_email?(user)
+    EmailAddressValidator.valid?(user.email)
+  end
 end

--- a/app/mailers/maintenance/user/api_key_expiration_mailer.rb
+++ b/app/mailers/maintenance/user/api_key_expiration_mailer.rb
@@ -4,7 +4,7 @@ module Maintenance
   module User
     class ApiKeyExpirationMailer < ApplicationMailer
       def expiration_notice(user, api_key)
-        return if user.email.blank?
+        return unless deliverable_email?(user)
 
         @user = user
         @api_key = api_key

--- a/app/mailers/maintenance/user/email_confirmation_mailer.rb
+++ b/app/mailers/maintenance/user/email_confirmation_mailer.rb
@@ -4,7 +4,7 @@ module Maintenance
   module User
     class EmailConfirmationMailer < ApplicationMailer
       def confirmation(user)
-        return if user.email.blank?
+        return unless deliverable_email?(user)
 
         @user = user
         mail(

--- a/app/mailers/maintenance/user/login_reminder_mailer.rb
+++ b/app/mailers/maintenance/user/login_reminder_mailer.rb
@@ -4,7 +4,7 @@ module Maintenance
   module User
     class LoginReminderMailer < ApplicationMailer
       def notice(user)
-        return if user.email.blank?
+        return unless deliverable_email?(user)
 
         @user = user
         mail(

--- a/app/mailers/maintenance/user/password_reset_mailer.rb
+++ b/app/mailers/maintenance/user/password_reset_mailer.rb
@@ -4,7 +4,7 @@ module Maintenance
   module User
     class PasswordResetMailer < ApplicationMailer
       def reset_request(user, nonce)
-        return if user.email.blank?
+        return unless deliverable_email?(user)
 
         @user = user
         @nonce = nonce

--- a/app/mailers/maintenance/user/user_feedback_mailer.rb
+++ b/app/mailers/maintenance/user/user_feedback_mailer.rb
@@ -6,7 +6,7 @@ module Maintenance
       helper DtextHelper
 
       def feedback_notice(user, feedback)
-        return if user.email.blank?
+        return unless deliverable_email?(user)
 
         @user = user
         @feedback = feedback

--- a/spec/logical/email_address_validator_spec.rb
+++ b/spec/logical/email_address_validator_spec.rb
@@ -166,4 +166,39 @@ RSpec.describe EmailAddressValidator do
       end
     end
   end
+
+  # The class-level predicate lets non-ActiveModel callers (e.g. ApplicationMailer)
+  # ask whether a stored string is a deliverable address without building a record.
+  # It must share the structural checks above so the two paths cannot drift.
+  describe ".valid?" do
+    it "returns true for a standard address" do
+      expect(described_class.valid?("user@example.com")).to be true
+    end
+
+    it "returns false for a malformed legacy address that the mail gem cannot parse" do
+      expect(described_class.valid?("Email- Something-Weird-Comes@hotmail.com")).to be false
+    end
+
+    it "returns false for a blank value" do
+      expect(described_class.valid?("")).to be false
+      expect(described_class.valid?(nil)).to be false
+    end
+
+    it "returns false for a display-name form" do
+      expect(described_class.valid?("Foo <a@b.com>")).to be false
+    end
+
+    it "returns false for an address with no @ sign" do
+      expect(described_class.valid?("notanemail")).to be false
+    end
+
+    it "returns false for a value with surrounding whitespace or newlines" do
+      expect(described_class.valid?("user@example.com\n")).to be false
+      expect(described_class.valid?(" user@example.com ")).to be false
+    end
+
+    it "returns false (without raising) for input that makes the mail parser raise a non-ParseError" do
+      expect(described_class.valid?("a@(b).com")).to be false
+    end
+  end
 end

--- a/spec/mailers/maintenance/user/api_key_expiration_mailer_spec.rb
+++ b/spec/mailers/maintenance/user/api_key_expiration_mailer_spec.rb
@@ -19,5 +19,12 @@ RSpec.describe Maintenance::User::ApiKeyExpirationMailer do
       allow(user).to receive(:email).and_return("")
       expect(described_class.expiration_notice(user, api_key).to).to be_nil
     end
+
+    it "does not raise and delivers nothing for a malformed legacy email" do
+      allow(user).to receive(:email).and_return("Email- Something-Weird-Comes@hotmail.com")
+      ActionMailer::Base.deliveries.clear
+      expect { described_class.expiration_notice(user, api_key).deliver_now }.not_to raise_error
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
   end
 end

--- a/spec/mailers/maintenance/user/email_confirmation_mailer_spec.rb
+++ b/spec/mailers/maintenance/user/email_confirmation_mailer_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe Maintenance::User::EmailConfirmationMailer do
       allow(user).to receive(:email).and_return("")
       expect(described_class.confirmation(user).to).to be_nil
     end
+
+    it "does not raise and delivers nothing for a malformed legacy email" do
+      allow(user).to receive(:email).and_return("Email- Something-Weird-Comes@hotmail.com")
+      ActionMailer::Base.deliveries.clear
+      expect { described_class.confirmation(user).deliver_now }.not_to raise_error
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
   end
 end

--- a/spec/mailers/maintenance/user/login_reminder_mailer_spec.rb
+++ b/spec/mailers/maintenance/user/login_reminder_mailer_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe Maintenance::User::LoginReminderMailer do
       allow(user).to receive(:email).and_return("")
       expect(described_class.notice(user).to).to be_nil
     end
+
+    it "does not raise and delivers nothing for a malformed legacy email" do
+      allow(user).to receive(:email).and_return("Email- Something-Weird-Comes@hotmail.com")
+      ActionMailer::Base.deliveries.clear
+      expect { described_class.notice(user).deliver_now }.not_to raise_error
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
   end
 end

--- a/spec/mailers/maintenance/user/password_reset_mailer_spec.rb
+++ b/spec/mailers/maintenance/user/password_reset_mailer_spec.rb
@@ -19,5 +19,12 @@ RSpec.describe Maintenance::User::PasswordResetMailer do
       allow(user).to receive(:email).and_return("")
       expect(described_class.reset_request(user, nonce).to).to be_nil
     end
+
+    it "does not raise and delivers nothing for a malformed legacy email" do
+      allow(user).to receive(:email).and_return("Email- Something-Weird-Comes@hotmail.com")
+      ActionMailer::Base.deliveries.clear
+      expect { described_class.reset_request(user, nonce).deliver_now }.not_to raise_error
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
   end
 end

--- a/spec/mailers/maintenance/user/user_feedback_mailer_spec.rb
+++ b/spec/mailers/maintenance/user/user_feedback_mailer_spec.rb
@@ -19,5 +19,12 @@ RSpec.describe Maintenance::User::UserFeedbackMailer do
       allow(user).to receive(:email).and_return("")
       expect(described_class.feedback_notice(user, feedback).to).to be_nil
     end
+
+    it "does not raise and delivers nothing for a malformed legacy email" do
+      allow(user).to receive(:email).and_return("Email- Something-Weird-Comes@hotmail.com")
+      ActionMailer::Base.deliveries.clear
+      expect { described_class.feedback_notice(user, feedback).deliver_now }.not_to raise_error
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Summary

Stops every account mailer from 500ing when a legacy account holds a malformed stored email address. Adds a class-level `EmailAddressValidator.valid?` predicate (sharing the existing validator's structural checks) and has each account mailer short-circuit its action when the address is not deliverable.

## Why this matters

Fixes #1712. Accounts whose stored email predates the current validator rules hold addresses the `mail` gem cannot parse into a recipient (e.g. `Email- Something-Weird-Comes@hotmail.com`). `ApplicationMailer#user_email` calls `email_address_with_name(user.email, ...)`, which raises an unrescued `Mail::Field::IncompleteParseError`, returning a 500 on password reset, resend-confirmation, and login-reminder flows, so those users cannot recover their accounts. The maintainer confirmed the issue extends to email re-confirmation and asked that we "check whether the address is actually valid before trying to send an email."

The migration `db/fixes/131_invalidate_malformed_emails.rb` marked these accounts unverified but left the malformed address in the `users` table, so the crash is reproducible against existing data.

### Approach

- New `EmailAddressValidator.valid?(email)` answers "is this string a deliverable address?" without building an ActiveModel record. The structural checks are extracted into a shared `validation_error` method that both `validate_each` and `.valid?` call, so the predicate and the model validation cannot drift. The instance validator's behavior is unchanged.
- Each account mailer (password reset, email confirmation, login reminder, API-key expiration, user feedback) replaces its `return if user.email.blank?` guard with `return unless deliverable_email?(user)`. `EmailAddressValidator.valid?` already returns false for a blank value, so the new guard is a strict superset of the old one.
- The guard lives at the mailer-action level rather than only nil-ing the recipient: a `Mail::Message` built with no destination raises `SMTP To address may not be blank` at delivery time, so suppressing the recipient alone would still crash `deliver_now`/`deliver_later`. Short-circuiting the action degrades to delivering nothing, matching the existing blank-email behavior.
- The mailer-facing predicate is hardened against values taken verbatim from the database: it rejects values that carry surrounding whitespace/CR-LF (which would otherwise survive into the recipient header) and treats any parser failure as invalid, so the caller can never raise.
- The stored address is left untouched; data cleanup is a separate concern, so the existing "If your email was on file..." messaging continues to behave correctly.

## Testing

- `spec/logical/email_address_validator_spec.rb`: added `.valid?` cases (standard address true; malformed legacy address, blank/nil, display-name form, missing-`@`, surrounding whitespace/newline, and a parser-raising input all false). The shared `validation_error` path keeps every existing instance-validator case green.
- `spec/mailers/maintenance/user/password_reset_mailer_spec.rb` and `email_confirmation_mailer_spec.rb`: added a malformed-legacy-email case asserting `deliver_now` does not raise and delivers nothing.
- The predicate's behavior was verified directly against `mail` 2.9.0 (the pinned version) across every validator rule plus the new robustness cases, and the unchanged instance-validator behavior was confirmed against the existing spec expectations. The full RSpec suite needs a database/Rails environment and was not run locally.

Fixes #1712

AI was used for assistance.
