### PR TITLE
[Autocomplete] Boost results that are inserted frequently

### DIFF
--- a/app/javascript/src/js/components/autocomplete/TagFrequencyCache.ts
+++ b/app/javascript/src/js/components/autocomplete/TagFrequencyCache.ts
@@ -1,0 +1,68 @@
+interface TagFrequencyEntry {
+  count: number;
+  lastUsed: number;
+}
+
+interface TagFrequencyStore {
+  entries: Record<string, TagFrequencyEntry>;
+}
+
+const STORAGE_KEY = "e6.autocomplete.tagfreq";
+const PRUNE_DAYS = 90;
+const MAX_ENTRIES = 500;
+
+export default class TagFrequencyCache {
+  private static _cache: TagFrequencyStore | null = null;
+
+  static record (tag: string): void {
+    const store = this.load();
+    const prev = store.entries[tag];
+    store.entries[tag] = {
+      count: prev ? prev.count + 1 : 1,
+      lastUsed: Date.now(),
+    };
+    this.prune(store);
+    this.save(store);
+  }
+
+  static score (tag: string): number {
+    const store = this.load();
+    const entry = store.entries[tag];
+    if (!entry) return 0;
+    const daysSince = (Date.now() - entry.lastUsed) / 86_400_000;
+    return (Math.log10(entry.count) + 1) / (1 + (daysSince / 30));
+  }
+
+  private static load (): TagFrequencyStore {
+    if (this._cache !== null) return this._cache;
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      this._cache = raw ? JSON.parse(raw) : { entries: {} };
+    } catch {
+      return { entries: {} };
+    }
+    return this._cache;
+  }
+
+  private static save (store: TagFrequencyStore): void {
+    this._cache = store;
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    } catch { /* quota exceeded or unavailable */ }
+  }
+
+  private static prune (store: TagFrequencyStore): void {
+    const cutoff = Date.now() - (PRUNE_DAYS * 86_400_000);
+    for (const key of Object.keys(store.entries)) {
+      if (store.entries[key].lastUsed < cutoff)
+        delete store.entries[key];
+    }
+
+    const keys = Object.keys(store.entries);
+    if (keys.length > MAX_ENTRIES) {
+      keys.sort((a, b) => store.entries[a].lastUsed - store.entries[b].lastUsed);
+      for (const key of keys.slice(0, keys.length - MAX_ENTRIES))
+        delete store.entries[key];
+    }
+  }
+}

--- a/app/javascript/src/js/components/autocomplete/TagFrequencyCache.ts
+++ b/app/javascript/src/js/components/autocomplete/TagFrequencyCache.ts
@@ -1,68 +1,89 @@
-interface TagFrequencyEntry {
-  count: number;
-  lastUsed: number;
-}
-
-interface TagFrequencyStore {
-  entries: Record<string, TagFrequencyEntry>;
-}
-
 const STORAGE_KEY = "e6.autocomplete.tagfreq";
 const PRUNE_DAYS = 90;
 const MAX_ENTRIES = 500;
 
 export default class TagFrequencyCache {
-  private static _cache: TagFrequencyStore | null = null;
 
+  // ========= Public API ========= //
+
+  /**
+   * Records the usage of a tag, incrementing its count and updating its last used timestamp.
+   * @param tag The name of the tag to record usage for
+   */
   static record (tag: string): void {
-    const store = this.load();
-    const prev = store.entries[tag];
-    store.entries[tag] = {
+    const store = this.cache;
+    const prev = store[tag];
+    store[tag] = {
       count: prev ? prev.count + 1 : 1,
       lastUsed: Date.now(),
     };
-    this.prune(store);
-    this.save(store);
+    this.save();
   }
 
+  /**
+   * Computes a score for a tag based on its usage frequency and recency, used for sorting autocomplete results.
+   * @param tag The name of the tag to compute the score for
+   * @returns A numeric score representing the tag's relevance, where higher scores indicate more frequently and recently used tags
+   */
   static score (tag: string): number {
-    const store = this.load();
-    const entry = store.entries[tag];
+    const store = this.cache;
+    const entry = store[tag];
     if (!entry) return 0;
     const daysSince = (Date.now() - entry.lastUsed) / 86_400_000;
     return (Math.log10(entry.count) + 1) / (1 + (daysSince / 30));
   }
 
-  private static load (): TagFrequencyStore {
-    if (this._cache !== null) return this._cache;
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      this._cache = raw ? JSON.parse(raw) : { entries: {} };
-    } catch {
-      return { entries: {} };
+
+  // ====== Cache Management ====== //
+
+  private static _cache: TagFrequencyStore | null = null;
+
+  private static get cache (): TagFrequencyStore {
+    if (this._cache === null) {
+      try { // Load cache from localStorage
+        const raw = localStorage.getItem(STORAGE_KEY);
+        this._cache = raw ? JSON.parse(raw) : {};
+      } catch { this._cache = {}; }
+
+      this.prune(); // Prune old data on load
     }
     return this._cache;
   }
 
-  private static save (store: TagFrequencyStore): void {
-    this._cache = store;
+  private static save (): void {
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.cache));
     } catch { /* quota exceeded or unavailable */ }
   }
 
-  private static prune (store: TagFrequencyStore): void {
+  private static prune (): void {
     const cutoff = Date.now() - (PRUNE_DAYS * 86_400_000);
-    for (const key of Object.keys(store.entries)) {
-      if (store.entries[key].lastUsed < cutoff)
-        delete store.entries[key];
+    const entryCount = Object.keys(this._cache).length;
+    if (entryCount === 0) return;
+
+    // Prune old entries
+    for (const [key, value] of Object.entries(this._cache)) {
+      if (value.lastUsed < cutoff) delete this._cache[key];
     }
 
-    const keys = Object.keys(store.entries);
+    // Prune least recently used if over max entries
+    const keys = Object.keys(this._cache);
     if (keys.length > MAX_ENTRIES) {
-      keys.sort((a, b) => store.entries[a].lastUsed - store.entries[b].lastUsed);
+      keys.sort((a, b) => this._cache[a].lastUsed - this._cache[b].lastUsed);
       for (const key of keys.slice(0, keys.length - MAX_ENTRIES))
-        delete store.entries[key];
+        delete this._cache[key];
     }
+
+    if (entryCount === Object.keys(this._cache).length)
+      return; // No change, skip save
+
+    this.save();
   }
+}
+
+type TagFrequencyStore = Record<string, TagFrequencyEntry>;
+
+interface TagFrequencyEntry {
+  count: number;
+  lastUsed: number;
 }

--- a/app/javascript/src/js/components/autocomplete/TagFrequencyCache.ts
+++ b/app/javascript/src/js/components/autocomplete/TagFrequencyCache.ts
@@ -1,4 +1,4 @@
-const STORAGE_KEY = "e6.autocomplete.tagfreq";
+const STORAGE_KEY = "e6.posts.acache.store";
 const PRUNE_DAYS = 90;
 const MAX_ENTRIES = 500;
 
@@ -57,24 +57,26 @@ export default class TagFrequencyCache {
   }
 
   private static prune (): void {
+    const cache = this.cache; // Ensure cache is loaded
+
     const cutoff = Date.now() - (PRUNE_DAYS * 86_400_000);
-    const entryCount = Object.keys(this._cache).length;
+    const entryCount = Object.keys(cache).length;
     if (entryCount === 0) return;
 
     // Prune old entries
-    for (const [key, value] of Object.entries(this._cache)) {
-      if (value.lastUsed < cutoff) delete this._cache[key];
+    for (const [key, value] of Object.entries(cache)) {
+      if (value.lastUsed < cutoff) delete cache[key];
     }
 
     // Prune least recently used if over max entries
-    const keys = Object.keys(this._cache);
+    const keys = Object.keys(cache);
     if (keys.length > MAX_ENTRIES) {
-      keys.sort((a, b) => this._cache[a].lastUsed - this._cache[b].lastUsed);
+      keys.sort((a, b) => cache[a].lastUsed - cache[b].lastUsed);
       for (const key of keys.slice(0, keys.length - MAX_ENTRIES))
-        delete this._cache[key];
+        delete cache[key];
     }
 
-    if (entryCount === Object.keys(this._cache).length)
+    if (entryCount === Object.keys(cache).length)
       return; // No change, skip save
 
     this.save();

--- a/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
@@ -1,6 +1,8 @@
 import Constants from "@/components/autocomplete/Constants";
 import Provider from "@/components/autocomplete/Provider";
+import TagFrequencyCache from "@/components/autocomplete/TagFrequencyCache";
 import * as Types from "@/components/autocomplete/Types";
+import LStorage from "@/utility/Storage";
 import Utility from "@/utility/utility";
 
 import PoolProvider from "./PoolProvider";
@@ -23,7 +25,16 @@ export default class TagQueryProvider extends Provider<Types.AutocompleteItem> {
     let results: Types.AutocompleteItem[] = [];
     if (parsed.metatag)
       results = await TagQueryProvider.findMetatags(parsed.metatag, parsed.term || "");
-    else results = await TagProvider.findTags(parsed.term);
+    else {
+      results = await TagProvider.findTags(parsed.term);
+      if (LStorage.Posts.AutocompleteCache) {
+        const scores = new Map(results.map((item, index) => [
+          item.name,
+          (results.length - index) + TagFrequencyCache.score(item.name),
+        ]));
+        results = results.slice().sort((a, b) => (scores.get(b.name) ?? 0) - (scores.get(a.name) ?? 0));
+      }
+    }
 
     if (parsed.prefix)
       results = results.map(item => ({
@@ -67,6 +78,10 @@ export default class TagQueryProvider extends Provider<Types.AutocompleteItem> {
   }
 
   public insert (input: HTMLInputElement, completion: string) {
+    const bareName = completion.replace(Constants.TAG_PREFIXES_REGEX, "$2");
+    if (!bareName.includes(":") && LStorage.Posts.AutocompleteCache)
+      TagFrequencyCache.record(bareName);
+
     const beforeCaret = input.value.substring(0, input.selectionStart).trim();
     const afterCaret = input.value.substring(input.selectionStart).trim();
 

--- a/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
@@ -32,7 +32,7 @@ export default class TagQueryProvider extends Provider<Types.AutocompleteItem> {
           item.name,
           (results.length - index) + TagFrequencyCache.score(item.name),
         ]));
-        results = results.slice().sort((a, b) => (scores.get(b.name) ?? 0) - (scores.get(a.name) ?? 0));
+        results = results.sort((a, b) => (scores.get(b.name) ?? 0) - (scores.get(a.name) ?? 0));
       }
     }
 

--- a/app/javascript/src/js/core/themes.js
+++ b/app/javascript/src/js/core/themes.js
@@ -6,7 +6,7 @@ const Theme = {};
 
 Theme.Values = {
   "Theme": ["Main", "Extra", "Palette", "Font", "StickyHeader", "Navbar", "Gestures", "Logo"],
-  "Posts": ["WikiExcerpt", "StickySearch"],
+  "Posts": ["WikiExcerpt", "StickySearch", "AutocompleteCache"],
   "Site": ["Events"],
 };
 

--- a/app/javascript/src/js/utility/Storage.ts
+++ b/app/javascript/src/js/utility/Storage.ts
@@ -39,6 +39,7 @@ export default class LStorage {
     HoverText: "long" as "short" | "long" | "none",
     TagPreview: true,
     Recommendations: "artist" as "artist" | "tags",
+    AutocompleteCache: true,
 
     TagScript: {
       ID: 1,
@@ -115,6 +116,7 @@ const StorageKeys: StorageConfig = {
     HoverText: "e6.posts.hovertext",
     TagPreview: "e6.posts.tagpreview",
     Recommendations: "e6.posts.recommended.type",
+    AutocompleteCache: "e6.posts.acache",
 
     TagScript: {
       ID: "current_tag_script_id",

--- a/app/views/static/theme.html.erb
+++ b/app/views/static/theme.html.erb
@@ -107,6 +107,13 @@
       <option value="2">Disabled</option>
     </select>
 
+    <label for="Posts_AutocompleteCache">Autocomplete Memory</label>
+    <select id="Posts_AutocompleteCache">
+      <option value="true">Enabled</option>
+      <option value="false">Disabled</option>
+    </select>
+    <div class="hint">When enabled, autocomplete will prioritize tags you use more frequently.</div>
+
 
   <h3>Navigation</h3>
     <label for="Theme_StickyHeader">Sticky Header</label>


### PR DESCRIPTION
New attempt at fixing the autocomplete issues.

<img width="451" height="184" alt="image" src="https://github.com/user-attachments/assets/fa55df77-c5c4-48fe-81cb-e63f354d30f4" />

The more someone uses the autocomplete to insert suggestions, the higher those suggestions appear in the list.
Uses a logarithmic scale, to make this process a bit smoother.
Includes auto-pruning: if you haven't inserted something in 90 days, it will be removed from memory.
Has a toggle in the Themes menu.