### PR TITLE
[Themes] Improve the toggle button colours

### DIFF
--- a/app/javascript/src/styles/common/_standard_elements.scss
+++ b/app/javascript/src/styles/common/_standard_elements.scss
@@ -175,7 +175,7 @@ label.st-toggle {
     top: 0.25rem;
     left: 0rem;
 
-    background: themed("color-link");
+    background: themed("color-button-inactive");
     border-radius: 0.25rem;
     transition: left 100ms, background-color 200ms;
   }
@@ -189,7 +189,7 @@ input[type="checkbox"].st-toggle:checked + label.st-toggle {
   &::after {
     content: "";
     left: 1.5rem;
-    background: themed("color-link-active");
+    background: themed("color-button-active");
   }
 }
 

--- a/app/javascript/src/styles/themes/_theme_bloodlust.scss
+++ b/app/javascript/src/styles/themes/_theme_bloodlust.scss
@@ -26,6 +26,8 @@ body[data-th-main="bloodlust"] {
   --color-link:                   #{$bloodlust-color-link};
   --color-link-hover:             #{$bloodlust-color-link-hover};
   --color-link-active:            #ffffff;
+
+  --color-button-inactive:        #{$bloodlust-color-text-muted};
   --color-button-active:          #e8c446;
 
   --color-link-last-page:         #{$bloodlust-color-text-muted};

--- a/app/javascript/src/styles/themes/_theme_hexagon.scss
+++ b/app/javascript/src/styles/themes/_theme_hexagon.scss
@@ -29,13 +29,15 @@ body[data-th-main="hexagon"] {
 
   // Main Colors
   --color-text:                   #{$hexagon-color-text};
-  --color-text-muted:             #999999;
+  --color-text-muted:             #{$hexagon-color-text-muted};
   --color-text-white:             #{$hexagon-color-text};
   --color-text-table-header:      #{darken($hexagon-color-text, 10%)};
 
   --color-link:                   #{$hexagon-color-link};
   --color-link-hover:             #{$hexagon-color-link-hover};
   --color-link-active:            #e8c446;
+
+  --color-button-inactive:        #{$hexagon-color-text-muted};
   --color-button-active:          #e8c446;
 
   --color-link-last-page:         #666;

--- a/app/javascript/src/styles/themes/_theme_hotdog.scss
+++ b/app/javascript/src/styles/themes/_theme_hotdog.scss
@@ -16,6 +16,8 @@ body[data-th-main="hotdog"] {
   --color-link:                   #000000;
   --color-link-hover:             #666666;
   --color-link-active:            #ffe380;
+
+  --color-button-inactive:        #999999;
   --color-button-active:          #ffe380;
 
   --color-active-tag:             #ff0000;

--- a/app/javascript/src/styles/themes/_theme_pony.scss
+++ b/app/javascript/src/styles/themes/_theme_pony.scss
@@ -16,6 +16,8 @@ body[data-th-main="pony"] {
   --color-link:                   #b4c7d9;
   --color-link-hover:             #e9f2fa;
   --color-link-active:            #e8c446;
+
+  --color-button-inactive:        #999999;
   --color-button-active:          #e8c446;
 
   --color-active-tag:             #6f36da;

--- a/app/javascript/src/styles/themes/_theme_serpent.scss
+++ b/app/javascript/src/styles/themes/_theme_serpent.scss
@@ -16,6 +16,8 @@ body[data-th-main="serpent"] {
   --color-link:                   #005500;
   --color-link-hover:             #3A8F3A;
   --color-link-active:            #e8c446;
+
+  --color-button-inactive:        #555555;
   --color-button-active:          #e8c446;
 
   --color-active-tag:             #44a544;


### PR DESCRIPTION
The goal here is really to fix the bloodlust theme: it's inverting the convention for toggle buttons. Inactive should be desaturated, active should be saturated.

<img width="110" height="105" alt="hexagon" src="https://github.com/user-attachments/assets/7df9c794-afcf-4590-ac93-799236a9f7d8" />
<img width="110" height="105" alt="bloodlust" src="https://github.com/user-attachments/assets/a8ebaa67-f7dc-4815-81eb-40413b0fb227" />
<img width="110" height="105" alt="pony" src="https://github.com/user-attachments/assets/502583ae-754f-44ae-8157-733004a520e1" />
<img width="110" height="105" alt="hotdog" src="https://github.com/user-attachments/assets/7f4c8dbb-f209-45f4-9df7-c1db1b60fb5b" />
<img width="110" height="105" alt="serpent" src="https://github.com/user-attachments/assets/e65af6a8-8ae2-44ca-b626-a486ff077a56" />

Note that I didn't change the active colour except for bloodlust, so serpent was always like this.