### PR TITLE
[Blacklist] Fix a race condition on the posts#show page

### DIFF
--- a/app/javascript/src/js/core/blacklist/index.ts
+++ b/app/javascript/src/js/core/blacklist/index.ts
@@ -121,10 +121,18 @@ class Blacklist {
    * @param {JQuery<HTMLElement> | JQuery<HTMLElement>[]} $posts Posts to register
    */
   public addPosts ($posts: JQuery<HTMLElement> | JQuery<HTMLElement>[]) {
-    PostCache.register($posts);
+    const newElements = PostCache.register($posts);
 
     for (const filter of Object.values(this.filters))
       filter.updateWithElements($posts);
+
+    // Immediately apply the blacklist class to any newly registered elements that are already hidden.
+    // updatePostVisibility() does not apply the class to posts whose status did not change.
+    for (const $element of newElements) {
+      const id = $element.data("id");
+      if (this.hiddenPosts.has(id))
+        $element.addClass("blacklisted").trigger("blk:hide");
+    }
   }
 
   /**

--- a/app/javascript/src/js/models/PostCache.ts
+++ b/app/javascript/src/js/models/PostCache.ts
@@ -141,7 +141,8 @@ export default class PostCache {
    * Save post thumbnails so that they can be referred to later
    * @param {JQuery<HTMLElement> | JQuery<HTMLElement>[]} $elements Post elements
    */
-  static register ($elements: JQuery<HTMLElement> | JQuery<HTMLElement>[]) {
+  static register ($elements: JQuery<HTMLElement> | JQuery<HTMLElement>[]): JQuery<HTMLElement>[] {
+    const added: JQuery<HTMLElement>[] = [];
     for (let $post of $elements) {
       $post = $($post);
       $post.removeClass("blacklistable");
@@ -157,7 +158,9 @@ export default class PostCache {
 
       this._elements[postData.id].push($post);
       this._elementCount++;
+      added.push($post);
     }
+    return added;
   }
 
   /**


### PR DESCRIPTION
A bug on the posts#show page would prevent the main post from being hidden by the blacklist if there was a deferred thumbnail belonging to the same post anywhere on the page.