### PR TITLE
[Favorites] Improve performance

### DIFF
--- a/app/components/paginator_component.rb
+++ b/app/components/paginator_component.rb
@@ -48,7 +48,7 @@ class PaginatorComponent < ViewComponent::Base
 
   def prev_path
     return nav_params_for(current_page - 1) if @mode == :numbered
-    nav_params_for("a#{records.first&.id || 0}")
+    nav_params_for("a#{sequential_first_id}")
   end
 
   def has_next?
@@ -58,7 +58,15 @@ class PaginatorComponent < ViewComponent::Base
 
   def next_path
     return nav_params_for(current_page + 1) if @mode == :numbered
-    nav_params_for("b#{records.last&.id || 0}")
+    nav_params_for("b#{sequential_last_id}")
+  end
+
+  def sequential_first_id
+    (records.respond_to?(:sequential_first_id) ? records.sequential_first_id : records.first&.id) || 0
+  end
+
+  def sequential_last_id
+    (records.respond_to?(:sequential_last_id) ? records.sequential_last_id : records.last&.id) || 0
   end
 
   ##############################

--- a/app/logical/danbooru/paginator/paginated_array.rb
+++ b/app/logical/danbooru/paginator/paginated_array.rb
@@ -11,8 +11,17 @@ module Danbooru
         @total_count = options[:total_count]
         @max_numbered_pages = options[:max_numbered_pages] || Danbooru.config.max_numbered_pages
         @pagination_mode = options[:pagination_mode]
+        @sequential_first_id = options[:sequential_first_id]
+        @sequential_last_id = options[:sequential_last_id]
+        @is_first_page = options[:is_first_page]
+        @is_last_page = options[:is_last_page]
         real_array = orig_array || []
         @orig_size = real_array.size
+
+        if options[:finalized]
+          super(real_array)
+          return
+        end
 
         case @pagination_mode
         when :sequential_before, :sequential_after
@@ -28,7 +37,16 @@ module Danbooru
         end
       end
 
+      def sequential_first_id
+        @sequential_first_id || first&.id
+      end
+
+      def sequential_last_id
+        @sequential_last_id || last&.id
+      end
+
       def is_first_page?
+        return @is_first_page unless @is_first_page.nil?
         case @pagination_mode
         when :numbered
           current_page == 1
@@ -40,6 +58,7 @@ module Danbooru
       end
 
       def is_last_page?
+        return @is_last_page unless @is_last_page.nil?
         case @pagination_mode
         when :numbered
           current_page >= total_pages

--- a/app/logical/post_sets/favorites.rb
+++ b/app/logical/post_sets/favorites.rb
@@ -16,19 +16,26 @@ module PostSets
       "fav:#{@user.name}"
     end
 
-    def current_page
-      [page.to_i, 1].max
-    end
-
     def posts
       @post_count ||= ::Post.tag_match("fav:#{@user.name} status:any").count_only
       @posts ||= begin
         favs = ::Favorite.for_user(@user.id)
                          .includes(post: :uploader)
-                         .order(created_at: :desc)
+                         .order(id: :desc)
                          .paginate_posts(page, total_count: @post_count, limit: @limit)
-        new_opts = { pagination_mode: :numbered, records_per_page: favs.records_per_page, total_count: @post_count, current_page: current_page }
-        ::Danbooru::Paginator::PaginatedArray.new(favs.map(&:post), new_opts)
+        favorites = favs.records
+        new_opts = {
+          pagination_mode: favs.pagination_mode,
+          records_per_page: favs.records_per_page,
+          total_count: @post_count,
+          current_page: favs.current_page,
+          sequential_first_id: favorites.first&.id,
+          sequential_last_id: favorites.last&.id,
+          is_first_page: favs.is_first_page?,
+          is_last_page: favs.is_last_page?,
+          finalized: true,
+        }
+        ::Danbooru::Paginator::PaginatedArray.new(favorites.map(&:post), new_opts)
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -739,7 +739,7 @@ class User < ApplicationRecord
     end
 
     def favorite_limit
-      Danbooru.config.legacy_favorite_limit.fetch(id, 80_000)
+      Danbooru.config.legacy_favorite_limit.fetch(id) { Danbooru.config.favorite_limit }
     end
 
     def api_regen_multiplier

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -83,9 +83,13 @@ module Danbooru
       }
     end
 
-    # Prevent new users from going above 80k while allowing those currently above
-    # it to continue adding new favorites with the old limit.
-    # { 123 => 200_000 }
+    # The maximum number of favorites a user may keep.
+    def favorite_limit
+      200_000
+    end
+
+    # Per-user overrides for favorite_limit, e.g. to grandfather users already above the default.
+    # { 123 => 1_000_000 }
     def legacy_favorite_limit
       {}
     end

--- a/db/migrate/20260604082526_replace_favorites_user_id_index.rb
+++ b/db/migrate/20260604082526_replace_favorites_user_id_index.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ReplaceFavoritesUserIdIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    Favorite.without_timeout do
+      add_index :favorites, %i[user_id id], name: "index_favorites_on_user_id_and_id", algorithm: :concurrently
+      remove_index :favorites, name: "index_favorites_on_user_id_and_created_at", algorithm: :concurrently
+    end
+  end
+
+  def down
+    Favorite.without_timeout do
+      add_index :favorites, %i[user_id created_at], name: "index_favorites_on_user_id_and_created_at", algorithm: :concurrently
+      remove_index :favorites, name: "index_favorites_on_user_id_and_id", algorithm: :concurrently
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4223,10 +4223,10 @@ CREATE INDEX index_favorites_on_user_id ON public.favorites USING btree (user_id
 
 
 --
--- Name: index_favorites_on_user_id_and_created_at; Type: INDEX; Schema: public; Owner: -
+-- Name: index_favorites_on_user_id_and_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_favorites_on_user_id_and_created_at ON public.favorites USING btree (user_id, created_at);
+CREATE INDEX index_favorites_on_user_id_and_id ON public.favorites USING btree (user_id, id);
 
 
 --
@@ -5407,6 +5407,7 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260604082526'),
 ('20260526234030'),
 ('20260520175932'),
 ('20260519151649'),

--- a/spec/requests/favorites_controller_spec.rb
+++ b/spec/requests/favorites_controller_spec.rb
@@ -26,6 +26,19 @@ RSpec.describe FavoritesController do
       expect(response.parsed_body["posts"]).to be_an(Array)
     end
 
+    it "orders favorites by most recently added and seeks by favorite id" do
+      sign_in_as member
+      posts = create_list(:post, 3)
+      posts.each { |p| FavoriteManager.add!(user: member, post: p) }
+
+      get favorites_path(user_id: member.id, format: :json, limit: 1)
+      expect(response.parsed_body["posts"].pluck("id")).to eq([posts[2].id])
+
+      boundary = Favorite.for_user(member.id).order(id: :desc).first.id
+      get favorites_path(user_id: member.id, format: :json, limit: 1, page: "b#{boundary}")
+      expect(response.parsed_body["posts"].pluck("id")).to eq([posts[1].id])
+    end
+
     it "redirects to posts path when tags param is a string" do
       get favorites_path(tags: "cat dog")
       expect(response).to redirect_to(posts_path(tags: "cat dog"))


### PR DESCRIPTION
Swaps the favorite index from created_at to just id (same structure as votes table), which allows faster lookups on deep pages. Also fixes ordering on pages above 750. 

Increases the favorite limit to 200,000, moved into its own config var, although the limit could now (or later) be removed. 

Migration builds new indexes after deploy. Old index is retained if the new index fails to build. 

This PR has been tested on a local representative postgres setup with 6.4 mil posts, 1 mil users, 100 of which had 1 mil favorites, 1 mil of which had 1-40 favorites, 600k which had ~500 favorites.

Comparing, with a 1 mil favs user:
In 2023 (limit introduction) page 1 was 2000ms, page 2 was 2000ms, page 750 was 2000ms. 
After PR #1080, page 1 was 0.15ms, page 2 was 0.19ms, page 750 was 106ms.
With this PR, Page 1 is 0.15ms, page 2 is 0.19ms, page 750 is 47ms.
