### PR TITLE
[WikiPages] Add notices to tags added automatically

### DIFF
--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -112,6 +112,7 @@ module IconHelper
 
     # WikiPages
     copy: %(<rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/>),
+    info: %(<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>),
   }.freeze
 
   def svg_icon(name, *args)

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -65,6 +65,7 @@
 @import "views/tickets/tickets";
 @import "views/uploads/uploads";
 @import "views/users/users";
+@import "views/wiki_pages/wiki_pages";
 
 @import "specific/admin_dashboards.scss";
 @import "specific/api_keys.scss";

--- a/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
+++ b/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
@@ -1,0 +1,24 @@
+#c-wiki-pages {
+  .automated-tag-notice {
+    max-width: 50rem;
+    background: themed("color-section");
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    box-sizing: border-box;
+    border-left: 0.25rem solid palette("background-orange");
+
+    h3 {
+      display: flex;
+      gap: 0.5rem;
+
+      font-size: 1rem;
+      line-height: 1rem;
+      margin-bottom: 0.25rem;
+
+      svg {
+        width: 1rem;
+        height: 1rem;
+      }
+    }
+  }
+}

--- a/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
+++ b/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
@@ -1,11 +1,13 @@
 #c-wiki-pages {
   .automated-tag-notice {
     max-width: 50rem;
-    background: themed("color-section");
-    border-radius: 0.25rem;
-    padding: 0.5rem;
     box-sizing: border-box;
+    padding: 0.5rem;
+    margin: 0.5rem 0;
+    
+    background: themed("color-section");
     border-left: 0.25rem solid palette("background-orange");
+    border-radius: 0.25rem;
 
     h3 {
       display: flex;

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -845,6 +845,10 @@ class Post < ApplicationRecord
         long_playtime short_playtime
       ] + FileMethods::FILE_TYPE.values
 
+      # NOTE: when adding, removing, or changing any of these values, make sure to also
+      # update the corresponding labels in Danbooru.config.automated_tag_notices.
+      # Otherwise, users may be confused by missing or incorrect help messages.
+
       if has_dimensions?
         tags << "superabsurd_res" if image_width >= 10_000 && image_height >= 10_000
         tags << "absurd_res" if image_width >= 3200 || image_height >= 2400

--- a/app/views/wiki_pages/_automated_tag.html.erb
+++ b/app/views/wiki_pages/_automated_tag.html.erb
@@ -3,6 +3,6 @@
 <% if tag.present? && Danbooru.config.automated_tag_notices.key?(tag) %>
   <div class="automated-tag-notice dtext-container">
     <h3><%= svg_icon(:info) %> Automated Tag</h3>
-    <%= format_text Danbooru.config.automated_tag_notices[tag] + "\nIt should not be added or removed manually." %>
+    <%= format_text "#{Danbooru.config.automated_tag_notices[tag]}\nIt should not be added or removed manually." %>
   </div>
 <% end %>

--- a/app/views/wiki_pages/_automated_tag.html.erb
+++ b/app/views/wiki_pages/_automated_tag.html.erb
@@ -1,0 +1,8 @@
+<%# locals: (tag:) %>
+
+<% if Danbooru.config.automated_tag_notices.key?(tag) %>
+  <div class="automated-tag-notice dtext-container">
+    <h3><%= svg_icon(:info) %> Automated Tag</h3>
+    <%= format_text Danbooru.config.automated_tag_notices[tag] + "\nIt should not be added or removed manually." %>
+  </div>
+<% end %>

--- a/app/views/wiki_pages/_automated_tag.html.erb
+++ b/app/views/wiki_pages/_automated_tag.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (tag:) %>
 
-<% if Danbooru.config.automated_tag_notices.key?(tag) %>
+<% if tag.present? && Danbooru.config.automated_tag_notices.key?(tag) %>
   <div class="automated-tag-notice dtext-container">
     <h3><%= svg_icon(:info) %> Automated Tag</h3>
     <%= format_text Danbooru.config.automated_tag_notices[tag] + "\nIt should not be added or removed manually." %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -26,6 +26,8 @@
         <div class="wiki-page-redirect"><%= svg_icon(:corner_down_right, width: 12, height: 12) %> <%= @wiki_page.title %></div>
       <% end %>
 
+      <%= render partial: "automated_tag", locals: { tag: wiki_content.title } %>
+
       <div id="wiki-page-body" class="dtext-container">
         <% if wiki_content.body.present? %>
           <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>  

--- a/app/views/wiki_pages/show_or_new.html.erb
+++ b/app/views/wiki_pages/show_or_new.html.erb
@@ -12,6 +12,9 @@
           </button>
         <% end %>
       </h1>
+
+      <%= render partial: "automated_tag", locals: { tag: @wiki_page.title } %>
+
       <div id="wiki-page-body" class="dtext-container">
         <p>This wiki page is empty. <%= link_to "Click here to add details", new_wiki_page_path(wiki_page: { title: params[:title] }) %>.</p>
       </div>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -882,7 +882,7 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
 
     def automated_tag_notices
       values = {
-        thumbnail: "This tag is added automatically when the content is smaller than 250 pixels in width or height.",
+        thumbnail: "This tag is added automatically when the content is smaller than 250 pixels in width and height.",
         low_res: "This tag is added automatically when the content has a resolution lower than 500x500 pixels.",
         hi_res: "This tag is added automatically when the content has a width over 1600 pixels or height over 1200 pixels.",
         absurd_res: "This tag is added automatically when the content has a width over 3200 pixels or height over 2400 pixels.",
@@ -890,14 +890,19 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
 
         wide_image: "This tag is added automatically when the content is wider than 1024 pixels and the aspect ratio is wider than 4:1.",
         tall_image: "This tag is added automatically when the content is taller than 1024 pixels and the aspect ratio is taller than 1:4.",
+        long_image: "This tag is added automatically when the content is larger than 1024 pixels and the aspect ratio is larger than 4:1.",
 
         huge_filesize: "This tag is added automatically when the content has a file size larger than 30 megabytes.",
         long_playtime: "This tag is added automatically when the content has a video longer than 30 seconds.",
         short_playtime: "This tag is added automatically when the content has a video shorter than 30 seconds.",
 
         video: "This tag is added automatically to posts containing videos.",
-        animated: "This tag is added automatically to posts containing animated images.",
         flash: "This tag is added automatically to posts containing Flash files.",
+
+        animated: "This tag is added automatically to posts containing animated images.",
+        animated_gif: "This tag is added automatically to posts containing animated GIFs.",
+        animated_png: "This tag is added automatically to posts containing animated PNGs.",
+        animated_webp: "This tag is added automatically to posts containing animated WebPs.",
       }.stringify_keys
 
       FileMethods::FILE_TYPE.each_value do |file_type|

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -879,6 +879,33 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
         tags: true,
       }
     end
+
+    def automated_tag_notices
+      values = {
+        thumbnail: "This tag is added automatically when the content is smaller than 250 pixels in width or height.",
+        low_res: "This tag is added automatically when the content has a resolution lower than 500x500 pixels.",
+        hi_res: "This tag is added automatically when the content has a width over 1600 pixels or height over 1200 pixels.",
+        absurd_res: "This tag is added automatically when the content has a width over 3200 pixels or height over 2400 pixels.",
+        superabsurd_res: "This tag is added automatically when the content has a resolution over 10000x10000 pixels.",
+
+        wide_image: "This tag is added automatically when the content is wider than 1024 pixels and the aspect ratio is wider than 4:1.",
+        tall_image: "This tag is added automatically when the content is taller than 1024 pixels and the aspect ratio is taller than 1:4.",
+
+        huge_filesize: "This tag is added automatically when the content has a file size larger than 30 megabytes.",
+        long_playtime: "This tag is added automatically when the content has a video longer than 30 seconds.",
+        short_playtime: "This tag is added automatically when the content has a video shorter than 30 seconds.",
+
+        video: "This tag is added automatically to posts containing videos.",
+        animated: "This tag is added automatically to posts containing animated images.",
+        flash: "This tag is added automatically to posts containing Flash files.",
+      }.stringify_keys
+
+      FileMethods::FILE_TYPE.each_value do |file_type|
+        values[file_type] = "This tag does not exist. Searching for it is equivalent to {{type:#{file_type}}}."
+      end
+
+      values
+    end
   end
 
   class EnvironmentConfiguration


### PR DESCRIPTION
An attempt to make it clear that specific tags cannot be added or removed manually.

<img width="821" height="140" alt="image" src="https://github.com/user-attachments/assets/38bb9195-80f3-4dfe-ac1a-3934f5c5324e" />
