### PR TITLE
[Blueprints] Hide md5/ext and video samples for non-visible posts

### DIFF
--- a/app/blueprints/post_blueprint.rb
+++ b/app/blueprints/post_blueprint.rb
@@ -14,11 +14,12 @@ class PostBlueprint < Blueprinter::Base
   ### File Information ###
 
   field :files do |post|
+    visible = post.visible?
     output = {}
 
     output[:meta] = {
-      md5: post.md5,
-      ext: post.file_ext,
+      md5: visible ? post.md5 : nil,
+      ext: visible ? post.file_ext : nil,
       size: post.file_size,
       duration: post.duration&.to_f,
 
@@ -45,7 +46,7 @@ class PostBlueprint < Blueprinter::Base
       webp: nil,
     }
 
-    if post.visible?
+    if visible
       output[:original][:url] = post.file_url
 
       preview = post.preview_file_url_pair
@@ -57,7 +58,7 @@ class PostBlueprint < Blueprinter::Base
       output[:sample][:jpg] = sample[1]
     end
 
-    if post.is_video?
+    if visible && post.is_video?
       output[:video] = post.video_sample_list
     end
 

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe PostsController do
     # transactions returning IDs that no longer exist in the DB.
     before { allow(Post).to receive(:tag_match).and_return(Post.all) }
 
+    let(:video_samples) do
+      {
+        "original" => { "codec" => "vp9", "fps" => 30 },
+        "variants" => {
+          "mp4" => { "width" => 1280, "height" => 720, "size" => 4_000_000 },
+        },
+        "samples" => {
+          "720p" => { "width" => 1280, "height" => 720, "size" => 2_000_000 },
+        },
+      }
+    end
+
     it "returns 200 for anonymous" do
       get posts_path
       expect(response).to have_http_status(:ok)
@@ -40,6 +52,52 @@ RSpec.describe PostsController do
       expect(body).to be_an(Array)
       expect(body.first).to include("id", "files", "stats", "tags")
       expect(body.first["tags"]).to be_an(Array)
+    end
+
+    it "includes reconstructing file metadata and video samples for visible v2 posts" do
+      post = create(
+        :post,
+        file_ext: "webm",
+        image_width: 1280,
+        image_height: 720,
+        file_size: 5_000_000,
+        video_samples: video_samples,
+      )
+
+      get posts_path(format: :json), params: { v2: "true" }
+      expect(response).to have_http_status(:ok)
+
+      files = response.parsed_body.first["files"]
+      expect(files["meta"]).to include("md5" => post.md5, "ext" => "webm")
+      expect(files["video"]["original"]["url"]).to be_present
+      expect(files["video"]["variants"]["mp4"]["url"]).to be_present
+      expect(files["video"]["samples"]["720p"]["url"]).to be_present
+    end
+
+    it "hides reconstructing file metadata and video samples for login-blocked v2 posts" do
+      post = create(
+        :post,
+        file_ext: "webm",
+        image_width: 1280,
+        image_height: 720,
+        file_size: 5_000_000,
+        hide_from_anonymous: true,
+        video_samples: video_samples,
+      )
+
+      get posts_path(format: :json), params: { v2: "true" }
+      expect(response).to have_http_status(:ok)
+
+      files = response.parsed_body.first["files"]
+      expect(files["meta"]).to include("md5" => nil, "ext" => nil, "size" => post.file_size)
+      expect(files["original"]).to include(
+        "width" => post.image_width,
+        "height" => post.image_height,
+        "url" => nil,
+      )
+      expect(files["preview"]).to include("jpg" => nil, "webp" => nil)
+      expect(files["sample"]).to include("jpg" => nil, "webp" => nil)
+      expect(files).not_to have_key("video")
     end
 
     it "returns a post collection in the extended v2 format when requested" do


### PR DESCRIPTION
## Summary
Login-blocked posts null out their URL fields in the v2 JSON API, but `PostBlueprint` still exposes `files.meta.md5` and `files.meta.ext`, and video posts expose direct sample URLs in `files.video`. With the deterministic `/data/{md5[0..1]}/{md5[2..3]}/{md5}.{ext}` path, that is enough for an anonymous user to reconstruct the full file URL. This change nulls `md5`/`ext` and omits the video sample list when `post.visible?` is false, so the Blueprinter path matches what the legacy serializer already does.

## Why this matters
Sindrake's report in #1827 describes the leak: the legacy serializer path suppresses `md5` and `file_ext` for non-visible posts via `Post::ApiMethods#hidden_attributes` (app/models/post.rb), but the newer Blueprinter path never replicated that behavior, so the v2 API quietly undoes the access control. The fix extends the `post.visible?` guard that already exists in the same `files` block for the URL fields.

Scope note: this covers the API response leak only. The second part of the issue, protecting the static file paths at the serving layer, drew pushback from API consumers in the thread and needs a maintainer decision on an access scheme, so it is intentionally untouched here.

## Testing
New request specs in `spec/requests/posts_controller_spec.rb` cover both directions: a visible v2 post still returns `md5`, `ext`, and the full `files.video` structure, and a login-blocked post returns null `md5`/`ext`, null URLs, intact size/width/height metadata, and no `video` key. The specs follow the existing v2 patterns in that file and run in the dockerized test environment.

Refs #1827

AI was used for assistance.
