### PR TITLE
[Misc] Fix a crash caused by a malformed cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
 
   before_action :reset_current_user
   before_action :sanitize_params
+  before_action :sanitize_cookies
   before_action :set_current_user
   around_action :set_time_zone
   before_action :validate_pagination_param_types
@@ -68,6 +69,22 @@ class ApplicationController < ActionController::Base
     end
 
     sanitize_hash.call(params)
+  end
+
+  # The ParameterSanitizer middleware scrubs the raw, still-URL-encoded Cookie header,
+  # but Rails percent-decodes cookie values afterwards. Decoding can reintroduce invalid
+  # UTF-8 bytes or null bytes (e.g. `nmm=%FF`), which then blow up later when something
+  # calls a string operation such as `blank?`/`present?` on the value while rendering.
+  # This mirrors sanitize_params for the decoded cookie jar.
+  def sanitize_cookies
+    scrubbed = {}
+    cookies.each do |key, value|
+      next unless value.is_a?(String)
+      next if value.valid_encoding? && value.exclude?("\u0000")
+
+      scrubbed[key] = value.scrub("").delete("\u0000")
+    end
+    cookies.update(scrubbed) if scrubbed.any?
   end
 
   def api_check

--- a/spec/requests/cookie_sanitization_spec.rb
+++ b/spec/requests/cookie_sanitization_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Regression coverage for ApplicationController#sanitize_cookies.
+#
+# A request carrying a cookie whose URL-encoded value decodes to invalid UTF-8
+# (e.g. `nmm=%FF`) used to crash while rendering the default layout: the head
+# partial calls `disable_mobile_mode?`, which runs `cookies[:nmm].present?`, and
+# String#blank? raises `ArgumentError: invalid byte sequence in UTF-8` on a
+# string with invalid encoding. The ParameterSanitizer middleware only scrubs
+# the still-encoded Cookie header, so the bad byte reappears once Rails decodes
+# the value. sanitize_cookies scrubs the decoded jar to close that gap.
+RSpec.describe "Cookie sanitization" do
+  # Anonymous, HTML, renders the default layout (and thus disable_mobile_mode?).
+  let(:path) { keyboard_shortcuts_path }
+
+  it "renders without crashing when a cookie decodes to invalid UTF-8" do
+    get path, headers: { "HTTP_COOKIE" => "nmm=%FF" }
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "renders without crashing when a cookie contains a null byte" do
+    get path, headers: { "HTTP_COOKIE" => "nmm=%001" }
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "leaves a well-formed cookie value intact" do
+    get path, headers: { "HTTP_COOKIE" => "nmm=1" }
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
A request with a cookie whose URL-encoded value decodes to invalid UTF-8 would cause a crash while rendering the layout.
For example: `Cookie: nmm=%FF`.

https://e6ai.net/admin/exceptions/178405