### PR TITLE
[Posts] Rework video dimension calculation to use ffprobe directly

### DIFF
--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -123,12 +123,12 @@ module FileMethods
 
   def calculate_dimensions(file_path)
     if is_video?
-      stdout, _stderr, status = Open3.capture3(Danbooru.config.ffprobe_path, "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=width,height", "-of", "csv=p=0:s=x", file_path)
-      unless status == 0
-        Rails.logger.warn("[FFPROBE STDOUT] #{stdout.chomp!}")
-        raise "Could not retrieve video dimensions"
+      stdout, stderr, status = Open3.capture3(Danbooru.config.ffprobe_path, "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=width,height", "-of", "csv=p=0:s=x", file_path)
+      unless status.success?
+        Rails.logger.warn("[FFPROBE STDERR] #{stderr.chomp}")
+        raise Upload::Error, "Could not retrieve video dimensions"
       end
-      stdout.chomp!.split("x").map(&:to_i)
+      stdout.chomp.split("x").map(&:to_i)
     elsif is_image?
       image = Vips::Image.new_from_file(file_path)
       [image.width, image.height]

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -123,9 +123,12 @@ module FileMethods
 
   def calculate_dimensions(file_path)
     if is_video?
-      video = FFMPEG::Movie.new(file_path)
-      [video.width, video.height]
-
+      stdout, _stderr, status = Open3.capture3(Danbooru.config.ffprobe_path, "-v", "error", "-select_streams", "v:0", "-show_entries", "stream=width,height", "-of", "csv=p=0:s=x", file_path)
+      unless status == 0
+        Rails.logger.warn("[FFPROBE STDOUT] #{stdout.chomp!}")
+        raise "Could not retrieve video dimensions"
+      end
+      stdout.chomp!.split("x").map(&:to_i)
     elsif is_image?
       image = Vips::Image.new_from_file(file_path)
       [image.width, image.height]

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -102,6 +102,10 @@ module Danbooru
       "/usr/bin/ffmpeg"
     end
 
+    def ffprobe_path
+      "/usr/bin/ffprobe"
+    end
+
     # Thumbnail size
     def small_image_width
       256

--- a/spec/logical/file_methods/file_utilities_spec.rb
+++ b/spec/logical/file_methods/file_utilities_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe FileMethods, type: :model do
     context "when ffprobe fails to retrieve video dimensions" do
       it "raises an error" do
         upload = build(:upload, file_ext: "mp4")
-        allow(Open3).to receive(:capture3).and_return(["", "ffprobe error", instance_double(Process::Status, success?: false)])
+        allow(Open3).to receive(:capture3).with(Danbooru.config.ffprobe_path, any_args).and_return(["", "ffprobe error", instance_double(Process::Status, success?: false)])
         expect { upload.calculate_dimensions("/path/to/video.mp4") }.to raise_error(Upload::Error, "Could not retrieve video dimensions")
       end
     end

--- a/spec/logical/file_methods/file_utilities_spec.rb
+++ b/spec/logical/file_methods/file_utilities_spec.rb
@@ -81,6 +81,14 @@ RSpec.describe FileMethods, type: :model do
         expect(upload.calculate_dimensions("/nonexistent/path.swf")).to eq([0, 0])
       end
     end
+
+    context "when ffprobe fails to retrieve video dimensions" do
+      it "raises an error" do
+        upload = build(:upload, file_ext: "mp4")
+        allow(Open3).to receive(:capture3).and_return(["", "ffprobe error", instance_double(Process::Status, success?: false)])
+        expect { upload.calculate_dimensions("/path/to/video.mp4") }.to raise_error(Upload::Error, "Could not retrieve video dimensions")
+      end
+    end
   end
 
   # ----------------------------------------------------------------------- #


### PR DESCRIPTION
The previous approach using `FFMPEG::Movile` would deadlock if the error exceeded the `stderr` OS pipe buffer.
Besides, we don't really need the full object anyways, since we are just trying to determine video width and height.