### PR TITLE
[Users] Don't create a ModAction when editing one's own blacklist through the staff endpoint

### DIFF
--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -74,7 +74,10 @@ module Staff
     def update_blacklist
       @user = User.find(params[:id])
       @user.update!(params[:user].permit([:blacklisted_tags]))
-      ModAction.log(:user_blacklist_changed, { user_id: @user.id })
+      # Sometimes staff uses the wrong UI to update their blacklist, no need to log it.
+      if CurrentUser.id != @user.id
+        ModAction.log(:user_blacklist_changed, { user_id: @user.id })
+      end
       redirect_to edit_blacklist_staff_user_path(@user), notice: "Blacklist updated"
     end
 

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -276,6 +276,12 @@ RSpec.describe Staff::UsersController do
         expect(ModAction.last[:values]).to include("user_id" => user.id)
       end
 
+      it "doesn't log a user_blacklist_changed ModAction when it's the user's own blacklist" do
+        expect { post update_blacklist_staff_user_path(admin), params: { user: { blacklisted_tags: "tag1" } } }
+          .not_to change(ModAction, :count)
+        expect(admin.reload.blacklisted_tags).to eq("tag1")
+      end
+
       it "redirects to edit_blacklist with a notice" do
         post update_blacklist_staff_user_path(user), params: { user: { blacklisted_tags: "tag1" } }
         expect(response).to redirect_to(edit_blacklist_staff_user_path(user))


### PR DESCRIPTION
Split from #2247

You clicked the wrong button, no one needs to know ;)