### PR TITLE
[Users] Add a generic "Staff" role

### DIFF
--- a/app/components/post_thumbnail_component.rb
+++ b/app/components/post_thumbnail_component.rb
@@ -47,7 +47,7 @@ class PostThumbnailComponent < ViewComponent::Base
   end
 
   def should_render_image?
-    !@post.is_deleted? || @user&.is_janitor? || @user&.can_approve_posts?
+    !@post.is_deleted? || @user&.is_staff? || @user&.can_approve_posts?
   end
 
   ##############################
@@ -120,7 +120,7 @@ class PostThumbnailComponent < ViewComponent::Base
     @tooltip_text ||= begin
       tooltip = "Rating: #{@post.rating}\nID: #{@post.id}\nDate: #{@post.created_at}\nStatus: #{@post.status}\nScore: #{@post.score}"
 
-      if @user.present? && @user.is_janitor?
+      if @user.present? && @user.is_staff?
         tooltip += "\nUploader: #{@post.uploader_name}"
         if @post.is_flagged? || @post.is_deleted?
           flag = @post.flags.order(id: :desc).first

--- a/app/controllers/admin/automod_dmails_controller.rb
+++ b/app/controllers/admin/automod_dmails_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class AutomodDmailsController < ApplicationController
     respond_to :html, :json
-    before_action :janitor_only
+    before_action :staff_only
 
     def index
       @user = User.system

--- a/app/controllers/admin/exceptions_controller.rb
+++ b/app/controllers/admin/exceptions_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class ExceptionsController < ApplicationController
     respond_to :json, :html
-    before_action :janitor_only
+    before_action :staff_only
 
     def index
       @exception_logs = ExceptionLog.search(search_params).includes(:user).paginate(params[:page], limit: 100)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -82,7 +82,7 @@ module Admin
       @user = User.find(params[:id])
 
       if @user.is_staff? && !CurrentUser.user.is_bd_staff?
-        redirect_to user_path(@user), alert: "Only BD staff can request password resets for staff accounts"
+        return redirect_to user_path(@user), alert: "Only BD staff can request password resets for staff accounts" # rubocop:disable Style/RedundantReturn
       end
     end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -3,7 +3,7 @@
 module Admin
   class UsersController < ApplicationController
     before_action :admin_only
-    before_action :is_bd_staff_only, only: %i[request_password_reset password_reset anonymize anonymize_confirm]
+    before_action :is_bd_staff_only, only: %i[anonymize anonymize_confirm]
     before_action :requires_reauthentication, only: %i[anonymize_confirm]
     respond_to :html, :json
 
@@ -80,10 +80,18 @@ module Admin
 
     def request_password_reset
       @user = User.find(params[:id])
+
+      if @user.is_staff? && !CurrentUser.user.is_bd_staff?
+        redirect_to user_path(@user), alert: "Only BD staff can request password resets for staff accounts"
+      end
     end
 
     def password_reset
       @user = User.find(params[:id])
+
+      if @user.is_staff? && !CurrentUser.user.is_bd_staff?
+        redirect_to user_path(@user), alert: "Only BD staff can request password resets for staff accounts"
+      end
 
       unless User.authenticate(CurrentUser.name, params[:admin][:password])
         return redirect_to request_password_reset_admin_user_path(@user), notice: "Password wrong"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -90,7 +90,7 @@ module Admin
       @user = User.find(params[:id])
 
       if @user.is_staff? && !CurrentUser.user.is_bd_staff?
-        redirect_to user_path(@user), alert: "Only BD staff can request password resets for staff accounts"
+        return redirect_to user_path(@user), alert: "Only BD staff can request password resets for staff accounts"
       end
 
       unless User.authenticate(CurrentUser.name, params[:admin][:password])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -162,7 +162,7 @@ class ApplicationController < ActionController::Base
     @backtrace = Rails.backtrace_cleaner.clean(@exception.backtrace)
     format = :html unless format.in?(%i[html json atom])
 
-    if !CurrentUser.user.is_janitor? && message == exception.message
+    if !CurrentUser.user.is_staff? && message == exception.message
       @message = "An unexpected error occurred."
     end
 

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -124,7 +124,7 @@ class ArtistsController < ApplicationController
 
   def artist_params
     permitted_params = %i[name other_names other_names_string group_name url_string notes]
-    permitted_params += %i[linked_user_id is_locked] if CurrentUser.is_janitor?
+    permitted_params += %i[linked_user_id is_locked] if CurrentUser.is_staff?
 
     params.fetch(:artist, {}).permit(permitted_params)
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -169,7 +169,7 @@ class CommentsController < ApplicationController
   def comment_params(context)
     permitted_params = %i[body]
     permitted_params += %i[do_not_bump_post post_id] if context == :create
-    permitted_params += %i[is_sticky] if CurrentUser.is_janitor?
+    permitted_params += %i[is_sticky] if CurrentUser.is_staff?
     permitted_params += %i[is_hidden] if CurrentUser.is_moderator?
 
     params.fetch(:comment, {}).permit(permitted_params)

--- a/app/controllers/concerns/render_partial_safely.rb
+++ b/app/controllers/concerns/render_partial_safely.rb
@@ -11,7 +11,7 @@ module RenderPartialSafely
     logger.error("Partial render failed: #{e.class} - #{e.message}")
     logger.error(e.backtrace.join("\n")) if Rails.env.development?
 
-    message = if request.local? || CurrentUser.user&.is_janitor?
+    message = if request.local? || CurrentUser.user&.is_staff?
                 "#{e.class}: #{e.message}"
               else
                 "An unexpected error occurred while updating the page."

--- a/app/controllers/moderator/dashboards_controller.rb
+++ b/app/controllers/moderator/dashboards_controller.rb
@@ -2,7 +2,7 @@
 
 module Moderator
   class DashboardsController < ApplicationController
-    before_action :janitor_only
+    before_action :staff_only
 
     def show
       @dashboard = Moderator::Dashboard::Report.new(params[:min_date] || 2.days.ago.to_date, params[:max_level] || 20)

--- a/app/controllers/moderator/post_diffs_controller.rb
+++ b/app/controllers/moderator/post_diffs_controller.rb
@@ -2,7 +2,7 @@
 
 module Moderator
   class PostDiffsController < ApplicationController
-    before_action :janitor_only
+    before_action :staff_only
 
     def show
       return unless params[:post_a].present? && params[:post_b].present?

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -3,7 +3,7 @@
 class PoolsController < ApplicationController
   respond_to :html, :json
   before_action :member_only, except: %i[index show gallery]
-  before_action :janitor_only, only: %i[destroy]
+  before_action :staff_only, only: %i[destroy]
   before_action :ensure_lockdown_disabled, except: %i[index show gallery]
 
   def index

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -251,7 +251,7 @@ class PostsController < ApplicationController
       edit_reason
     ]
     permitted_params += %i[is_rating_locked] if CurrentUser.is_privileged?
-    permitted_params += %i[is_note_locked bg_color] if CurrentUser.is_janitor?
+    permitted_params += %i[is_note_locked bg_color] if CurrentUser.is_staff?
     permitted_params += %i[is_comment_locked] if CurrentUser.is_moderator?
     permitted_params += %i[is_status_locked is_comment_disabled locked_tags hide_from_anonymous hide_from_search_engines hide_favorites_list] if CurrentUser.is_admin?
 

--- a/app/controllers/tag_corrections_controller.rb
+++ b/app/controllers/tag_corrections_controller.rb
@@ -2,7 +2,7 @@
 
 class TagCorrectionsController < ApplicationController
   respond_to :html, :json
-  before_action :janitor_only, only: %i[new create]
+  before_action :staff_only, only: %i[new create]
 
   def show
     @correction = TagCorrection.new(params[:tag_id])

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -3,7 +3,7 @@
 class TicketsController < ApplicationController
   respond_to :html, :json, except: %i[create new]
   before_action :member_only, except: %i[index]
-  before_action :janitor_only, only: %i[update claim unclaim]
+  before_action :staff_only, only: %i[update claim unclaim]
 
   def index
     @tickets = Ticket

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -2,7 +2,7 @@
 
 class UploadsController < ApplicationController
   before_action :member_only
-  before_action :janitor_only, only: [:index, :show]
+  before_action :staff_only, only: [:index, :show]
   before_action :ensure_uploads_enabled, only: %i[new create]
   respond_to :html, :json
   content_security_policy only: [:new] do |p|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   skip_before_action :api_check
   before_action :logged_in_only, only: %i[edit settings upload_limit update]
   before_action :member_only, only: %i[custom_style avatar_menu]
-  before_action :janitor_only, only: %i[toggle_uploads fix_counts]
+  before_action :janitor_only, only: %i[toggle_uploads disable_uploads fix_counts]
   before_action :admin_only, only: %i[flush_favorites]
   before_action :check_upload_disable_reason, only: %i[disable_uploads]
 

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -112,7 +112,7 @@ class WikiPagesController < ApplicationController
   private
 
   def ensure_can_edit(page, user)
-    return if user.is_janitor?
+    return if user.is_staff?
     raise User::PrivilegeError, "Wiki page is locked." if page.is_locked
   end
 
@@ -126,9 +126,9 @@ class WikiPagesController < ApplicationController
   def wiki_page_params(context)
     permitted_params = %i[body category_id edit_reason]
     permitted_params += %i[parent] if CurrentUser.is_privileged?
-    permitted_params += %i[is_locked is_deleted skip_secondary_validations] if CurrentUser.is_janitor?
+    permitted_params += %i[is_locked is_deleted skip_secondary_validations] if CurrentUser.is_staff?
     permitted_params += %i[category_is_locked] if CurrentUser.is_admin?
-    permitted_params += %i[title] if context == :create || CurrentUser.is_janitor?
+    permitted_params += %i[title] if context == :create || CurrentUser.is_staff?
 
     params.fetch(:wiki_page, {}).permit(permitted_params)
   end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -43,7 +43,7 @@ module PostsHelper
       short_url = url.omit(:scheme).to_s.sub(%r{^/+}, "").sub(%r{/+$}, "")
       source_link = decorated_link_to(short_url, url.to_s, target: "_blank", rel: "nofollow noreferrer noopener")
 
-      if CurrentUser.is_janitor?
+      if CurrentUser.is_staff?
         # remove ?query=test#example
         url_no_final_path = url.omit(:query, :fragment)
         # remove last /part

--- a/app/javascript/src/js/components/ThumbnailEngine.ts
+++ b/app/javascript/src/js/components/ThumbnailEngine.ts
@@ -61,7 +61,7 @@ export default class ThumbnailEngine {
       })
       .appendTo(article);
 
-    if (!post.isUnavailable && (!post.isDeleted || User.is.janitor))
+    if (!post.isUnavailable && (!post.isDeleted || User.is.staff))
       link.append(this.renderPicture(post));
 
     // Footer

--- a/app/javascript/src/js/models/User.js
+++ b/app/javascript/src/js/models/User.js
@@ -71,6 +71,7 @@ export default class User {
         privileged: data.userIsPrivileged === "true",
         formerStaff: data.userIsFormerStaff === "true",
 
+        staff: data.userIsStaff === "true",
         janitor: data.userIsJanitor === "true",
         moderator: data.userIsModerator === "true",
         admin: data.userIsAdmin === "true",

--- a/app/javascript/src/styles/common/user_styles.scss
+++ b/app/javascript/src/styles/common/user_styles.scss
@@ -1,11 +1,12 @@
 $levels: (
-  "blocked"
-  "member"
-  "privileged"
-  "former-staff"
-  "janitor"
-  "moderator"
-  "admin"
+  "blocked",
+  "member",
+  "privileged",
+  "former-staff",
+  "staff",
+  "janitor",
+  "moderator",
+  "admin",
 );
 
 @each $level in $levels {

--- a/app/javascript/src/styles/themes/_theme_hexagon.scss
+++ b/app/javascript/src/styles/themes/_theme_hexagon.scss
@@ -73,6 +73,9 @@ body[data-th-main="hexagon"] {
 
   --color-user-former-staff:      #78dca5;
   --color-user-former-staff-alt:  #4da073;
+
+  --color-user-staff:             #d82828;
+  --color-user-staff-alt:         #cc5151;
   --color-user-janitor:           #d82828;
   --color-user-janitor-alt:       #cc5151;
   --color-user-moderator:         #d82828;

--- a/app/logical/user_level.rb
+++ b/app/logical/user_level.rb
@@ -6,10 +6,11 @@ module UserLevel
     "Blocked" => 10,
     "Member" => 20,
     "Privileged" => 30,
-    "Former Staff" => 34,
-    "Janitor" => 35,
-    "Moderator" => 40,
-    "Admin" => 50,
+    "Former Staff" => 40,
+    "Staff" => 50,
+    "Janitor" => 60,
+    "Moderator" => 70,
+    "Admin" => 80,
   }.freeze
   REVERSE_MAPPING = MAPPING.invert.freeze
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -140,7 +140,7 @@ class Appeal < ApplicationRecord
     end
 
     def visible(user)
-      if user.is_janitor?
+      if user.is_staff?
         all
       else
         for_creator(user.id)
@@ -206,7 +206,7 @@ class Appeal < ApplicationRecord
 
   def can_view?(user = CurrentUser.user)
     # Should not happen - individual ticket types override this method.
-    return true if user.is_janitor?
+    return true if user.is_staff?
     return true if user.id == creator_id
     false
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -398,7 +398,7 @@ class Artist < ApplicationRecord
     end
 
     def validate_user_can_edit
-      return if CurrentUser.is_janitor?
+      return if CurrentUser.is_staff?
 
       if is_locked?
         errors.add(:base, "Artist is locked")
@@ -407,7 +407,7 @@ class Artist < ApplicationRecord
     end
 
     def wiki_page_not_locked
-      return if CurrentUser.is_janitor?
+      return if CurrentUser.is_staff?
 
       if @notes.present? && is_note_locked? && wiki_page&.body != @notes
         errors.add(:base, "Wiki page is locked")
@@ -546,7 +546,7 @@ class Artist < ApplicationRecord
   end
 
   def editable_by?(user)
-    return true if user.is_janitor?
+    return true if user.is_staff?
     !is_locked?
   end
 
@@ -564,7 +564,7 @@ class Artist < ApplicationRecord
   end
 
   def is_note_locked?
-    return false if CurrentUser.is_janitor?
+    return false if CurrentUser.is_staff?
     wiki_page&.is_locked? || false
   end
 

--- a/app/models/avoid_posting_version.rb
+++ b/app/models/avoid_posting_version.rb
@@ -21,7 +21,7 @@ class AvoidPostingVersion < ApplicationRecord
   module ApiMethods
     def hidden_attributes
       attr = super
-      attr += %i[staff_notes] unless CurrentUser.is_janitor?
+      attr += %i[staff_notes] unless CurrentUser.is_staff?
       attr
     end
   end

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -152,7 +152,7 @@ class Dmail < ApplicationRecord
     # System user must be able to send dmails at a very high rate, do not rate limit the system user.
     return true if bypass_limits == true
     return true if from_id == User.system.id
-    return true if from.is_janitor?
+    return true if from.is_staff?
 
     allowed = CurrentUser.can_dmail_with_reason
     if allowed != true
@@ -176,12 +176,12 @@ class Dmail < ApplicationRecord
       return false
     end
     return true if from_id == User.system.id
-    return true if from.is_janitor?
+    return true if from.is_staff?
     if to.disable_user_dmails
       errors.add(:to_name, "has disabled DMails")
       return false
     end
-    if from.disable_user_dmails && !to.is_janitor?
+    if from.disable_user_dmails && !to.is_staff?
       errors.add(:to_name, "is not a valid recipient while blocking DMails from others. You may only message janitors and above")
       return false
     end

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -236,7 +236,7 @@ class ModAction < ApplicationRecord
         sanitized_values = sanitized_values.slice("ticket_id")
       end
 
-      if !CurrentUser.is_janitor? && %i[appeal_update].include?(action.to_sym)
+      if !CurrentUser.is_staff? && %i[appeal_update].include?(action.to_sym)
         sanitized_values = sanitized_values.slice("appeal_id")
       end
 

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -195,7 +195,7 @@ class Pool < ApplicationRecord
   end
 
   def deletable_by?(user)
-    user.is_janitor?
+    user.is_staff?
   end
 
   def create_mod_action_for_delete
@@ -359,7 +359,7 @@ class Pool < ApplicationRecord
   end
 
   def category_changeable_by?(user)
-    user.is_janitor? || (user.is_member? && post_count <= Danbooru.config.pool_category_change_limit)
+    user.is_staff? || (user.is_member? && post_count <= Danbooru.config.pool_category_change_limit)
   end
 
   def updater_can_change_category

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1054,7 +1054,7 @@ class Post < ApplicationRecord
           self.rating = $1
 
         when /^(-?)locked:notes?$/i
-          self.is_note_locked = ($1 != "-") if CurrentUser.is_janitor?
+          self.is_note_locked = ($1 != "-") if CurrentUser.is_staff?
 
         when /^(-?)locked:rating$/i
           self.is_rating_locked = ($1 != "-") if CurrentUser.is_privileged?

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -145,7 +145,7 @@ class PostFlag < ApplicationRecord
       errors.add(:creator, "cannot flag posts")
     end
 
-    return if creator.is_janitor?
+    return if creator.is_staff?
 
     allowed = creator.can_post_flag_with_reason
     if allowed != true

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -109,8 +109,8 @@ class PostReplacement < ApplicationRecord
       throw :abort
     end
 
-    # Janitor bypass replacement limits
-    return true if creator.is_janitor?
+    # Staff bypass replacement limits
+    return true if creator.is_staff?
 
     if post.replacements.where(creator_id: creator.id).where("created_at > ?", 1.day.ago).count >= Danbooru.config.post_replacement_per_day_limit
       errors.add(:creator, "has already suggested too many replacements for this post today")
@@ -415,7 +415,7 @@ class PostReplacement < ApplicationRecord
 
       def visible(user)
         return where.not(status: "rejected") if user.is_logged_out?
-        return all if user.is_janitor?
+        return all if user.is_staff?
         where("creator_id = ? or status != ?", user.id, "rejected")
       end
     end
@@ -431,7 +431,7 @@ class PostReplacement < ApplicationRecord
   end
 
   def original_file_visible_to?(user)
-    user.is_janitor?
+    user.is_staff?
   end
 
   def upload_as_pending?

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -116,7 +116,7 @@ class PostSet < ApplicationRecord
     end
 
     def can_make_public
-      if is_public && creator.younger_than(3.days) && !creator.is_janitor?
+      if is_public && creator.younger_than(3.days) && !creator.is_staff?
         errors.add(:base, "Can't make a set public until your account is at least three days old")
         false
       else
@@ -133,7 +133,7 @@ class PostSet < ApplicationRecord
     end
 
     def set_per_hour_limit
-      if PostSet.where("created_at > ? AND creator_id = ?", 1.hour.ago, creator.id).count > 6 && !creator.is_janitor?
+      if PostSet.where("created_at > ? AND creator_id = ?", 1.hour.ago, creator.id).count > 6 && !creator.is_staff?
         errors.add(:base, "You have already created 6 sets in the last hour.")
         false
       else

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -400,7 +400,7 @@ class Tag < ApplicationRecord
   end
 
   def category_editable_by_implicit?(user)
-    return false unless user.is_janitor?
+    return false unless user.is_staff?
     return false if is_locked?
     return false if post_count >= Danbooru.config.tag_type_change_cutoff
     true

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -307,7 +307,7 @@ class Ticket < ApplicationRecord
     def visible(user)
       if user.is_moderator?
         all
-      elsif user.is_janitor?
+      elsif user.is_staff?
         for_creator(user.id).or(where.not(qtype: %w[dmail user]))
       else
         for_creator(user.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -378,10 +378,6 @@ class User < ApplicationRecord
       is_bd_staff
     end
 
-    def is_staff?
-      is_janitor?
-    end
-
     def is_artist?
       @is_artist ||= artists.any?
     end
@@ -406,7 +402,7 @@ class User < ApplicationRecord
     end
 
     def staff_cant_disable_dmail
-      self.disable_user_dmails = false if is_janitor?
+      self.disable_user_dmails = false if is_staff?
     end
 
     def level_css_class
@@ -561,9 +557,9 @@ class User < ApplicationRecord
     create_user_throttle(:wiki_edit, -> { Danbooru.config.wiki_edit_limit - WikiPageVersion.for_user(id).where("updated_at > ?", 1.hour.ago).count },
                          :general_bypass_throttle?, 7.days)
     create_user_throttle(:pool, -> { Danbooru.config.pool_limit - Pool.for_user(id).where("created_at > ?", 1.hour.ago).count },
-                         :is_janitor?, 7.days)
+                         :is_staff?, 7.days)
     create_user_throttle(:pool_edit, -> { Danbooru.config.pool_edit_limit - PoolVersion.for_user(id).where("updated_at > ?", 1.hour.ago).count },
-                         :is_janitor?, 3.days)
+                         :is_staff?, 3.days)
     create_user_throttle(:pool_post_edit, -> { Danbooru.config.pool_post_edit_limit - PoolVersion.for_user(id).where("updated_at > ?", 1.hour.ago).group(:pool_id).count(:pool_id).length },
                          :general_bypass_throttle?, 7.days)
     create_user_throttle(:note_edit, -> { Danbooru.config.note_edit_limit - NoteVersion.for_user(id).where("updated_at > ?", 1.hour.ago).count },
@@ -636,9 +632,9 @@ class User < ApplicationRecord
     )
 
     create_user_throttle(:suggest_tag, -> { Danbooru.config.tag_suggestion_limit - (TagAlias.for_creator(id).where("created_at > ?", 1.hour.ago).count + TagImplication.for_creator(id).where("created_at > ?", 1.hour.ago).count + BulkUpdateRequest.for_creator(id).where("created_at > ?", 1.hour.ago).count) },
-                         :is_janitor?, 7.days)
+                         :is_staff?, 7.days)
     create_user_throttle(:forum_vote, -> { Danbooru.config.forum_vote_limit - ForumPostVote.by(id).where("created_at > ?", 1.hour.ago).count },
-                         :is_janitor?, 3.days)
+                         :is_staff?, 3.days)
 
     def can_remove_from_pools?
       is_member? && older_than(7.days)
@@ -649,15 +645,15 @@ class User < ApplicationRecord
     end
 
     def can_view_flagger?(flagger_id)
-      is_janitor? || flagger_id == id
+      is_staff? || flagger_id == id
     end
 
     def can_view_flagger_on_post?(flag)
-      is_janitor? || flag.creator_id == id || flag.is_deletion
+      is_staff? || flag.creator_id == id || flag.is_deletion
     end
 
     def can_replace?
-      is_janitor? || replacements_beta?
+      is_staff? || replacements_beta?
     end
 
     def can_view_staff_notes?

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -249,7 +249,7 @@ class WikiPage < ApplicationRecord
   end
 
   def validate_not_locked
-    if is_locked? && !CurrentUser.is_janitor?
+    if is_locked? && !CurrentUser.is_staff?
       errors.add(:is_locked, "and cannot be updated")
       false
     end

--- a/app/views/appeals/show.html.erb
+++ b/app/views/appeals/show.html.erb
@@ -120,7 +120,7 @@
     <% end %>
   </div>
 
-  <% if CurrentUser.is_staff? && @appeal.can_handle? %>
+  <% if @appeal.can_handle? %>
     <%= custom_form_for(@appeal, html: { class: "appeal-display-response" }) do |f| %>
       <%= f.input :status, collection: [%w[Approved approved], %w[Investigating partial], %w[Rejected rejected]], selected: @appeal.status || "approved" %>
       <% unless @appeal.pending? %>

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -2,7 +2,7 @@
   <% if @artist.new_record? %>
     <%# FIXME: Probably wrong type in the production database %>
     <%= f.input :name, as: :string, autocomplete: "tag" %>
-  <% elsif !@artist.dnp_restricted? && CurrentUser.user.is_janitor? %>
+  <% elsif !@artist.dnp_restricted? && CurrentUser.user.is_staff? %>
     <%= f.input :name, autocomplete: "tag", hint: "Change to rename this artist entry and its wiki page." %>
   <% else %>
     <p><%= @artist.name %></p>
@@ -10,7 +10,7 @@
       <p>Name, other names, and group name cannot be edited for artists on the <%= link_to "Avoid Posting", avoid_posting_static_path %> list.</p>
     <% end %>
   <% end %>
-  <% if CurrentUser.is_janitor? %>
+  <% if CurrentUser.is_staff? %>
     <%= f.input :linked_user_id, label: "Linked User ID" %>
     <%= f.input :is_locked, label: "Locked" %>
   <% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -11,7 +11,7 @@
   <% if comment.new_record? %>
     <%= f.input :do_not_bump_post, :label => "No bump" %>
   <% end %>
-  <% if CurrentUser.is_janitor? %>
+  <% if CurrentUser.is_staff? %>
     <%= f.input :is_sticky, label: "Sticky" %>
   <% end %>
 <% end %>

--- a/app/views/comments/_index_by_post.html.erb
+++ b/app/views/comments/_index_by_post.html.erb
@@ -1,5 +1,5 @@
 <div id="p-index-by-post">
-  <% if !CurrentUser.user.is_janitor? %>
+  <% if !CurrentUser.user.is_staff? %>
     <div style="margin-bottom: 1em;">
       <h2>Before commenting, read the <%= link_to "how to comment guide", wiki_pages_path(:search => {:title => "howto:comment"}) %>.</h2>
     </div>

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -44,7 +44,7 @@
   <% if (post.is_comment_locked? || post.is_comment_disabled?) && !CurrentUser.user.is_moderator? %>
   <% elsif CurrentUser.user.is_member? %>
     <div class="new-comment">
-      <% if CurrentUser.user.is_logged_in? && !CurrentUser.user.is_janitor? %>
+      <% if CurrentUser.user.is_logged_in? && !CurrentUser.user.is_staff? %>
         <h2>Before commenting, read the <%= link_to "how to comment guide", wiki_pages_path(:search => {:title => "howto:comment"}) %>.</h2>
       <% end %>
       <p><%= link_to "Post comment", new_comment_path(comment: { post_id: post.id }), :class => "expand-comment-response" %></p>

--- a/app/views/help/_secondary_links.html.erb
+++ b/app/views/help/_secondary_links.html.erb
@@ -10,7 +10,7 @@
       <%= subnav_link_to "Edit", edit_help_page_path(@help) %>
       <%= subnav_link_to "Delete", help_page_path(@help), method: :delete, data: { confirm: "Are you sure you want to delete this entry?" } %>
     <% end %>
-    <% if CurrentUser.is_janitor? %>
+    <% if CurrentUser.is_staff? %>
       <%= subnav_link_to "Edit Wiki Page", edit_wiki_page_path(id: @help.wiki_page) %>
     <% end %>
 

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -7,7 +7,7 @@
     ["Deletion", "deletion"],
   ], include_blank: true %>
   <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true %>
-  <% if CurrentUser.is_janitor? %>
+  <% if CurrentUser.is_staff? %>
     <%= f.input :note %>
     <%= f.user :creator %>
   <% end %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -35,7 +35,7 @@
                 <div class="post-flag-note">
                   <div class="post-flag-note-header"><%= svg_icon(:chevron_right) %> Notes</div>
                   <div class="dtext-container post-flag-note-body">
-                    <% if CurrentUser.is_staff? %>
+                    <% if CurrentUser.is_janitor? %>
                       <%= link_to svg_icon(:trash), clear_note_post_flag_path(post_flag), method: :post, data: { confirm: "Are you sure you want to clear this note?" }, class: "post-flag-clear-note-link" %>
                     <% end %>
                     <%= format_text post_flag.note %>

--- a/app/views/posts/partials/index/_mode_menu.html.erb
+++ b/app/views/posts/partials/index/_mode_menu.html.erb
@@ -16,7 +16,7 @@
         <option value="rating-e">Rate Explicit</option>
         <option value="tag-script">Tag script</option>
       <% end %>
-      <% if CurrentUser.is_janitor? %>
+      <% if CurrentUser.is_staff? %>
         <option value="remove-parent">Remove Parent</option>
         <option value="lock-rating">Lock rating</option>
         <option value="lock-note">Lock notes</option>

--- a/app/views/posts/partials/show/content/_edit.html.erb
+++ b/app/views/posts/partials/show/content/_edit.html.erb
@@ -6,7 +6,7 @@
     <button type="button" class="st-button" id="post-edit-close"><%= svg_icon(:times) %><span>Cancel</span></button>
   </h3>
 
-  <% unless CurrentUser.user.is_janitor? %>
+  <% unless CurrentUser.user.is_staff? %>
     <div style="margin-bottom: 0.5rem;">
       <p>Before editing, read the <%= link_to "how to tag guide", wiki_page_path(id: "e621:tags") %>.</p>
     </div>
@@ -60,7 +60,7 @@
       <%= f.label :blank, "Lock" %>
 
       <fieldset class="locks">
-        <% if CurrentUser.is_janitor? %>
+        <% if CurrentUser.is_staff? %>
           <%= f.input :is_note_locked, label: "Notes" %>
         <% end %>
         <%= f.input :is_rating_locked, label: "Rating" %>
@@ -74,7 +74,7 @@
     </div>
   <% end %>
 
-  <% if CurrentUser.is_janitor? %>
+  <% if CurrentUser.is_staff? %>
     <%= f.input :bg_color, label: "Background Color", input_html: { size: 10 } %>
   <% end %>
 

--- a/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
+++ b/app/views/posts/partials/show/content/notices/_flag_reasons.html.erb
@@ -25,7 +25,7 @@
         <div class="post-flag-note">
           <div class="post-flag-note-header"><%= svg_icon(:chevron_right) %> Notes</div>
           <div class="dtext-container post-flag-note-body">
-            <% if CurrentUser.user.is_staff? %>
+            <% if CurrentUser.user.is_janitor? %>
               <%= link_to svg_icon(:trash), clear_note_post_flag_path(flag), method: :post, data: { confirm: "Are you sure you want to clear this note?" }, class: "post-flag-clear-note-link" %>
             <% end %>
             <%= format_text flag.note %>

--- a/app/views/posts/partials/show/sidebar/_information.html.erb
+++ b/app/views/posts/partials/show/sidebar/_information.html.erb
@@ -77,9 +77,9 @@
     Posted: <%= link_to time_ago_in_words_tagged(post.created_at), posts_path(tags: "date:#{post.created_at.to_date}"), rel: "nofollow" %>
     <meta itemprop="uploadDate" content="<%= post.created_at.iso8601 %>">
   </li>
-  <% if CurrentUser.is_janitor? || post.uploader_linked_artists.any? %>
+  <% if CurrentUser.is_staff? || post.uploader_linked_artists.any? %>
     <li>
-      Uploader: <%= link_to_user(post.uploader) %> <%= render(UserFeedbackComponent.new(user: post.uploader, style: :inline)) if CurrentUser.is_janitor? %>
+      Uploader: <%= link_to_user(post.uploader) %> <%= render(UserFeedbackComponent.new(user: post.uploader, style: :inline)) if CurrentUser.is_staff? %>
       <% if post.uploader_linked_artists.any? %>
         <%= svg_icon(:chexagon, class: "chexagon", title: "The uploader is linked to one of the artist tags") %>
       <% end %>

--- a/app/views/posts/partials/show/sidebar/_options.html.erb
+++ b/app/views/posts/partials/show/sidebar/_options.html.erb
@@ -58,7 +58,7 @@
         <li><%= tag.a "Destroy", href: "#", id: "destroy-post-link", data: { pid: post.id } %></li>
       <% end %>
     <% end %>
-    <% if CurrentUser.is_staff? %>
+    <% if CurrentUser.is_janitor? %>
       <li><%= tag.a "Regenerate Thumbnails", href: "#", id: "regenerate-image-samples-link", data: { pid: post.id } %></li>
       <% if post.is_video? %>
         <li><%= tag.a "Regenerate Video Samples", href: "#", id: "regenerate-video-samples-link", data: { pid: post.id } %></li>

--- a/app/views/posts/partials/show/sidebar/_options.html.erb
+++ b/app/views/posts/partials/show/sidebar/_options.html.erb
@@ -58,7 +58,7 @@
         <li><%= tag.a "Destroy", href: "#", id: "destroy-post-link", data: { pid: post.id } %></li>
       <% end %>
     <% end %>
-    <% if CurrentUser.is_janitor? %>
+    <% if CurrentUser.is_staff? %>
       <li><%= tag.a "Regenerate Thumbnails", href: "#", id: "regenerate-image-samples-link", data: { pid: post.id } %></li>
       <% if post.is_video? %>
         <li><%= tag.a "Regenerate Video Samples", href: "#", id: "regenerate-video-samples-link", data: { pid: post.id } %></li>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -58,7 +58,7 @@
             Adobe Flash has reached end of life, and no longer works in browsers. Please see <a href="/forum_topics/22535" rel="nofollow">this thread</a> on the forum for details on how you can continue to play this file.
             <br>Keyboard shortcuts are disabled on this page because it contains flash.
           </div>
-          <% if CurrentUser.is_janitor? %>
+          <% if CurrentUser.is_staff? %>
             <%= render "posts/partials/show/content/notices/notices", post: @post %>
           <% end %>
         </div>
@@ -90,7 +90,7 @@
           <%= render "posts/partials/show/content/children", post: @post %>
         </div>
 
-        <% if !CurrentUser.is_janitor? %>
+        <% if !CurrentUser.is_staff? %>
           <%= render "posts/partials/show/content/notices/notices", post: @post %>
         <% end %>
       </div>

--- a/app/views/static/error.html.erb
+++ b/app/views/static/error.html.erb
@@ -1,4 +1,4 @@
-<% if CurrentUser.user.try(:is_janitor?) && @exception.present? %>
+<% if CurrentUser.user.try(:is_staff?) && @exception.present? %>
   <h1><%= @exception.class.to_s %> exception raised</h1>
 
   <p><%= @message || @exception.message.dup.force_encoding("utf-8") %></p>

--- a/app/views/tags/_secondary_links.html.erb
+++ b/app/views/tags/_secondary_links.html.erb
@@ -14,7 +14,7 @@
     <%= subnav_link_to "Wiki Page", show_or_new_wiki_pages_path(title: @tag.name) %>
     <%= subnav_link_to "Edit", edit_tag_path(@tag) %>
     <%= subnav_link_to "Category History", tag_type_versions_path(search: { tag: @tag.name }), data: { hotkey: "history" } %>
-    <% if CurrentUser.is_janitor? %>
+    <% if CurrentUser.is_staff? %>
       <%= subnav_link_to "Fix", new_tag_correction_path(tag_id: @tag.id) %>
     <% end %>
   <% end %>

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -26,7 +26,7 @@
                 <%= link_to "edit", edit_tag_path(tag) %>
               <% end %>
               | <%= link_to "history", tag_type_versions_path(search: {tag: tag.name}) %>
-              <% if CurrentUser.is_janitor? %>
+              <% if CurrentUser.is_staff? %>
                 | <%= link_to "fix", new_tag_correction_path(:tag_id => tag.id) %>
               <% end %>
             </td>

--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -37,7 +37,7 @@
       <% end %>
     <% else %>
       <p>An error occurred: <%= render_status(@upload) %></p>
-      <% if CurrentUser.user.is_janitor? %>
+      <% if CurrentUser.user.is_staff? %>
         <%= render "static/backtrace", backtrace: @upload.backtrace.to_s.split("\n") %>
       <% end %>
     <% end %>

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -19,7 +19,7 @@
     <% end %>
 
     <% if CurrentUser.user.is_admin? %>
-      <% if @user.is_staff? && !CurrentUser.user.is_bd_staff? %>
+      <% if !@user.is_staff? || CurrentUser.user.is_bd_staff? %>
         <%= subnav_link_to "Reset Password", request_password_reset_admin_user_path(@user) %>
       <% end %>
       <%= subnav_link_to "Edit Blacklist", edit_blacklist_admin_user_path(@user) %>

--- a/app/views/users/_secondary_links.html.erb
+++ b/app/views/users/_secondary_links.html.erb
@@ -19,7 +19,7 @@
     <% end %>
 
     <% if CurrentUser.user.is_admin? %>
-      <% if CurrentUser.user.is_bd_staff? %>
+      <% if @user.is_staff? && !CurrentUser.user.is_bd_staff? %>
         <%= subnav_link_to "Reset Password", request_password_reset_admin_user_path(@user) %>
       <% end %>
       <%= subnav_link_to "Edit Blacklist", edit_blacklist_admin_user_path(@user) %>

--- a/app/views/users/partials/show/_staff_info.html.erb
+++ b/app/views/users/partials/show/_staff_info.html.erb
@@ -35,15 +35,17 @@
       | <%= link_to "Replacements", post_replacements_path(search: { creator_name: user.name, status: "pending" }) %>
     </span>
 
-    <h4>Uploads</h4>
-    <span>
-      <% if user.no_uploading %>
-        <%= link_to "Disabled", toggle_uploads_user_path(user), class: "text-red text-bold" %>
-      <% else %>
-        <%= link_to "Enabled", toggle_uploads_user_path(user) %>
-      <% end %>
-      | <%= link_to "Refresh counts", fix_counts_user_path(user) %>
-    </span>
+    <% if CurrentUser.is_janitor? %>
+      <h4>Uploads</h4>
+      <span>
+        <% if user.no_uploading %>
+          <%= link_to "Disabled", toggle_uploads_user_path(user), class: "text-red text-bold" %>
+        <% else %>
+          <%= link_to "Enabled", toggle_uploads_user_path(user) %>
+        <% end %>
+        | <%= link_to "Refresh counts", fix_counts_user_path(user) %>
+      </span>
+    <% end %>
 
     <% if CurrentUser.is_moderator? && UserRevert.can_revert?(user) %>
       <h4>Tag Changes</h4>

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -98,11 +98,11 @@
     </div>
   <% end %>
 
-  <% if CurrentUser.user.id == user.id || CurrentUser.is_janitor? %>
+  <% if CurrentUser.user.id == user.id || CurrentUser.is_staff? %>
     <div class="profile-line">
       <h4><%= svg_icon(:ticket) %> Tickets</h4>
       <span class="profile-line-number"><%= presenter.ticket_count(self) %></span>
-      <% if CurrentUser.is_janitor? %>
+      <% if CurrentUser.is_staff? %>
         <span class="profile-line-extra">
           [<%= link_to "pending", tickets_path(search: { creator_id: user.id, status: "pending" }) %>]
           [<%= link_to "accused", tickets_path(search: { accused_id: user.id }) %>]
@@ -111,11 +111,11 @@
     </div>
   <% end %>
 
-  <% if CurrentUser.user.id == user.id || CurrentUser.is_janitor? %>
+  <% if CurrentUser.user.id == user.id || CurrentUser.is_staff? %>
     <div class="profile-line">
       <h4><%= svg_icon(:gavel) %> Appeals</h4>
       <span class="profile-line-number"><%= presenter.appeal_count(self) %></span>
-      <% if CurrentUser.is_janitor? %>
+      <% if CurrentUser.is_staff? %>
         <span class="profile-line-extra">
           [<%= link_to "pending", appeals_path(search: { creator_id: user.id, status: "pending" }) %>]
         </span>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -4,7 +4,7 @@
   <%= custom_form_for(@wiki_page) do |f| %>
     <% if @wiki_page.new_record? %>
       <%= f.input :title, error: false, autocomplete: "tag" %>
-    <% elsif CurrentUser.is_janitor? %>
+    <% elsif CurrentUser.is_staff? %>
       <%= f.input :title, error: false, autocomplete: "tag", hint: "Change to rename this wiki page. Move the tag and update any wikis linking to this page first." %>
     <% else %>
       <h1 id="wiki-page-title"><%= @wiki_page.pretty_title %></h1>
@@ -26,11 +26,11 @@
 
     <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page", input_html: { disabled: !CurrentUser.is_privileged? } %>
 
-    <% if CurrentUser.is_janitor? %>
+    <% if CurrentUser.is_staff? %>
       <%= f.input :is_locked, :label => "Lock Page" %>
     <% end %>
 
-    <% if CurrentUser.is_janitor? && @wiki_page.errors[:title]&.any? { |error| error.include?("Move the posts and update any wikis linking to this page first.") }  %>
+    <% if CurrentUser.is_staff? && @wiki_page.errors[:title]&.any? { |error| error.include?("Move the posts and update any wikis linking to this page first.") } %>
       <%= f.input :skip_secondary_validations, as: :boolean, label: "Force rename", hint: "Ignore the renaming requirements" %>
     <% end %>
 

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -21,7 +21,7 @@
         <%= subnav_link_to "Edit Tag Type", edit_tag_path(@wiki_page.tag) %>
       <% end %>
 
-      <% if CurrentUser.is_janitor?%>
+      <% if CurrentUser.is_staff?%>
         <%= subnav_link_to "Fix Tag Count", new_tag_correction_path(tag_id: @wiki_page.tag.id) %>
       <% end %>
     <% end %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -638,7 +638,7 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
     end
 
     def can_user_see_post?(user, post)
-      return false if post.is_deleted? && !user.is_janitor?
+      return false if post.is_deleted? && !user.is_staff?
       !(is_user_restricted?(user) && is_post_restricted?(post))
     end
 

--- a/db/migrate/20260612160840_update_staff_user_levels.rb
+++ b/db/migrate/20260612160840_update_staff_user_levels.rb
@@ -12,7 +12,7 @@ class UpdateStaffUserLevels < ActiveRecord::Migration[8.1]
 
   def down
     User.without_timeout do
-      User.where(level: 50).update_all(level: 20) # Staff
+      User.where(level: 50).update_all(level: 20) # Staff become Members, for safety
       User.where(level: 40).update_all(level: 34) # Former Staff
       User.where(level: 60).update_all(level: 35) # Janitor
       User.where(level: 70).update_all(level: 40) # Moderator

--- a/db/migrate/20260612160840_update_staff_user_levels.rb
+++ b/db/migrate/20260612160840_update_staff_user_levels.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class UpdateStaffUserLevels < ActiveRecord::Migration[8.1]
+  def up
+    User.without_timeout do
+      User.where(level: 50).update_all(level: 80) # Admin
+      User.where(level: 40).update_all(level: 70) # Moderator
+      User.where(level: 35).update_all(level: 60) # Janitor
+      User.where(level: 34).update_all(level: 40) # Former Staff
+    end
+  end
+
+  def down
+    User.without_timeout do
+      User.where(level: 50).update_all(level: 20) # Staff
+      User.where(level: 40).update_all(level: 34) # Former Staff
+      User.where(level: 60).update_all(level: 35) # Janitor
+      User.where(level: 70).update_all(level: 40) # Moderator
+      User.where(level: 80).update_all(level: 50) # Admin
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2099,79 +2099,6 @@ ALTER SEQUENCE public.staff_notes_id_seq OWNED BY public.staff_notes.id;
 
 
 --
--- Name: staff_wiki_versions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.staff_wiki_versions (
-    id bigint NOT NULL,
-    staff_wiki_id integer NOT NULL,
-    updater_id integer NOT NULL,
-    updater_ip_addr inet NOT NULL,
-    title character varying NOT NULL,
-    body text DEFAULT ''::text NOT NULL,
-    reason character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: staff_wiki_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.staff_wiki_versions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: staff_wiki_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.staff_wiki_versions_id_seq OWNED BY public.staff_wiki_versions.id;
-
-
---
--- Name: staff_wikis; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.staff_wikis (
-    id bigint NOT NULL,
-    creator_id integer NOT NULL,
-    updater_id integer NOT NULL,
-    title character varying NOT NULL,
-    body text DEFAULT ''::text NOT NULL,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    qtype character varying DEFAULT 'general'::character varying NOT NULL,
-    related_id integer,
-    claimant_id integer
-);
-
-
---
--- Name: staff_wikis_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.staff_wikis_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: staff_wikis_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.staff_wikis_id_seq OWNED BY public.staff_wikis.id;
-
-
---
 -- Name: tag_aliases; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3202,20 +3129,6 @@ ALTER TABLE ONLY public.staff_notes ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
--- Name: staff_wiki_versions id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.staff_wiki_versions ALTER COLUMN id SET DEFAULT nextval('public.staff_wiki_versions_id_seq'::regclass);
-
-
---
--- Name: staff_wikis id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.staff_wikis ALTER COLUMN id SET DEFAULT nextval('public.staff_wikis_id_seq'::regclass);
-
-
---
 -- Name: tag_aliases id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3775,22 +3688,6 @@ ALTER TABLE ONLY public.staff_audit_logs
 
 ALTER TABLE ONLY public.staff_notes
     ADD CONSTRAINT staff_notes_pkey PRIMARY KEY (id);
-
-
---
--- Name: staff_wiki_versions staff_wiki_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.staff_wiki_versions
-    ADD CONSTRAINT staff_wiki_versions_pkey PRIMARY KEY (id);
-
-
---
--- Name: staff_wikis staff_wikis_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.staff_wikis
-    ADD CONSTRAINT staff_wikis_pkey PRIMARY KEY (id);
 
 
 --
@@ -5022,27 +4919,6 @@ CREATE INDEX index_staff_notes_on_user_id ON public.staff_notes USING btree (use
 
 
 --
--- Name: index_staff_wiki_versions_on_staff_wiki_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_staff_wiki_versions_on_staff_wiki_id ON public.staff_wiki_versions USING btree (staff_wiki_id);
-
-
---
--- Name: index_staff_wiki_versions_on_updater_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_staff_wiki_versions_on_updater_id ON public.staff_wiki_versions USING btree (updater_id);
-
-
---
--- Name: index_staff_wikis_on_lower_title; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_staff_wikis_on_lower_title ON public.staff_wikis USING btree (lower((title)::text));
-
-
---
 -- Name: index_tag_aliases_on_antecedent_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5584,8 +5460,6 @@ SET search_path TO "$user", public;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260612160840'),
 ('20260608170029'),
-('20260602151619'),
-('20260602151618'),
 ('20260530165214'),
 ('20260530162738'),
 ('20260526234030'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2099,6 +2099,79 @@ ALTER SEQUENCE public.staff_notes_id_seq OWNED BY public.staff_notes.id;
 
 
 --
+-- Name: staff_wiki_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.staff_wiki_versions (
+    id bigint NOT NULL,
+    staff_wiki_id integer NOT NULL,
+    updater_id integer NOT NULL,
+    updater_ip_addr inet NOT NULL,
+    title character varying NOT NULL,
+    body text DEFAULT ''::text NOT NULL,
+    reason character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: staff_wiki_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.staff_wiki_versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: staff_wiki_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.staff_wiki_versions_id_seq OWNED BY public.staff_wiki_versions.id;
+
+
+--
+-- Name: staff_wikis; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.staff_wikis (
+    id bigint NOT NULL,
+    creator_id integer NOT NULL,
+    updater_id integer NOT NULL,
+    title character varying NOT NULL,
+    body text DEFAULT ''::text NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    qtype character varying DEFAULT 'general'::character varying NOT NULL,
+    related_id integer,
+    claimant_id integer
+);
+
+
+--
+-- Name: staff_wikis_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.staff_wikis_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: staff_wikis_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.staff_wikis_id_seq OWNED BY public.staff_wikis.id;
+
+
+--
 -- Name: tag_aliases; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3129,6 +3202,20 @@ ALTER TABLE ONLY public.staff_notes ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
+-- Name: staff_wiki_versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_wiki_versions ALTER COLUMN id SET DEFAULT nextval('public.staff_wiki_versions_id_seq'::regclass);
+
+
+--
+-- Name: staff_wikis id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_wikis ALTER COLUMN id SET DEFAULT nextval('public.staff_wikis_id_seq'::regclass);
+
+
+--
 -- Name: tag_aliases id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3688,6 +3775,22 @@ ALTER TABLE ONLY public.staff_audit_logs
 
 ALTER TABLE ONLY public.staff_notes
     ADD CONSTRAINT staff_notes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: staff_wiki_versions staff_wiki_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_wiki_versions
+    ADD CONSTRAINT staff_wiki_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: staff_wikis staff_wikis_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.staff_wikis
+    ADD CONSTRAINT staff_wikis_pkey PRIMARY KEY (id);
 
 
 --
@@ -4919,6 +5022,27 @@ CREATE INDEX index_staff_notes_on_user_id ON public.staff_notes USING btree (use
 
 
 --
+-- Name: index_staff_wiki_versions_on_staff_wiki_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_staff_wiki_versions_on_staff_wiki_id ON public.staff_wiki_versions USING btree (staff_wiki_id);
+
+
+--
+-- Name: index_staff_wiki_versions_on_updater_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_staff_wiki_versions_on_updater_id ON public.staff_wiki_versions USING btree (updater_id);
+
+
+--
+-- Name: index_staff_wikis_on_lower_title; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_staff_wikis_on_lower_title ON public.staff_wikis USING btree (lower((title)::text));
+
+
+--
 -- Name: index_tag_aliases_on_antecedent_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5458,7 +5582,10 @@ ALTER TABLE ONLY public.staff_notes
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260612160840'),
 ('20260608170029'),
+('20260602151619'),
+('20260602151618'),
 ('20260530165214'),
 ('20260530162738'),
 ('20260526234030'),

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -45,6 +45,10 @@ FactoryBot.define do
       level { UserLevel::FORMER_STAFF }
     end
 
+    factory :staff_user do
+      level { UserLevel::STAFF }
+    end
+
     factory :janitor_user do
       level { UserLevel::JANITOR }
     end

--- a/spec/models/avoid_posting_version/permissions_spec.rb
+++ b/spec/models/avoid_posting_version/permissions_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe AvoidPostingVersion do
 
   # -------------------------------------------------------------------------
   # #hidden_attributes — staff_notes visibility
-  #
-  # NOTE: This model gates staff_notes on is_janitor?, while AvoidPosting gates
-  # them on is_staff?. This means janitors can see staff_notes in version
-  # history but not on the main record — likely an unintentional inconsistency.
   # -------------------------------------------------------------------------
   describe "#hidden_attributes" do
     let(:version) { create(:avoid_posting_version, staff_notes: "secret note") }
@@ -22,6 +18,11 @@ RSpec.describe AvoidPostingVersion do
     it "includes :staff_notes for a regular member" do
       CurrentUser.user = create(:user)
       expect(version.hidden_attributes).to include(:staff_notes)
+    end
+
+    it "does not include :staff_notes for a staff member" do
+      CurrentUser.user = create(:staff_user)
+      expect(version.hidden_attributes).not_to include(:staff_notes)
     end
 
     it "does not include :staff_notes for a janitor" do

--- a/spec/models/dmail/class_methods_spec.rb
+++ b/spec/models/dmail/class_methods_spec.rb
@@ -7,7 +7,7 @@ require "rails_helper"
 # --------------------------------------------------------------------------- #
 
 RSpec.describe Dmail do
-  # Use admin as the sender so that `from.is_janitor?` returns true and the
+  # Use admin as the sender so that `from.is_staff?` returns true and the
   # recipient's copy skips rate-limit checks inside `user_not_limited`.
   include_context "as admin"
 

--- a/spec/models/post_event/instance_methods_spec.rb
+++ b/spec/models/post_event/instance_methods_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PostEvent do
   # --------------------------------------------------------------------------- #
   #                         #is_creator_visible?                                #
   # --------------------------------------------------------------------------- #
-  # can_view_flagger?(flagger_id) => user.is_janitor? || user.id == flagger_id
+  # can_view_flagger?(flagger_id) => user.is_staff? || user.id == flagger_id
 
   describe "#is_creator_visible?" do
     let(:flagger) { create(:user) }

--- a/spec/models/staff_note/permissions_spec.rb
+++ b/spec/models/staff_note/permissions_spec.rb
@@ -6,7 +6,7 @@ require "rails_helper"
 #                       StaffNote Permissions                                 #
 # --------------------------------------------------------------------------- #
 #
-# is_staff? delegates to is_janitor?, so janitor/moderator/admin all pass.
+# is_staff? includes higher ranked users, so janitor/moderator/admin all pass.
 # A plain member does not.
 #
 # The note is created by `janitor` (the creator) in all tests below.

--- a/spec/models/user/factory_spec.rb
+++ b/spec/models/user/factory_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe User do
       expect(build(:banned_user)).to be_valid
     end
 
+    it "produces a valid staff user" do
+      expect(build(:staff_user)).to be_valid
+    end
+
     it "produces a valid janitor user" do
       expect(build(:janitor_user)).to be_valid
     end

--- a/spec/models/user/level_methods_spec.rb
+++ b/spec/models/user/level_methods_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe User do
         expect(user.is_admin?).to be(true)
         expect(user.is_moderator?).to be(true)
         expect(user.is_janitor?).to be(true)
+        expect(user.is_staff?).to be(true)
         expect(user.is_member?).to be(true)
       end
 
@@ -158,6 +159,7 @@ RSpec.describe User do
         expect(user.is_admin?).to be(false)
         expect(user.is_moderator?).to be(false)
         expect(user.is_janitor?).to be(false)
+        expect(user.is_staff?).to be(false)
       end
 
       it "returns false for an unpersisted user" do

--- a/spec/models/user/level_methods_spec.rb
+++ b/spec/models/user/level_methods_spec.rb
@@ -170,21 +170,6 @@ RSpec.describe User do
     end
 
     # -------------------------------------------------------------------------
-    # #is_staff?
-    # -------------------------------------------------------------------------
-    describe "#is_staff?" do
-      it "returns true for a janitor" do
-        user = create(:janitor_user)
-        expect(user.is_staff?).to be(true)
-      end
-
-      it "returns false for a regular member" do
-        user = create(:user)
-        expect(user.is_staff?).to be(false)
-      end
-    end
-
-    # -------------------------------------------------------------------------
     # #is_approver?
     # -------------------------------------------------------------------------
     describe "#is_approver?" do

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe Admin::UsersController do
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns 403 for a non-BD-staff admin when the target is staff" do
+    it "returns 302 with an alert for a non-BD-staff admin when the target is staff" do
       staff_user = create(:janitor_user)
       sign_in_as admin
       get request_password_reset_admin_user_path(staff_user)
@@ -344,7 +344,7 @@ RSpec.describe Admin::UsersController do
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns 403 for a non-BD-staff admin when the target is staff" do
+    it "returns 302 with an alert for a non-BD-staff admin when the target is staff" do
       staff_user = create(:janitor_user)
       sign_in_as admin
       post password_reset_admin_user_path(staff_user), params: { admin: { password: "hexerade" } }

--- a/spec/requests/admin/users_controller_spec.rb
+++ b/spec/requests/admin/users_controller_spec.rb
@@ -5,9 +5,10 @@ require "rails_helper"
 RSpec.describe Admin::UsersController do
   include_context "as admin"
 
-  let(:admin)    { create(:admin_user) }
-  let(:bd_staff) { create(:bd_staff_user) }
-  let(:user)     { create(:user) }
+  let(:moderator) { create(:moderator_user) }
+  let(:admin)     { create(:admin_user) }
+  let(:bd_staff)  { create(:bd_staff_user) }
+  let(:user)      { create(:user) }
 
   # ---------------------------------------------------------------------------
   # GET /admin/users/alt_list
@@ -293,15 +294,30 @@ RSpec.describe Admin::UsersController do
       expect(response).to redirect_to(new_session_path(url: request_password_reset_admin_user_path(user)))
     end
 
-    it "returns 403 for a non-BD-staff admin" do
-      sign_in_as admin
+    it "returns 403 for a moderator" do
+      sign_in_as moderator
       get request_password_reset_admin_user_path(user)
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for BD staff" do
-      sign_in_as bd_staff
+    it "returns 200 for an admin" do
+      sign_in_as admin
       get request_password_reset_admin_user_path(user)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 403 for a non-BD-staff admin when the target is staff" do
+      staff_user = create(:janitor_user)
+      sign_in_as admin
+      get request_password_reset_admin_user_path(staff_user)
+      expect(response).to redirect_to(user_path(staff_user))
+      expect(flash[:alert]).to eq("Only BD staff can request password resets for staff accounts")
+    end
+
+    it "returns 200 for a BD-staff admin when the target is staff" do
+      staff_user = create(:janitor_user)
+      sign_in_as bd_staff
+      get request_password_reset_admin_user_path(staff_user)
       expect(response).to have_http_status(:ok)
     end
   end
@@ -316,14 +332,35 @@ RSpec.describe Admin::UsersController do
       expect(response).to redirect_to(new_session_path)
     end
 
-    it "returns 403 for a non-BD-staff admin" do
-      sign_in_as admin
+    it "returns 403 for a moderator" do
+      sign_in_as moderator
       post password_reset_admin_user_path(user), params: { admin: { password: "hexerade" } }
       expect(response).to have_http_status(:forbidden)
     end
 
-    context "as bd_staff" do
-      before { sign_in_as bd_staff }
+    it "returns 200 for an admin" do
+      sign_in_as admin
+      post password_reset_admin_user_path(user), params: { admin: { password: "hexerade" } }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 403 for a non-BD-staff admin when the target is staff" do
+      staff_user = create(:janitor_user)
+      sign_in_as admin
+      post password_reset_admin_user_path(staff_user), params: { admin: { password: "hexerade" } }
+      expect(response).to redirect_to(user_path(staff_user))
+      expect(flash[:alert]).to eq("Only BD staff can request password resets for staff accounts")
+    end
+
+    it "returns 200 for a BD-staff admin when the target is staff" do
+      staff_user = create(:janitor_user)
+      sign_in_as bd_staff
+      post password_reset_admin_user_path(staff_user), params: { admin: { password: "hexerade" } }
+      expect(response).to have_http_status(:ok)
+    end
+
+    context "as an admin" do
+      before { sign_in_as admin }
 
       it "redirects back with a notice when the password is wrong" do
         post password_reset_admin_user_path(user), params: { admin: { password: "wrongpassword" } }

--- a/spec/requests/post_flags_controller_spec.rb
+++ b/spec/requests/post_flags_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe PostFlagsController do
 
   # Members older than 3 days bypass the :REJ_NEWBIE throttle gate on post_flag creation.
   let(:member)      { create(:user, created_at: 4.days.ago) }
+  let(:staff)       { create(:staff_user) }
   let(:janitor)     { create(:janitor_user) }
   let(:admin)       { create(:admin_user) }
   let(:post_record) { create(:post) }
@@ -175,6 +176,12 @@ RSpec.describe PostFlagsController do
       expect(response).to have_http_status(:forbidden)
     end
 
+    it "returns 403 for a staff member" do
+      sign_in_as staff
+      delete "/posts/#{post_record.id}/flag"
+      expect(response).to have_http_status(:forbidden)
+    end
+
     it "unflags the post for a janitor" do
       sign_in_as janitor
       expect { delete "/posts/#{post_record.id}/flag" }.to change { post_record.reload.is_flagged }.from(true).to(false)
@@ -203,6 +210,12 @@ RSpec.describe PostFlagsController do
 
     it "returns 403 for a regular member" do
       sign_in_as member
+      post clear_note_post_flag_path(post_flag)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for a staff member" do
+      sign_in_as staff
       post clear_note_post_flag_path(post_flag)
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/tickets_controller_spec.rb
+++ b/spec/requests/tickets_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe TicketsController do
 
   let(:member)          { create(:user) }
   let(:other_member)    { create(:user) }
+  let(:staff)           { create(:staff_user) }
   let(:janitor)         { create(:janitor_user) }
   let(:moderator)       { create(:moderator_user) }
   let(:other_moderator) { create(:moderator_user) }
@@ -150,7 +151,7 @@ RSpec.describe TicketsController do
   end
 
   # ---------------------------------------------------------------------------
-  # PATCH /tickets/:id — update (janitor_only gate; moderator effective)
+  # PATCH /tickets/:id — update (staff_only gate; moderator effective)
   # ---------------------------------------------------------------------------
 
   describe "PATCH /tickets/:id" do
@@ -167,8 +168,8 @@ RSpec.describe TicketsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 403 for a janitor" do
-      sign_in_as janitor
+    it "returns 403 for a staff member" do
+      sign_in_as staff
       patch ticket_path(ticket), params: update_params
       expect(response).to have_http_status(:forbidden)
     end
@@ -214,7 +215,7 @@ RSpec.describe TicketsController do
   end
 
   # ---------------------------------------------------------------------------
-  # POST /tickets/:id/claim — claim (janitor_only gate; moderator effective)
+  # POST /tickets/:id/claim — claim (staff_only gate; moderator effective)
   # ---------------------------------------------------------------------------
 
   describe "POST /tickets/:id/claim" do
@@ -229,8 +230,8 @@ RSpec.describe TicketsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 403 for a janitor" do
-      sign_in_as janitor
+    it "returns 403 for a staff member" do
+      sign_in_as staff
       post claim_ticket_path(ticket)
       expect(response).to have_http_status(:forbidden)
     end
@@ -256,7 +257,7 @@ RSpec.describe TicketsController do
   end
 
   # ---------------------------------------------------------------------------
-  # POST /tickets/:id/unclaim — unclaim (janitor_only gate; moderator effective)
+  # POST /tickets/:id/unclaim — unclaim (staff_only gate; moderator effective)
   # ---------------------------------------------------------------------------
 
   describe "POST /tickets/:id/unclaim" do
@@ -271,8 +272,8 @@ RSpec.describe TicketsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 403 for a janitor" do
-      sign_in_as janitor
+    it "returns 403 for a staff member" do
+      sign_in_as staff
       post unclaim_ticket_path(ticket)
       expect(response).to have_http_status(:forbidden)
     end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -372,7 +372,16 @@ RSpec.describe UsersController do
       end
     end
 
-    # is_staff? (i.e. is_janitor?) is required inside the action to show the form.
+    context "as a staff member" do
+      before { sign_in_as create(:staff_user) }
+
+      it "returns 403" do
+        get toggle_uploads_user_path(target)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    # is_janitor? is required inside the action to show the form.
     context "as a janitor when the target's uploads are enabled" do
       before { sign_in_as create(:janitor_user) }
 
@@ -405,6 +414,15 @@ RSpec.describe UsersController do
 
     context "as a member" do
       before { sign_in_as create(:user) }
+
+      it "returns 403" do
+        post disable_uploads_user_path(target), params: { staff_note: { body: "reason" } }
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "as a staff member" do
+      before { sign_in_as create(:staff_user) }
 
       it "returns 403" do
         post disable_uploads_user_path(target), params: { staff_note: { body: "reason" } }


### PR DESCRIPTION
On request from management, added a generic "staff" role - equivalent to Janitor for the most part, with a couple exceptions:
- Cannot handle post approvals / deletions (gated behind the "approver" flag)
- Cannot handle deletion appeals
- Cannot regenerate thumbnails, video samples, and perform AI checks
- Cannot disable/enable users' ability to upload posts
- Cannot recalculate users' cached post counts

Additionally, fixed a pre-existing permissions issue.
- Admins should be allowed to reset the password for non-staff users.
- BD staff should be allowed to reset passwords for anyone.

This permission was tightened out of concern that admins could take over users' accounts.
However, since only BD staff can directly change emails, this is not really a problem. Letting admins help users reset passwords directly without having to escalate to BD staff is preferable.