### PR TITLE
[Misc] Clean up some extraneous meta tags and body attributes

### DIFF
--- a/app/blueprints/user_include_blueprint.rb
+++ b/app/blueprints/user_include_blueprint.rb
@@ -33,6 +33,7 @@ class UserIncludeBlueprint < Blueprinter::Base
       default_image_size: user.default_image_size,
       comment_threshold: user.comment_threshold,
       blacklist_users: user.blacklist_users?,
+      autocomplete: user.enable_auto_complete?,
     }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -154,7 +154,6 @@ module ApplicationHelper
         controller: controller_param,
         action: action_param,
         **data_attributes_for(user, "user", attributes),
-        hotkeys_enabled: CurrentUser.user.enable_keyboard_navigation?,
       },
     }
   end

--- a/app/javascript/src/js/components/autocomplete/Constants.ts
+++ b/app/javascript/src/js/components/autocomplete/Constants.ts
@@ -1,12 +1,10 @@
-import Utility from "@/utility/utility";
-
 export default class Constants {
   static readonly TAG_PREFIXES = ["-", "~"];
 
   // Passed on from the back-end via meta tags
-  static readonly TAG_CATEGORIES: string[] = JSON.parse(Utility.meta("tag-categories") || "[]");
-  static readonly METATAGS: string[] = JSON.parse(Utility.meta("metatags") || "[]");
-  static readonly ORDER_METATAGS: string[] = JSON.parse(Utility.meta("order-metatags") || "[]");
+  static readonly TAG_CATEGORIES: string[] = Constants.readMetadata("tag-categories");
+  static readonly METATAGS: string[] = Constants.readMetadata("metatags");
+  static readonly ORDER_METATAGS: string[] = Constants.readMetadata("order-metatags");
 
   static readonly STATIC_METATAGS = {
     order: Constants.ORDER_METATAGS,
@@ -30,4 +28,20 @@ export default class Constants {
   static readonly METATAGS_REGEX = Constants.METATAGS.length > 0
     ? new RegExp("^(" + Constants.METATAGS.join("|") + "):(.*)", "i")
     : null;
+
+  /**
+   * Reads metadata from a meta tag in the document head.
+   * @param key The name of the meta tag to read.
+   * @returns An array of strings parsed from the meta tag's content, or an empty array if the meta tag is not found or cannot be parsed.
+   */
+  private static readMetadata (key: string): string[] {
+    const element = document.querySelector(`meta[name="${key}"]`);
+    if (!element) return [];
+    try {
+      return JSON.parse(element.getAttribute("content") || "[]");
+    } catch {
+      console.warn(`Failed to parse metadata for key "${key}".`);
+      return [];
+    }
+  }
 }

--- a/app/javascript/src/js/components/autocomplete/index.ts
+++ b/app/javascript/src/js/components/autocomplete/index.ts
@@ -1,6 +1,5 @@
 import AutocompleteWidget from "@/components/autocomplete/AutocompleteWidget";
 import Logger from "@/utility/Logger";
-import Utility from "@/utility/utility";
 
 import Provider from "@/components/autocomplete/Provider";
 import ArtistProvider from "@/components/autocomplete/providers/ArtistProvider";
@@ -9,6 +8,7 @@ import TagProvider from "@/components/autocomplete/providers/TagProvider";
 import TagQueryProvider from "@/components/autocomplete/providers/TagQueryProvider";
 import UserProvider from "@/components/autocomplete/providers/UserProvider";
 import WikiProvider from "@/components/autocomplete/providers/WikiProvider";
+import CurrentUser from "@/models/CurrentUser";
 
 const PROVIDERS: Record<string, new () => Provider> = {
   "tag-query": TagQueryProvider,
@@ -26,8 +26,7 @@ export default class Autocomplete {
   private static Logger = new Logger("Autocomplete");
 
   public static initialize_all () {
-    if (Utility.meta("enable-auto-complete") !== "true")
-      return;
+    if (!CurrentUser.settings.autocomplete) return;
 
     const match_counts: Record<string, number> = {};
     for (const type of Object.keys(PROVIDERS)) {

--- a/app/javascript/src/js/models/CurrentUser.ts
+++ b/app/javascript/src/js/models/CurrentUser.ts
@@ -95,6 +95,7 @@ class CurrentUser {
       defaultImageSize: settingsObj["default_image_size"] || "large",
       commentThreshold: settingsObj["comment_threshold"] || -10,
       blacklistUsers: !!settingsObj["blacklist_users"],
+      autocomplete: !!settingsObj["autocomplete"],
     };
 
     // Blacklist
@@ -260,4 +261,5 @@ interface CurrentUserSettings {
   defaultImageSize: string,
   commentThreshold: number,
   blacklistUsers: boolean,
+  autocomplete: boolean,
 }

--- a/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
+++ b/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
@@ -50,7 +50,6 @@ import autocompletableInput from "@/components/autocompletable_input.vue";
 import filePreview from "@/pages/uploads/new/file_preview.vue";
 import fileInput from "@/pages/uploads/new/file_input.vue";
 import sources from "@/pages/uploads/new/sources.vue";
-import Utility from "@/utility/utility";
 import CurrentUser from "@/models/CurrentUser";
 
 export default {

--- a/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
+++ b/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
@@ -51,6 +51,7 @@ import filePreview from "@/pages/uploads/new/file_preview.vue";
 import fileInput from "@/pages/uploads/new/file_input.vue";
 import sources from "@/pages/uploads/new/sources.vue";
 import Utility from "@/utility/utility";
+import CurrentUser from "@/models/CurrentUser";
 
 export default {
   components: {
@@ -74,7 +75,7 @@ export default {
       nonUrlSourceWarning: false,
       submitting: false,
       submittedReason: undefined,
-      canApprove: Utility.meta("current-user-can-approve-posts") === "true",
+      canApprove: CurrentUser.can.approvePosts,
       uploadAsPending: false,
     };
   },

--- a/app/javascript/src/js/pages/posts/post_mode_menu.js
+++ b/app/javascript/src/js/pages/posts/post_mode_menu.js
@@ -10,6 +10,7 @@ import SStorage from "@/utility/storage/Session";
 import TaskQueue from "@/utility/TaskQueue";
 import PostVote from "@/models/PostVote";
 import Autocomplete from "@/components/autocomplete";
+import CurrentUser from "@/models/CurrentUser";
 
 let PostModeMenu = {};
 
@@ -96,7 +97,7 @@ PostModeMenu.initialize_edit_form = function () {
 PostModeMenu.close_edit_form = function () {
   Hotkeys.enabled = true;
   $("#quick-edit-div").slideUp("fast");
-  if (Utility.meta("enable-auto-complete") === "true") {
+  if (CurrentUser.settings.autocomplete) {
     const field = document.getElementById("post_tag_string");
     const autocompleter = Autocomplete.instances.get(field);
     if (autocompleter) autocompleter.close();

--- a/app/javascript/src/js/pages/posts/post_mode_menu.js
+++ b/app/javascript/src/js/pages/posts/post_mode_menu.js
@@ -1,4 +1,3 @@
-import Utility from "@/utility/utility";
 import Post from "@/pages/posts/posts";
 import Favorite from "@/models/Favorite";
 import PostSet from "@/pages/posts/show/PostSet";

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -6,6 +6,7 @@ import SVGIcon from "@/utility/SVGIcon";
 import TaskQueue from "@/utility/TaskQueue";
 import ToastManager from "@/utility/Toast";
 import Utility from "@/utility/utility";
+import CurrentUser from "@/models/CurrentUser";
 
 let Post = {};
 
@@ -922,7 +923,7 @@ Post.set_as_avatar = function (id) {
   TaskQueue.add(() => {
     $.ajax({
       method: "PATCH",
-      url: `/users/${Utility.meta("current-user-id")}.json`,
+      url: `/users/${CurrentUser.id}.json`,
       data: {
         "user[avatar_id]": id,
       },

--- a/app/javascript/src/js/pages/posts/show/tag_editor.vue
+++ b/app/javascript/src/js/pages/posts/show/tag_editor.vue
@@ -27,7 +27,6 @@ import relatedTags from "@/pages/uploads/new/related.vue";
 import tagPreview from "@/pages/uploads/new/tag_preview.vue";
 import Post from '../posts';
 import Autocomplete from "@/components/autocomplete";
-import Utility from "@/utility/utility.js";
 import CurrentUser from "@/models/CurrentUser";
 
 function tagSorter(a, b) {

--- a/app/javascript/src/js/pages/posts/show/tag_editor.vue
+++ b/app/javascript/src/js/pages/posts/show/tag_editor.vue
@@ -28,6 +28,7 @@ import tagPreview from "@/pages/uploads/new/tag_preview.vue";
 import Post from '../posts';
 import Autocomplete from "@/components/autocomplete";
 import Utility from "@/utility/utility.js";
+import CurrentUser from "@/models/CurrentUser";
 
 function tagSorter(a, b) {
   return a.name > b.name ? 1 : -1;
@@ -58,7 +59,7 @@ export default {
       el.style.height = el.scrollHeight + "px";
       el.focus();
     }, 20);
-    if (Utility.meta("enable-auto-complete") !== "true")
+    if (!CurrentUser.settings.autocomplete)
       return;
     Autocomplete.initialize_autocomplete('tag-edit');
   },

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -16,7 +16,6 @@
   <meta name="blacklist-users" content="false">
 <% end %>
 <meta name="style-usernames" content="<%= CurrentUser.user.style_usernames? %>">
-<meta name="last-forum-read-at" content="<%= CurrentUser.user.last_forum_read_at %>">
 
 <%# Data for autocomplete %>
 <meta name="metatags" content="<%= TagQuery::METATAGS.to_json %>">

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -7,10 +7,7 @@
 <% unless disable_mobile_mode? %>
   <meta name="viewport" content="width=device-width,initial-scale=1">
 <% end %>
-<meta name="current-user-name" content="<%= CurrentUser.name %>">
-<meta name="current-user-id" content="<%= CurrentUser.id %>">
-<meta name="current-user-can-approve-posts" content="<%= CurrentUser.can_approve_posts? %>">
-<meta name="user-comment-threshold" content="<%= CurrentUser.comment_threshold %>">
+
 <% if CurrentUser.user.blacklisted_tags.present? %>
   <meta name="blacklisted-tags" content="<%= CurrentUser.user.blacklisted_tags.split(/(?:\r|\n)+/).to_json %>">
   <meta name="blacklist-users" content="<%= CurrentUser.blacklist_users? %>">
@@ -18,11 +15,18 @@
   <meta name="blacklisted-tags" content="[]">
   <meta name="blacklist-users" content="false">
 <% end %>
+<meta name="style-usernames" content="<%= CurrentUser.user.style_usernames? %>">
+<meta name="last-forum-read-at" content="<%= CurrentUser.user.last_forum_read_at %>">
+
+<%# Data for autocomplete %>
 <meta name="metatags" content="<%= TagQuery::METATAGS.to_json %>">
 <meta name="order-metatags" content="<%= TagQuery::ORDER_METATAGS_AUTOCOMPLETE.to_json %>">
 <meta name="tag-categories" content="<%= TagCategory::MAPPING.keys.to_json %>">
-<meta name="style-usernames" content="<%= CurrentUser.user.style_usernames? %>">
-<meta name="last-forum-read-at" content="<%= CurrentUser.user.last_forum_read_at %>">
+
+<%# Site configuration for JavaScript %>
+<script type="text/plain" id="site-settings" data-encoding="base64"><%= site_settings_base64 %></script>
+<script type="text/plain" id="site-user" data-encoding="base64"><%= site_user_base64 %></script>
+
 <% if CurrentUser.user.custom_style.present? %>
   <%= stylesheet_link_tag custom_style_users_path(md5: Digest::MD5.hexdigest(CurrentUser.user.custom_style)), media: "screen", nonce: true %>
 <% end %>
@@ -59,10 +63,6 @@
   "url" : "<%= root_url %>"
 }
 </script>
-
-<%# Site configuration for JavaScript %>
-<script type="text/plain" id="site-settings" data-encoding="base64"><%= site_settings_base64 %></script>
-<script type="text/plain" id="site-user" data-encoding="base64"><%= site_user_base64 %></script>
 
 <style id="blacklisted-hider">
   .thumbnail, #image-container, #c-comments .post {

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -18,8 +18,6 @@
   <meta name="blacklisted-tags" content="[]">
   <meta name="blacklist-users" content="false">
 <% end %>
-<meta name="enable-js-navigation" content="<%= CurrentUser.user.enable_keyboard_navigation %>">
-<meta name="enable-auto-complete" content="<%= CurrentUser.user.enable_auto_complete %>">
 <meta name="metatags" content="<%= TagQuery::METATAGS.to_json %>">
 <meta name="order-metatags" content="<%= TagQuery::ORDER_METATAGS_AUTOCOMPLETE.to_json %>">
 <meta name="tag-categories" content="<%= TagCategory::MAPPING.keys.to_json %>">

--- a/app/views/static/home.html.erb
+++ b/app/views/static/home.html.erb
@@ -82,7 +82,6 @@
   <% if @mascot_background_url.present? %>
     <%= tag.link(rel: "preload", as: "image", href: @mascot_background_url, fetchpriority: "high") %>
   <% end %>
-  <meta name="enable-auto-complete" content="<%= CurrentUser.user.enable_auto_complete %>">
   <%= tag.meta(name: "description", content: Danbooru.config.description) %>
   <%= tag.meta(property: "og:site_name", content: Danbooru.config.app_name) %>
   <%= tag.meta(property: "og:title", content: Danbooru.config.app_name) %>

--- a/spec/blueprints/user_include_blueprint_spec.rb
+++ b/spec/blueprints/user_include_blueprint_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UserIncludeBlueprint do
 
   describe "settings field" do
     it "has the expected keys" do
-      expect(result[:settings].keys).to match_array(%i[hotkeys per_page default_image_size comment_threshold blacklist_users])
+      expect(result[:settings].keys).to match_array(%i[hotkeys per_page default_image_size comment_threshold blacklist_users autocomplete])
     end
   end
 


### PR DESCRIPTION
The CurrentUser class is a better way of passing settings to the front-end.
The old way using meta tags and body attributes are no longer necessary, and can be removed.

Left the blacklist-related metatags in place. These are oftentimes used by third party tools, and are updated dynamically.
Left the `style-usernames` setting in place, since it's due to be removed entirely soon.
Unsure what to do with the `last-forum-read-at` setting. It does not seem to be used anywhere, but I left it in place anyways.