### PR TITLE
[Misc] Fix flaky image sampler tests

### DIFF
--- a/spec/logical/image_sampler/calc_background_color_spec.rb
+++ b/spec/logical/image_sampler/calc_background_color_spec.rb
@@ -25,16 +25,19 @@ RSpec.describe ImageSampler do
     end
 
     it "uses the default '152f56' when called with no argument" do
-      expect(described_class.calc_background_color).to eq([21, 47, 86])
+      allow(Danbooru.config.custom_configuration).to receive(:default_bg_color).and_return("0088ff")
+      expect(described_class.calc_background_color).to eq([0, 136, 255])
     end
 
     context "when hex_color is blank" do
       it "falls back to the default for an empty string" do
-        expect(described_class.calc_background_color("")).to eq([21, 47, 86])
+        allow(Danbooru.config.custom_configuration).to receive(:default_bg_color).and_return("0088ff")
+        expect(described_class.calc_background_color("")).to eq([0, 136, 255])
       end
 
       it "falls back to the default for nil" do
-        expect(described_class.calc_background_color(nil)).to eq([21, 47, 86])
+        allow(Danbooru.config.custom_configuration).to receive(:default_bg_color).and_return("0088ff")
+        expect(described_class.calc_background_color(nil)).to eq([0, 136, 255])
       end
     end
   end


### PR DESCRIPTION
These tests failed on the e6ai fork because they hard-coded the RGB values of `default_bg_color`.