### PR TITLE
[Misc] Better way to rescue errors from IP spoofing attempts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,7 +36,7 @@ class ApplicationController < ActionController::Base
   # Raised when HTTP_CLIENT_IP and HTTP_X_FORWARDED_FOR disagree.
   # Likely scanner probes. Not actionable - no need to send these to the exception log.
   rescue_from ActionDispatch::RemoteIp::IpSpoofAttackError, with: -> {
-    Rails.logger.warn("IP spoof attempt: CLIENT_IP=#{request.env['HTTP_CLIENT_IP']} XFF=#{request.env['HTTP_X_FORWARDED_FOR']} UA=#{request.user_agent}")
+    Rails.logger.warn("IP spoof attempt: CLIENT_IP=#{request.env['HTTP_CLIENT_IP'].inspect} XFF=#{request.env['HTTP_X_FORWARDED_FOR'].inspect} UA=#{request.user_agent.inspect}")
     head 400
   }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,13 @@ class ApplicationController < ActionController::Base
   # here, so calling `rescue_exception` would cause a double render error.
   rescue_from ActionController::InvalidCrossOriginRequest, with: -> {}
 
+  # Raised when HTTP_CLIENT_IP and HTTP_X_FORWARDED_FOR disagree.
+  # Likely scanner probes. Not actionable - no need to send these to the exception log.
+  rescue_from ActionDispatch::RemoteIp::IpSpoofAttackError, with: -> {
+    Rails.logger.warn("IP spoof attempt: CLIENT_IP=#{request.env['HTTP_CLIENT_IP']} XFF=#{request.env['HTTP_X_FORWARDED_FOR']} UA=#{request.user_agent}")
+    head 400
+  }
+
   def check_valid_username
     return if params[:controller] == "user_name_change_requests"
 

--- a/app/models/exception_log.rb
+++ b/app/models/exception_log.rb
@@ -32,11 +32,7 @@ class ExceptionLog < ApplicationRecord
     end
 
     create!(
-      ip_addr: begin
-        request.remote_ip
-      rescue ActionDispatch::RemoteIp::IpSpoofAttackError
-        "0.0.0.0"
-      end,
+      ip_addr: request.remote_ip,
       class_name: unwrapped_exception.class.name,
       message: unwrapped_exception.message,
       trace: unwrapped_exception.backtrace.join("\n"),

--- a/spec/models/exception_log/class_methods_spec.rb
+++ b/spec/models/exception_log/class_methods_spec.rb
@@ -59,13 +59,6 @@ RSpec.describe ExceptionLog do
       expect(log.ip_addr.to_s).to eq("10.0.0.1")
     end
 
-    it "handles ActionDispatch::RemoteIp::IpSpoofAttackError being raised" do
-      request = make_request
-      allow(request).to receive(:remote_ip).and_raise(ActionDispatch::RemoteIp::IpSpoofAttackError)
-      log = ExceptionLog.add(make_exception, CurrentUser.id, request)
-      expect(log.ip_addr.to_s).to eq("0.0.0.0")
-    end
-
     it "stores the user_id" do
       user = create(:user)
       log  = ExceptionLog.add(make_exception, user.id, make_request)


### PR DESCRIPTION
These are automated, distributed, and not actionable.
No need to dump them all into the exception log.

Removed old handling of these errors in the ExceptionLog model, as it is not necessary anymore.