### PR TITLE
[StaffWikis] Give all staff access to the wiki

### DIFF
--- a/app/controllers/staff_wiki_refs_controller.rb
+++ b/app/controllers/staff_wiki_refs_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class StaffWikiRefsController < ApplicationController
-  before_action :janitor_only
+  before_action :staff_only
 
   def create
     @staff_wiki = StaffWiki.find(params[:staff_wiki_id])

--- a/app/controllers/staff_wiki_versions_controller.rb
+++ b/app/controllers/staff_wiki_versions_controller.rb
@@ -2,7 +2,7 @@
 
 class StaffWikiVersionsController < ApplicationController
   respond_to :html, :json
-  before_action :janitor_only
+  before_action :staff_only
 
   def index
     @staff_wiki_versions = StaffWikiVersion.search(search_params).paginate(params[:page], limit: params[:limit], search_count: params[:search])

--- a/app/controllers/staff_wikis_controller.rb
+++ b/app/controllers/staff_wikis_controller.rb
@@ -2,7 +2,7 @@
 
 class StaffWikisController < ApplicationController
   respond_to :html, :json
-  before_action :janitor_only
+  before_action :staff_only
   before_action :admin_only, only: [:destroy]
 
   def index

--- a/app/views/layouts/navigation/_main_links.html.erb
+++ b/app/views/layouts/navigation/_main_links.html.erb
@@ -11,6 +11,3 @@
 <%= decorated_nav_link_to("Blips", :megaphone, blips_path) %>
 <%= decorated_nav_link_to("Comments", :message_square, comments_path) %>
 <%= decorated_nav_link_to("Forum", :lectern, forum_topics_path, class: (CurrentUser.has_forum_been_updated? ? "notification" : nil)) %>
-<% if CurrentUser.is_janitor? %>
-  <%= decorated_nav_link_to("Staff Wiki", :book, staff_wikis_path) %>
-<% end %>

--- a/spec/requests/staff_wiki_versions_controller_spec.rb
+++ b/spec/requests/staff_wiki_versions_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe StaffWikiVersionsController do
   include_context "as admin"
 
   let(:member)  { create(:user) }
-  let(:janitor) { create(:janitor_user) }
+  let(:staff)   { create(:staff_user) }
   let(:admin)   { create(:admin_user) }
   let!(:wiki)   { create(:staff_wiki) }
   let(:version) { wiki.versions.first }
@@ -32,14 +32,14 @@ RSpec.describe StaffWikiVersionsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for a janitor" do
-      sign_in_as janitor
+    it "returns 200 for a staff member" do
+      sign_in_as staff
       get staff_wiki_versions_path
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns a JSON array for a janitor" do
-      sign_in_as janitor
+    it "returns a JSON array for a staff member" do
+      sign_in_as staff
       get staff_wiki_versions_path(format: :json)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to be_an(Array)
@@ -53,7 +53,7 @@ RSpec.describe StaffWikiVersionsController do
 
       it "returns only versions for the given updater_id" do
         v = version
-        sign_in_as janitor
+        sign_in_as staff
         get staff_wiki_versions_path(format: :json, search: { updater_id: other_user.id })
         ids = response.parsed_body.pluck("id")
         expect(ids).to include(other_version.id)
@@ -69,7 +69,7 @@ RSpec.describe StaffWikiVersionsController do
 
       it "returns only versions for the given updater_name" do
         v = version
-        sign_in_as janitor
+        sign_in_as staff
         get staff_wiki_versions_path(format: :json, search: { updater_name: other_user.name })
         ids = response.parsed_body.pluck("id")
         expect(ids).to include(other_version.id)
@@ -83,7 +83,7 @@ RSpec.describe StaffWikiVersionsController do
       it "filters by staff_wiki_id" do
         v       = version
         other_v = other_wiki.versions.first
-        sign_in_as janitor
+        sign_in_as staff
         get staff_wiki_versions_path(format: :json, search: { staff_wiki_id: wiki.id })
         ids = response.parsed_body.pluck("id")
         expect(ids).to include(v.id)
@@ -91,7 +91,7 @@ RSpec.describe StaffWikiVersionsController do
       end
 
       it "returns no results for an out-of-range staff_wiki_id" do
-        sign_in_as janitor
+        sign_in_as staff
         get staff_wiki_versions_path(format: :json, search: { staff_wiki_id: "995859912741" })
         expect(response).to have_http_status(:ok)
         expect(response.parsed_body).to eq([])
@@ -104,7 +104,7 @@ RSpec.describe StaffWikiVersionsController do
       it "returns only versions matching the title" do
         v       = version
         other_v = other_wiki.versions.first
-        sign_in_as janitor
+        sign_in_as staff
         get staff_wiki_versions_path(format: :json, search: { title: wiki.title })
         ids = response.parsed_body.pluck("id")
         expect(ids).to include(v.id)
@@ -118,7 +118,7 @@ RSpec.describe StaffWikiVersionsController do
       it "returns only versions matching the body" do
         v       = version
         other_v = other_wiki.versions.first
-        sign_in_as janitor
+        sign_in_as staff
         get staff_wiki_versions_path(format: :json, search: { body: wiki.body })
         ids = response.parsed_body.pluck("id")
         expect(ids).to include(v.id)
@@ -142,7 +142,7 @@ RSpec.describe StaffWikiVersionsController do
       end
 
       it "returns 403 when a non-admin passes ip_addr" do
-        sign_in_as janitor
+        sign_in_as staff
         get staff_wiki_versions_path(format: :json, search: { ip_addr: "9.9.9.9" })
         expect(response).to have_http_status(:forbidden)
       end
@@ -165,14 +165,14 @@ RSpec.describe StaffWikiVersionsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for a janitor" do
-      sign_in_as janitor
+    it "returns 200 for a staff member" do
+      sign_in_as staff
       get staff_wiki_version_path(version)
       expect(response).to have_http_status(:ok)
     end
 
     it "returns 404 for a non-existent id" do
-      sign_in_as janitor
+      sign_in_as staff
       get staff_wiki_version_path(id: 0)
       expect(response).to have_http_status(:not_found)
     end
@@ -187,7 +187,7 @@ RSpec.describe StaffWikiVersionsController do
     let(:later_version)   { wiki.versions.last }
 
     before do
-      CurrentUser.scoped(janitor, "127.0.0.1") { wiki.update!(body: "updated body") }
+      CurrentUser.scoped(staff, "127.0.0.1") { wiki.update!(body: "updated body") }
     end
 
     it "redirects anonymous to the login page" do
@@ -202,20 +202,20 @@ RSpec.describe StaffWikiVersionsController do
     end
 
     it "returns 200 with valid thispage and otherpage params" do
-      sign_in_as janitor
+      sign_in_as staff
       get diff_staff_wiki_versions_path(thispage: earlier_version.id, otherpage: later_version.id)
       expect(response).to have_http_status(:ok)
     end
 
     it "redirects with a notice when thispage is blank" do
-      sign_in_as janitor
+      sign_in_as staff
       get diff_staff_wiki_versions_path(thispage: "", otherpage: later_version.id)
       expect(response).to redirect_to(staff_wikis_path)
       expect(flash[:notice]).to eq("You must select two versions to diff")
     end
 
     it "redirects with a notice when otherpage is blank" do
-      sign_in_as janitor
+      sign_in_as staff
       get diff_staff_wiki_versions_path(thispage: earlier_version.id, otherpage: "")
       expect(response).to redirect_to(staff_wikis_path)
       expect(flash[:notice]).to eq("You must select two versions to diff")

--- a/spec/requests/staff_wikis_controller_spec.rb
+++ b/spec/requests/staff_wikis_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StaffWikisController do
 
   let(:staff_wiki) { create(:staff_wiki) }
   let(:member)     { create(:user) }
-  let(:janitor)    { create(:janitor_user) }
+  let(:staff)      { create(:staff_user) }
   let(:admin)      { create(:admin_user) }
 
   # ---------------------------------------------------------------------------
@@ -31,14 +31,14 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for a janitor" do
-      sign_in_as janitor
+    it "returns 200 for a staff member" do
+      sign_in_as staff
       get staff_wikis_path
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns a JSON array for a janitor" do
-      sign_in_as janitor
+    it "returns a JSON array for a staff member" do
+      sign_in_as staff
       get staff_wikis_path(format: :json)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to be_an(Array)
@@ -46,7 +46,7 @@ RSpec.describe StaffWikisController do
 
     it "filters results by title search param" do
       staff_wiki
-      sign_in_as janitor
+      sign_in_as staff
       get staff_wikis_path(format: :json, search: { title: staff_wiki.title })
       expect(response.parsed_body.pluck("id")).to include(staff_wiki.id)
     end
@@ -73,8 +73,8 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for a janitor" do
-      sign_in_as janitor
+    it "returns 200 for a staff member" do
+      sign_in_as staff
       get search_staff_wikis_path
       expect(response).to have_http_status(:ok)
     end
@@ -101,14 +101,14 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for a janitor" do
-      sign_in_as janitor
+    it "returns 200 for a staff member" do
+      sign_in_as staff
       get staff_wiki_path(staff_wiki)
       expect(response).to have_http_status(:ok)
     end
 
-    it "returns JSON with expected fields for a janitor" do
-      sign_in_as janitor
+    it "returns JSON with expected fields for a staff member" do
+      sign_in_as staff
       get staff_wiki_path(staff_wiki, format: :json)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("id" => staff_wiki.id, "title" => staff_wiki.title)
@@ -131,8 +131,8 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for a janitor" do
-      sign_in_as janitor
+    it "returns 200 for a staff member" do
+      sign_in_as staff
       get new_staff_wiki_path
       expect(response).to have_http_status(:ok)
     end
@@ -154,8 +154,8 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 200 for a janitor" do
-      sign_in_as janitor
+    it "returns 200 for a staff member" do
+      sign_in_as staff
       get edit_staff_wiki_path(staff_wiki)
       expect(response).to have_http_status(:ok)
     end
@@ -185,8 +185,8 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    context "as a janitor" do
-      before { sign_in_as janitor }
+    context "as a staff member" do
+      before { sign_in_as staff }
 
       it "creates a staff wiki" do
         expect { post staff_wikis_path, params: valid_params }.to change(StaffWiki, :count).by(1)
@@ -227,21 +227,21 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "updates the body for a janitor" do
-      sign_in_as janitor
+    it "updates the body for a staff member" do
+      sign_in_as staff
       patch staff_wiki_path(staff_wiki), params: update_params
       expect(staff_wiki.reload.body).to eq("Updated body content.")
     end
 
-    it "redirects after a successful update for a janitor" do
-      sign_in_as janitor
+    it "redirects after a successful update for a staff member" do
+      sign_in_as staff
       patch staff_wiki_path(staff_wiki), params: update_params
       expect(response).to have_http_status(:redirect)
     end
 
     it "does not update with an invalid title" do
       original_title = staff_wiki.title
-      sign_in_as janitor
+      sign_in_as staff
       patch staff_wiki_path(staff_wiki), params: invalid_params
       expect(staff_wiki.reload.title).to eq(original_title)
     end
@@ -268,8 +268,8 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 403 for a janitor" do
-      sign_in_as janitor
+    it "returns 403 for a staff member" do
+      sign_in_as staff
       delete staff_wiki_path(staff_wiki)
       expect(response).to have_http_status(:forbidden)
     end
@@ -316,14 +316,14 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "reverts to the given version for a janitor" do
-      sign_in_as janitor
+    it "reverts to the given version for a staff member" do
+      sign_in_as staff
       put revert_staff_wiki_path(staff_wiki), params: { version_id: version.id }
       expect(staff_wiki.reload.body).to eq(original_body)
     end
 
-    it "redirects after revert for a janitor" do
-      sign_in_as janitor
+    it "redirects after revert for a staff member" do
+      sign_in_as staff
       put revert_staff_wiki_path(staff_wiki), params: { version_id: version.id }
       expect(response).to have_http_status(:redirect)
     end
@@ -345,10 +345,10 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "sets the claimant to the current janitor" do
-      sign_in_as janitor
+    it "sets the claimant to the current staff member" do
+      sign_in_as staff
       post claim_staff_wiki_path(staff_wiki)
-      expect(staff_wiki.reload.claimant_id).to eq(janitor.id)
+      expect(staff_wiki.reload.claimant_id).to eq(staff.id)
     end
   end
 
@@ -357,7 +357,7 @@ RSpec.describe StaffWikisController do
   # ---------------------------------------------------------------------------
 
   describe "POST /staff_wikis/:id/unclaim" do
-    before { staff_wiki.update_columns(claimant_id: janitor.id) }
+    before { staff_wiki.update_columns(claimant_id: staff.id) }
 
     it "redirects anonymous to the login page for HTML" do
       post unclaim_staff_wiki_path(staff_wiki)
@@ -370,8 +370,8 @@ RSpec.describe StaffWikisController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "clears the claimant for a janitor" do
-      sign_in_as janitor
+    it "clears the claimant for a staff member" do
+      sign_in_as staff
       post unclaim_staff_wiki_path(staff_wiki)
       expect(staff_wiki.reload.claimant_id).to be_nil
     end


### PR DESCRIPTION
The staff wiki prototype predated the generic staff role's existence, and thus did not account that.
This PR brings it back in line with the expected permissions baseline.