### PR TITLE
[Posts] Fix a flaky `#previous_version_uploaders` test

### DIFF
--- a/spec/models/post/uploader_methods_spec.rb
+++ b/spec/models/post/uploader_methods_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Post do
         expect(replacement1.creator).to eq(user1)
         expect(replacement2.creator).to eq(user2)
         expect(replacement3.creator).to eq(user1)
-        expect(post.previous_version_uploaders).to eq([user1, user2])
+        expect(post.previous_version_uploaders).to contain_exactly(user1, user2)
       end
 
       it "returns empty if the post was never replaced" do


### PR DESCRIPTION
This test sometimes failed in CI because the rows could be returned in any order - while the test expected a specific one.