### PR TITLE
[IQDB] Fix slow concurrency reset job

### DIFF
--- a/app/jobs/iqdb_concurrency_reset_job.rb
+++ b/app/jobs/iqdb_concurrency_reset_job.rb
@@ -5,6 +5,7 @@ class IqdbConcurrencyResetJob < ApplicationJob
 
   def perform
     keys = Cache.redis.smembers("iqdb:concurrent:keys")
+    return if keys.blank?
     Cache.redis.del(*keys) if keys.any?
     Cache.redis.del("iqdb:concurrent:keys")
   end

--- a/app/jobs/iqdb_concurrency_reset_job.rb
+++ b/app/jobs/iqdb_concurrency_reset_job.rb
@@ -6,5 +6,6 @@ class IqdbConcurrencyResetJob < ApplicationJob
   def perform
     keys = Cache.redis.smembers("iqdb:concurrent:keys")
     Cache.redis.del(*keys) if keys.any?
+    Cache.redis.del("iqdb:concurrent:keys")
   end
 end

--- a/app/jobs/iqdb_concurrency_reset_job.rb
+++ b/app/jobs/iqdb_concurrency_reset_job.rb
@@ -6,7 +6,7 @@ class IqdbConcurrencyResetJob < ApplicationJob
   def perform
     keys = Cache.redis.smembers("iqdb:concurrent:keys")
     return if keys.blank?
-    Cache.redis.del(*keys) if keys.any?
+    Cache.redis.del(*keys)
     Cache.redis.del("iqdb:concurrent:keys")
   end
 end

--- a/app/jobs/iqdb_concurrency_reset_job.rb
+++ b/app/jobs/iqdb_concurrency_reset_job.rb
@@ -4,7 +4,7 @@ class IqdbConcurrencyResetJob < ApplicationJob
   queue_as :low_prio
 
   def perform
-    keys = Cache.redis.scan_each(match: "iqdb:concurrent*").to_a
+    keys = Cache.redis.smembers("iqdb:concurrent:keys")
     Cache.redis.del(*keys) if keys.any?
   end
 end

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -183,6 +183,8 @@ module IqdbProxy
 
   def with_query_semaphore
     count = Cache.redis.incr(redis_key)
+    Cache.redis.sadd("iqdb:concurrent:keys", redis_key)
+
     if count > Danbooru.config.iqdb_max_concurrent_queries
       Cache.redis.eval(DECR_FLOOR_ZERO, keys: [redis_key])
       raise BusyError, "IQDB is temporarily busy. Please try again later."

--- a/spec/jobs/iqdb_concurrency_reset_job_spec.rb
+++ b/spec/jobs/iqdb_concurrency_reset_job_spec.rb
@@ -6,20 +6,21 @@ RSpec.describe IqdbConcurrencyResetJob do
   describe "#perform" do
     context "when IQDB counter keys exist" do
       before do
-        allow(Cache.redis).to receive(:scan_each).with(match: "iqdb:concurrent*")
-                                                 .and_return(["iqdb:concurrent:e621", "iqdb:concurrent:e926"])
+        allow(Cache.redis).to receive(:smembers).with("iqdb:concurrent:keys")
+                                                  .and_return(["iqdb:concurrent:e621", "iqdb:concurrent:e926"])
         allow(Cache.redis).to receive(:del)
       end
 
       it "deletes all matching keys" do
         described_class.perform_now
         expect(Cache.redis).to have_received(:del).with("iqdb:concurrent:e621", "iqdb:concurrent:e926")
+        expect(Cache.redis).to have_received(:del).with("iqdb:concurrent:keys")
       end
     end
 
     context "when no IQDB counter keys exist" do
       before do
-        allow(Cache.redis).to receive(:scan_each).with(match: "iqdb:concurrent*").and_return([])
+        allow(Cache.redis).to receive(:smembers).with("iqdb:concurrent:keys").and_return([])
         allow(Cache.redis).to receive(:del)
       end
 

--- a/spec/jobs/iqdb_concurrency_reset_job_spec.rb
+++ b/spec/jobs/iqdb_concurrency_reset_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe IqdbConcurrencyResetJob do
     context "when IQDB counter keys exist" do
       before do
         allow(Cache.redis).to receive(:smembers).with("iqdb:concurrent:keys")
-                                                  .and_return(["iqdb:concurrent:e621", "iqdb:concurrent:e926"])
+                                                .and_return(["iqdb:concurrent:e621", "iqdb:concurrent:e926"])
         allow(Cache.redis).to receive(:del)
       end
 


### PR DESCRIPTION
Evidently, the old implementation scanned over all 6.7 million entries stored in redis to fetch 4 key names.
We are better off just caching the key names as well.