### PR TITLE
[TagQuery] Alias playtime duration tags to equivalent `duration` values

### DIFF
--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1555,10 +1555,20 @@ class TagQuery
   # Same as `TagQuery::REGEX_VALID_TAG_CHECK`, but disallows `*`
   REGEX_VALID_TAG_CHECK_2 = /[\*\,\#\$\%\\]/
 
+  # TODO: Add `FileMethods::FILE_TYPE` to this
+  # TODO: Add to autocomplete
+  METATAG_ALIASES = {
+    "long_playtime" => ->(tag, type) { [type, :duration, [:gte, 30.0]] },
+    "short_playtime" => ->(tag, type) { [type, :duration, [:lt, 30.0]] },
+  }.freeze
+
   # Checks if a certain tag should be transformed into a metatag, and adds it accordingly if so.
   def intercept_metatag_alias(tag, type)
     if FileMethods::FILE_TYPE.value?(tag)
       add_to_query(type, :filetype, tag)
+      return true
+    elsif (v = METATAG_ALIASES[tag])
+      add_to_query(*(v.call(tag, type)))
       return true
     end
     nil


### PR DESCRIPTION
Added METATAG_ALIASES for long and short playtime tags.

- [x] Base implementation
   - [ ] Add unit tests
- [ ] Account for in [`Post.add_automatic_tags`](https://github.com/e621ng/e621ng/blob/feat/playtime-tags-to-duration/app/models/post.rb#L837).
   - [ ] Add unit tests