### PR TITLE
[Posts] Small fix to search controls

### DIFF
--- a/app/javascript/src/styles/views/posts/show/_show.desktop.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.desktop.scss
@@ -20,17 +20,16 @@
 
       #toggle-fullscreen { display: flex; }
 
-      .sc-btn {
-        height: inherit;
-        width: inherit;
-        svg { height: inherit;}
+      button.sc-btn {
+        height: 1.5rem;
+        svg { height: 1.25rem; }
       }
     }
   }
 
   & > .sidebar {
     box-shadow: inset -0.25rem 0px 0.25rem -0.25rem themed("color-background");
-    padding: 0.25rem 0.75rem 0.5rem 0.5rem;
+    padding: 1.75rem 0.75rem 0.5rem 0.5rem;
   }
 
   & > .content {


### PR DESCRIPTION
The issue where the `.search-controls` buttons would overlap `Blacklisted (##)` has been fixed.

The buttons used to be `1.5rem` tall on `posts#index` and `1.25rem` tall on `posts#show`, this has been unified.
<img width="256" height="140" alt="output" src="https://github.com/user-attachments/assets/080f1c44-7ad1-4ef8-9fb5-b8916ffb7e5f" />
