### PR TITLE
[Session] DELETE now redirects to referer if possible

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,7 @@ class SessionsController < ApplicationController
       RateLimiter.hit("login:#{request.remote_ip}", 6.hours)
       DanbooruLogger.add_attributes("user.login" => "fail")
       respond_to do |fmt|
-        fmt.html { redirect_back(fallback_location: new_session_path, notice: "Username / Password was incorrect.") }
+        fmt.html { redirect_back(fallback_location: new_session_path, allow_other_host: false, notice: "Username / Password was incorrect.") }
         fmt.json { render(json: { error: "Username / Password was incorrect." }, status: 401) }
       end
     end
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
     session.delete(:user_id)
     cookies.delete(:remember)
     session.delete(:last_authenticated_at)
-    redirect_back_or_to(root_path, notice: "You are now logged out")
+    redirect_back_or_to(root_path, allow_other_host: false, notice: "You are now logged out")
   end
 
   def confirm_password

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
     session.delete(:user_id)
     cookies.delete(:remember)
     session.delete(:last_authenticated_at)
-    redirect_to(request.referer || root_path, notice: "You are now logged out")
+    redirect_back_or_to(root_path, notice: "You are now logged out")
   end
 
   def confirm_password

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
     session.delete(:user_id)
     cookies.delete(:remember)
     session.delete(:last_authenticated_at)
-    redirect_to(posts_path, notice: "You are now logged out")
+    redirect_to(request.referer || root_path, notice: "You are now logged out")
   end
 
   def confirm_password

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -103,10 +103,12 @@ RSpec.describe SessionsController do
       make_session(member)
     end
 
-    it "redirects to referer or root_path" do
+    it "redirects to referer when present" do
       delete session_path, headers: { "Referer" => posts_path }
       expect(response).to redirect_to(posts_path)
+    end
 
+    it "redirects to root_path when no referer" do
       delete session_path
       expect(response).to redirect_to(root_path)
     end

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -103,9 +103,12 @@ RSpec.describe SessionsController do
       make_session(member)
     end
 
-    it "redirects to posts_path" do
-      delete session_path
+    it "redirects to referer or root_path" do
+      delete session_path, headers: { "Referer" => posts_path }
       expect(response).to redirect_to(posts_path)
+
+      delete session_path
+      expect(response).to redirect_to(root_path)
     end
 
     it "clears session[:user_id]" do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -113,6 +113,11 @@ RSpec.describe SessionsController do
       expect(response).to redirect_to(root_path)
     end
 
+    it "does not redirect to an external referer" do
+      delete session_path, headers: { "Referer" => "https://evil.example.com" }
+      expect(response).to redirect_to(root_path)
+    end
+
     it "clears session[:user_id]" do
       delete session_path
       expect(session[:user_id]).to be_nil


### PR DESCRIPTION
The session DELETE method now redirects the user back to where it was located using the referer header. If not present, the root path is used (instead of `/posts`)