### PR TITLE
[Tags] Add secondary order by name for post_count

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -354,7 +354,7 @@ class Tag < ApplicationRecord
       end
 
       if params[:name].present?
-        q = q.where("tags.name": normalize_name(params[:name]).split(","))
+        q = q.where(name: normalize_name(params[:name]).split(","))
       end
 
       if params[:category].present?
@@ -367,32 +367,30 @@ class Tag < ApplicationRecord
       end
 
       if params[:has_wiki].to_s.truthy?
-        q = q.joins(:wiki_page).where("wiki_pages.is_deleted = false")
+        q = q.joins(:wiki_page) # INNER JOIN only returns rows where the joined table has a matching row
       elsif params[:has_wiki].to_s.falsy?
-        q = q.joins("LEFT JOIN wiki_pages ON tags.name = wiki_pages.title").where("wiki_pages.title IS NULL OR wiki_pages.is_deleted = true")
+        q = q.left_joins(:wiki_page).where("wiki_pages.id": nil)
       end
 
       if params[:has_artist].to_s.truthy?
-        q = q.joins("INNER JOIN artists ON tags.name = artists.name")
+        q = q.joins(:artist)
       elsif params[:has_artist].to_s.falsy?
-        q = q.joins("LEFT JOIN artists ON tags.name = artists.name").where("artists.name IS NULL")
+        q = q.left_joins(:artist).where("artists.id": nil)
       end
 
       q = q.attribute_matches(:is_locked, params[:is_locked])
 
       case params[:order]
       when "name"
-        q = q.order("name")
-      when "date"
-        q = q.order("id desc")
+        q = q.order(:name)
       when "similarity"
         q = q.order_similarity(params[:fuzzy_name_matches]) if params[:fuzzy_name_matches].present?
       when "id_asc"
         q = q.order(id: :asc)
-      when "id_desc"
+      when "id_desc", "date"
         q = q.order(id: :desc)
       else
-        q = q.order("post_count desc")
+        q = q.order(post_count: :desc, name: :asc)
       end
 
       q

--- a/spec/requests/tags_controller_spec.rb
+++ b/spec/requests/tags_controller_spec.rb
@@ -55,6 +55,29 @@ RSpec.describe TagsController do
         expect(names).not_to include(matching_tag.name)
       end
     end
+
+    context "with order" do
+      let!(:tags) do
+        [
+          ["apple",  20],
+          ["banana", 20],
+          ["cherry", 20],
+          ["mango",  10],
+          ["orange", 10],
+          ["cat",     5],
+          ["dog",     5],
+          ["fox",     5],
+          ["ant",     1],
+        ].map { |k, v| create(:tag, name: k, post_count: v) }
+      end
+
+      it "orders secondary by name for post_count" do
+        get tags_path(format: :json, search: { order: "post_count", hide_empty: "no" })
+        expect(response).to(have_http_status(:ok))
+        names = response.parsed_body.pluck("name")
+        expect(names).to(eq(tags.map(&:name)))
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
As mentioned in [the bug report topic](https://e621.net/forum_topics/25734?page=56#forum_post_498359), when sorting by post_count the results have no secondary order, so tags with the same post count end up sorted randomly by whatever order the database returns them in

I included a test for ordering and while I also did a bit of nearby code cleanup in the tag model's search, I kept it simple and changed no other behavior 

<details>
<summary>minor unrelated gripes</summary>
<sub>by the way the change to overmind is mildly annoying for dev, since bringing the containers up no longer fails if the rails process crashes immediately, it acts like everything is fine and you have to look at the container logs (or notice it can't be reached) to notice something went wrong</sub>
<br><br>
<sub>Also a rake task to generate the oidc signing key (which could be mentioned in the error) would be useful for migrating existing setups for that new change</sub>
</details>