### PR TITLE
[Misc] Fix settings corruption issues

### DIFF
--- a/app/javascript/src/js/models/CurrentUser.ts
+++ b/app/javascript/src/js/models/CurrentUser.ts
@@ -8,7 +8,8 @@ const _get = function () {
   if (loaded) return _data;
   try {
     const base64 = document.getElementById("site-user").textContent;
-    const json = atob(base64);
+    const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+    const json = new TextDecoder().decode(bytes);
     _data = JSON.parse(json);
     loaded = true;
     return _data;

--- a/app/javascript/src/js/utility/Settings.ts
+++ b/app/javascript/src/js/utility/Settings.ts
@@ -3,7 +3,8 @@ const _get = function () {
   if (loaded) return _data;
   try {
     const base64 = document.getElementById("site-settings").textContent;
-    const json = atob(base64);
+    const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+    const json = new TextDecoder().decode(bytes);
     _data = JSON.parse(json);
     loaded = true;
     return _data;


### PR DESCRIPTION
When user and site settings get passed on to the front-end via either CurrentUser or Settings, they are decoded form base64.
Previously, this was done via `atob`. However, that only returned a Latin-1 binary string.

Evidently, some users have unicode characters in their blacklist – typically comments.
Those end up corrupted during the decoding. If the user saves the blacklist through JS (quick edit or quick toggle), this corrupted value gets passed on to the back-end. Each round trip re-expands the multi-byte sequences, which eventually results in the blacklist hitting the length limit.

The solution in this PR decodes the base64 values to UTF-8 instead.