### PR TITLE
[PostVotes] Fix post scores being calculated incorrectly when locking votes

### DIFF
--- a/app/logical/vote_manager.rb
+++ b/app/logical/vote_manager.rb
@@ -94,7 +94,7 @@ class VoteManager
       if vote.score > 0
         vote_cols << "up_score = up_score - 1"
       else
-        vote_cols << "down_score = down_score - 1"
+        vote_cols << "down_score = down_score + 1"
       end
       Post.where(id: post.id).update_all(vote_cols.join(", "))
 

--- a/db/fixes/137_fix_post_scores_from_locked_votes.rb
+++ b/db/fixes/137_fix_post_scores_from_locked_votes.rb
@@ -19,7 +19,6 @@ module Fixes
           fixed += 1
 
           post.update_columns(down_score: down_score)
-          post.update_hotness!
           post.update_index
         end
 

--- a/db/fixes/137_fix_post_scores_from_locked_votes.rb
+++ b/db/fixes/137_fix_post_scores_from_locked_votes.rb
@@ -12,7 +12,7 @@ module Fixes
 
         Post.joins(:votes).where(votes: { score: 0 }).distinct.find_each do |post|
           processed += 1
-          down_score = post.votes.where("score < 0").count
+          down_score = 0 - post.votes.where("score < 0").count
           puts "Processed #{processed} posts, fixed #{fixed} posts" if processed % 1000 == 0
 
           next if post.down_score == down_score

--- a/db/fixes/137_fix_post_scores_from_locked_votes.rb
+++ b/db/fixes/137_fix_post_scores_from_locked_votes.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Fixes
+  class FixPostScoresFromLockedVotes
+    def self.run
+      # Due to incorrect score calculations, all posts that had negative votes locked (set to score = 0)
+      # have incorrect total scores. This fix will recalculate the scores for all posts that have locked votes.
+
+      Post.without_timeout do
+        # Find posts with at least one locked vote (score = 0) and recalculate their scores
+        Post.joins(:votes).where(votes: { score: 0 }).distinct.find_each do |post|
+          # Recalculate the scores for the post
+          up_score = post.votes.where("score > 0").count
+          down_score = post.votes.where("score < 0").count
+          total_score = up_score - down_score
+
+          # Update the post's scores
+          post.update_columns(score: total_score, up_score: up_score, down_score: down_score)
+
+          # Update hotness and index for the post
+          post.update_hotness!
+          post.update_index
+        end
+      end
+    end
+  end
+end
+
+Fixes::FixPostScoresFromLockedVotes.run

--- a/db/fixes/137_fix_post_scores_from_locked_votes.rb
+++ b/db/fixes/137_fix_post_scores_from_locked_votes.rb
@@ -3,24 +3,27 @@
 module Fixes
   class FixPostScoresFromLockedVotes
     def self.run
-      # Due to incorrect score calculations, all posts that had negative votes locked (set to score = 0)
-      # have incorrect total scores. This fix will recalculate the scores for all posts that have locked votes.
+      # Due to incorrect score calculations, all posts that had negative votes
+      # locked (set to score = 0) have incorrect `down_score` value.
 
       Post.without_timeout do
-        # Find posts with at least one locked vote (score = 0) and recalculate their scores
+        processed = 0
+        fixed = 0
+
         Post.joins(:votes).where(votes: { score: 0 }).distinct.find_each do |post|
-          # Recalculate the scores for the post
-          up_score = post.votes.where("score > 0").count
+          processed += 1
           down_score = post.votes.where("score < 0").count
-          total_score = up_score - down_score
+          puts "Processed #{processed} posts, fixed #{fixed} posts" if processed % 1000 == 0
 
-          # Update the post's scores
-          post.update_columns(score: total_score, up_score: up_score, down_score: down_score)
+          next if post.down_score == down_score
+          fixed += 1
 
-          # Update hotness and index for the post
+          post.update_columns(down_score: down_score)
           post.update_hotness!
           post.update_index
         end
+
+        puts "Processed #{processed} posts, fixed #{fixed} posts"
       end
     end
   end

--- a/spec/logical/vote_manager/post_vote_spec.rb
+++ b/spec/logical/vote_manager/post_vote_spec.rb
@@ -219,12 +219,10 @@ RSpec.describe VoteManager do
           .to change { post.reload.score }.by(1)
       end
 
-      # FIXME: lock! uses `down_score = down_score - 1` for downvotes (vote_manager.rb:91) but
-      # should use `+ 1` to move down_score toward 0, mirroring what unvote! does (vote_manager.rb:68).
-      # it "increments post.down_score toward 0" do
-      #   expect { described_class.lock!(vote.id) }
-      #     .to change { post.reload.down_score }.by(1)
-      # end
+      it "increments post.down_score toward 0" do
+        expect { described_class.lock!(vote.id) }
+          .to change { post.reload.down_score }.by(1)
+      end
     end
 
     context "with a non-existent id" do


### PR DESCRIPTION
Due to a bug in VoteManager, locking negative votes drove the `down_score` value further into the negatives, rather than resetting it. The other vote values were correct.

As such, in addition to fixing the bug, we'll have to recalculate the `down_score` value for all posts with locked votes.