### PR TITLE
[OAuth] Match id_token lifetime to access token expiry

### DIFF
--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -10,6 +10,8 @@ Doorkeeper::OpenidConnect.configure do
 
   signing_key -> { OidcSigningKey.pem }
 
+  expiration Doorkeeper.config.access_token_expires_in
+
   subject_types_supported [:public]
 
   resource_owner_from_access_token do |access_token|


### PR DESCRIPTION
This is convenient for clients and the more standard way to do it.