### PR TITLE
[Users] Rename "Commission Information" to "Artist Information"

### DIFF
--- a/app/views/staff/users/edit.html.erb
+++ b/app/views/staff/users/edit.html.erb
@@ -19,7 +19,7 @@
       </div>
 
       <%= f.input :profile_about, as: :dtext, label: "About", limit: Danbooru.config.user_about_max_size, allow_color: true %>
-      <%= f.input :profile_artinfo, as: :dtext, label: "Commission Info", limit: Danbooru.config.user_about_max_size, allow_color: true %>
+      <%= f.input :profile_artinfo, as: :dtext, label: "Artist Info", limit: Danbooru.config.user_about_max_size, allow_color: true %>
       <%= f.input :custom_title, input_html: { size: 50 }, hint: "Replaces the level badge text. Leave blank to show level." %>
       <%= f.input :base_upload_limit %>
 

--- a/app/views/users/partials/edit/_basic.html.erb
+++ b/app/views/users/partials/edit/_basic.html.erb
@@ -89,8 +89,8 @@
   </tab-body>
 </tab-entry>
 
-<tab-entry tab="<%= tab_name %>" group="profile" class="bigtext" search="user profile commission info">
-  <tab-head><%= form.label :profile_artinfo, "Commission Info" %></tab-head>
+<tab-entry tab="<%= tab_name %>" group="profile" class="bigtext" search="user profile artist info">
+  <tab-head><%= form.label :profile_artinfo, "Artist Info" %></tab-head>
   <tab-body>
     <%= form.input_field :profile_artinfo,
       as: :dtext,

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,7 +27,7 @@
         <button role="tab" name="about">About</button>
       <% end %>
       <% if has_artinfo %>
-        <button role="tab" name="artinfo">Commission Info</button>
+        <button role="tab" name="artinfo">Artist Info</button>
       <% end %>
       <button role="tab" name="stats">Stats</button>
     </tabs-menu>


### PR DESCRIPTION
The user page already shows "Artist Information" in desktop mode, so fix it for mobile mode and user editors.