### PR TITLE
[Posts] Fix an issue with comment anchor links not working on mobile

### DIFF
--- a/app/javascript/src/js/pages/posts/show/MobileTabs.ts
+++ b/app/javascript/src/js/pages/posts/show/MobileTabs.ts
@@ -17,6 +17,20 @@ function bootstrapTabs () {
         $el.attr("aria-selected", String($el.data("action") === action));
       });
   });
+
+  // Comment anchor links will not work on mobile unless the user has the comments tab open.
+  if (window.innerWidth > 800 || CStorage.postMobileTabState === "comments") return;
+  const commentID = window.location.hash.match(/^#?comment-(\d+)/)?.[1];
+  if (!commentID) return;
+  const comment = $("article[data-comment-id='" + commentID + "']");
+  if (!comment.length) return;
+
+  container.attr("data-tab-state", "comments");
+  // If the tabs get switched early enough, the browser will scroll to the content on its own.
+  window.setTimeout(() => {
+    const offset = comment.offset()?.top ?? 0;
+    if (offset) window.scrollTo({ top: offset, behavior: "smooth" });
+  }, 100);
 }
 
 function bootstrapGoUpButton () {

--- a/app/javascript/src/js/pages/posts/show/MobileTabs.ts
+++ b/app/javascript/src/js/pages/posts/show/MobileTabs.ts
@@ -9,28 +9,31 @@ function bootstrapTabs () {
     const action = $(event.currentTarget).data("action");
     if (!validActions.includes(action)) return;
     CStorage.postMobileTabState = action;
-
-    container
-      .attr("data-tab-state", action)
-      .find(".post-mobile-tab").each((_, el) => {
-        const $el = $(el);
-        $el.attr("aria-selected", String($el.data("action") === action));
-      });
+    switchToTab(container, action);
   });
 
   // Comment anchor links will not work on mobile unless the user has the comments tab open.
   if (window.innerWidth > 800 || CStorage.postMobileTabState === "comments") return;
   const commentID = window.location.hash.match(/^#?comment-(\d+)/)?.[1];
   if (!commentID) return;
-  const comment = $("article[data-comment-id='" + commentID + "']");
+  const comment = $(`article[data-comment-id="${commentID}"]`);
   if (!comment.length) return;
 
-  container.attr("data-tab-state", "comments");
+  switchToTab(container, "comments");
   // If the tabs get switched early enough, the browser will scroll to the content on its own.
   window.setTimeout(() => {
     const offset = comment.offset()?.top ?? 0;
     if (offset) window.scrollTo({ top: offset, behavior: "smooth" });
   }, 100);
+}
+
+function switchToTab (container: JQuery<HTMLElement>, tab: "comments" | "tags") {
+  container
+    .attr("data-tab-state", tab)
+    .find(".post-mobile-tab").each((_, el) => {
+      const $el = $(el);
+      $el.attr("aria-selected", String($el.data("action") === tab));
+    });
 }
 
 function bootstrapGoUpButton () {


### PR DESCRIPTION
Fixes #2013.

If the user has the "Tags" tab open, comment links would not work as the corresponding comments are hidden from view.
This fix switches tabs when necessary, and scrolls down to the comment.