### PR TITLE
[CSRF] Reject cross-site form submission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,15 @@ class ApplicationController < ActionController::Base
   class APIThrottled < StandardError; end
   class FeatureUnavailable < StandardError; end
 
-  # NOTE: this gets flagged by CodeQL as a CSRF vulnerability, but it's a false positive.
-  # This check is only skipped for requests with API authentication, which are made by clients
-  # that don't support CSRF tokens. All browser-based actions still require CSRF protection.
-  skip_forgery_protection if: -> { SessionLoader.new(request).has_api_authentication? }
+  # CSRF is skipped only for API-authenticated requests (clients that don't support CSRF tokens),
+  # AND only when the request is not a cross-origin browser submission. A hidden cross-site <form>
+  # can supply login/api_key params, but browser always attaches a cross-origin Origin header to it.
+  # Requiring a same-origin (or origin-less, i.e. non-browser) request closes that forgery vector
+  # while leaving genuine API clients unaffected.
+  skip_forgery_protection if: -> do
+    loader = SessionLoader.new(request)
+    loader.has_api_authentication? && loader.same_origin_request?
+  end
 
   before_action :reset_current_user
   before_action :sanitize_params

--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -55,6 +55,13 @@ class SessionLoader
     has_bearer_token? || basic_auth_or_login_params?
   end
 
+  # A forged cross-site form submission always carries an Origin header pointing at the attacker's
+  # page, whereas non-browser API clients (curl, bots) send none. Mirror Rails' own same-origin
+  # comparison so CSRF is only skipped for genuine first-party or non-browser requests.
+  def same_origin_request?
+    request.origin.nil? || request.origin == request.base_url
+  end
+
   def has_bearer_token?
     bearer_token.present?
   end

--- a/spec/logical/session_loader_spec.rb
+++ b/spec/logical/session_loader_spec.rb
@@ -50,6 +50,25 @@ RSpec.describe SessionLoader do
   end
 
   # ---------------------------------------------------------------------------
+  # #same_origin_request?
+  # ---------------------------------------------------------------------------
+  describe "#same_origin_request?" do
+    it "returns true when no Origin header is present (non-browser client)" do
+      expect(loader.same_origin_request?).to be true
+    end
+
+    it "returns true when the Origin matches the request's own origin" do
+      env["HTTP_ORIGIN"] = request.base_url
+      expect(loader.same_origin_request?).to be true
+    end
+
+    it "returns false when the Origin is cross-site (forged browser submission)" do
+      env["HTTP_ORIGIN"] = "https://attacker.example"
+      expect(loader.same_origin_request?).to be false
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #has_remember_token?
   # ---------------------------------------------------------------------------
   describe "#has_remember_token?" do


### PR DESCRIPTION
API-authenticated requests must either be same-origin, or have no origin at all (non-browser).