### PR TITLE
[StaffWikis] Miscellaneous tweaks and fixes

### DIFF
--- a/app/controllers/staff_wikis_controller.rb
+++ b/app/controllers/staff_wikis_controller.rb
@@ -97,6 +97,6 @@ class StaffWikisController < ApplicationController
   end
 
   def search_params
-    permit_search_params %i[title body_matches creator_id creator_name order]
+    permit_search_params %i[title body_matches creator_id creator_name editor_id order]
   end
 end

--- a/app/javascript/entrypoints/v_staff-wikis_show.ts
+++ b/app/javascript/entrypoints/v_staff-wikis_show.ts
@@ -1,0 +1,8 @@
+// staff_wikis # show
+
+import E621Type from "@/interfaces/E621";
+declare const E621: E621Type;
+
+import "@/pages/staff_wikis/StaffWikiReferences";
+
+E621.Registry.register("v_staff-wikis_show");

--- a/app/javascript/src/js/pages/staff_wikis/StaffWikiReferences.ts
+++ b/app/javascript/src/js/pages/staff_wikis/StaffWikiReferences.ts
@@ -1,0 +1,18 @@
+function bootstrapReferencesEdit() {
+  const wrapper = document.getElementById("staff-wiki-references");
+  if (!wrapper) return;
+
+  const editButton = document.getElementById("staff-wiki-references-edit");
+  if (!editButton) return;
+
+  let isEditing = false;
+  editButton.addEventListener("click", () => {
+    isEditing = !isEditing;
+    wrapper.setAttribute("data-editing", String(isEditing));
+    editButton.textContent = isEditing ? "Done" : "Edit";
+  });
+}
+
+$(() => {
+  bootstrapReferencesEdit();
+});

--- a/app/javascript/src/js/pages/staff_wikis/StaffWikiReferences.ts
+++ b/app/javascript/src/js/pages/staff_wikis/StaffWikiReferences.ts
@@ -1,4 +1,4 @@
-function bootstrapReferencesEdit() {
+function bootstrapReferencesEdit () {
   const wrapper = document.getElementById("staff-wiki-references");
   if (!wrapper) return;
 

--- a/app/javascript/src/styles/views/artists/show/_show.scss
+++ b/app/javascript/src/styles/views/artists/show/_show.scss
@@ -1,3 +1,4 @@
 #c-artists #a-show {
   @import "partials/avoid_posting_label";
+  @import "partials/staff_wiki_label";
 }

--- a/app/javascript/src/styles/views/artists/show/partials/_staff_wiki_label.scss
+++ b/app/javascript/src/styles/views/artists/show/partials/_staff_wiki_label.scss
@@ -1,0 +1,17 @@
+#staff-wiki-label {
+  background: themed("color-section");
+
+  width: max-content;
+  min-width: 20rem;
+
+  margin: 0.5rem 0;
+  padding: 0.5rem;
+  @include st-padding(050);
+  @include st-radius;
+
+  border-left: 0.25rem solid themed("color-tag-invalid");
+
+  h3 {
+    margin-bottom: 0.5rem;
+  }
+}

--- a/app/javascript/src/styles/views/staff_wikis/_staff_wikis.scss
+++ b/app/javascript/src/styles/views/staff_wikis/_staff_wikis.scss
@@ -76,9 +76,10 @@ body.c-staff-wikis.a-show #page {
 
   #staff-wiki-references {
     display: grid;
-    grid-template-columns: 1rem auto 1rem;
+    grid-template-columns: 1rem auto;
     width: 14rem;
     gap: 0.25rem;
+    position: relative;
 
     h2 {
       grid-column: 1 / -1;
@@ -86,6 +87,16 @@ body.c-staff-wikis.a-show #page {
       font-weight: normal;
       font-size: 0.75rem;
       color: themed("color-text-muted");
+    }
+
+    &-edit {
+      position: absolute;
+      right: 0;
+      background: none;
+      font-size: 0.75rem;
+      color: themed("color-link");
+      font-family: monospace;
+      &:hover { color: themed("color-link-active"); }
     }
 
     .reference-item-label {
@@ -121,6 +132,7 @@ body.c-staff-wikis.a-show #page {
       border-radius: 0.25rem;
     }
     .reference-item-remove {
+      display: none;
       padding: 0.25rem 0;
       height: 1.5rem;
       box-sizing: border-box;
@@ -129,7 +141,7 @@ body.c-staff-wikis.a-show #page {
     .reference-form {
       grid-column: 1 / -1;
 
-      display: flex;
+      display: none;
       gap: 0.25rem;
       margin: 0.25rem 0;
 
@@ -152,6 +164,13 @@ body.c-staff-wikis.a-show #page {
         min-width: unset;
         box-sizing: border-box;
       }
+    }
+
+    // Display state
+    &[data-editing="true"] {
+      grid-template-columns: 1rem auto 1rem;
+      .reference-item-remove { display: block; }
+      .reference-form { display: flex; }
     }
   }
 

--- a/app/models/staff_wiki.rb
+++ b/app/models/staff_wiki.rb
@@ -9,6 +9,7 @@ class StaffWiki < ApplicationRecord
   normalizes :body, with: ->(body) { body.gsub("\r\n", "\n") }
 
   validates :title, presence: true, length: { minimum: 1, maximum: 100 }
+  validate :validate_not_duplicate_title, on: :create
   validates :body, length: { maximum: Danbooru.config.wiki_page_max_size }
   validate :validate_claimant_id
 
@@ -26,6 +27,12 @@ class StaffWiki < ApplicationRecord
 
       unless User.exists?(claimant_id)
         errors.add(:claimant_id, "must refer to an existing user")
+      end
+    end
+
+    def validate_not_duplicate_title
+      if new_record? && self.class.where(title: title).exists?
+        errors.add(:title, "already exists")
       end
     end
   end

--- a/app/models/staff_wiki.rb
+++ b/app/models/staff_wiki.rb
@@ -9,7 +9,7 @@ class StaffWiki < ApplicationRecord
   normalizes :body, with: ->(body) { body.gsub("\r\n", "\n") }
 
   validates :title, presence: true, length: { minimum: 1, maximum: 100 }
-  validate :validate_not_duplicate_title, on: :create
+  validates :title, uniqueness: { case_sensitive: false }, on: :create
   validates :body, length: { maximum: Danbooru.config.wiki_page_max_size }
   validate :validate_claimant_id
 
@@ -27,12 +27,6 @@ class StaffWiki < ApplicationRecord
 
       unless User.exists?(claimant_id)
         errors.add(:claimant_id, "must refer to an existing user")
-      end
-    end
-
-    def validate_not_duplicate_title
-      if new_record? && self.class.where(title: title).exists?
-        errors.add(:title, "already exists")
       end
     end
   end

--- a/app/models/staff_wiki.rb
+++ b/app/models/staff_wiki.rb
@@ -42,6 +42,10 @@ class StaffWiki < ApplicationRecord
       q = q.attribute_matches(:body, params[:body_matches])
       q = q.where_user(:creator_id, :creator, params)
 
+      if params[:editor_id].present?
+        q = q.where(id: StaffWikiVersion.where(updater_id: params[:editor_id]).select(:staff_wiki_id))
+      end
+
       case params[:order]
       when "title"
         q.order("title")

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -10,16 +10,29 @@
     <% if @artist.is_dnp? %>
       <div id="avoid-posting-label">
         <h3><%= link_to "Avoid Posting", avoid_posting_path(@artist.avoid_posting) %></h3>
-        <% if @artist.avoid_posting.pretty_details.present? %>
-          <div class="dtext-container">
+        <div class="dtext-container">
+          <% if @artist.avoid_posting.pretty_details.present? %>
             <%= format_text(@artist.avoid_posting.pretty_details, inline: true) %>
-          </div>
-        <% end %>
+          <% else %>
+            Do not upload artwork created by this artist.
+          <% end %>
+        </div>
         <% if CurrentUser.is_staff? && @artist.avoid_posting.staff_notes.present? %>
           <div class="dtext-container">
             <b>Note:</b> <%= format_text(@artist.avoid_posting.staff_notes, inline: true) %>
           </div>
         <% end %>
+      </div>
+    <% end %>
+
+    <% if CurrentUser.user.is_staff? && @staff_wikis.any? %>
+      <div id="staff-wiki-label">
+        <h3>Investigations</h3>
+        <ul>
+          <% @staff_wikis.each do |page| %>
+            <li><%= link_to page.title, staff_wiki_path(page) %></li>
+          <% end %>
+        </ul>
       </div>
     <% end %>
 

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -45,7 +45,7 @@
       <% @staff_wikis.each do |page| %>
         <li><%= link_to page.title, staff_wiki_path(page) %></li>
       <% end %>
-      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name}" }) %></li>
+      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name} #{Time.now.strftime("%Y-%m-%d")}" }) %></li>
     </ul>
   <% end %>
 </ul>

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -42,7 +42,7 @@
   <% if CurrentUser.user.is_staff? %>
     <li><strong>Other</strong></li>
     <ul>
-      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name} #{Time.now.strftime('%Y-%m-%d')}" }) %></li>
+      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name} #{Date.current}" }) %></li>
     </ul>
   <% end %>
 </ul>

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -42,7 +42,7 @@
   <% if CurrentUser.user.is_staff? %>
     <li><strong>Other</strong></li>
     <ul>
-      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name} #{Time.now.strftime("%Y-%m-%d")}" }) %></li>
+      <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name} #{Time.now.strftime('%Y-%m-%d')}" }) %></li>
     </ul>
   <% end %>
 </ul>

--- a/app/views/artists/_summary.html.erb
+++ b/app/views/artists/_summary.html.erb
@@ -40,11 +40,8 @@
     </ul>
   <% end %>
   <% if CurrentUser.user.is_staff? %>
-    <li><strong>Investigations</strong></li>
+    <li><strong>Other</strong></li>
     <ul>
-      <% @staff_wikis.each do |page| %>
-        <li><%= link_to page.title, staff_wiki_path(page) %></li>
-      <% end %>
       <li><%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "artist", related_id: artist.id, title: "Artist: #{artist.name} #{Time.now.strftime("%Y-%m-%d")}" }) %></li>
     </ul>
   <% end %>

--- a/app/views/staff_wikis/_search.html.erb
+++ b/app/views/staff_wikis/_search.html.erb
@@ -2,5 +2,6 @@
   <%= f.input :title, label: "Title", hint: "Use * for wildcard searches" %>
   <%= f.input :body_matches, label: "Body" %>
   <%= f.user :creator %>
+  <%= f.input :editor_id, label: "Editor ID" if params[:search][:editor_id].present? %>
   <%= f.input :order, collection: [%w[Name title], %w[Date time]] %>
 <% end %>

--- a/app/views/staff_wikis/_search.html.erb
+++ b/app/views/staff_wikis/_search.html.erb
@@ -2,6 +2,6 @@
   <%= f.input :title, label: "Title", hint: "Use * for wildcard searches" %>
   <%= f.input :body_matches, label: "Body" %>
   <%= f.user :creator %>
-  <%= f.input :editor_id, label: "Editor ID" if params[:search][:editor_id].present? %>
+  <%= f.input :editor_id, label: "Editor ID" if params.dig(:search, :editor_id).present? %>
   <%= f.input :order, collection: [%w[Name title], %w[Date time]] %>
 <% end %>

--- a/app/views/staff_wikis/_secondary_links.html.erb
+++ b/app/views/staff_wikis/_secondary_links.html.erb
@@ -2,6 +2,8 @@
   <%= subnav_link_to "Listing", staff_wikis_path %>
   <%= subnav_link_to "Search", search_staff_wikis_path %>
   <%= subnav_link_to "New", new_staff_wiki_path %>
+  <li class="divider"></li>
+  <%= subnav_link_to "Mine", staff_wikis_path(search: { editor_id: CurrentUser.id }) %>
 
   <% if @staff_wiki&.persisted? %>
     <li class="divider"></li>

--- a/app/views/staff_wikis/index.html.erb
+++ b/app/views/staff_wikis/index.html.erb
@@ -8,6 +8,7 @@
         <thead>
           <tr>
             <th>Title</th>
+            <th>Claimant</th>
             <th>Last edited</th>
             <th>History</th>
           </tr>
@@ -16,6 +17,7 @@
           <% @staff_wikis.each do |staff_wiki| %>
             <tr>
               <td><%= link_to staff_wiki.title, staff_wiki_path(staff_wiki) %></td>
+              <td><% if staff_wiki.claimant_id %><%= link_to_user staff_wiki.claimant %><% end %></td>
               <td><%= compact_time staff_wiki.updated_at %> by <%= link_to_user staff_wiki.updater %></td>
               <td><%= link_to "History", staff_wiki_versions_path(search: { staff_wiki_id: staff_wiki.id }) %></td>
             </tr>

--- a/app/views/staff_wikis/partials/_references.html.erb
+++ b/app/views/staff_wikis/partials/_references.html.erb
@@ -1,7 +1,8 @@
 <%# locals: (references:, staff_wiki:) %>
 
-<section id="staff-wiki-references">
+<section id="staff-wiki-references" data-editing="false">
   <h2>References</h2>
+  <button id="staff-wiki-references-edit" class="st-toggle">Edit</button>
 
   <% references.each do |reference| %>
     <div

--- a/app/views/staff_wikis/partials/_related.html.erb
+++ b/app/views/staff_wikis/partials/_related.html.erb
@@ -1,11 +1,13 @@
 <%# locals: related_pages %>
 
-<section id="staff-wiki-related">
-  <h2>Related</h2>
+<% if related_pages.any? %>
+  <section id="staff-wiki-related">
+    <h2>Related</h2>
 
-  <% related_pages.each do |wiki| %>
-    <div class="related-item">
-      <%= link_to wiki.title, wiki %>
-    </div>
-  <% end %>
-</section>
+    <% related_pages.each do |wiki| %>
+      <div class="related-item">
+        <%= link_to wiki.title, wiki %>
+      </div>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/users/partials/show/_investigations.html.erb
+++ b/app/views/users/partials/show/_investigations.html.erb
@@ -14,7 +14,7 @@
         <% end %>
       </ul>
     <% end %>
-    <%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "user", related_id: user.id, title: "User: #{user.name} #{Time.now.strftime('%Y-%m-%d')}" }) %>
+    <%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "user", related_id: user.id, title: "User: #{user.name} #{Date.current}" }) %>
   </div>
 </div>
 <% end %>

--- a/app/views/users/partials/show/_investigations.html.erb
+++ b/app/views/users/partials/show/_investigations.html.erb
@@ -14,7 +14,7 @@
         <% end %>
       </ul>
     <% end %>
-    <%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "user", related_id: user.id, title: "User: #{user.name} #{Time.now.strftime("%Y-%m-%d")}" }) %>
+    <%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "user", related_id: user.id, title: "User: #{user.name} #{Time.now.strftime('%Y-%m-%d')}" }) %>
   </div>
 </div>
 <% end %>

--- a/app/views/users/partials/show/_investigations.html.erb
+++ b/app/views/users/partials/show/_investigations.html.erb
@@ -14,7 +14,7 @@
         <% end %>
       </ul>
     <% end %>
-    <%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "user", related_id: user.id, title: "User: #{user.name}" }) %>
+    <%= link_to "New Investigation", new_staff_wiki_path(staff_wiki: { related_type: "user", related_id: user.id, title: "User: #{user.name} #{Time.now.strftime("%Y-%m-%d")}" }) %>
   </div>
 </div>
 <% end %>


### PR DESCRIPTION
Includes the following changes, based on the feedback from the staff team:
- Added the current date to the default investigation name for both users and artists
- Added a toggle to show/hide the reference editing options
- Hidden the "related" section if no related pages could be found
- Added the claimant's name to the staff wiki index
- Added a way to find all staff wikis current user has ever contributed to
- Fixed an error when creating a staff wiki page with a duplicate title
- Tweaked the investigation UI on the artist page to be more prominent