### PR TITLE
[IQDB] Add better throttling

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -64,8 +64,8 @@ class IqdbQueriesController < ApplicationController
         RateLimiter.hit("img:anon:#{CurrentUser.ip_addr}", 60.seconds)
       else
         raise APIThrottled if RateLimiter.check_limit("img:#{CurrentUser.ip_addr}", 1, 2.seconds)
-        RateLimiter.hit("img:#{CurrentUser.ip_addr}", 2.seconds)
         raise APIThrottled if RateLimiter.check_limit("img:user:#{CurrentUser.user.id}", 1, 2.seconds)
+        RateLimiter.hit("img:#{CurrentUser.ip_addr}", 2.seconds)
         RateLimiter.hit("img:user:#{CurrentUser.user.id}", 2.seconds)
       end
     end

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -58,10 +58,15 @@ class IqdbQueriesController < ApplicationController
     return if Danbooru.config.disable_throttles?
 
     if %i[file url post_id hash].any? { |key| search_params[key].present? }
-      if RateLimiter.check_limit("img:#{CurrentUser.ip_addr}", 1, 2.seconds)
-        raise APIThrottled
+      if CurrentUser.user.is_anonymous?
+        raise APIThrottled if IqdbProxy.anon_lockdown?
+        raise APIThrottled if RateLimiter.check_limit("img:anon:#{CurrentUser.ip_addr}", 1, 60.seconds)
+        RateLimiter.hit("img:anon:#{CurrentUser.ip_addr}", 60.seconds)
       else
+        raise APIThrottled if RateLimiter.check_limit("img:#{CurrentUser.ip_addr}", 1, 2.seconds)
         RateLimiter.hit("img:#{CurrentUser.ip_addr}", 2.seconds)
+        raise APIThrottled if RateLimiter.check_limit("img:user:#{CurrentUser.user.id}", 1, 2.seconds)
+        RateLimiter.hit("img:user:#{CurrentUser.user.id}", 2.seconds)
       end
     end
   end

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -9,6 +9,7 @@ module IqdbProxy
 
   CIRCUIT_FAILURES_KEY = "iqdb:circuit:failures"
   CIRCUIT_OPEN_KEY     = "iqdb:circuit:open"
+  ANON_LOCKDOWN_KEY    = "iqdb:anon:lockdown"
 
   # Atomic INCR; sets expiry only on first write to implement a fixed-window counter.
   INCR_WITH_EXPIRY = <<~LUA
@@ -127,6 +128,10 @@ module IqdbProxy
     { channels: { r: r, g: g, b: b } }
   end
 
+  def anon_lockdown?
+    Cache.redis.exists?(ANON_LOCKDOWN_KEY)
+  end
+
   def check_circuit!
     return unless Cache.redis.exists?(CIRCUIT_OPEN_KEY)
     raise CircuitOpenError, "IQDB is temporarily unavailable. Please try again later."
@@ -157,7 +162,8 @@ module IqdbProxy
     return unless opened
 
     Cache.redis.del(CIRCUIT_FAILURES_KEY)
-    Rails.logger.warn("IqdbProxy: circuit opened — IQDB is returning errors. Cooldown: #{cooldown}s")
+    Cache.redis.set(ANON_LOCKDOWN_KEY, Time.now.to_i, ex: Danbooru.config.iqdb_anon_lockdown_duration)
+    Rails.logger.warn("IqdbProxy: circuit opened — IQDB is returning errors. Cooldown: #{cooldown}s. Anonymous access locked out for #{Danbooru.config.iqdb_anon_lockdown_duration}s.")
   end
 
   # Query semaphore

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -719,6 +719,10 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
       30
     end
 
+    def iqdb_anon_lockdown_duration
+      3600
+    end
+
     def opensearch_host
     end
 

--- a/spec/logical/iqdb_proxy_spec.rb
+++ b/spec/logical/iqdb_proxy_spec.rb
@@ -76,6 +76,12 @@ RSpec.describe IqdbProxy do
           )
         end
 
+        it "does not open the circuit if it is already open" do
+          allow(Cache.redis).to receive(:exists?).with(IqdbProxy::CIRCUIT_OPEN_KEY).and_return(true)
+          expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::CircuitOpenError)
+          expect(Cache.redis).not_to have_received(:set).with(IqdbProxy::CIRCUIT_OPEN_KEY, anything, anything)
+        end
+
         it "clears the failure counter after opening" do
           expect { described_class.query_hash("deadbeef", 60) }.to raise_error(IqdbProxy::Error)
           expect(Cache.redis).to have_received(:del).with(IqdbProxy::CIRCUIT_FAILURES_KEY)

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -213,23 +213,77 @@ RSpec.describe IqdbQueriesController do
   end
 
   # ---------------------------------------------------------------------------
-  # Throttling
+  # Throttling — authenticated user (existing behaviour)
   # ---------------------------------------------------------------------------
 
   describe "throttling" do
+    let(:user) { create(:user) }
+
     before do
+      sign_in_as user
       allow(IqdbProxy).to receive(:query_hash).and_return([])
-      allow(RateLimiter).to receive(:check_limit).and_return(true)
+      allow(RateLimiter).to receive(:check_limit).with("img:127.0.0.1", 1, 2.seconds).and_return(false)
+      allow(RateLimiter).to receive(:check_limit).with("img:user:#{user.id}", 1, 2.seconds).and_return(false)
     end
 
     it "returns 429 when the rate limit is exceeded" do
+      allow(RateLimiter).to receive(:check_limit).with("img:127.0.0.1", 1, 2.seconds).and_return(true)
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end
 
-    it "checks the rate limit keyed by IP address" do
+    it "checks the rate limit keyed by IP address and user ID" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(RateLimiter).to have_received(:check_limit).with("img:127.0.0.1", 1, 2.seconds)
+      expect(RateLimiter).to have_received(:check_limit).with("img:user:#{user.id}", 1, 2.seconds)
+    end
+
+    it "is not blocked by the anonymous lockdown" do
+      allow(IqdbProxy).to receive(:anon_lockdown?).and_return(true)
+      allow(RateLimiter).to receive(:check_limit).and_return(false)
+      allow(RateLimiter).to receive(:hit)
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Throttling — anonymous user
+  # ---------------------------------------------------------------------------
+
+  describe "throttling — anonymous user" do
+    before do
+      allow(IqdbProxy).to receive_messages(enabled?: true, query_hash: [], anon_lockdown?: false)
+      allow(RateLimiter).to receive(:check_limit).and_return(false)
+      allow(RateLimiter).to receive(:hit)
+    end
+
+    it "allows requests within the 1/min limit" do
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "checks the rate limit with the anon-specific key" do
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(RateLimiter).to have_received(:check_limit).with("img:anon:127.0.0.1", 1, 60.seconds)
+    end
+
+    it "returns 429 when the per-IP rate limit is exceeded" do
+      allow(RateLimiter).to receive(:check_limit).with("img:anon:127.0.0.1", 1, 60.seconds).and_return(true)
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 when the anonymous lockdown is active" do
+      allow(IqdbProxy).to receive(:anon_lockdown?).and_return(true)
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "does not call RateLimiter when the lockdown is active" do
+      allow(IqdbProxy).to receive(:anon_lockdown?).and_return(true)
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(RateLimiter).not_to have_received(:check_limit)
     end
   end
 end

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -213,10 +213,25 @@ RSpec.describe IqdbQueriesController do
   end
 
   # ---------------------------------------------------------------------------
-  # Throttling — authenticated user (existing behaviour)
+  # Throttling — disabled
   # ---------------------------------------------------------------------------
 
-  describe "throttling" do
+  describe "throttling — disabled" do
+    before { allow(Danbooru.config.custom_configuration).to receive(:disable_throttles?).and_return(true) }
+
+    it "allows requests without hitting the RateLimiter" do
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:ok)
+      expect(RateLimiter).not_to have_received(:check_limit)
+      expect(RateLimiter).not_to have_received(:hit)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Throttling — authenticated user
+  # ---------------------------------------------------------------------------
+
+  describe "throttling - authenticated user" do
     let(:user) { create(:user) }
 
     before do

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -222,12 +222,16 @@ RSpec.describe IqdbQueriesController do
     before do
       sign_in_as user
       allow(IqdbProxy).to receive(:query_hash).and_return([])
-      allow(RateLimiter).to receive(:check_limit).with("img:127.0.0.1", 1, 2.seconds).and_return(false)
-      allow(RateLimiter).to receive(:check_limit).with("img:user:#{user.id}", 1, 2.seconds).and_return(false)
     end
 
-    it "returns 429 when the rate limit is exceeded" do
+    it "returns 429 when the per-IP rate limit is exceeded" do
       allow(RateLimiter).to receive(:check_limit).with("img:127.0.0.1", 1, 2.seconds).and_return(true)
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "returns 429 when the per-user rate limit is exceeded" do
+      allow(RateLimiter).to receive(:check_limit).with("img:user:#{user.id}", 1, 2.seconds).and_return(true)
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end
@@ -239,9 +243,6 @@ RSpec.describe IqdbQueriesController do
     end
 
     it "is not blocked by the anonymous lockdown" do
-      allow(IqdbProxy).to receive(:anon_lockdown?).and_return(true)
-      allow(RateLimiter).to receive(:check_limit).and_return(false)
-      allow(RateLimiter).to receive(:hit)
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -217,7 +217,10 @@ RSpec.describe IqdbQueriesController do
   # ---------------------------------------------------------------------------
 
   describe "throttling — disabled" do
-    before { allow(Danbooru.config.custom_configuration).to receive(:disable_throttles?).and_return(true) }
+    before do
+      allow(Danbooru.config.custom_configuration).to receive(:disable_throttles?).and_return(true)
+      allow(IqdbProxy).to receive(:query_hash).and_return([])
+    end
 
     it "allows requests without hitting the RateLimiter" do
       get iqdb_queries_path, params: { hash: "deadbeef" }

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -243,6 +243,7 @@ RSpec.describe IqdbQueriesController do
     end
 
     it "is not blocked by the anonymous lockdown" do
+      allow(IqdbProxy).to receive(:anon_lockdown?).and_return(true)
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
Significantly increased the timeout for anonymous users.
Added a lockdown mode if the short circuit in IqdbProxy is ever tripped - disables anon access is IQDB is overwhelmed.
Added a secondary throttle by user ID, to prevent attempts to bypass throttles via API key sharing.