### PR TITLE
[IQDB] Failsafe for iqdb service repeatedly returning errors

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -44,6 +44,8 @@ class IqdbQueriesController < ApplicationController
     end
   rescue Downloads::File::Error => e
     render_expected_error(404, e.message)
+  rescue IqdbProxy::CircuitOpenError => e
+    render_expected_error(503, e.message)
   rescue IqdbProxy::BusyError => e
     render_expected_error(429, e.message)
   rescue IqdbProxy::Error => e

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -132,6 +132,9 @@ module IqdbProxy
     raise CircuitOpenError, "IQDB is temporarily unavailable. Please try again later."
   end
 
+  # Error circuit breaker
+  # Prevents further requests to IQDB if it repeatedly returns errors.
+
   def record_circuit_outcome
     response = yield
     record_circuit_failure unless response.status == 200
@@ -157,6 +160,9 @@ module IqdbProxy
     Rails.logger.warn("IqdbProxy: circuit opened — IQDB is returning errors. Cooldown: #{cooldown}s")
   end
 
+  # Query semaphore
+  # Prevents too many concurrent queries to IQDB, which can cause it to become unresponsive.
+
   def redis_key
     ["iqdb:concurrent", Danbooru.config.server_name].compact.join(":")
   end
@@ -181,6 +187,7 @@ module IqdbProxy
       Cache.redis.eval(DECR_FLOOR_ZERO, keys: [redis_key])
     end
   end
+
   private_class_method :with_query_semaphore
   private_class_method :check_circuit!, :record_circuit_outcome, :record_circuit_failure, :open_circuit!
 end

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -3,8 +3,19 @@
 module IqdbProxy
   class Error < StandardError; end
   class BusyError < Error; end
+  class CircuitOpenError < Error; end
 
   IQDB_NUM_PIXELS = 128
+
+  CIRCUIT_FAILURES_KEY = "iqdb:circuit:failures"
+  CIRCUIT_OPEN_KEY     = "iqdb:circuit:open"
+
+  # Atomic INCR; sets expiry only on first write to implement a fixed-window counter.
+  INCR_WITH_EXPIRY = <<~LUA
+    local v = redis.call('incr', KEYS[1])
+    if v == 1 then redis.call('expire', KEYS[1], ARGV[1]) end
+    return v
+  LUA
 
   module_function
 
@@ -55,11 +66,12 @@ module IqdbProxy
   end
 
   def query_file(file, score_cutoff, v2_format: false)
+    check_circuit!
     with_query_semaphore do
       thumb = generate_thumbnail(file.path)
       return [] unless thumb
 
-      response = make_request("/query", :post, get_channels_data(thumb))
+      response = record_circuit_outcome { make_request("/query", :post, get_channels_data(thumb)) }
       return [] if response.status != 200
 
       process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
@@ -67,8 +79,9 @@ module IqdbProxy
   end
 
   def query_hash(hash, score_cutoff, v2_format: false)
+    check_circuit!
     with_query_semaphore do
-      response = make_request "/query", :post, { hash: hash }
+      response = record_circuit_outcome { make_request("/query", :post, { hash: hash }) }
       return [] if response.status != 200
 
       process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
@@ -114,6 +127,36 @@ module IqdbProxy
     { channels: { r: r, g: g, b: b } }
   end
 
+  def check_circuit!
+    return unless Cache.redis.exists?(CIRCUIT_OPEN_KEY)
+    raise CircuitOpenError, "IQDB is temporarily unavailable. Please try again later."
+  end
+
+  def record_circuit_outcome
+    response = yield
+    record_circuit_failure unless response.status == 200
+    response
+  rescue IqdbProxy::Error
+    record_circuit_failure
+    raise
+  end
+
+  def record_circuit_failure
+    count = Cache.redis.eval(INCR_WITH_EXPIRY,
+                             keys: [CIRCUIT_FAILURES_KEY],
+                             argv: [Danbooru.config.iqdb_circuit_failure_window])
+    open_circuit! if count >= Danbooru.config.iqdb_circuit_failure_threshold
+  end
+
+  def open_circuit!
+    cooldown = Danbooru.config.iqdb_circuit_cooldown
+    opened = Cache.redis.set(CIRCUIT_OPEN_KEY, Time.now.to_i, ex: cooldown, nx: true)
+    return unless opened
+
+    Cache.redis.del(CIRCUIT_FAILURES_KEY)
+    Rails.logger.warn("IqdbProxy: circuit opened — IQDB is returning errors. Cooldown: #{cooldown}s")
+  end
+
   def redis_key
     ["iqdb:concurrent", Danbooru.config.server_name].compact.join(":")
   end
@@ -139,4 +182,5 @@ module IqdbProxy
     end
   end
   private_class_method :with_query_semaphore
+  private_class_method :check_circuit!, :record_circuit_outcome, :record_circuit_failure, :open_circuit!
 end

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -707,6 +707,18 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
       20
     end
 
+    def iqdb_circuit_failure_threshold
+      10
+    end
+
+    def iqdb_circuit_failure_window
+      60
+    end
+
+    def iqdb_circuit_cooldown
+      30
+    end
+
     def opensearch_host
     end
 

--- a/spec/logical/iqdb_proxy_spec.rb
+++ b/spec/logical/iqdb_proxy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IqdbProxy do
 
   before do
     allow(described_class).to receive(:make_request).and_return(mock_response)
-    allow(Cache.redis).to receive_messages(incr: 1, eval: 0)
+    allow(Cache.redis).to receive_messages(incr: 1, eval: 0, exists?: false)
   end
 
   describe ".redis_key" do
@@ -18,6 +18,80 @@ RSpec.describe IqdbProxy do
     it "includes server_name when configured" do
       allow(Danbooru.config.custom_configuration).to receive(:server_name).and_return("e621")
       expect(described_class.redis_key).to eq("iqdb:concurrent:e621")
+    end
+  end
+
+  describe "circuit breaker" do
+    describe ".query_hash" do
+      context "when the circuit is open" do
+        before { allow(Cache.redis).to receive(:exists?).with(IqdbProxy::CIRCUIT_OPEN_KEY).and_return(true) }
+
+        it "raises CircuitOpenError without calling IQDB" do
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::CircuitOpenError)
+          expect(described_class).not_to have_received(:make_request)
+        end
+      end
+
+      context "when make_request raises an error" do
+        before { allow(described_class).to receive(:make_request).and_raise(IqdbProxy::Error, "network failure") }
+
+        it "records a circuit failure" do
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::Error)
+          expect(Cache.redis).to have_received(:eval).with(IqdbProxy::INCR_WITH_EXPIRY,
+            keys: [IqdbProxy::CIRCUIT_FAILURES_KEY],
+            argv: [Danbooru.config.iqdb_circuit_failure_window])
+        end
+      end
+
+      context "when IQDB returns a non-200 response" do
+        let(:failing_response) { instance_double(Faraday::Response, status: 503, body: "") }
+        before { allow(described_class).to receive(:make_request).and_return(failing_response) }
+
+        it "records a circuit failure" do
+          described_class.query_hash("deadbeef", 60)
+          expect(Cache.redis).to have_received(:eval).with(IqdbProxy::INCR_WITH_EXPIRY,
+            keys: [IqdbProxy::CIRCUIT_FAILURES_KEY],
+            argv: [Danbooru.config.iqdb_circuit_failure_window])
+        end
+      end
+
+      context "when the failure threshold is reached" do
+        before do
+          allow(described_class).to receive(:make_request).and_raise(IqdbProxy::Error, "network failure")
+          allow(Cache.redis).to receive(:eval)
+            .with(IqdbProxy::INCR_WITH_EXPIRY, anything)
+            .and_return(Danbooru.config.iqdb_circuit_failure_threshold)
+          allow(Cache.redis).to receive(:set).and_return(true)
+          allow(Cache.redis).to receive(:del)
+        end
+
+        it "opens the circuit" do
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::Error)
+          expect(Cache.redis).to have_received(:set).with(
+            IqdbProxy::CIRCUIT_OPEN_KEY,
+            anything,
+            ex: Danbooru.config.iqdb_circuit_cooldown,
+            nx: true
+          )
+        end
+
+        it "clears the failure counter after opening" do
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::Error)
+          expect(Cache.redis).to have_received(:del).with(IqdbProxy::CIRCUIT_FAILURES_KEY)
+        end
+      end
+    end
+
+    describe ".query_file" do
+      context "when the circuit is open" do
+        before { allow(Cache.redis).to receive(:exists?).with(IqdbProxy::CIRCUIT_OPEN_KEY).and_return(true) }
+
+        it "raises CircuitOpenError without calling IQDB" do
+          fake_file = instance_double(File, path: "/tmp/fake.jpg")
+          expect { described_class.query_file(fake_file, 60) }.to raise_error(IqdbProxy::CircuitOpenError)
+          expect(described_class).not_to have_received(:make_request)
+        end
+      end
     end
   end
 

--- a/spec/logical/iqdb_proxy_spec.rb
+++ b/spec/logical/iqdb_proxy_spec.rb
@@ -38,20 +38,21 @@ RSpec.describe IqdbProxy do
         it "records a circuit failure" do
           expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::Error)
           expect(Cache.redis).to have_received(:eval).with(IqdbProxy::INCR_WITH_EXPIRY,
-            keys: [IqdbProxy::CIRCUIT_FAILURES_KEY],
-            argv: [Danbooru.config.iqdb_circuit_failure_window])
+                                                           keys: [IqdbProxy::CIRCUIT_FAILURES_KEY],
+                                                           argv: [Danbooru.config.iqdb_circuit_failure_window])
         end
       end
 
       context "when IQDB returns a non-200 response" do
         let(:failing_response) { instance_double(Faraday::Response, status: 503, body: "") }
+
         before { allow(described_class).to receive(:make_request).and_return(failing_response) }
 
         it "records a circuit failure" do
           described_class.query_hash("deadbeef", 60)
           expect(Cache.redis).to have_received(:eval).with(IqdbProxy::INCR_WITH_EXPIRY,
-            keys: [IqdbProxy::CIRCUIT_FAILURES_KEY],
-            argv: [Danbooru.config.iqdb_circuit_failure_window])
+                                                           keys: [IqdbProxy::CIRCUIT_FAILURES_KEY],
+                                                           argv: [Danbooru.config.iqdb_circuit_failure_window])
         end
       end
 
@@ -71,7 +72,7 @@ RSpec.describe IqdbProxy do
             IqdbProxy::CIRCUIT_OPEN_KEY,
             anything,
             ex: Danbooru.config.iqdb_circuit_cooldown,
-            nx: true
+            nx: true,
           )
         end
 

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -193,6 +193,12 @@ RSpec.describe IqdbQueriesController do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "returns 503 when the IQDB circuit is open" do
+      allow(IqdbProxy).to receive(:query_hash).and_raise(IqdbProxy::CircuitOpenError, "IQDB temporarily unavailable")
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:service_unavailable)
+    end
+
     it "returns 500 on IqdbProxy::Error" do
       allow(IqdbProxy).to receive(:query_hash).and_raise(IqdbProxy::Error, "service unavailable")
       get iqdb_queries_path, params: { hash: "deadbeef" }


### PR DESCRIPTION
Prevents IQDB Proxy from trying to reach the IQDB service if it's repeatedly returning errors.
Default settings are: 10 errors within 60 seconds triggers a 30 second cooldown.