### PR TITLE
[DbExports] Add a legacy export path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -456,15 +456,12 @@ Rails.application.routes.draw do
     end
   end
 
-  # #region Aliases
-  # #region Resource Shorthand
+  # Resource Shorthand
   resources :wpages, controller: "wiki_pages"
   resources :ftopics, controller: "forum_topics"
   resources :fposts, controller: "forum_posts"
-  # #endregion Resource Shorthand
 
-  # #region Legacy aliases
-  # #region Pre-Danbooru Paths
+  # Legacy aliases
   get "/artist" => redirect { |_params, req| "/artists?page=#{req.params[:page]}&search[name]=#{CGI.escape(req.params[:name].to_s)}" }
   get "/artist/index" => redirect { |_params, req| "/artists?page=#{req.params[:page]}" }
   get "/artist/show/:id" => redirect("/artists/%{id}")
@@ -550,9 +547,8 @@ Rails.application.routes.draw do
   get "/wiki/show" => redirect { |_params, req| "/wiki_pages?title=#{CGI.escape(req.params[:title].to_s)}" }
   get "/wiki/recent_changes" => redirect { |_params, req| "/wiki_page_versions?search[updater_id]=#{req.params[:user_id]}" }
   get "/wiki/history/:title" => redirect("/wiki_page_versions?title=%{title}")
-  # #endregion Pre-Danbooru Paths
 
-  # #region Static controller revamp
+  # Static controller routes
   get "/static/keyboard_shortcuts" => "static#keyboard_shortcuts", :as => "keyboard_shortcuts"
   get "/static/site_map" => "static#site_map", :as => "site_map"
   get "/static/privacy" => "static#privacy", as: "privacy_policy"
@@ -568,16 +564,13 @@ Rails.application.routes.draw do
   get "/static/furid" => "static#furid", as: "furid"
   get "/meta_searches/tags" => "meta_searches#tags", :as => "meta_searches_tags"
   get "/robots.txt" => "static#robots", as: :robots
-  # #endregion Static controller revamp
 
-  # #region Misc
+  # Load balancer health checks
   get "status" => "rails/health#show", as: :rails_health_check
   get "health" => "health#index", as: :health_check
+
   # Path before [#2116](https://github.com/e621ng/e621ng/pull/2116)
-  get "/db_export", to: redirect(path: "/db_exports")
-  # #endregion Misc
-  # #endregion Legacy aliases
-  # #endregion Aliases
+  get "/db_export", to: redirect("/db_exports")
 
   root to: "static#home"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -456,12 +456,15 @@ Rails.application.routes.draw do
     end
   end
 
-  # aliases
+  # #region Aliases
+  # #region Resource Shorthand
   resources :wpages, controller: "wiki_pages"
   resources :ftopics, controller: "forum_topics"
   resources :fposts, controller: "forum_posts"
+  # #endregion Resource Shorthand
 
-  # legacy aliases
+  # #region Legacy aliases
+  # #region Pre-Danbooru Paths
   get "/artist" => redirect { |_params, req| "/artists?page=#{req.params[:page]}&search[name]=#{CGI.escape(req.params[:name].to_s)}" }
   get "/artist/index" => redirect { |_params, req| "/artists?page=#{req.params[:page]}" }
   get "/artist/show/:id" => redirect("/artists/%{id}")
@@ -547,7 +550,9 @@ Rails.application.routes.draw do
   get "/wiki/show" => redirect { |_params, req| "/wiki_pages?title=#{CGI.escape(req.params[:title].to_s)}" }
   get "/wiki/recent_changes" => redirect { |_params, req| "/wiki_page_versions?search[updater_id]=#{req.params[:user_id]}" }
   get "/wiki/history/:title" => redirect("/wiki_page_versions?title=%{title}")
+  # #endregion Pre-Danbooru Paths
 
+  # #region Static controller revamp
   get "/static/keyboard_shortcuts" => "static#keyboard_shortcuts", :as => "keyboard_shortcuts"
   get "/static/site_map" => "static#site_map", :as => "site_map"
   get "/static/privacy" => "static#privacy", as: "privacy_policy"
@@ -563,9 +568,16 @@ Rails.application.routes.draw do
   get "/static/furid" => "static#furid", as: "furid"
   get "/meta_searches/tags" => "meta_searches#tags", :as => "meta_searches_tags"
   get "/robots.txt" => "static#robots", as: :robots
+  # #endregion Static controller revamp
 
+  # #region Misc
   get "status" => "rails/health#show", as: :rails_health_check
   get "health" => "health#index", as: :health_check
+  # Path before [#2116](https://github.com/e621ng/e621ng/pull/2116)
+  get "/db_export", to: redirect(path: "/db_exports")
+  # #endregion Misc
+  # #endregion Legacy aliases
+  # #endregion Aliases
 
   root to: "static#home"
 

--- a/spec/requests/db_exports_controller_spec.rb
+++ b/spec/requests/db_exports_controller_spec.rb
@@ -37,4 +37,11 @@ RSpec.describe DbExportsController do
       expect(entry["url"]).to be_present
     end
   end
+
+  describe "GET /db_export" do
+    it "redirects to /db_exports" do
+      get "/db_export"
+      expect(response).to redirect_to("/db_exports")
+    end
+  end
 end


### PR DESCRIPTION
> [!WARNING]
> Made w/ web editor; not tested locally

Old [`/db_export`](https://e621.net/db_export) redirects to new [`/db_exports`](https://e621.net/db_exports) path.