### PR TITLE
[Appeals] Redirect unappealable deletions to the post

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -31,7 +31,15 @@ class AppealsController < ApplicationController
     end
 
     unless @appeal.can_create_for?(CurrentUser.user)
-      redirect_to appeals_path, alert: "This deletion can't be appealed or has already been resolved."
+      redirect_path = appeals_path
+      # For a post flag, send the user back to the post: either it's undeleted, it's been re-deleted
+      # (so they need to use the new flag's appeal button), or it's something they just can't appeal.
+      # Anyway it's more helpful for the user to see the current post status than the appeals index.
+      content = @appeal.content
+      if content.is_a?(::PostFlag) && (post = content.post.presence)
+        redirect_path = post_path(post)
+      end
+      redirect_to redirect_path, alert: "This deletion can't be appealed or has already been resolved."
       return
     end
 

--- a/spec/requests/appeals_controller_spec.rb
+++ b/spec/requests/appeals_controller_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe AppealsController do
       expect(response).to redirect_to(new_session_path(url: new_appeal_path))
     end
 
-    it "redirects to the appeals index for a member who is not the post uploader" do
+    it "redirects to the flag's post for a member who is not the post uploader" do
       sign_in_as other_member
       get new_appeal_path(qtype: "flag", disp_id: post_flag.id)
-      expect(response).to redirect_to(appeals_path)
+      expect(response).to redirect_to(post_path(post_flag.post))
       expect(flash[:alert]).to eq("This deletion can't be appealed or has already been resolved.")
     end
 


### PR DESCRIPTION
More useful to show the user the post than the appeals index.