### PR TITLE
[CI] Properly skip the tests job on draft PRs

### DIFF
--- a/.github/workflows/run-checks.yml
+++ b/.github/workflows/run-checks.yml
@@ -121,13 +121,14 @@ jobs:
   tests:
     runs-on: ubuntu-22.04
     needs: test-runner
-    if: always()
+    # Tests are skipped on draft PRs to save on actions usage.
+    # Skipping this job keeps draft PRs from being marked as failing:
+    # a skipped job reports "success" to branch protection.
+    if: always() && needs.test-runner.result != 'skipped'
     steps:
       - name: Check test results
-        run: |
-          if [[ "${{ needs.test-runner.result }}" != "success" ]]; then
-            exit 1
-          fi
+        if: needs.test-runner.result != 'success'
+        run: exit 1
 
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Previously, draft PRs skipped the test runner jobs, but still ran (and failed) the main `tests` job that relied on them.
As a result, the required check was marked as a failure.

Now, the `tests` job is skipped as well.
The `coverage-report` shouldn't run either.