### PR TITLE
[OAuth] Permit loopback redirect URIs in production

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -37,7 +37,10 @@ Doorkeeper.configure do
     reason.nil?
   end
 
-  force_ssl_in_redirect_uri Rails.env.production?
+  # Require HTTPS redirect URIs in production, except loopback IPs for native apps (RFC 8252).
+  force_ssl_in_redirect_uri do |uri|
+    Rails.env.production? && %w[127.0.0.1 [::1]].exclude?(uri.host)
+  end
 
   skip_authorization do |resource_owner, client|
     requested = client.scopes.to_a


### PR DESCRIPTION
This allows desktop apps to use the loopback IPs as their callback URL for OAuth. 
Specifically excludes localhost for security reasons.