### PR TITLE
[IQDB] Limit the number of concurrent connections

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -44,6 +44,8 @@ class IqdbQueriesController < ApplicationController
     end
   rescue Downloads::File::Error => e
     render_expected_error(404, e.message)
+  rescue IqdbProxy::BusyError => e
+    render_expected_error(429, e.message)
   rescue IqdbProxy::Error => e
     render_expected_error(500, e.message)
   end

--- a/app/jobs/iqdb_concurrency_reset_job.rb
+++ b/app/jobs/iqdb_concurrency_reset_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class IqdbConcurrencyResetJob < ApplicationJob
+  queue_as :low_prio
+
+  def perform
+    keys = Cache.redis.scan_each(match: "iqdb:concurrent*").to_a
+    Cache.redis.del(*keys) if keys.any?
+  end
+end

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -5,7 +5,6 @@ module IqdbProxy
   class BusyError < Error; end
 
   IQDB_NUM_PIXELS = 128
-  IQDB_SEMAPHORE = Concurrent::Semaphore.new(Danbooru.config.iqdb_max_concurrent_queries)
 
   module_function
 
@@ -115,14 +114,29 @@ module IqdbProxy
     { channels: { r: r, g: g, b: b } }
   end
 
+  def redis_key
+    ["iqdb:concurrent", Danbooru.config.server_name].compact.join(":")
+  end
+
+  # Atomically decrements the key but floors it at zero.
+  # Prevents the counter from going negative when a reset races with an in-flight request.
+  DECR_FLOOR_ZERO = <<~LUA
+    local v = redis.call('decr', KEYS[1])
+    if v < 0 then redis.call('set', KEYS[1], '0') end
+    return v
+  LUA
+
   def with_query_semaphore
-    raise BusyError, "IQDB is temporarily busy. Please try again later." unless IQDB_SEMAPHORE.try_acquire
+    count = Cache.redis.incr(redis_key)
+    if count > Danbooru.config.iqdb_max_concurrent_queries
+      Cache.redis.eval(DECR_FLOOR_ZERO, keys: [redis_key])
+      raise BusyError, "IQDB is temporarily busy. Please try again later."
+    end
     begin
       yield
     ensure
-      IQDB_SEMAPHORE.release
+      Cache.redis.eval(DECR_FLOOR_ZERO, keys: [redis_key])
     end
   end
-  module_function :with_query_semaphore
   private_class_method :with_query_semaphore
 end

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -2,8 +2,10 @@
 
 module IqdbProxy
   class Error < StandardError; end
+  class BusyError < Error; end
 
   IQDB_NUM_PIXELS = 128
+  IQDB_SEMAPHORE = Concurrent::Semaphore.new(Danbooru.config.iqdb_max_concurrent_queries)
 
   module_function
 
@@ -16,7 +18,8 @@ module IqdbProxy
   end
 
   def make_request(path, request_type, body = nil)
-    conn = Faraday.new(Danbooru.config.faraday_options)
+    opts = Danbooru.config.faraday_options.deep_merge(request: { timeout: Danbooru.config.iqdb_read_timeout })
+    conn = Faraday.new(opts)
     conn.send(request_type, endpoint + path, body&.to_json, { content_type: "application/json" })
   rescue Faraday::Error
     raise Error, "This service is temporarily unavailable. Please try again later."
@@ -53,20 +56,24 @@ module IqdbProxy
   end
 
   def query_file(file, score_cutoff, v2_format: false)
-    thumb = generate_thumbnail(file.path)
-    return [] unless thumb
+    with_query_semaphore do
+      thumb = generate_thumbnail(file.path)
+      return [] unless thumb
 
-    response = make_request("/query", :post, get_channels_data(thumb))
-    return [] if response.status != 200
+      response = make_request("/query", :post, get_channels_data(thumb))
+      return [] if response.status != 200
 
-    process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
+      process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
+    end
   end
 
   def query_hash(hash, score_cutoff, v2_format: false)
-    response = make_request "/query", :post, { hash: hash }
-    return [] if response.status != 200
+    with_query_semaphore do
+      response = make_request "/query", :post, { hash: hash }
+      return [] if response.status != 200
 
-    process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
+      process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
+    end
   end
 
   def process_iqdb_result(json, score_cutoff, v2_format: false)
@@ -107,4 +114,15 @@ module IqdbProxy
     end
     { channels: { r: r, g: g, b: b } }
   end
+
+  def with_query_semaphore
+    raise BusyError, "IQDB is temporarily busy. Please try again later." unless IQDB_SEMAPHORE.try_acquire
+    begin
+      yield
+    ensure
+      IQDB_SEMAPHORE.release
+    end
+  end
+  module_function :with_query_semaphore
+  private_class_method :with_query_semaphore
 end

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -702,6 +702,7 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
       5
     end
 
+    # This should be set to a value lower than half of the total number of pitchfork workers.
     def iqdb_max_concurrent_queries
       20
     end

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -698,6 +698,14 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
     def iqdb_server
     end
 
+    def iqdb_read_timeout
+      5
+    end
+
+    def iqdb_max_concurrent_queries
+      20
+    end
+
     def opensearch_host
     end
 

--- a/config/initializers/iqdb_concurrency_reset.rb
+++ b/config/initializers/iqdb_concurrency_reset.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  Cache.redis.del(IqdbProxy.redis_key)
+rescue Redis::BaseError => e
+  Rails.logger.warn("Could not reset IQDB concurrency counter on startup: #{e.message}")
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -43,6 +43,12 @@ Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
       "queue" => "low_prio",
       "description" => "Generate the daily public database exports",
     },
+    "IqdbConcurrencyResetJob" => {
+      "cron" => "* * * * *",
+      "class" => "IqdbConcurrencyResetJob",
+      "queue" => "low_prio",
+      "description" => "Reset IQDB concurrent request counter to recover from worker crashes",
+    },
   }
 
   Sidekiq::Cron::Job.load_from_hash schedule

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -44,7 +44,7 @@ Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
       "description" => "Generate the daily public database exports",
     },
     "IqdbConcurrencyResetJob" => {
-      "cron" => "* * * * *",
+      "cron" => "0 * * * *",
       "class" => "IqdbConcurrencyResetJob",
       "queue" => "low_prio",
       "description" => "Reset IQDB concurrent request counter to recover from worker crashes",

--- a/spec/jobs/iqdb_concurrency_reset_job_spec.rb
+++ b/spec/jobs/iqdb_concurrency_reset_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IqdbConcurrencyResetJob do
     context "when IQDB counter keys exist" do
       before do
         allow(Cache.redis).to receive(:scan_each).with(match: "iqdb:concurrent*")
-          .and_return(["iqdb:concurrent:e621", "iqdb:concurrent:e926"])
+                                                 .and_return(["iqdb:concurrent:e621", "iqdb:concurrent:e926"])
         allow(Cache.redis).to receive(:del)
       end
 

--- a/spec/jobs/iqdb_concurrency_reset_job_spec.rb
+++ b/spec/jobs/iqdb_concurrency_reset_job_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IqdbConcurrencyResetJob do
+  describe "#perform" do
+    context "when IQDB counter keys exist" do
+      before do
+        allow(Cache.redis).to receive(:scan_each).with(match: "iqdb:concurrent*")
+          .and_return(["iqdb:concurrent:e621", "iqdb:concurrent:e926"])
+        allow(Cache.redis).to receive(:del)
+      end
+
+      it "deletes all matching keys" do
+        described_class.perform_now
+        expect(Cache.redis).to have_received(:del).with("iqdb:concurrent:e621", "iqdb:concurrent:e926")
+      end
+    end
+
+    context "when no IQDB counter keys exist" do
+      before do
+        allow(Cache.redis).to receive(:scan_each).with(match: "iqdb:concurrent*").and_return([])
+        allow(Cache.redis).to receive(:del)
+      end
+
+      it "does not call DEL" do
+        described_class.perform_now
+        expect(Cache.redis).not_to have_received(:del)
+      end
+    end
+  end
+end

--- a/spec/logical/iqdb_proxy_spec.rb
+++ b/spec/logical/iqdb_proxy_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IqdbProxy do
+  let(:mock_response) { double("FaradayResponse", status: 200, body: "[]") }
+
+  before do
+    allow(described_class).to receive(:make_request).and_return(mock_response)
+    allow(Cache.redis).to receive(:incr).and_return(1)
+    allow(Cache.redis).to receive(:eval).and_return(0)
+  end
+
+  describe ".redis_key" do
+    it "returns the base key when server_name is not configured" do
+      expect(described_class.redis_key).to eq("iqdb:concurrent")
+    end
+
+    it "includes server_name when configured" do
+      allow(Danbooru.config.custom_configuration).to receive(:server_name).and_return("e621")
+      expect(described_class.redis_key).to eq("iqdb:concurrent:e621")
+    end
+  end
+
+  describe "concurrency semaphore" do
+    describe ".query_hash" do
+      it "increments the Redis counter before querying IQDB" do
+        described_class.query_hash("deadbeef", 60)
+        expect(Cache.redis).to have_received(:incr).with(described_class.redis_key)
+      end
+
+      it "decrements the counter after a successful query" do
+        described_class.query_hash("deadbeef", 60)
+        expect(Cache.redis).to have_received(:eval).with(IqdbProxy::DECR_FLOOR_ZERO, keys: [described_class.redis_key])
+      end
+
+      it "decrements the counter when the query raises an error" do
+        allow(described_class).to receive(:make_request).and_raise(IqdbProxy::Error, "unavailable")
+        expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::Error)
+        expect(Cache.redis).to have_received(:eval).with(IqdbProxy::DECR_FLOOR_ZERO, keys: [described_class.redis_key])
+      end
+
+      context "when the concurrency cap is exhausted" do
+        before { allow(Cache.redis).to receive(:incr).and_return(Danbooru.config.iqdb_max_concurrent_queries + 1) }
+
+        it "raises BusyError" do
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::BusyError)
+        end
+
+        it "does not call IQDB" do
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::BusyError)
+          expect(described_class).not_to have_received(:make_request)
+        end
+
+        it "decrements the counter without yielding" do
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::BusyError)
+          expect(Cache.redis).to have_received(:eval).with(IqdbProxy::DECR_FLOOR_ZERO, keys: [described_class.redis_key])
+        end
+      end
+    end
+  end
+end

--- a/spec/logical/iqdb_proxy_spec.rb
+++ b/spec/logical/iqdb_proxy_spec.rb
@@ -3,12 +3,11 @@
 require "rails_helper"
 
 RSpec.describe IqdbProxy do
-  let(:mock_response) { double("FaradayResponse", status: 200, body: "[]") }
+  let(:mock_response) { instance_double(Faraday::Response, status: 200, body: "[]") }
 
   before do
     allow(described_class).to receive(:make_request).and_return(mock_response)
-    allow(Cache.redis).to receive(:incr).and_return(1)
-    allow(Cache.redis).to receive(:eval).and_return(0)
+    allow(Cache.redis).to receive_messages(incr: 1, eval: 0)
   end
 
   describe ".redis_key" do

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -198,6 +198,12 @@ RSpec.describe IqdbQueriesController do
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:internal_server_error)
     end
+
+    it "returns 429 when the IQDB semaphore is exhausted" do
+      allow(IqdbProxy).to receive(:query_hash).and_raise(IqdbProxy::BusyError, "IQDB is temporarily busy")
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:too_many_requests)
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Prevent IQDB from exhausting the pitchfork worker pool if it gets overwhelmed.