### PR TITLE
[Misc] Make select inputs blank option clearer

### DIFF
--- a/app/views/appeals/_search.html.erb
+++ b/app/views/appeals/_search.html.erb
@@ -20,5 +20,5 @@
       %w[Approved approved],
       %w[Rejected rejected],
     ],
-  }.to_a, group_label_method: :first, group_method: :last, include_blank: true %>
+  }.to_a, group_label_method: :first, group_method: :last, include_blank: "Any" %>
 <% end %>

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -4,7 +4,7 @@
       <%= f.input :artist_name, label: "Artist Name", autocomplete: "artist" %>
       <%= f.input :url_matches, label: "URL" %>
       <%= f.input :normalized_url_matches, label: "Normalized URL" %>
-      <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+      <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
       <%= f.input :order, collection: [["ID", "id"], ["Created", "created_at"], ["Updated", "updated_at"]] %>
     <% end %>
 

--- a/app/views/artists/_search.html.erb
+++ b/app/views/artists/_search.html.erb
@@ -4,7 +4,7 @@
   <%= f.input :url_matches, label: "URL", as: :string %>
   <%= f.user :creator %>
   <%= f.user :linked_user, label: "Linked User" %>
-  <%= f.input :has_tag, label: "Has tag?", collection: [["Yes", true], ["No", false]], include_blank: true %>
-  <%= f.input :is_linked, label: "Linked?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :has_tag, label: "Has tag?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
+  <%= f.input :is_linked, label: "Linked?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
   <%= f.input :order, collection: [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]] %>
 <% end %>

--- a/app/views/avoid_posting_versions/_search.html.erb
+++ b/app/views/avoid_posting_versions/_search.html.erb
@@ -7,5 +7,5 @@
   <%= f.input :artist_name, label: "Artist Name", hide_unless_value: true %>
   <%= f.input :artist_id, label: "Artist ID", hide_unless_value: true %>
   <%= f.input :any_other_name_matches, label: "Other Names", hide_unless_value: true %>
-  <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
 <% end %>

--- a/app/views/avoid_postings/_search.html.erb
+++ b/app/views/avoid_postings/_search.html.erb
@@ -14,6 +14,6 @@
   <% if CurrentUser.is_staff? %>
     <%= f.input :staff_notes, label: "Staff Notes" %>
   <% end %>
-  <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true %>
-  <%= f.input :order, collection: [["Artist Name", "artist_name"], %w[Created created_at], %w[Updated updated_at]], include_blank: true %>
+  <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
+  <%= f.input :order, collection: [["Artist Name", "artist_name"], %w[Created created_at], %w[Updated updated_at]], include_blank: "Any" %>
 <% end %>

--- a/app/views/bans/_search.html.erb
+++ b/app/views/bans/_search.html.erb
@@ -2,6 +2,6 @@
   <%= f.user :user %>
   <%= f.user :banner %>
   <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard" %>
-  <%= f.input :expired, label: "Expired?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :expired, label: "Expired?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
   <%= f.input :order, include_blank: false, collection: [%w[Created id_desc], %w[Expiration expires_at_desc]] %>
 <% end %>

--- a/app/views/bulk_update_requests/_search.html.erb
+++ b/app/views/bulk_update_requests/_search.html.erb
@@ -3,6 +3,6 @@
   <%= f.user :approver %>
   <%= f.input :title_matches, label: "Title" %>
   <%= f.input :script_matches, label: "Script" %>
-  <%= f.input :status, label: "Status", collection: %w[pending approved rejected], include_blank: true %>
+  <%= f.input :status, label: "Status", collection: %w[pending approved rejected], include_blank: "Any" %>
   <%= f.input :order, collection: [%w[Status status_desc], %w[Last\ updated updated_at_desc], %w[Newest id_desc], %w[Oldest id_asc]], include_blank: false %>
 <% end %>

--- a/app/views/comments/_search.html.erb
+++ b/app/views/comments/_search.html.erb
@@ -9,9 +9,9 @@
     <%= f.input :ip_addr, label: "IP Address" %>
   <% end %>
   <% if CurrentUser.is_moderator? %>
-    <%= f.input :is_hidden, label: "Hidden?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+    <%= f.input :is_hidden, label: "Hidden?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
   <% end %>
-  <%= f.input :is_sticky, label: "Sticky?", collection: [["Yes", true], ["No", false]], include_blank: true %>
-  <%= f.input :do_not_bump_post, label: "Bumping?", collection: [["Yes", false], ["No", true]], include_blank: true %>
+  <%= f.input :is_sticky, label: "Sticky?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
+  <%= f.input :do_not_bump_post, label: "Bumping?", collection: [["Yes", false], ["No", true]], include_blank: "Any" %>
   <%= f.input :order, include_blank: false, collection: [%w[Created id_desc], %w[Updated updated_at_desc], %w[Score score_desc], %w[Post post_id_desc]] %>
 <% end %>

--- a/app/views/edit_histories/_search.html.erb
+++ b/app/views/edit_histories/_search.html.erb
@@ -5,5 +5,5 @@
   <% if CurrentUser.is_admin? %>
     <%= f.input :ip_addr, label: "Editor IP" %>
   <% end %>
-  <%= f.input :versionable_type, label: "Type", collection: EditHistory::TYPE_MAP.values.map { |v| [v, v] }, include_blank: true %>
+  <%= f.input :versionable_type, label: "Type", collection: EditHistory::TYPE_MAP.values.map { |v| [v, v] }, include_blank: "Any" %>
 <% end %>

--- a/app/views/forum_posts/_search.html.erb
+++ b/app/views/forum_posts/_search.html.erb
@@ -2,5 +2,5 @@
   <%= f.input :topic_title_matches, label: "Title" %>
   <%= f.input :body_matches, label: "Body" %>
   <%= f.user :creator, label: "Author" %>
-  <%= f.input :topic_category_id, label: "Category", collection: ForumCategory.visible.reverse_mapping, include_blank: true %>
+  <%= f.input :topic_category_id, label: "Category", collection: ForumCategory.visible.reverse_mapping, include_blank: "Any" %>
 <% end %>

--- a/app/views/mod_actions/_search.html.erb
+++ b/app/views/mod_actions/_search.html.erb
@@ -10,5 +10,5 @@
           ]
         end
       ),
-      include_blank: true %>
+      include_blank: "Any" %>
 <% end %>

--- a/app/views/post_events/_search.html.erb
+++ b/app/views/post_events/_search.html.erb
@@ -1,5 +1,5 @@
 <%= form_search path: post_events_path do |f| %>
   <%= f.input :post_id, label: "Post #" %>
   <%= f.user :creator %>
-  <%= f.input :action, label: "Action", collection: PostEvent.search_options_for(CurrentUser.user).map { |k| [k.to_s.capitalize.tr("_"," "), k.to_s] }, include_blank: true %>
+  <%= f.input :action, label: "Action", collection: PostEvent.search_options_for(CurrentUser.user).map { |k| [k.to_s.capitalize.tr("_"," "), k.to_s] }, include_blank: "Any" %>
 <% end %>

--- a/app/views/post_flag_reasons/_form.html.erb
+++ b/app/views/post_flag_reasons/_form.html.erb
@@ -5,8 +5,8 @@
   <%= f.input :needs_explanation, as: :boolean, label: "Additional details required" %>
   <%= f.input :needs_parent_id, as: :boolean, label: "Requires parent post id" %>
   <%= f.input :needs_staff_reason, as: :boolean, label: "Requires a staff provided reason", hint: "Disables \"Delete with given reason\"" %>
-  <%= f.input :target_date, as: :date, start_year: 2007, end_year: Time.zone.today.year + 3, include_blank: true, label: "Date activation", hint: "Enable or disable this flag according to the post date. Leave blank to disable." %>
-  <%= f.input :target_date_kind, as: :select, include_blank: true, collection: [%w[Before before], %w[After after]], label: "Date activation kind", hint: "Enable the flag before or after the date?" %>
+  <%= f.input :target_date, as: :date, start_year: 2007, end_year: Time.zone.today.year + 3, include_blank: "Any", label: "Date activation", hint: "Enable or disable this flag according to the post date. Leave blank to disable." %>
+  <%= f.input :target_date_kind, as: :select, include_blank: "Any", collection: [%w[Before before], %w[After after]], label: "Date activation kind", hint: "Enable the flag before or after the date?" %>
   <%= f.input :target_tag, as: :string, label: "Tag activation", hint: "Enable or disable this flag according to a post tag. Prefix with \"-\" to negate. Leave blank to disable." %>
   <%= f.input :index, as: :integer, label: "Order index", input_html: { min: 0 } %>
   <%= f.button :submit, "Submit" %>

--- a/app/views/post_flag_reasons/_form.html.erb
+++ b/app/views/post_flag_reasons/_form.html.erb
@@ -5,8 +5,8 @@
   <%= f.input :needs_explanation, as: :boolean, label: "Additional details required" %>
   <%= f.input :needs_parent_id, as: :boolean, label: "Requires parent post id" %>
   <%= f.input :needs_staff_reason, as: :boolean, label: "Requires a staff provided reason", hint: "Disables \"Delete with given reason\"" %>
-  <%= f.input :target_date, as: :date, start_year: 2007, end_year: Time.zone.today.year + 3, include_blank: "Any", label: "Date activation", hint: "Enable or disable this flag according to the post date. Leave blank to disable." %>
-  <%= f.input :target_date_kind, as: :select, include_blank: "Any", collection: [%w[Before before], %w[After after]], label: "Date activation kind", hint: "Enable the flag before or after the date?" %>
+  <%= f.input :target_date, as: :date, start_year: 2007, end_year: Time.zone.today.year + 3, include_blank: true, label: "Date activation", hint: "Enable or disable this flag according to the post date. Leave blank to disable." %>
+  <%= f.input :target_date_kind, as: :select, include_blank: true, collection: [%w[Before before], %w[After after]], label: "Date activation kind", hint: "Enable the flag before or after the date?" %>
   <%= f.input :target_tag, as: :string, label: "Tag activation", hint: "Enable or disable this flag according to a post tag. Prefix with \"-\" to negate. Leave blank to disable." %>
   <%= f.input :index, as: :integer, label: "Order index", input_html: { min: 0 } %>
   <%= f.button :submit, "Submit" %>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -5,8 +5,8 @@
   <%= f.input :type, collection: [
     ["Flag", "flag"],
     ["Deletion", "deletion"],
-  ], include_blank: true %>
-  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  ], include_blank: "Any" %>
+  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
   <% if CurrentUser.is_staff? %>
     <%= f.input :note %>
     <%= f.user :creator %>

--- a/app/views/post_replacements/_search.html.erb
+++ b/app/views/post_replacements/_search.html.erb
@@ -4,10 +4,10 @@
   <%= f.user :creator %>
   <%= f.user :approver, label: "Handler" %>
   <%= f.user %i[uploader_name_on_approve uploader_id_on_approve], label: "Original Uploader" %>
-  <%= f.input :status, collection: ["pending", "rejected", "approved", "promoted", "original"], include_blank: true %>
-  <%= f.input :file_ext, collection: FileMethods::FILE_TYPE, include_blank: true, label: "File Type" %>
+  <%= f.input :status, collection: ["pending", "rejected", "approved", "promoted", "original"], include_blank: "Any" %>
+  <%= f.input :file_ext, collection: FileMethods::FILE_TYPE, include_blank: "Any", label: "File Type" %>
   <%= f.input :reason, label: "Reason" %>
   <%= f.input :file_name, label: "File Name" %>
   <%= f.input :source, label: "Source" %>
-  <%= f.input :penalized, label: "Penalized?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+  <%= f.input :penalized, label: "Penalized?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
 <% end %>

--- a/app/views/post_sets/_search.html.erb
+++ b/app/views/post_sets/_search.html.erb
@@ -3,7 +3,7 @@
   <%= f.input :shortname, label: "Short Name" %>
   <%= f.user :creator %>
   <% if CurrentUser.is_moderator? %>
-    <%= f.input :is_public, label: "Public?", collection: [["Yes", true], ["No", false]], include_blank: true %>
+    <%= f.input :is_public, label: "Public?", collection: [["Yes", true], ["No", false]], include_blank: "Any" %>
   <% end %>
   <%= f.input :order, collection: [%w[Name name], ['Short Name', 'shortname'], ['Post Count', 'post_count'], %w[Created created_at], %w[Updated updated_at]], include_blank: false %>
 <% end %>

--- a/app/views/post_versions/_search.html.erb
+++ b/app/views/post_versions/_search.html.erb
@@ -4,7 +4,7 @@
   <%= f.input :reason, label: "Reason" %>
   <%= f.input :description, label: "Description" %>
   <%= f.input :description_changed, label: "Description Changed", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
-  <%= f.input :rating_changed, label: "Rating Changed To", collection: rating_collection, include_blank: "Any" %>
+  <%= f.input :rating_changed, label: "Rating Changed To", collection: rating_collection + [["Any rating", "any"]], include_blank: "Any" %>
   <%= f.input :rating, label: "Final Rating", collection: rating_collection, include_blank: "Any" %>
   <%= f.input :parent_id, label: "Parent ID" %>
   <%= f.input :parent_id_changed, label: "Parent Changed To" %>

--- a/app/views/post_versions/_search.html.erb
+++ b/app/views/post_versions/_search.html.erb
@@ -3,9 +3,9 @@
   <%= f.input :post_id, label: "Post #" %>
   <%= f.input :reason, label: "Reason" %>
   <%= f.input :description, label: "Description" %>
-  <%= f.input :description_changed, label: "Description Changed", collection: [%w[Yes true], %w[No false]], include_blank: true %>
-  <%= f.input :rating_changed, label: "Rating Changed To", collection: rating_collection + [%w[Any any]], include_blank: true %>
-  <%= f.input :rating, label: "Final Rating", collection: rating_collection, include_blank: true %>
+  <%= f.input :description_changed, label: "Description Changed", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
+  <%= f.input :rating_changed, label: "Rating Changed To", collection: rating_collection + [%w[Any any]], include_blank: "Any" %>
+  <%= f.input :rating, label: "Final Rating", collection: rating_collection, include_blank: "Any" %>
   <%= f.input :parent_id, label: "Parent ID" %>
   <%= f.input :parent_id_changed, label: "Parent Changed To" %>
   <%= f.input :tags, label: "Final Tags" %>
@@ -14,6 +14,6 @@
   <%= f.input :locked_tags, label: "Final Locked Tags" %>
   <%= f.input :locked_tags_added, label: "Added Locked Tags" %>
   <%= f.input :locked_tags_removed, label: "Removed Locked Tags" %>
-  <%= f.input :source_changed, label: "Source Changed", collection: [%w[Yes true], %w[No false]], include_blank: true %>
-  <%= f.input :uploads, label: "Uploads", collection: [%w[Included included], %w[Excluded excluded], %w[Only only]], include_blank: true %>
+  <%= f.input :source_changed, label: "Source Changed", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
+  <%= f.input :uploads, label: "Uploads", collection: [%w[Included included], %w[Excluded excluded], %w[Only only]], include_blank: "Any" %>
 <% end %>

--- a/app/views/post_versions/_search.html.erb
+++ b/app/views/post_versions/_search.html.erb
@@ -4,7 +4,7 @@
   <%= f.input :reason, label: "Reason" %>
   <%= f.input :description, label: "Description" %>
   <%= f.input :description_changed, label: "Description Changed", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
-  <%= f.input :rating_changed, label: "Rating Changed To", collection: rating_collection + [%w[Any any]], include_blank: "Any" %>
+  <%= f.input :rating_changed, label: "Rating Changed To", collection: rating_collection, include_blank: "Any" %>
   <%= f.input :rating, label: "Final Rating", collection: rating_collection, include_blank: "Any" %>
   <%= f.input :parent_id, label: "Parent ID" %>
   <%= f.input :parent_id_changed, label: "Parent Changed To" %>

--- a/app/views/related_tags/show.html.erb
+++ b/app/views/related_tags/show.html.erb
@@ -4,7 +4,7 @@
     <section>
       <%= form_search(path: related_tag_path, always_display: true) do |f| %>
         <%= f.input :query, autocomplete: "tag" %>
-        <%= f.input :category_id, collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: true %>
+        <%= f.input :category_id, collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: "Any" %>
       <% end %>
     </section>
     <% if @related_tags.query.present? %>

--- a/app/views/staff/post/disapprovals/index.html.erb
+++ b/app/views/staff/post/disapprovals/index.html.erb
@@ -7,8 +7,8 @@
       <%= f.input :post_id, label: "Post ID" %>
       <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
       <%= f.input :message, hint: "Use * for wildcard" %>
-      <%= f.input :reason, collection: %w[borderline_quality borderline_relevancy other].map { |x| [x.humanize, x] }, include_blank: true %>
-      <%= f.input :has_message, label: "Has Message?", collection: %w[Yes No], include_blank: true %>
+      <%= f.input :reason, collection: %w[borderline_quality borderline_relevancy other].map { |x| [x.humanize, x] }, include_blank: "Any" %>
+      <%= f.input :has_message, label: "Has Message?", collection: %w[Yes No], include_blank: "Any" %>
       <%= f.input :order, collection: [["ID", "id_desc"], ["Post ID", "post_id_desc"]] %>
     <% end %>
 

--- a/app/views/tag_relationships/_search.html.erb
+++ b/app/views/tag_relationships/_search.html.erb
@@ -6,8 +6,8 @@
   <%= f.input :consequent_name, label: "To", autocomplete: "tag" %>
   <%= f.user :creator %>
   <%= f.user :approver %>
-  <%= f.input :antecedent_tag_category, label: "From Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: true %>
-  <%= f.input :consequent_tag_category, label: "To Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: true %>
-  <%= f.input :status, label: "Status", collection: %w[Approved Active Pending Deleted Retired Processing Queued], include_blank: true %>
+  <%= f.input :antecedent_tag_category, label: "From Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: "Any" %>
+  <%= f.input :consequent_tag_category, label: "To Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: "Any" %>
+  <%= f.input :status, label: "Status", collection: %w[Approved Active Pending Deleted Retired Processing Queued], include_blank: "Any" %>
   <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]] %>
 <% end %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -1,8 +1,8 @@
 <%= form_search(path: tags_path) do |f| %>
   <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", autocomplete: "tag" %>
-  <%= f.input :category, label: "Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: true %>
+  <%= f.input :category, label: "Category", collection: TagCategory::CANONICAL_MAPPING.to_a, include_blank: "Any" %>
   <%= f.input :order, collection: [%w[Count count], %w[Name name], %w[Newest date]], include_blank: false %>
-  <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true %>
-  <%= f.input :has_artist, label: "Has artist?", collection: %w[yes no], include_blank: true %>
+  <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: "Any" %>
+  <%= f.input :has_artist, label: "Has artist?", collection: %w[yes no], include_blank: "Any" %>
   <%= f.input :hide_empty, label: "Hide empty?", as: :boolean, default: true %>
 <% end %>

--- a/app/views/takedowns/_search.html.erb
+++ b/app/views/takedowns/_search.html.erb
@@ -3,7 +3,7 @@
                                                       ["Inactive", "inactive"],
                                                       ["Denied", "denied"],
                                                       ["Partially Approved", "partial"],
-                                                      ["Approved", "approved"]], include_blank: true %>
+                                                      ["Approved", "approved"]], include_blank: "Any" %>
   <% if CurrentUser.is_moderator? || CurrentUser.is_approver? %>
     <br />
     <%= f.input :source, label: 'Source' %>
@@ -12,12 +12,12 @@
     <%= f.input :reason_hidden, label: 'Reason hidden?', collection: [
       ["Yes", true],
       ["No", false],
-    ], include_blank: true %>
+    ], include_blank: "Any" %>
     <%= f.input :instructions, label: "Instructions" %>
     <%= f.input :post_id, label: "Post ID" %>
     <br />
     <%= f.input :creator_name, label: "Creator" %>
-    <%= f.input :creator_logged_in, label: "Has Account?", collection: %w[yes no], include_blank: true %>
+    <%= f.input :creator_logged_in, label: "Has Account?", collection: %w[yes no], include_blank: "Any" %>
   <% end %>
   <% if CurrentUser.is_admin? %>
     <br />

--- a/app/views/tickets/_search.html.erb
+++ b/app/views/tickets/_search.html.erb
@@ -16,12 +16,12 @@
       ["Set complaint", "set"],
       ["Post complaint", "post"],
       ["Replacement complaint", "replacement"]
-  ], include_blank: true %>
+  ], include_blank: "Any" %>
   <%= f.input :status, collection: [
       ["Pending + Unclaimed", "pending_unclaimed"],
       ["Pending + Claimed", "pending_claimed"],
       ["Approved/investigated", "approved"],
       ["Under investigation", "partial"],
       ["Pending", "pending"],
-  ], include_blank: true %>
+  ], include_blank: "Any" %>
 <% end %>

--- a/app/views/uploads/_search.html.erb
+++ b/app/views/uploads/_search.html.erb
@@ -2,5 +2,5 @@
   <%= f.user :uploader %>
   <%= f.input :post_tags_match, label: "Post Tags" %>
   <%= f.input :source_matches, label: "Source" %>
-  <%= f.input :status, collection: [%w[Completed completed], %w[Processing processing], %w[Pending pending], %w[Duplicate *duplicate*], %w[Error error*]], include_blank: true %>
+  <%= f.input :status, collection: [%w[Completed completed], %w[Processing processing], %w[Pending pending], %w[Duplicate *duplicate*], %w[Error error*]], include_blank: "Any" %>
 <% end %>

--- a/app/views/user_feedbacks/_search.html.erb
+++ b/app/views/user_feedbacks/_search.html.erb
@@ -3,7 +3,7 @@
   <%= f.user :creator %>
   <%= f.input :body_matches, label: "Message" %>
   <% if CurrentUser.is_staff? %>
-    <%= f.input :deleted, label: "Deleted?", collection: [%w[Excluded excluded], %w[Included included], %w[Only only]], include_blank: true %>
+    <%= f.input :deleted, label: "Deleted?", collection: [%w[Excluded excluded], %w[Included included], %w[Only only]], include_blank: "Any" %>
   <% end %>
-  <%= f.input :category, collection: %w[positive negative neutral], include_blank: true %>
+  <%= f.input :category, collection: %w[positive negative neutral], include_blank: "Any" %>
 <% end %>

--- a/app/views/user_votes/_common_index.html.erb
+++ b/app/views/user_votes/_common_index.html.erb
@@ -7,8 +7,8 @@
       <br>
       <strong>Filters:</strong><br />
       <%= f.user :"#{type.model_type}_creator", label: "#{type.model_type.capitalize} Creator" %>
-      <%= f.input :timeframe, label: "Timeframe", include_blank: true, collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]] %>
-      <%= f.input :score, label: "Type", include_blank: true, collection: [["Upvote", "1"], ["Locked", "0"], ["Downvote", "-1"]] %>
+      <%= f.input :timeframe, label: "Timeframe", include_blank: "Any", collection: [["Last Week", "7"], ["Last Month", "30"], ["Last Three Months", "90"], ["Last Year", "360"]] %>
+      <%= f.input :score, label: "Type", include_blank: "Any", collection: [["Upvote", "1"], ["Locked", "0"], ["Downvote", "-1"]] %>
       <% if CurrentUser.is_admin? %>
         <%= f.input :user_ip_addr, label: "IP Address" %>
         <%= f.input :duplicates_only, label: "Duplicates Only", as: :boolean %>

--- a/app/views/users/_search.html.erb
+++ b/app/views/users/_search.html.erb
@@ -7,12 +7,12 @@
     <%= f.input :email_matches, label: "Email", hint: "Use * for wildcard" %>
   <% end %>
 
-  <%= f.input :level, collection: User.level_hash.to_a, include_blank: true %>
-  <%= f.input :min_level, collection: User.level_hash.to_a, include_blank: true %>
-  <%= f.input :max_level, collection: User.level_hash.to_a, include_blank: true %>
+  <%= f.input :level, collection: User.level_hash.to_a, include_blank: "Any" %>
+  <%= f.input :min_level, collection: User.level_hash.to_a, include_blank: "Any" %>
+  <%= f.input :max_level, collection: User.level_hash.to_a, include_blank: "Any" %>
 
-  <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: true %>
-  <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: true %>
+  <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
+  <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
 
   <%= f.input :order, collection: [["Join date", "date"], ["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]] %>
 <% end %>

--- a/app/views/wiki_pages/_search.html.erb
+++ b/app/views/wiki_pages/_search.html.erb
@@ -4,7 +4,7 @@
   <%= f.user :creator %>
   <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page" %>
   <%= f.input :other_names_match, label: "Other names", hint: "Use * for wildcard searches" %>
-  <%= f.input :other_names_present, collection: %w[Yes No], include_blank: true %>
+  <%= f.input :other_names_present, collection: %w[Yes No], include_blank: "Any" %>
   <%= f.input :hide_deleted, collection: %w[Yes No] %>
   <%= f.input :order, collection: [%w[Name title], %w[Date time], %w[Posts post_count]] %>
 <% end %>


### PR DESCRIPTION
Closes #2210 by replacing all of `include_blank: true` values in search forms to `include_blank: "Any"`, showing the text "Any" instead of a blank option.