### PR TITLE
[Users] Fix slow user registration in development

### DIFF
--- a/app/models/email_blacklist.rb
+++ b/app/models/email_blacklist.rb
@@ -57,13 +57,15 @@ class EmailBlacklist < ApplicationRecord
   end
 
   def self.get_mx_records(domain)
-    return [] if Rails.env.test?
+    return [] if Rails.env.test? || Rails.env.development?
     Resolv::DNS.open do |dns|
       dns.getresources(
         domain,
         Resolv::DNS::Resource::IN::MX,
       ).map { |mx| mx.exchange.to_s.force_encoding("UTF-8") }.flatten
     end
+  rescue Resolv::ResolvError, Resolv::ResolvTimeout
+    []
   end
 
   def invalidate_cache

--- a/app/models/email_blacklist.rb
+++ b/app/models/email_blacklist.rb
@@ -57,7 +57,7 @@ class EmailBlacklist < ApplicationRecord
   end
 
   def self.get_mx_records(domain)
-    return [] if Rails.env.test? || Rails.env.development?
+    return [] if Rails.env.local?
     Resolv::DNS.open do |dns|
       dns.getresources(
         domain,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -259,7 +259,7 @@ class User < ApplicationRecord
     end
 
     def password_is_secure
-      analysis = Zxcvbn.test(password, [name, email])
+      analysis = ZXCVBN_TESTER.test(password, [name, email])
       return unless analysis.score < 2
       if analysis.feedback.warning
         errors.add(:password, "is insecure: #{analysis.feedback.warning}")

--- a/config/initializers/zxcvbn.rb
+++ b/config/initializers/zxcvbn.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Zxcvbn::Tester reads ~650 KB of word-list files from disk on initialization.
+# Zxcvbn.test() creates a new Tester on every call, making password validation
+# extremely slow. Cache a single instance here so the work only happens once
+# per process.
+ZXCVBN_TESTER = Zxcvbn::Tester.new


### PR DESCRIPTION
Dev environment struggles with checking the MX records for placeholder domains.
In addition to that, zxcvbn instantiated a new copy of `Zxcvbn::Tester` and re-parsed its ~650 KB of word-list files from disk on each sign-up.

This PR fixes both of these issues.