### PR TITLE
[Posts] Unified spacing above search field

### DIFF
--- a/app/javascript/src/styles/views/posts/index/_index.desktop.scss
+++ b/app/javascript/src/styles/views/posts/index/_index.desktop.scss
@@ -9,8 +9,7 @@
 
   & > .search {
     box-shadow: inset -0.25rem 0px 0.25rem -0.25rem themed("color-background");
-    margin: 0.25rem 0 0;
-    padding: 0.5rem;
+    padding: 0.25rem 0.75rem 0.5rem 0.5rem;
 
     .search-controls {
       top: unset;

--- a/app/javascript/src/styles/views/posts/index/_index.desktop.scss
+++ b/app/javascript/src/styles/views/posts/index/_index.desktop.scss
@@ -9,7 +9,8 @@
 
   & > .search {
     box-shadow: inset -0.25rem 0px 0.25rem -0.25rem themed("color-background");
-    padding: 0.25rem 0.75rem 0.5rem 0.5rem;
+    margin: 0.25rem 0 0;
+    padding: 0.5rem;
 
     .search-controls {
       top: unset;

--- a/app/javascript/src/styles/views/posts/index/partials/_fullscreen.scss
+++ b/app/javascript/src/styles/views/posts/index/partials/_fullscreen.scss
@@ -8,9 +8,6 @@
     border-radius: 0.25rem 0.25rem 0 0;
     box-shadow: inset 0px -0.25rem 0.25rem -0.25rem themed("color-background");
 
-    margin: 0.25rem 0 0;
-    padding: 0.5rem;
-
     flex-wrap: wrap;
     justify-content: right;
     z-index: 11; // above posts and labels

--- a/app/javascript/src/styles/views/posts/index/partials/_fullscreen.scss
+++ b/app/javascript/src/styles/views/posts/index/partials/_fullscreen.scss
@@ -7,6 +7,7 @@
     display: flex;
     border-radius: 0.25rem 0.25rem 0 0;
     box-shadow: inset 0px -0.25rem 0.25rem -0.25rem themed("color-background");
+    padding: 0.25rem 0.75rem 0.5rem 0.5rem;
 
     flex-wrap: wrap;
     justify-content: right;


### PR DESCRIPTION
The margin and padding above the search bar was inconsistent between Default and Fullscreen view. This has been unified.

The alternatives were keeping or removing the spacing for both layouts, I found it prettier to keep the spacing.
<img width="1838" height="150" alt="output" src="https://github.com/user-attachments/assets/684d858c-7adf-4bc8-ae15-32242c652a08" />
