### PR TITLE
[Autocomplete] Insert multiple tags while holding Ctrl

### DIFF
--- a/app/javascript/src/js/components/autocomplete/AutocompleteWidget.ts
+++ b/app/javascript/src/js/components/autocomplete/AutocompleteWidget.ts
@@ -233,9 +233,7 @@ export default class AutocompleteWidget {
     if (item) {
       const index = Array.from(this.dropdown.children).indexOf(item);
       if (index >= 0 && this.results[index]) {
-        // Holding the meta key inserts the tag but leaves the dropdown open,
-        // allowing multiple tags to be picked in a row. The stale list is
-        // refreshed on the next keystroke.
+        // Holding the control key inserts the tag but leaves the dropdown open
         this.selectItem(this.results[index], event.ctrlKey);
       }
     }

--- a/app/javascript/src/js/components/autocomplete/AutocompleteWidget.ts
+++ b/app/javascript/src/js/components/autocomplete/AutocompleteWidget.ts
@@ -194,7 +194,7 @@ export default class AutocompleteWidget {
           event.preventDefault();
           event.stopPropagation();
 
-          this.selectItem(this.results[this.selectedIndex]);
+          this.selectItem(this.results[this.selectedIndex], event.ctrlKey);
         }
         break;
       case "Escape":
@@ -206,8 +206,8 @@ export default class AutocompleteWidget {
           event.preventDefault();
 
           if (this.selectedIndex >= 0)
-            this.selectItem(this.results[this.selectedIndex]);
-          else this.selectItem(this.results[0]);
+            this.selectItem(this.results[this.selectedIndex], event.ctrlKey);
+          else this.selectItem(this.results[0], event.ctrlKey);
         }
         break;
     }
@@ -233,7 +233,10 @@ export default class AutocompleteWidget {
     if (item) {
       const index = Array.from(this.dropdown.children).indexOf(item);
       if (index >= 0 && this.results[index]) {
-        this.selectItem(this.results[index]);
+        // Holding the meta key inserts the tag but leaves the dropdown open,
+        // allowing multiple tags to be picked in a row. The stale list is
+        // refreshed on the next keystroke.
+        this.selectItem(this.results[index], event.ctrlKey);
       }
     }
   }
@@ -322,11 +325,12 @@ export default class AutocompleteWidget {
   /**
    * Handles the selection of an autocomplete item, invoking the insert function and closing the dropdown.
    * @param item The autocomplete item that was selected.
+   * @param keepOpen When true, the dropdown is left open after inserting, so the user can pick more tags in a row.
    */
-  private selectItem (item: AutocompleteItem) {
+  private selectItem (item: AutocompleteItem, keepOpen = false) {
     this.justSelected = true;
     this.provider.insert(this.input, item.name);
-    this.isOpen = false;
+    if (!keepOpen) this.isOpen = false;
     this.input.focus();
   }
 }

--- a/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
@@ -82,10 +82,16 @@ export default class TagQueryProvider extends Provider<Types.AutocompleteItem> {
     if (!bareName.includes(":") && LStorage.Posts.AutocompleteCache)
       TagFrequencyCache.record(bareName);
 
-    const beforeCaret = input.value.substring(0, input.selectionStart).trim();
+    const rawBeforeCaret = input.value.substring(0, input.selectionStart);
     const afterCaret = input.value.substring(input.selectionStart).trim();
 
-    const newBeforeCaret = beforeCaret.replace(/\S+$/, completion);
+    // Replace the partial tag directly before the caret.
+    // When the caret sits after whitespace (e.g. a tag was just inserted with the dropdown kept open),
+    // there is no partial tag, so append a new one instead of overwriting the previous complete tag.
+    const beforeCaret = rawBeforeCaret.trim();
+    const newBeforeCaret = /\S$/.test(rawBeforeCaret)
+      ? beforeCaret.replace(/\S+$/, completion)
+      : (beforeCaret.length ? beforeCaret + " " : "") + completion;
 
     const needsSpace = afterCaret.length === 0 || !afterCaret.startsWith(" ");
     const finalValue = newBeforeCaret + (needsSpace ? " " : "") + afterCaret;


### PR DESCRIPTION
By popular demand.

While holding the Ctrl key, inserting suggestions from autocomplete will not close the dropdown.
Clicking on suggestions after the first one will append them to the input.

https://github.com/user-attachments/assets/1269f272-d9aa-45e0-be45-4ee503d58305

Fixes #2258.
