### PR TITLE
[Posts] Reowner expanded

### DIFF
--- a/app/controllers/admin/reowner_controller.rb
+++ b/app/controllers/admin/reowner_controller.rb
@@ -12,6 +12,7 @@ module Admin
       @old_user = User.find_by_name_or_id(@reowner_params[:old_owner])
       @new_user = User.find_by_name_or_id(@reowner_params[:new_owner])
       query = @reowner_params[:search]
+      reowner_versions = @reowner_params[:reowner_versions]&.truthy?
       post_events = @reowner_params[:post_events]&.truthy?
 
       unless @old_user && @new_user
@@ -23,7 +24,7 @@ module Admin
       moved_post_ids = []
       Post.tag_match("user:!#{@old_user.id} #{query}").limit(300).each do |p|
         moved_post_ids << p.id
-        p.reowner!(@new_user, @old_user, reowner_versions: true, post_events: post_events)
+        p.reowner!(@new_user, @old_user, reowner_versions: reowner_versions, post_events: post_events)
       end
 
       StaffAuditLog.log(:post_owner_reassign, CurrentUser.user, { old_user_id: @old_user.id, new_user_id: @new_user.id, query: query, post_ids: moved_post_ids })
@@ -34,7 +35,9 @@ module Admin
     private
 
     def new_params
-      params.require(:reowner).permit(%i[old_owner search new_owner post_events])
+      params.require(:reowner)
+            .permit(%i[old_owner search new_owner reowner_versions post_events])
+            .with_defaults(reowner_versions: true)
     end
   end
 end

--- a/app/controllers/admin/reowner_controller.rb
+++ b/app/controllers/admin/reowner_controller.rb
@@ -12,8 +12,8 @@ module Admin
       @old_user = User.find_by_name_or_id(@reowner_params[:old_owner])
       @new_user = User.find_by_name_or_id(@reowner_params[:new_owner])
       query = @reowner_params[:search]
-      reowner_versions = @reowner_params[:reowner_versions]&.truthy?
-      post_events = @reowner_params[:post_events]&.truthy?
+      reowner_versions = ActiveModel::Type::Boolean.new.cast(@reowner_params[:reowner_versions])
+      post_events = ActiveModel::Type::Boolean.new.cast(@reowner_params[:post_events])
 
       unless @old_user && @new_user
         flash[:notice] = "Old or new user failed to look up. Use !id for name to use an id"

--- a/app/controllers/admin/reowner_controller.rb
+++ b/app/controllers/admin/reowner_controller.rb
@@ -23,15 +23,7 @@ module Admin
       moved_post_ids = []
       Post.tag_match("user:!#{@old_user.id} #{query}").limit(300).each do |p|
         moved_post_ids << p.id
-        p.do_not_version_changes = true
-        p.update({ uploader_id: @new_user.id })
-        p.versions.where(updater_id: @old_user.id).find_each do |pv|
-          pv.update_column(:updater_id, @new_user.id)
-          pv.update_index
-        end
-        if post_events
-          PostEvent.add(p.id, CurrentUser.user, :owner_changed, { old_owner: @old_user.id, new_owner: @new_user.id })
-        end
+        p.reowner!(@new_user, @old_user, reowner_versions: true, post_events: post_events)
       end
 
       StaffAuditLog.log(:post_owner_reassign, CurrentUser.user, { old_user_id: @old_user.id, new_user_id: @new_user.id, query: query, post_ids: moved_post_ids })

--- a/app/controllers/admin/reowner_controller.rb
+++ b/app/controllers/admin/reowner_controller.rb
@@ -24,7 +24,7 @@ module Admin
       moved_post_ids = []
       Post.tag_match("user:!#{@old_user.id} #{query}").limit(300).each do |p|
         moved_post_ids << p.id
-        p.reowner!(@new_user, @old_user, reowner_versions: reowner_versions, post_events: post_events)
+        p.reowner!(@new_user, reowner_versions: reowner_versions, post_events: post_events)
       end
 
       StaffAuditLog.log(:post_owner_reassign, CurrentUser.user, { old_user_id: @old_user.id, new_user_id: @new_user.id, query: query, post_ids: moved_post_ids })

--- a/app/controllers/admin/reowner_controller.rb
+++ b/app/controllers/admin/reowner_controller.rb
@@ -12,6 +12,8 @@ module Admin
       @old_user = User.find_by_name_or_id(@reowner_params[:old_owner])
       @new_user = User.find_by_name_or_id(@reowner_params[:new_owner])
       query = @reowner_params[:search]
+      post_events = @reowner_params[:post_events]&.truthy?
+
       unless @old_user && @new_user
         flash[:notice] = "Old or new user failed to look up. Use !id for name to use an id"
         redirect_back fallback_location: new_admin_reowner_path
@@ -27,17 +29,20 @@ module Admin
           pv.update_column(:updater_id, @new_user.id)
           pv.update_index
         end
+        if post_events
+          PostEvent.add(p.id, CurrentUser.user, :owner_changed, { old_owner: @old_user.id, new_owner: @new_user.id })
+        end
       end
 
       StaffAuditLog.log(:post_owner_reassign, CurrentUser.user, { old_user_id: @old_user.id, new_user_id: @new_user.id, query: query, post_ids: moved_post_ids })
-      flash[:notice] = "Post ownership reassigned"
+      flash[:notice] = "Ownership reassigned for #{moved_post_ids.length} post(s)"
       redirect_back fallback_location: new_admin_reowner_path
     end
 
     private
 
     def new_params
-      params.require(:reowner).permit(%i[old_owner search new_owner])
+      params.require(:reowner).permit(%i[old_owner search new_owner post_events])
     end
   end
 end

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -134,6 +134,7 @@ module Moderator
 
       def reowner
         @post = ::Post.find(params[:id])
+
         reowner_params = new_reowner_params
         @new_owner = User.find_by_name_or_id(reowner_params[:new_owner]) # rubocop:disable Rails/DynamicFindBy
         if @new_owner.blank?
@@ -142,7 +143,14 @@ module Moderator
         end
         reowner_versions = ActiveModel::Type::Boolean.new.cast(reowner_params[:reowner_versions])
         post_events = ActiveModel::Type::Boolean.new.cast(reowner_params[:post_events])
-        @post.reowner!(@new_owner, reowner_versions: reowner_versions, post_events: post_events)
+
+        old_owner_id = @post.reowner!(@new_owner, reowner_versions: reowner_versions, post_events: post_events)
+
+        if old_owner_id.present? && !post_events
+          # Always log the change somewhere
+          StaffAuditLog.log(:post_owner_reassign, CurrentUser.user, { old_user_id: old_owner_id, new_user_id: @new_owner.id, query: "", post_ids: [@post.id] })
+        end
+
         respond_with(@post)
       end
 

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -4,7 +4,7 @@ module Moderator
   module Post
     class PostsController < ApplicationController
       before_action :approver_only, except: %i[regenerate_thumbnails regenerate_videos]
-      before_action :janitor_only, only: %i[regenerate_thumbnails regenerate_videos ai_check]
+      before_action :janitor_only, only: %i[regenerate_thumbnails regenerate_videos ai_check reowner]
       before_action :admin_only, only: [:expunge]
       skip_before_action :api_check
 
@@ -122,6 +122,17 @@ module Moderator
         @post = ::Post.find(params[:id])
         @ai_result = @post.check_for_ai_content
         redirect_back fallback_location: post_path(@post)
+      end
+
+      def reowner
+        @post = ::Post.find(params[:id])
+        @new_owner = User.find_by_name_or_id(params[:new_owner]) # rubocop:disable Rails/DynamicFindBy
+        if @new_owner.blank?
+          flash[:alert] = "New user could not be found by name: try using !<ID> instead."
+          return
+        end
+        @post.reowner!(@new_owner)
+        respond_with(@post)
       end
     end
   end

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -128,7 +128,7 @@ module Moderator
         @post = ::Post.find(params[:id])
         @previous_owners = @post.previous_version_uploaders
         respond_with(@previous_owners) do |format|
-          format.json { render json: @previous_owners.to_json }
+          format.json { render json: @previous_owners.map { |owner| owner.slice(:id, :name) }.to_json }
         end
       end
 

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -124,11 +124,19 @@ module Moderator
         redirect_back fallback_location: post_path(@post)
       end
 
+      def previous_owners
+        @post = ::Post.find(params[:id])
+        @previous_owners = @post.previous_version_uploaders
+        respond_with(@previous_owners) do |format|
+          format.json { render json: @previous_owners.to_json }
+        end
+      end
+
       def reowner
         @post = ::Post.find(params[:id])
         @new_owner = User.find_by_name_or_id(params[:new_owner]) # rubocop:disable Rails/DynamicFindBy
         if @new_owner.blank?
-          flash[:alert] = "New user could not be found by name: try using !<ID> instead."
+          flash[:alert] = "New owner could not be found. Try using !<userId> instead of a name."
           return
         end
         @post.reowner!(@new_owner)

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -134,13 +134,24 @@ module Moderator
 
       def reowner
         @post = ::Post.find(params[:id])
-        @new_owner = User.find_by_name_or_id(params[:new_owner]) # rubocop:disable Rails/DynamicFindBy
+        reowner_params = new_reowner_params
+        @new_owner = User.find_by_name_or_id(reowner_params[:new_owner]) # rubocop:disable Rails/DynamicFindBy
         if @new_owner.blank?
           flash[:alert] = "New owner could not be found. Try using !<userId> instead of a name."
           return
         end
-        @post.reowner!(@new_owner)
+        reowner_versions = ActiveModel::Type::Boolean.new.cast(reowner_params[:reowner_versions])
+        post_events = ActiveModel::Type::Boolean.new.cast(reowner_params[:post_events])
+        @post.reowner!(@new_owner, reowner_versions: reowner_versions, post_events: post_events)
         respond_with(@post)
+      end
+
+      private
+
+      def new_reowner_params
+        params.require(:reowner)
+              .permit(%i[new_owner reowner_versions post_events])
+              .with_defaults(reowner_versions: false, post_events: true)
       end
     end
   end

--- a/app/decorators/post_event_decorator.rb
+++ b/app/decorators/post_event_decorator.rb
@@ -21,6 +21,10 @@ class PostEventDecorator < ApplicationDecorator
       "From: post ##{vals['source_post_id']}"
     when "changed_bg_color"
       "To: #{vals['bg_color'] || 'None'}"
+    when "owner_changed"
+      old_owner = "\"#{User.id_to_name(vals['old_owner'])}\":/users/#{vals['old_owner']}"
+      new_owner = "\"#{User.id_to_name(vals['new_owner'])}\":/users/#{vals['new_owner']}"
+      "#{old_owner} → #{new_owner}"
     end
   end
 end

--- a/app/javascript/entrypoints/v_posts_show.ts
+++ b/app/javascript/entrypoints/v_posts_show.ts
@@ -14,6 +14,8 @@ import "@/pages/posts/show/recommended";
 import "@/pages/posts/show/related_tag";
 import "@/pages/posts/show/SwipeGestureHandler";
 
+import PostReowner from "@/pages/moderator/post/posts/PostReowner";
+
 import "@/pages/post_flags/post_flags"; // We only need expandable notes from here
 
 E621.Registry.register("v_posts_show", { Note });
@@ -21,4 +23,5 @@ E621.Registry.register("v_posts_show", { Note });
 $(() => {
   PostSet.initialize_add_to_set_link();
   PostSet.initialize_remove_from_set_links();
+  PostReowner.initialize_links();
 });

--- a/app/javascript/src/js/pages/moderator/post/posts/PostReowner.ts
+++ b/app/javascript/src/js/pages/moderator/post/posts/PostReowner.ts
@@ -32,6 +32,8 @@ export default class PostReowner {
       const reownerStatus = $("#reowner-dialog-status");
       const reownerSelect = $("#reowner-dialog-select");
       const reownerInput = $("#reowner-dialog-input");
+      const reownerReownerVersions = $("#reowner-dialog-reowner-versions");
+      const reownerPostEvents = $("#reowner-dialog-post-events");
       const reownerOkButton = $("#reowner-dialog-ok");
 
       const inputElement = reownerInput[0] as HTMLInputElement;
@@ -89,7 +91,9 @@ export default class PostReowner {
       form.off("submit").on("submit", (event: JQuery.SubmitEvent) => {
         event.preventDefault();
         const newOwner = reownerInput.val() as string;
-        PostReowner.reowner(postId, newOwner);
+        const reownerVersions = reownerReownerVersions?.prop("checked") as boolean | undefined;
+        const postEvents = reownerPostEvents?.prop("checked") as boolean | undefined;
+        PostReowner.reowner(postId, newOwner, reownerVersions, postEvents);
         return false;
       });
 
@@ -132,7 +136,7 @@ export default class PostReowner {
     }
   }
 
-  private static reowner (post_id: string, new_owner: string): void {
+  private static reowner (post_id: string, new_owner: string, reowner_versions: boolean = false, post_events: boolean = true): void {
     Post.notice_update("inc");
     let hasError = false;
     TaskQueue.add(async () => {
@@ -140,7 +144,13 @@ export default class PostReowner {
         await $.ajax({
           type: "POST",
           url: `/moderator/post/posts/${post_id}/reowner.json`,
-          data: { new_owner: new_owner },
+          data: {
+            reowner: {
+              new_owner: new_owner,
+              reowner_versions: reowner_versions,
+              post_events: post_events,
+            },
+          },
         });
         E621.Toast.notice("Reownered post.");
         location.reload();

--- a/app/javascript/src/js/pages/moderator/post/posts/PostReowner.ts
+++ b/app/javascript/src/js/pages/moderator/post/posts/PostReowner.ts
@@ -1,0 +1,160 @@
+import E621Type from "@/interfaces/E621";
+import Post from "@/pages/posts/posts";
+import TaskQueue from "@/utility/TaskQueue";
+import Dialog from "@/utility/dialog";
+
+declare const E621: E621Type;
+
+interface PreviousOwner {
+  id: number;
+  name: string;
+}
+
+interface ApiResponseError {
+  responseJSON?: {
+    errors?: string[];
+    reason?: string;
+  };
+}
+
+export default class PostReowner {
+  static initialize_links (): void {
+    let reownerDialog: Dialog | null = null;
+
+    $("#reowner-post-link").on("click", async (e: JQuery.ClickEvent) => {
+      e.preventDefault();
+
+      const postId = $("meta[name=post-id]").attr("content") as string;
+
+      const previousOwnersPromise: Promise<PreviousOwner[]> = PostReowner.previous_owners(postId);
+
+      const form = $("#reowner-dialog");
+      const reownerStatus = $("#reowner-dialog-status");
+      const reownerSelect = $("#reowner-dialog-select");
+      const reownerInput = $("#reowner-dialog-input");
+      const reownerOkButton = $("#reowner-dialog-ok");
+
+      const inputElement = reownerInput[0] as HTMLInputElement;
+      const selectElement = reownerSelect[0] as HTMLSelectElement;
+      const okButtonElemnent = reownerOkButton[0] as HTMLButtonElement;
+
+      // Until the previous owner list is loaded
+      reownerStatus.text("Loading...");
+      inputElement.style.display = "none";
+      selectElement.style.display = "none";
+      okButtonElemnent.disabled = true;
+
+      const toggleOkButton = (): void => {
+        const newOwner = reownerInput.val() as string | undefined;
+        const hasNewOwner = (newOwner?.trim() || "").length > 0;
+        okButtonElemnent.disabled = !hasNewOwner;
+      };
+
+      reownerInput.on("input", toggleOkButton);
+
+      const updateReownerInput = (selectValue: string): void => {
+        if (selectValue === "0") {
+          inputElement.disabled = false;
+          inputElement.style.display = "";
+          reownerInput.val("");
+        } else {
+          inputElement.disabled = true;
+          inputElement.style.display = "none";
+          if (selectValue) {
+            reownerInput.val(`!${selectValue}`);
+          }
+        }
+        toggleOkButton();
+      };
+
+      if (reownerDialog === null) {
+        reownerDialog = new Dialog("#reowner-dialog", { width: 250 });
+
+        reownerSelect.on("change", (event: JQuery.ChangeEvent) => {
+          const target = event.target as HTMLSelectElement;
+          updateReownerInput(target.value);
+        });
+
+        $("#reowner-dialog-cancel").on("click", () => reownerDialog?.close());
+
+        $(document).on("keydown", (event: JQuery.KeyDownEvent) => {
+          // .isFocused would make more sense if it existed
+          if (event.key === "Enter" && reownerDialog?.isOpen) {
+            event.preventDefault();
+            form.trigger("submit");
+          }
+        });
+      }
+
+      form.off("submit").on("submit", (event: JQuery.SubmitEvent) => {
+        event.preventDefault();
+        const newOwner = reownerInput.val() as string;
+        PostReowner.reowner(postId, newOwner);
+        return false;
+      });
+
+      reownerDialog.open();
+
+      const previousOwners = await previousOwnersPromise;
+
+      reownerSelect.empty();
+      previousOwners.forEach((owner: PreviousOwner) => {
+        reownerSelect.append($("<option>").val(owner.id).text(`${owner.name} (${owner.id})`));
+      });
+
+      if (reownerSelect.data("allow-other")) {
+        reownerSelect.append($("<option>").val(0).text("Other..."));
+      }
+
+      updateReownerInput(reownerSelect.val() as string | undefined);
+
+      if (previousOwners.length > 0) {
+        reownerStatus.text("");
+        selectElement.style.display = "";
+      } else {
+        reownerStatus.text("No previous owners found.");
+      }
+    });
+  }
+
+  private static async previous_owners (post_id: string): Promise<PreviousOwner[]> {
+    try {
+      return await $.ajax({
+        type: "GET",
+        url: `/moderator/post/posts/${post_id}/previous_owners.json`,
+      });
+    } catch (error: any) {
+      const apiError = error as ApiResponseError;
+      const errors = apiError?.responseJSON?.errors || [apiError?.responseJSON?.reason] || ["Unknown error"];
+      const message = $.map(errors, (msg: string) => msg).join("; ");
+      E621.Toast.alert("Error: " + message);
+      return [];
+    }
+  }
+
+  private static reowner (post_id: string, new_owner: string): void {
+    Post.notice_update("inc");
+    let hasError = false;
+    TaskQueue.add(async () => {
+      try {
+        await $.ajax({
+          type: "POST",
+          url: `/moderator/post/posts/${post_id}/reowner.json`,
+          data: { new_owner: new_owner },
+        });
+        E621.Toast.notice("Reownered post.");
+        location.reload();
+      } catch (error: any) {
+        const apiError = error as ApiResponseError;
+        const errors = apiError?.responseJSON?.errors || [apiError?.responseJSON?.reason] || ["Unknown error"];
+        const message = $.map(errors, (msg: string) => msg).join("; ");
+        E621.Toast.alert("Error: " + message);
+        hasError = true;
+      } finally {
+        if (!hasError) {
+          Post.notice_update("dec");
+        }
+      }
+    }, { name: "Post.reowner" });
+  }
+}

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -220,22 +220,44 @@ Post.initialize_links = function () {
     e.preventDefault();
   });
   let reownerDialog = null;
-  $("#reowner-post-link").on("click", e => {
+  $("#reowner-post-link").on("click", async e => {
     e.preventDefault();
+
+    const postId = $("meta[name=post-id]").attr("content");
+    const previousOwnersPromise = Post.previous_owners(postId);
+
     const form = $("#reowner-dialog");
+    const reownerStatus = $("#reowner-dialog-status");
     const reownerSelect = $("#reowner-dialog-select");
     const reownerInput = $("#reowner-dialog-input");
-    const postId = $("meta[name=post-id]").attr("content");
+    const reownerOkButton = $("#reowner-dialog-ok");
+
+    // Until the previous owner list is loaded
+    reownerStatus.text("Loading...");
+    reownerInput[0].style.display = "none";
+    reownerSelect[0].style.display = "none";
+    reownerOkButton[0].disabled = true;
+
+    const toggleOkButton = () => {
+      const hasNewOwner = (reownerInput.val()?.trim() || "").length > 0;
+      reownerOkButton[0].disabled = !hasNewOwner;
+    };
+    reownerInput.on("input", toggleOkButton);
 
     const updateReownerInput = selectValue => {
       if (selectValue === "0") {
         reownerInput[0].disabled = false;
+        reownerInput[0].style.display = "";
+        reownerInput.val("");
       } else {
         reownerInput[0].disabled = true;
-        reownerInput.val(`!${selectValue}`);
+        reownerInput[0].style.display = "none";
+        if (selectValue) {
+          reownerInput.val(`!${selectValue}`);
+        }
       }
+      toggleOkButton();
     };
-    updateReownerInput(reownerSelect.val());
 
     if (reownerDialog === null) {
       reownerDialog = new Dialog("#reowner-dialog", { width: 250 });
@@ -257,7 +279,22 @@ Post.initialize_links = function () {
     });
 
     reownerDialog.open();
-    console.log("show dialog");
+
+    const previousOwners = await previousOwnersPromise;
+
+    reownerSelect.empty();
+    previousOwners.forEach(owner => reownerSelect.append($("<option>").val(owner.id).text(`${owner.name} (${owner.id})`)));
+    if (reownerSelect.data("allow-other")) {
+      reownerSelect.append($("<option>").val(0).text("Other..."));
+    }
+
+    updateReownerInput(reownerSelect.val());
+    if (previousOwners.length > 0) {
+      reownerStatus.text("");
+      reownerSelect[0].style.display = "";
+    } else {
+      reownerStatus.text("No previous owners found.");
+    }
   });
 };
 
@@ -977,17 +1014,31 @@ Post.set_as_avatar = function (id) {
   }, { name: "Post.set_as_avatar" });
 };
 
+Post.previous_owners = async function (post_id) {
+  try {
+    return await $.ajax({
+      type: "GET",
+      url: `/moderator/post/posts/${post_id}/previous_owners.json`,
+    });
+  } catch (error) {
+    const errors = error?.responseJSON?.errors || [error?.responseJSON?.reason] || ["Unknown error"];
+    const message = $.map(errors, (msg) => msg).join("; ");
+    E621.Toast.alert("Error: " + message);
+    return [];
+  }
+};
+
 Post.reowner = function (post_id, new_owner) {
   Post.notice_update("inc");
   let error = false;
   TaskQueue.add(() => {
-    console.log(`Reownering post ${post_id} to: ${new_owner}`);
     $.ajax({
       type: "POST",
       url: `/moderator/post/posts/${post_id}/reowner.json`,
       data: {new_owner: new_owner},
     }).fail(function (data) {
-      var message = $.map(data.responseJSON.errors, (msg) => msg).join("; ");
+      const errors = data?.responseJSON?.errors || [data?.responseJSON?.reason] || ["Unknown error"];
+      var message = $.map(errors, (msg) => msg).join("; ");
       E621.Toast.alert("Error: " + message);
       error = true;
     }).done(function () {

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -7,7 +7,6 @@ import SVGIcon from "@/utility/SVGIcon";
 import TaskQueue from "@/utility/TaskQueue";
 import ToastManager from "@/utility/Toast";
 import Utility from "@/utility/utility";
-import Dialog from "@/utility/dialog";
 
 let Post = {};
 
@@ -218,83 +217,6 @@ Post.initialize_links = function () {
     }
 
     e.preventDefault();
-  });
-  let reownerDialog = null;
-  $("#reowner-post-link").on("click", async e => {
-    e.preventDefault();
-
-    const postId = $("meta[name=post-id]").attr("content");
-    const previousOwnersPromise = Post.previous_owners(postId);
-
-    const form = $("#reowner-dialog");
-    const reownerStatus = $("#reowner-dialog-status");
-    const reownerSelect = $("#reowner-dialog-select");
-    const reownerInput = $("#reowner-dialog-input");
-    const reownerOkButton = $("#reowner-dialog-ok");
-
-    // Until the previous owner list is loaded
-    reownerStatus.text("Loading...");
-    reownerInput[0].style.display = "none";
-    reownerSelect[0].style.display = "none";
-    reownerOkButton[0].disabled = true;
-
-    const toggleOkButton = () => {
-      const hasNewOwner = (reownerInput.val()?.trim() || "").length > 0;
-      reownerOkButton[0].disabled = !hasNewOwner;
-    };
-    reownerInput.on("input", toggleOkButton);
-
-    const updateReownerInput = selectValue => {
-      if (selectValue === "0") {
-        reownerInput[0].disabled = false;
-        reownerInput[0].style.display = "";
-        reownerInput.val("");
-      } else {
-        reownerInput[0].disabled = true;
-        reownerInput[0].style.display = "none";
-        if (selectValue) {
-          reownerInput.val(`!${selectValue}`);
-        }
-      }
-      toggleOkButton();
-    };
-
-    if (reownerDialog === null) {
-      reownerDialog = new Dialog("#reowner-dialog");
-      reownerSelect.on("change", event => updateReownerInput(event.target.value));
-      $("#reowner-dialog-cancel").on("click", () => reownerDialog.close());
-      $(document).on("keydown", (event) => {
-        // .isFocused would make more sense if it existed
-        if (event.key === "Enter" && reownerDialog.isOpen) {
-          event.preventDefault();
-          form.trigger("submit");
-        }
-      });
-    }
-
-    form.off("submit").on("submit", event => {
-      event.preventDefault();
-      Post.reowner(postId, reownerInput.val());
-      return false;
-    });
-
-    reownerDialog.open();
-
-    const previousOwners = await previousOwnersPromise;
-
-    reownerSelect.empty();
-    previousOwners.forEach(owner => reownerSelect.append($("<option>").val(owner.id).text(`${owner.name} (${owner.id})`)));
-    if (reownerSelect.data("allow-other")) {
-      reownerSelect.append($("<option>").val(0).text("Other..."));
-    }
-
-    updateReownerInput(reownerSelect.val());
-    if (previousOwners.length > 0) {
-      reownerStatus.text("");
-      reownerSelect[0].style.display = "";
-    } else {
-      reownerStatus.text("No previous owners found.");
-    }
   });
 };
 
@@ -1012,43 +934,6 @@ Post.set_as_avatar = function (id) {
       E621.Toast.notice("Post set as avatar. You can crop it further <a href='/maintenance/user/avatar/edit'>here</a>.");
     });
   }, { name: "Post.set_as_avatar" });
-};
-
-Post.previous_owners = async function (post_id) {
-  try {
-    return await $.ajax({
-      type: "GET",
-      url: `/moderator/post/posts/${post_id}/previous_owners.json`,
-    });
-  } catch (error) {
-    const errors = error?.responseJSON?.errors || [error?.responseJSON?.reason] || ["Unknown error"];
-    const message = $.map(errors, (msg) => msg).join("; ");
-    E621.Toast.alert("Error: " + message);
-    return [];
-  }
-};
-
-Post.reowner = function (post_id, new_owner) {
-  Post.notice_update("inc");
-  let error = false;
-  TaskQueue.add(() => {
-    $.ajax({
-      type: "POST",
-      url: `/moderator/post/posts/${post_id}/reowner.json`,
-      data: {new_owner: new_owner},
-    }).fail(function (data) {
-      const errors = data?.responseJSON?.errors || [data?.responseJSON?.reason] || ["Unknown error"];
-      var message = $.map(errors, (msg) => msg).join("; ");
-      E621.Toast.alert("Error: " + message);
-      error = true;
-    }).done(function () {
-      E621.Toast.notice("Reownered post.");
-      location.reload();
-    }).always(function () {
-      if (!error)
-        Post.notice_update("dec");
-    });
-  }, { name: "Post.reowner" });
 };
 
 $(() => {

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -260,7 +260,7 @@ Post.initialize_links = function () {
     };
 
     if (reownerDialog === null) {
-      reownerDialog = new Dialog("#reowner-dialog", { width: 250 });
+      reownerDialog = new Dialog("#reowner-dialog");
       reownerSelect.on("change", event => updateReownerInput(event.target.value));
       $("#reowner-dialog-cancel").on("click", () => reownerDialog.close());
       $(document).on("keydown", (event) => {
@@ -272,7 +272,7 @@ Post.initialize_links = function () {
       });
     }
 
-    form.on("submit", event => {
+    form.off("submit").on("submit", event => {
       event.preventDefault();
       Post.reowner(postId, reownerInput.val());
       return false;

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -7,6 +7,7 @@ import SVGIcon from "@/utility/SVGIcon";
 import TaskQueue from "@/utility/TaskQueue";
 import ToastManager from "@/utility/Toast";
 import Utility from "@/utility/utility";
+import Dialog from "@/utility/dialog";
 
 let Post = {};
 
@@ -217,6 +218,46 @@ Post.initialize_links = function () {
     }
 
     e.preventDefault();
+  });
+  let reownerDialog = null;
+  $("#reowner-post-link").on("click", e => {
+    e.preventDefault();
+    const form = $("#reowner-dialog");
+    const reownerSelect = $("#reowner-dialog-select");
+    const reownerInput = $("#reowner-dialog-input");
+    const postId = $("meta[name=post-id]").attr("content");
+
+    const updateReownerInput = selectValue => {
+      if (selectValue === "0") {
+        reownerInput[0].disabled = false;
+      } else {
+        reownerInput[0].disabled = true;
+        reownerInput.val(`!${selectValue}`);
+      }
+    };
+    updateReownerInput(reownerSelect.val());
+
+    if (reownerDialog === null) {
+      reownerDialog = new Dialog("#reowner-dialog", { width: 250 });
+      reownerSelect.on("change", event => updateReownerInput(event.target.value));
+      $("#reowner-dialog-cancel").on("click", () => reownerDialog.close());
+      $(document).on("keydown", (event) => {
+        // .isFocused would make more sense if it existed
+        if (event.key === "Enter" && reownerDialog.isOpen) {
+          event.preventDefault();
+          form.trigger("submit");
+        }
+      });
+    }
+
+    form.on("submit", event => {
+      event.preventDefault();
+      Post.reowner(postId, reownerInput.val());
+      return false;
+    });
+
+    reownerDialog.open();
+    console.log("show dialog");
   });
 };
 
@@ -934,6 +975,29 @@ Post.set_as_avatar = function (id) {
       E621.Toast.notice("Post set as avatar. You can crop it further <a href='/maintenance/user/avatar/edit'>here</a>.");
     });
   }, { name: "Post.set_as_avatar" });
+};
+
+Post.reowner = function (post_id, new_owner) {
+  Post.notice_update("inc");
+  let error = false;
+  TaskQueue.add(() => {
+    console.log(`Reownering post ${post_id} to: ${new_owner}`);
+    $.ajax({
+      type: "POST",
+      url: `/moderator/post/posts/${post_id}/reowner.json`,
+      data: {new_owner: new_owner},
+    }).fail(function (data) {
+      var message = $.map(data.responseJSON.errors, (msg) => msg).join("; ");
+      E621.Toast.alert("Error: " + message);
+      error = true;
+    }).done(function () {
+      E621.Toast.notice("Reownered post.");
+      location.reload();
+    }).always(function () {
+      if (!error)
+        Post.notice_update("dec");
+    });
+  }, { name: "Post.reowner" });
 };
 
 $(() => {

--- a/app/javascript/src/styles/views/posts/show/_show.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.scss
@@ -19,6 +19,7 @@ body.c-posts.a-show-seq {
 
   @import "partials/detailed_rejection";
   @import "partials/delete_with_reason";
+  @import "partials/reowner";
   @import "partials/add_to_pool";
   @import "partials/notes";
   @import "partials/edit_form";

--- a/app/javascript/src/styles/views/posts/show/partials/_reowner.scss
+++ b/app/javascript/src/styles/views/posts/show/partials/_reowner.scss
@@ -1,0 +1,21 @@
+#reowner-dialog {
+  display: flex;
+  flex-flow: column;
+  gap: 0.5rem;
+
+  & > .input { margin-bottom: 0; }
+  input[type="text"], select {
+    max-width: none;
+    width: 100%;
+    margin: 0.25rem 0 0.25rem 0;
+    box-sizing: border-box;
+    resize: none;
+  }
+
+  div.reowner-dialog-submit {
+    display: flex;
+    gap: 0.5rem;
+
+    button { width: 50%; }
+  }
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1314,6 +1314,7 @@ class Post < ApplicationRecord
     end
 
     def reowner!(new_owner, old_owner = nil, reowner_versions: false, post_events: true)
+      raise ::User::PrivilegeError unless CurrentUser.is_janitor?
       new_owner_id = new_owner&.id
       raise ::User::PrivilegeError, "Cannot assign a new owner that isn't a previous owner" unless
         CurrentUser.is_admin? || previous_version_uploaders.any? { |uploader| uploader.id == new_owner_id }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1315,6 +1315,7 @@ class Post < ApplicationRecord
 
     def reowner!(new_owner, reowner_versions: false, post_events: true)
       raise ::User::PrivilegeError unless CurrentUser.is_janitor?
+      raise ::User::PrivilegeError if (reowner_versions || !post_events) && !CurrentUser.is_bd_staff?
 
       new_owner_id = new_owner&.id
       raise ::User::PrivilegeError, "Cannot assign a new owner that isn't a previous owner" unless

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1303,6 +1303,33 @@ class Post < ApplicationRecord
       end
       User.id_to_name(uploader_id)
     end
+
+    def previous_version_uploaders
+      previous_uploader_ids = replacements
+                              .where(status: %w[original approved])
+                              .where.not(creator_id: uploader_id)
+                              .distinct
+                              .pluck(:creator_id)
+      User.where(id: previous_uploader_ids)
+    end
+
+    def reowner!(new_owner, old_owner = nil, reowner_versions: false, post_events: true)
+      new_owner_id = new_owner&.id
+      raise ::User::PrivilegeError, "Cannot assign a new owner that isn't a previous owner" unless
+        CurrentUser.is_admin? || previous_version_uploaders.include?(new_owner_id)
+      old_owner_id = old_owner&.id || uploader_id
+      self.do_not_version_changes = true
+      update({ uploader_id: new_owner_id })
+      if reowner_versions
+        versions.where(updater_id: old_owner_id).find_each do |version|
+          version.update_column(:updater_id, new_owner_id)
+          version.update_index
+        end
+      end
+      if post_events
+        PostEvent.add(id, CurrentUser.user, :owner_changed, { old_owner: old_owner_id, new_owner: new_owner_id })
+      end
+    end
   end
 
   module SetMethods

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1313,12 +1313,16 @@ class Post < ApplicationRecord
       User.where(id: previous_uploader_ids)
     end
 
-    def reowner!(new_owner, old_owner = nil, reowner_versions: false, post_events: true)
+    def reowner!(new_owner, reowner_versions: false, post_events: true)
       raise ::User::PrivilegeError unless CurrentUser.is_janitor?
+
       new_owner_id = new_owner&.id
       raise ::User::PrivilegeError, "Cannot assign a new owner that isn't a previous owner" unless
         CurrentUser.is_admin? || previous_version_uploaders.any? { |uploader| uploader.id == new_owner_id }
-      old_owner_id = old_owner&.id || uploader_id
+
+      old_owner_id = uploader_id
+      return if new_owner_id == old_owner_id # nothing to do
+
       self.do_not_version_changes = true
       update({ uploader_id: new_owner_id })
       if reowner_versions
@@ -1327,6 +1331,7 @@ class Post < ApplicationRecord
           version.update_index
         end
       end
+
       if post_events
         PostEvent.add(id, CurrentUser.user, :owner_changed, { old_owner: old_owner_id, new_owner: new_owner_id })
       end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1316,7 +1316,7 @@ class Post < ApplicationRecord
     def reowner!(new_owner, old_owner = nil, reowner_versions: false, post_events: true)
       new_owner_id = new_owner&.id
       raise ::User::PrivilegeError, "Cannot assign a new owner that isn't a previous owner" unless
-        CurrentUser.is_admin? || previous_version_uploaders.include?(new_owner_id)
+        CurrentUser.is_admin? || previous_version_uploaders.any? { |uploader| uploader.id == new_owner_id }
       old_owner_id = old_owner&.id || uploader_id
       self.do_not_version_changes = true
       update({ uploader_id: new_owner_id })

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1313,6 +1313,7 @@ class Post < ApplicationRecord
       User.where(id: previous_uploader_ids)
     end
 
+    # Reowner the post and return the old owner id, or nil if the new owner is the current owner.
     def reowner!(new_owner, reowner_versions: false, post_events: true)
       raise ::User::PrivilegeError unless CurrentUser.is_janitor?
       raise ::User::PrivilegeError if (reowner_versions || !post_events) && !CurrentUser.is_bd_staff?
@@ -1322,7 +1323,7 @@ class Post < ApplicationRecord
         CurrentUser.is_admin? || previous_version_uploaders.any? { |uploader| uploader.id == new_owner_id }
 
       old_owner_id = uploader_id
-      return if new_owner_id == old_owner_id # nothing to do
+      return nil if new_owner_id == old_owner_id # nothing to do
 
       self.do_not_version_changes = true
       update({ uploader_id: new_owner_id })
@@ -1336,6 +1337,8 @@ class Post < ApplicationRecord
       if post_events
         PostEvent.add(id, CurrentUser.user, :owner_changed, { old_owner: old_owner_id, new_owner: new_owner_id })
       end
+
+      old_owner_id
     end
   end
 

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -28,6 +28,7 @@ class PostEvent < ApplicationRecord
     expunged: 17,
     changed_bg_color: 21,
     replacement_penalty_changed: 24,
+    owner_changed: 25,
   }
   MOD_ONLY_SEARCH_ACTIONS = [
     actions[:comment_locked],

--- a/app/views/admin/reowner/new.html.erb
+++ b/app/views/admin/reowner/new.html.erb
@@ -7,6 +7,7 @@
     <%= f.input(:old_owner, label: "Old Owner", placeholder: "Use ! in front of an id for an id.", input_html: { size: 40 }) %>
     <%= f.input(:new_owner, label: "New Owner", placeholder: "Use ! in front of an id for an id.", input_html: { size: 40 }) %>
     <%= f.input(:search, label: "Search Query", input_html: { size: 40 }) %>
+    <%= f.input(:reowner_versions, label: "Reowner post versions", as: :boolean, input_html: { checked: true }) %>
     <%= f.input(:post_events, label: "Create post events", as: :boolean) %>
     <%= f.submit("Submit") %>
   <% end %>

--- a/app/views/admin/reowner/new.html.erb
+++ b/app/views/admin/reowner/new.html.erb
@@ -7,6 +7,7 @@
     <%= f.input(:old_owner, label: "Old Owner", placeholder: "Use ! in front of an id for an id.", input_html: { size: 40 }) %>
     <%= f.input(:new_owner, label: "New Owner", placeholder: "Use ! in front of an id for an id.", input_html: { size: 40 }) %>
     <%= f.input(:search, label: "Search Query", input_html: { size: 40 }) %>
+    <%= f.input(:post_events, label: "Create post events", as: :boolean) %>
     <%= f.submit("Submit") %>
   <% end %>
 </div>

--- a/app/views/moderator/post/posts/_reowner_dialog.html.erb
+++ b/app/views/moderator/post/posts/_reowner_dialog.html.erb
@@ -6,6 +6,16 @@
       </select>
     </div>
     <input type="text" id="reowner-dialog-input" placeholder="Name or ID prefixed with !">
+    <% if CurrentUser.is_bd_staff? %>
+      <label for="reowner-dialog-reowner-versions">
+        Reowner post versions
+        <input type="checkbox" id="reowner-dialog-reowner-versions">
+      </label>
+      <label for="reowner-dialog-post-events">
+        Create post events
+        <input type="checkbox" id="reowner-dialog-post-events" checked>
+      </label>
+    <% end %>
   </div>
 
   <div class="input reowner-dialog-submit">

--- a/app/views/moderator/post/posts/_reowner_dialog.html.erb
+++ b/app/views/moderator/post/posts/_reowner_dialog.html.erb
@@ -1,0 +1,24 @@
+<form class="simple_form" id="reowner-dialog" data-title="Reowner Post" data-width="500" data-position="center">
+  <div class="input">
+    <div id="reowner-dialog-labeled-input">
+      <label for="reowner-dialog-select">Previous Owners</label>
+      <select id="reowner-dialog-select">
+        <% @post.previous_version_uploaders.each do |uploader| %>
+          <option value="<%= uploader.id %>"><%= "#{uploader.name} (#{uploader.id})" %></option>
+        <% end %>
+        <% if CurrentUser.is_admin? %>
+          <option value="0">Other...</option>
+        <% end %>
+      </select>
+    </div>
+    <div id="reowner-dialog-labeled-input">
+      <label for="reowner-dialog-input">New Owner</label>
+      <input type="text" id="reowner-dialog-input" placeholder="Name or ID prefixed with !">
+    </div>
+  </div>
+
+  <div class="input reowner-dialog-submit">
+    <button type="button" class="st-button" id="reowner-dialog-cancel">Cancel</button>
+    <button type="submit" class="st-button submit" id="reowner-dialog-ok">OK</button>
+  </div>
+</form>

--- a/app/views/moderator/post/posts/_reowner_dialog.html.erb
+++ b/app/views/moderator/post/posts/_reowner_dialog.html.erb
@@ -1,4 +1,4 @@
-<form class="simple_form" id="reowner-dialog" data-title="Reowner Post" data-width="500" data-position="center">
+<form class="simple_form" id="reowner-dialog" data-title="Reowner Post" data-width="250" data-position="center">
   <div class="input">
     <div id="reowner-dialog-status"></div>
     <div id="reowner-dialog-labeled-input">

--- a/app/views/moderator/post/posts/_reowner_dialog.html.erb
+++ b/app/views/moderator/post/posts/_reowner_dialog.html.erb
@@ -1,20 +1,11 @@
 <form class="simple_form" id="reowner-dialog" data-title="Reowner Post" data-width="500" data-position="center">
   <div class="input">
+    <div id="reowner-dialog-status"></div>
     <div id="reowner-dialog-labeled-input">
-      <label for="reowner-dialog-select">Previous Owners</label>
-      <select id="reowner-dialog-select">
-        <% @post.previous_version_uploaders.each do |uploader| %>
-          <option value="<%= uploader.id %>"><%= "#{uploader.name} (#{uploader.id})" %></option>
-        <% end %>
-        <% if CurrentUser.is_admin? %>
-          <option value="0">Other...</option>
-        <% end %>
+      <select id="reowner-dialog-select" data-allow-other="<%= CurrentUser.is_admin? ? "true" : "false" %>">
       </select>
     </div>
-    <div id="reowner-dialog-labeled-input">
-      <label for="reowner-dialog-input">New Owner</label>
-      <input type="text" id="reowner-dialog-input" placeholder="Name or ID prefixed with !">
-    </div>
+    <input type="text" id="reowner-dialog-input" placeholder="Name or ID prefixed with !">
   </div>
 
   <div class="input reowner-dialog-submit">

--- a/app/views/posts/partials/show/sidebar/_options.html.erb
+++ b/app/views/posts/partials/show/sidebar/_options.html.erb
@@ -59,6 +59,7 @@
       <% end %>
     <% end %>
     <% if CurrentUser.is_janitor? %>
+      <li><%= tag.a "Reowner", href: "#", id: "reowner-post-link", data: { pid: post.id } %></li>
       <li><%= tag.a "Regenerate Thumbnails", href: "#", id: "regenerate-image-samples-link", data: { pid: post.id } %></li>
       <% if post.is_video? %>
         <li><%= tag.a "Regenerate Video Samples", href: "#", id: "regenerate-video-samples-link", data: { pid: post.id } %></li>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -224,6 +224,8 @@
       <% if CurrentUser.can_approve_posts? %>
         <%= render "post_disapprovals/detailed_rejection_dialog" %>
         <%= render "moderator/post/posts/delete_with_reason_dialog" %>
+      <% end %>
+      <% if CurrentUser.is_janitor? %>
         <%= render "moderator/post/posts/reowner_dialog" %>
       <% end %>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -38,7 +38,7 @@
         <h3>Related</h3>
         <%= render "posts/partials/show/sidebar/related", :post => @post %>
       </section>
-      
+
       <div class="go-up"><button type="button" class="st-button kinetic" title="Scroll to top" aria-label="Scroll to top"><%= svg_icon(:corner_right_up) %></button></div>
     </div>
 
@@ -224,6 +224,7 @@
       <% if CurrentUser.can_approve_posts? %>
         <%= render "post_disapprovals/detailed_rejection_dialog" %>
         <%= render "moderator/post/posts/delete_with_reason_dialog" %>
+        <%= render "moderator/post/posts/reowner_dialog" %>
       <% end %>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
           post :regenerate_thumbnails
           post :regenerate_videos
           get :ai_check
+          get :previous_owners
           post :reowner
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
           post :regenerate_thumbnails
           post :regenerate_videos
           get :ai_check
+          post :reowner
         end
       end
     end

--- a/spec/README.md
+++ b/spec/README.md
@@ -80,6 +80,7 @@ spec/
 ### Current user
 
 ```ruby
+include_context "as bd admin"
 include_context "as admin"
 include_context "as moderator"
 include_context "as janitor"
@@ -89,7 +90,7 @@ include_context "as member"
 
 Each context creates a user of that level and sets `CurrentUser.user` / `CurrentUser.ip_addr = "127.0.0.1"` in `before(:each)`, and clears both in `after(:each)`.
 
-Factory mapping: `admin` → `:admin_user`, `moderator` → `:moderator_user`, `janitor` → `:janitor_user`, `privileged` → `:privileged_user`, `member` → `:user`.
+Factory mapping: `bd admin` → `:bd_admin_user`, `admin` → `:admin_user`, `moderator` → `:moderator_user`, `janitor` → `:janitor_user`, `privileged` → `:privileged_user`, `member` → `:user`.
 
 ### Tag categories
 

--- a/spec/factories/post_replacement_factory.rb
+++ b/spec/factories/post_replacement_factory.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
       association :approver, factory: :user
     end
 
+    factory :pending_post_replacement do
+      status { "pending" }
+    end
+
     factory :rejected_post_replacement do
       status { "rejected" }
       association :approver, factory: :user

--- a/spec/models/post/uploader_methods_spec.rb
+++ b/spec/models/post/uploader_methods_spec.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Post do
+  include_context "as admin"
+
+  describe "UploaderMethods" do
+    describe "#previous_version_uploaders" do
+      it "returns the deduplicated list of previous replacement uploaders" do
+        post = create(:post)
+        user1 = create(:user)
+        user2 = create(:user)
+        replacement0 = create(:original_post_replacement, post: post, creator: post.uploader)
+        replacement1 = create(:approved_post_replacement, post: post, creator: user1)
+        replacement2 = create(:approved_post_replacement, post: post, creator: user2)
+        replacement3 = create(:approved_post_replacement, post: post, creator: user1)
+        expect(replacement0.creator).to eq(post.uploader)
+        expect(replacement1.creator).to eq(user1)
+        expect(replacement2.creator).to eq(user2)
+        expect(replacement3.creator).to eq(user1)
+        expect(post.previous_version_uploaders).to eq([user1, user2])
+      end
+
+      it "returns empty if the post was never replaced" do
+        post = create(:post)
+        expect(post.previous_version_uploaders).to eq([])
+      end
+
+      it "returns doesn't return pending or rejected replacement uploaders" do
+        post = create(:post)
+        user1 = create(:user)
+        user2 = create(:user)
+        user3 = create(:user)
+        replacement0 = create(:original_post_replacement, post: post, creator: post.uploader)
+        replacement1 = create(:approved_post_replacement, post: post, creator: user1)
+        replacement2 = create(:pending_post_replacement, post: post, creator: user2)
+        replacement3 = create(:rejected_post_replacement, post: post, creator: user3)
+        expect(replacement0.creator).to eq(post.uploader)
+        expect(replacement1.creator).to eq(user1)
+        expect(replacement2.creator).to eq(user2)
+        expect(replacement3.creator).to eq(user3)
+        expect(post.previous_version_uploaders).to eq([user1])
+      end
+    end
+
+    describe "#reowner!" do
+      let(:post) { create(:post) }
+      let(:new_owner) { create(:user) }
+      let!(:old_owner) { post.uploader }
+      let(:other_user) { create(:user) }
+
+      context "when the user is an admin" do
+        it "allows assigning any user as the new owner" do
+          post.reowner!(new_owner)
+          expect(post.reload.uploader_id).to eq(new_owner.id)
+        end
+      end
+
+      context "when the user is not a janitor" do
+        include_context "as member"
+
+        it "raises a PrivilegeError when assigning a user who is a previous version uploader" do
+          create(:approved_post_replacement, post: post, creator: new_owner)
+          expect do
+            post.reowner!(new_owner)
+          end.to raise_error(User::PrivilegeError)
+        end
+
+        it "raises a PrivilegeError when assigning a user who is not a previous uploader" do
+          expect do
+            post.reowner!(new_owner)
+          end.to raise_error(User::PrivilegeError)
+        end
+      end
+
+      context "when the user is a janitor" do
+        include_context "as janitor"
+
+        it "allows assigning a user who is a previous version uploader" do
+          create(:approved_post_replacement, post: post, creator: new_owner)
+          post.reowner!(new_owner)
+          expect(post.reload.uploader_id).to eq(new_owner.id)
+        end
+
+        it "raises a PrivilegeError when assigning a user who is not a previous uploader" do
+          expect do
+            post.reowner!(new_owner)
+          end.to raise_error(User::PrivilegeError)
+        end
+      end
+
+      describe "reowner_versions parameter" do
+        let!(:version1) do # rubocop:disable RSpec/IndexedLet
+          create(:post_version, post: post).tap { |v| v.update_column(:updater_id, old_owner.id) }
+        end
+        let!(:version2) do # rubocop:disable RSpec/IndexedLet
+          create(:post_version, post: post).tap { |v| v.update_column(:updater_id, old_owner.id) }
+        end
+        let!(:version3) do # rubocop:disable RSpec/IndexedLet
+          create(:post_version, post: post).tap { |v| v.update_column(:updater_id, other_user.id) }
+        end
+
+        it "updates the updater_id on previous versions when true" do
+          post.reowner!(new_owner, reowner_versions: true)
+          expect(version1.reload.updater_id).to eq(new_owner.id)
+          expect(version2.reload.updater_id).to eq(new_owner.id)
+          expect(version3.reload.updater_id).to eq(other_user.id)
+        end
+
+        it "does not update previous versions when false" do
+          post.reowner!(new_owner, reowner_versions: false)
+          expect(version1.reload.updater_id).to eq(old_owner.id)
+          expect(version2.reload.updater_id).to eq(old_owner.id)
+          expect(version3.reload.updater_id).to eq(other_user.id)
+        end
+      end
+
+      describe "post_events parameter" do
+        it "creates an owner_changed post event by default (true)" do
+          expect do
+            post.reowner!(new_owner)
+          end.to change { PostEvent.where(action: "owner_changed", post_id: post.id).count }.by(1)
+
+          event = PostEvent.last
+          expect(event.extra_data).to include("old_owner" => old_owner.id, "new_owner" => new_owner.id)
+        end
+
+        it "does not create a post event when false" do
+          expect do
+            post.reowner!(new_owner, post_events: false)
+          end.not_to change(PostEvent, :count)
+        end
+      end
+
+      it "skips versioning the post update itself" do
+        expect do
+          post.reowner!(new_owner, post_events: false)
+        end.not_to(change { post.versions.count })
+      end
+    end
+  end
+end

--- a/spec/models/post/uploader_methods_spec.rb
+++ b/spec/models/post/uploader_methods_spec.rb
@@ -131,6 +131,12 @@ RSpec.describe Post do
             post.reowner!(new_owner, post_events: false)
           end.not_to change(PostEvent, :count)
         end
+
+        it "does not create a post event when the old and new owners are the same" do
+          expect do
+            post.reowner!(old_owner, post_events: true)
+          end.not_to change(PostEvent, :count)
+        end
       end
 
       it "skips versioning the post update itself" do

--- a/spec/models/post/uploader_methods_spec.rb
+++ b/spec/models/post/uploader_methods_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Post do
         expect(post.previous_version_uploaders).to eq([])
       end
 
-      it "returns doesn't return pending or rejected replacement uploaders" do
+      it "doesn't return pending or rejected replacement uploaders" do
         post = create(:post)
         user1 = create(:user)
         user2 = create(:user)

--- a/spec/models/post/uploader_methods_spec.rb
+++ b/spec/models/post/uploader_methods_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe Post do
           post.reowner!(new_owner)
           expect(post.reload.uploader_id).to eq(new_owner.id)
         end
+
+        it "raises a PrivilegeError when reownering versions" do
+          expect do
+            post.reowner!(new_owner, reowner_versions: true)
+          end.to raise_error(User::PrivilegeError)
+        end
+
+        it "raises a PrivilegeError when disabling post events" do
+          expect do
+            post.reowner!(new_owner, post_events: false)
+          end.to raise_error(User::PrivilegeError)
+        end
       end
 
       context "when the user is not a janitor" do
@@ -90,59 +102,63 @@ RSpec.describe Post do
         end
       end
 
-      describe "reowner_versions parameter" do
-        let!(:version1) do # rubocop:disable RSpec/IndexedLet
-          create(:post_version, post: post).tap { |v| v.update_column(:updater_id, old_owner.id) }
-        end
-        let!(:version2) do # rubocop:disable RSpec/IndexedLet
-          create(:post_version, post: post).tap { |v| v.update_column(:updater_id, old_owner.id) }
-        end
-        let!(:version3) do # rubocop:disable RSpec/IndexedLet
-          create(:post_version, post: post).tap { |v| v.update_column(:updater_id, other_user.id) }
+      context "when the user is a BD admin" do
+        include_context "as bd admin"
+
+        describe "reowner_versions parameter" do
+          let!(:version1) do # rubocop:disable RSpec/IndexedLet
+            create(:post_version, post: post).tap { |v| v.update_column(:updater_id, old_owner.id) }
+          end
+          let!(:version2) do # rubocop:disable RSpec/IndexedLet
+            create(:post_version, post: post).tap { |v| v.update_column(:updater_id, old_owner.id) }
+          end
+          let!(:version3) do # rubocop:disable RSpec/IndexedLet
+            create(:post_version, post: post).tap { |v| v.update_column(:updater_id, other_user.id) }
+          end
+
+          it "updates the updater_id on previous versions when true" do
+            post.reowner!(new_owner, reowner_versions: true)
+            expect(version1.reload.updater_id).to eq(new_owner.id)
+            expect(version2.reload.updater_id).to eq(new_owner.id)
+            expect(version3.reload.updater_id).to eq(other_user.id)
+          end
+
+          it "does not update previous versions when false" do
+            post.reowner!(new_owner, reowner_versions: false)
+            expect(version1.reload.updater_id).to eq(old_owner.id)
+            expect(version2.reload.updater_id).to eq(old_owner.id)
+            expect(version3.reload.updater_id).to eq(other_user.id)
+          end
         end
 
-        it "updates the updater_id on previous versions when true" do
-          post.reowner!(new_owner, reowner_versions: true)
-          expect(version1.reload.updater_id).to eq(new_owner.id)
-          expect(version2.reload.updater_id).to eq(new_owner.id)
-          expect(version3.reload.updater_id).to eq(other_user.id)
+        describe "post_events parameter" do
+          it "creates an owner_changed post event by default (true)" do
+            expect do
+              post.reowner!(new_owner)
+            end.to change { PostEvent.where(action: "owner_changed", post_id: post.id).count }.by(1)
+
+            event = PostEvent.last
+            expect(event.extra_data).to include("old_owner" => old_owner.id, "new_owner" => new_owner.id)
+          end
+
+          it "does not create a post event when false" do
+            expect do
+              post.reowner!(new_owner, post_events: false)
+            end.not_to change(PostEvent, :count)
+          end
+
+          it "does not create a post event when the old and new owners are the same" do
+            expect do
+              post.reowner!(old_owner, post_events: true)
+            end.not_to change(PostEvent, :count)
+          end
         end
 
-        it "does not update previous versions when false" do
-          post.reowner!(new_owner, reowner_versions: false)
-          expect(version1.reload.updater_id).to eq(old_owner.id)
-          expect(version2.reload.updater_id).to eq(old_owner.id)
-          expect(version3.reload.updater_id).to eq(other_user.id)
-        end
-      end
-
-      describe "post_events parameter" do
-        it "creates an owner_changed post event by default (true)" do
-          expect do
-            post.reowner!(new_owner)
-          end.to change { PostEvent.where(action: "owner_changed", post_id: post.id).count }.by(1)
-
-          event = PostEvent.last
-          expect(event.extra_data).to include("old_owner" => old_owner.id, "new_owner" => new_owner.id)
-        end
-
-        it "does not create a post event when false" do
+        it "skips versioning the post update itself" do
           expect do
             post.reowner!(new_owner, post_events: false)
-          end.not_to change(PostEvent, :count)
+          end.not_to(change { post.versions.count })
         end
-
-        it "does not create a post event when the old and new owners are the same" do
-          expect do
-            post.reowner!(old_owner, post_events: true)
-          end.not_to change(PostEvent, :count)
-        end
-      end
-
-      it "skips versioning the post update itself" do
-        expect do
-          post.reowner!(new_owner, post_events: false)
-        end.not_to(change { post.versions.count })
       end
     end
   end

--- a/spec/requests/moderator/post/posts_controller_spec.rb
+++ b/spec/requests/moderator/post/posts_controller_spec.rb
@@ -304,4 +304,76 @@ RSpec.describe Moderator::Post::PostsController do
       expect(response).to have_http_status(:redirect)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # GET /moderator/post/posts/:id/previous_owners
+  # ---------------------------------------------------------------------------
+
+  describe "GET /moderator/post/posts/:id/previous_owners" do
+    it "redirects anonymous to the login page" do
+      get previous_owners_moderator_post_post_path(post_record)
+      expect(response).to redirect_to(new_session_path(url: previous_owners_moderator_post_post_path(post_record)))
+    end
+
+    it "returns 403 for a member" do
+      sign_in_as member
+      get previous_owners_moderator_post_post_path(post_record)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 200 and the JSON array for an approver" do
+      sign_in_as approver
+      user1 = create(:user)
+      allow_any_instance_of(Post).to receive(:previous_version_uploaders).and_return([user1]) # rubocop:disable RSpec/AnyInstance
+      get previous_owners_moderator_post_post_path(post_record, format: :json)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.first["id"]).to eq(user1.id)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # POST /moderator/post/posts/:id/reowner
+  # ---------------------------------------------------------------------------
+
+  describe "POST /moderator/post/posts/:id/reowner" do
+    let(:new_owner) { create(:user) }
+
+    it "redirects anonymous to the login page" do
+      post reowner_moderator_post_post_path(post_record)
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 403 for a member" do
+      sign_in_as member
+      post reowner_moderator_post_post_path(post_record)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for an approver without janitor level" do
+      sign_in_as approver
+      post reowner_moderator_post_post_path(post_record)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for a janitor without approver rights" do
+      sign_in_as janitor
+      post reowner_moderator_post_post_path(post_record)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as a janitor with approver rights" do
+      before { sign_in_as janitor_approver }
+
+      it "sets a flash alert if the new owner could not be found" do
+        post reowner_moderator_post_post_path(post_record), params: { new_owner: "I_AM_NOT_A_USER" }
+        expect(flash[:alert]).to match(/New owner could not be found/)
+      end
+
+      it "calls reowner! and redirects if the user is found" do
+        allow_any_instance_of(Post).to receive(:reowner!).with(new_owner).and_return(true) # rubocop:disable RSpec/AnyInstance
+        post reowner_moderator_post_post_path(post_record), params: { new_owner: new_owner.name }
+        expect(response).to redirect_to(post_path(post_record))
+      end
+    end
+  end
 end

--- a/spec/requests/moderator/post/posts_controller_spec.rb
+++ b/spec/requests/moderator/post/posts_controller_spec.rb
@@ -365,13 +365,13 @@ RSpec.describe Moderator::Post::PostsController do
       before { sign_in_as janitor_approver }
 
       it "sets a flash alert if the new owner could not be found" do
-        post reowner_moderator_post_post_path(post_record), params: { new_owner: "I_AM_NOT_A_USER" }
+        post reowner_moderator_post_post_path(post_record), params: { reowner: { new_owner: "I_AM_NOT_A_USER" } }
         expect(flash[:alert]).to match(/New owner could not be found/)
       end
 
       it "calls reowner! and redirects if the user is found" do
-        allow_any_instance_of(Post).to receive(:reowner!).with(new_owner).and_return(true) # rubocop:disable RSpec/AnyInstance
-        post reowner_moderator_post_post_path(post_record), params: { new_owner: new_owner.name }
+        allow_any_instance_of(Post).to receive(:reowner!).with(new_owner, post_events: true, reowner_versions: false).and_return(true) # rubocop:disable RSpec/AnyInstance
+        post reowner_moderator_post_post_path(post_record), params: { reowner: { new_owner: new_owner.name } }
         expect(response).to redirect_to(post_path(post_record))
       end
     end

--- a/spec/requests/moderator/post/posts_controller_spec.rb
+++ b/spec/requests/moderator/post/posts_controller_spec.rb
@@ -370,9 +370,21 @@ RSpec.describe Moderator::Post::PostsController do
       end
 
       it "calls reowner! and redirects if the user is found" do
-        allow_any_instance_of(Post).to receive(:reowner!).with(new_owner, post_events: true, reowner_versions: false).and_return(true) # rubocop:disable RSpec/AnyInstance
-        post reowner_moderator_post_post_path(post_record), params: { reowner: { new_owner: new_owner.name } }
+        allow_any_instance_of(Post).to receive(:reowner!).with(new_owner, post_events: true, reowner_versions: false).and_return(9999) # rubocop:disable RSpec/AnyInstance
+        expect do
+          post reowner_moderator_post_post_path(post_record), params: { reowner: { new_owner: new_owner.name } }
+        end.not_to change(StaffAuditLog, :count)
         expect(response).to redirect_to(post_path(post_record))
+      end
+
+      it "creates a staff audit log entry when disabling reowner post events" do
+        allow_any_instance_of(Post).to receive(:reowner!).with(new_owner, post_events: false, reowner_versions: false).and_return(9999) # rubocop:disable RSpec/AnyInstance
+        expect do
+          post reowner_moderator_post_post_path(post_record), params: { reowner: { new_owner: new_owner.name, post_events: false } }
+        end.to change(StaffAuditLog, :count).by(1)
+        expect(response).to redirect_to(post_path(post_record))
+        expect(StaffAuditLog.last.action).to eq("post_owner_reassign")
+        expect(StaffAuditLog.last[:values]).to include("old_user_id" => 9999, "new_user_id" => new_owner.id, "query" => "", "post_ids" => [post_record.id])
       end
     end
   end

--- a/spec/support/current_user_contexts.rb
+++ b/spec/support/current_user_contexts.rb
@@ -3,6 +3,7 @@
 # Shared contexts for setting the current user in specs.
 #
 # Usage:
+#   include_context "as bd admin"
 #   include_context "as admin"
 #   include_context "as moderator"
 #   include_context "as janitor"
@@ -14,6 +15,7 @@
 # Both are cleared in an after hook.
 
 {
+  "bd admin"   => :bd_admin_user,
   "admin"      => :admin_user,
   "moderator"  => :moderator_user,
   "janitor"    => :janitor_user,


### PR DESCRIPTION
Add a `Reowner` action on posts for janitors:
- Opens a dialog with a dropdown list of previous post owners
  - A previous post owner is a creator for an "approved" or "original" replacement
  - The list is deduplicated and excludes the current owner
  - If the user is an admin, there's also an "Other..." option
- The janitor picks the new owner from the list and confirms
  - The post owner is changed
  - A post event is created
  - Post version owners remain **unchanged**
- An admin can also pick the "Other..." option
  - A text input appears 
  - The admin enters any user name, or user ID prefixed with `!`
  - The admin confirms and the rest is the same as for a janitor
- A BD admin has additional options to override the post version and event behaviour
  - Create post events (defaults to true)
  - Reowner post versions (defaults to false)

Improve the `/admin/reowner/new` endpoint
- Expose previously hardcoded behaviour as options
  - Create post events (defaults to false)
  - Reowner post versions (defaults to true)
- Show the number of reownered post in the notice

Implementation details:
- The list of previous owners is lazily loaded from a new `GET /moderator/post/posts/:id/previous_owners.json` endpoint

This relates to #1449, while it implements the same feature in a more roundabout way, it's really intended to fix owners on already replaced posts.

Allowing admins to arbitrarily reowner is a new thing, this is currently BD staff only using the `/admin/reowner/new` endpoint, but it's also a less powerful version of it:
- One post at a time
- Always creates post events
- Doesn't change post version owners

In any case I can add config values for the permissions if deemed necessary.