### PR TITLE
[Users] Prevent admins from accidentally changing the level of banned users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -48,7 +48,7 @@ module Admin
         @user.mark_verified! if params[:user][:verified].to_s.truthy?
         @user.mark_unverified! if params[:user][:verified].to_s.falsy?
       end
-      unless @user.is_restricted? && params[:user][:level].present?
+      if !@user.is_restricted? && params[:user][:level].present?
         @user.promote_to!(params[:user][:level], params[:user])
       end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -48,7 +48,9 @@ module Admin
         @user.mark_verified! if params[:user][:verified].to_s.truthy?
         @user.mark_unverified! if params[:user][:verified].to_s.falsy?
       end
-      @user.promote_to!(params[:user][:level], params[:user]) if params[:user][:level]
+      unless @user.is_blocked?
+        @user.promote_to!(params[:user][:level], params[:user]) if params[:user][:level]
+      end
 
       old_username = @user.name
       desired_username = params[:user][:name]

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -48,7 +48,7 @@ module Admin
         @user.mark_verified! if params[:user][:verified].to_s.truthy?
         @user.mark_unverified! if params[:user][:verified].to_s.falsy?
       end
-      unless @user.is_blocked?
+      unless @user.is_restricted?
         @user.promote_to!(params[:user][:level], params[:user]) if params[:user][:level]
       end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -48,8 +48,8 @@ module Admin
         @user.mark_verified! if params[:user][:verified].to_s.truthy?
         @user.mark_unverified! if params[:user][:verified].to_s.falsy?
       end
-      unless @user.is_restricted?
-        @user.promote_to!(params[:user][:level], params[:user]) if params[:user][:level]
+      unless @user.is_restricted? && params[:user][:level].present?
+        @user.promote_to!(params[:user][:level], params[:user])
       end
 
       old_username = @user.name

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -26,7 +26,11 @@
       <% if CurrentUser.is_bd_staff? || !@user.is_bd_staff? %>
         <div class="input integer optional">
           <label for="user_level" class="optional">Level</label>
-          <%= user_level_select(:user, :level) %>
+          <% if @user.is_blocked? %>
+            <i>Blocked users cannot have their level changed.</i>
+          <% else %>
+            <%= user_level_select(:user, :level) %>
+          <% end %>
         </div>
       <% end %>
 

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -26,7 +26,7 @@
       <% if CurrentUser.is_bd_staff? || !@user.is_bd_staff? %>
         <div class="input integer optional">
           <label for="user_level" class="optional">Level</label>
-          <% if @user.is_blocked? %>
+          <% if @user.is_restricted? %>
             <i>Blocked users cannot have their level changed.</i>
           <% else %>
             <%= user_level_select(:user, :level) %>

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -219,6 +219,12 @@ RSpec.describe Admin::UsersController do
         patch admin_user_path(user), params: { user: { profile_about: "x", level: UserLevel::PRIVILEGED } }
         expect(user.reload.level).to eq(UserLevel::PRIVILEGED)
       end
+
+      it "does not promote a restricted user" do
+        banned_user = create(:banned_user)
+        patch admin_user_path(banned_user), params: { user: { profile_about: "x", level: UserLevel::PRIVILEGED } }
+        expect(banned_user.reload.level).not_to eq(UserLevel::PRIVILEGED)
+      end
     end
   end
 


### PR DESCRIPTION
Admins would go to clear the bio of a banned user and accidentally reset their level back to "Member", since the dropdown no longer includes the "Banned" level.