### PR TITLE
[Home] Fix mispositioned forum notification dot

### DIFF
--- a/app/javascript/src/styles/common/navigation.scss
+++ b/app/javascript/src/styles/common/navigation.scss
@@ -488,7 +488,7 @@ body.c-static.a-home {
 
     menu.nav-secondary { display: none; }
 
-    menu.nav-tools { border-radius: .25rem; }
+    menu.nav-tools { border-radius: 0.25rem; }
   }
 
   @include window-smaller-than(50rem) {

--- a/app/javascript/src/styles/common/navigation.scss
+++ b/app/javascript/src/styles/common/navigation.scss
@@ -483,13 +483,12 @@ body.c-static.a-home {
       }
     }
 
-    menu.nav-secondary {
-      display: none;
-    }
+    // Prevents forum notification dot from being disjoint.
+    menu.nav-primary { align-items: center; }
 
-    menu.nav-tools {
-      border-radius: .25rem;
-    }
+    menu.nav-secondary { display: none; }
+
+    menu.nav-tools { border-radius: .25rem; }
   }
 
   @include window-smaller-than(50rem) {


### PR DESCRIPTION
> [!WARNING]
> Made with web editor; not fully tested locally. Testing was done by directly changing the styles in the browser.

Fixes this.
<img width="366" height="108" alt="image" src="https://github.com/user-attachments/assets/f2ec4c10-9bf1-4815-99bc-6b3e9b7fac0b" />
