### PR TITLE
[WikiPages] Add "featured posts" section

### DIFF
--- a/app/components/post_thumbnail_component.rb
+++ b/app/components/post_thumbnail_component.rb
@@ -73,6 +73,7 @@ class PostThumbnailComponent < ViewComponent::Base
     klass << "rating-explicit" if post.rating == "e"
     klass << "blacklistable" unless options[:no_blacklist]
     klass << "no-stats" unless should_show_stats?
+    klass << "native" if options[:native]
     klass
   end
 
@@ -135,7 +136,11 @@ class PostThumbnailComponent < ViewComponent::Base
   end
 
   def preview_urls
-    @preview_urls ||= post.preview_file_url_pair
+    @preview_urls ||= if options[:show_samples]
+                        post.sample_url_pair
+                      else
+                        post.preview_file_url_pair
+                      end
   end
 
   def alt_text

--- a/app/controllers/wiki_page_versions_controller.rb
+++ b/app/controllers/wiki_page_versions_controller.rb
@@ -21,6 +21,12 @@ class WikiPageVersionsController < ApplicationController
 
     @thispage = WikiPageVersion.find(ParseValue.safe_id(params[:thispage].to_s))
     @otherpage = WikiPageVersion.find(ParseValue.safe_id(params[:otherpage].to_s))
+
+    # Determine the changes between featured post ID arrays in the two versions
+    thispage_featured_posts = @thispage.featured_posts || []
+    otherpage_featured_posts = @otherpage.featured_posts || []
+    @featured_posts_added = otherpage_featured_posts - thispage_featured_posts
+    @featured_posts_removed = thispage_featured_posts - otherpage_featured_posts
   end
 
   private

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -124,7 +124,7 @@ class WikiPagesController < ApplicationController
   end
 
   def wiki_page_params(context)
-    permitted_params = %i[body category_id edit_reason]
+    permitted_params = %i[body category_id edit_reason featured_posts_string]
     permitted_params += %i[parent] if CurrentUser.is_privileged?
     permitted_params += %i[is_locked is_deleted skip_secondary_validations] if CurrentUser.is_staff?
     permitted_params += %i[category_is_locked] if CurrentUser.is_admin?

--- a/app/javascript/entrypoints/v_wiki-pages_edit.ts
+++ b/app/javascript/entrypoints/v_wiki-pages_edit.ts
@@ -1,0 +1,1 @@
+import "./v_wiki-pages_new";

--- a/app/javascript/entrypoints/v_wiki-pages_new.ts
+++ b/app/javascript/entrypoints/v_wiki-pages_new.ts
@@ -1,0 +1,8 @@
+// wiki_pages # new
+
+import E621Type from "@/interfaces/E621";
+declare const E621: E621Type;
+
+import "@/pages/wiki_pages/FeaturedPostsPreview";
+
+E621.Registry.register("v_wiki-pages_new");

--- a/app/javascript/src/js/pages/wiki_pages/FeaturedPostsPreview.ts
+++ b/app/javascript/src/js/pages/wiki_pages/FeaturedPostsPreview.ts
@@ -1,0 +1,160 @@
+import ThumbnailEngine from "@/components/ThumbnailEngine";
+import PostCache, { DeferredPostData } from "@/models/PostCache";
+import Logger from "@/utility/Logger";
+
+/**
+ * Live preview for the wiki page "featured posts" input.
+ * Validates the space-separated ID list client-side (mirroring WikiPage#validate_featured_posts)
+ * and renders a thumbnail row so authors see the result before submitting.
+ */
+class FeaturedPostsPreview {
+  private static Logger = new Logger("FeaturedPostsPreview");
+
+  private static readonly DEBOUNCE_MS = 250;
+
+  private static $input: JQuery<HTMLElement>;
+  private static $wrapper: JQuery<HTMLElement>;
+  private static $error: JQuery<HTMLElement>;
+  private static $list: JQuery<HTMLElement>;
+  private static max = 0;
+
+  private static debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private static requestID = 0;
+
+  static init () {
+    this.$wrapper = $("#featured-posts-preview");
+    this.$input = $("#wiki_page_featured_posts_string");
+    if (this.$wrapper.length === 0 || this.$input.length === 0) return;
+
+    this.$error = this.$wrapper.find(".featured-posts-preview-error");
+    this.$list = this.$wrapper.find(".featured-posts-preview-list");
+    this.max = parseInt(this.$wrapper.data("max")) || 0;
+
+    this.$input.on("input", () => {
+      if (this.debounceTimer) clearTimeout(this.debounceTimer);
+      this.debounceTimer = setTimeout(() => this.update(), this.DEBOUNCE_MS);
+    });
+
+    // Render whatever is already in the field on page load (relevant on edit).
+    this.update();
+  }
+
+  // ============================== //
+  // ======== Validation ========== //
+  // ============================== //
+
+  private static async update () {
+    const requestID = ++this.requestID;
+    const raw = String(this.$input.val() || "").trim();
+
+    if (raw.length === 0) {
+      this.clearError();
+      this.clearList();
+      return;
+    }
+
+    const tokens = raw.split(/\s+/);
+
+    // 1. Non-numeric tokens
+    const invalid = tokens.filter((token) => !/^\d+$/.test(token));
+    if (invalid.length > 0) {
+      this.showError(`Invalid post IDs: ${invalid.join(", ")}`);
+      this.clearList();
+      return;
+    }
+
+    const ids = tokens.map((token) => parseInt(token));
+
+    // 2. Count limit
+    if (this.max > 0 && ids.length > this.max) {
+      this.showError(`Cannot have more than ${this.max} posts`);
+      this.clearList();
+      return;
+    }
+
+    // 3. Duplicates
+    if (new Set(ids).size !== ids.length) {
+      this.showError("Cannot contain duplicate posts");
+      this.clearList();
+      return;
+    }
+
+    this.clearError();
+    await this.renderPosts(ids, requestID);
+  }
+
+  // ============================== //
+  // ========= Rendering ========== //
+  // ============================== //
+
+  private static async renderPosts (ids: number[], requestID: number) {
+    const uncached = ids.filter((id) => !PostCache.get(id));
+    if (uncached.length > 0) {
+      const posts = await this.fetchPosts(uncached);
+      if (this.expired(requestID)) return;
+      if (!posts) {
+        this.showError("Failed to load posts");
+        return;
+      }
+      for (const post of posts)
+        PostCache.fromDeferredPosts(post.id, post, true);
+    }
+
+    if (this.expired(requestID)) return;
+
+    // Any requested ID the API didn't return is nonexistent/unavailable.
+    const missing = ids.filter((id) => !PostCache.get(id));
+    if (missing.length > 0)
+      this.showError(`Contains invalid post IDs: ${missing.join(", ")}`);
+
+    this.clearList();
+    for (const id of ids) {
+      const post = PostCache.get(id);
+      if (!post || post.isDeleted) continue;
+      const thumbnail = ThumbnailEngine.render(post, { showStatistics: false, inline: true });
+      if (thumbnail) this.$list.append(thumbnail);
+    }
+  }
+
+  private static async fetchPosts (ids: number[]): Promise<DeferredPostData[] | null> {
+    this.Logger.log("Fetching posts:", ids);
+    try {
+      const response = await fetch(`/posts.json?v2=true&mode=thumbnail&tags=id:${ids.join(",")}`);
+      if (!response.ok) {
+        console.error(`Failed to fetch posts: ${response.statusText}`);
+        return null;
+      }
+      return await response.json();
+    } catch (error) {
+      console.error(`Error fetching posts: ${error}`);
+      return null;
+    }
+  }
+
+  // ============================== //
+  // ========== Helpers =========== //
+  // ============================== //
+
+  private static expired (requestID: number) {
+    return requestID !== this.requestID;
+  }
+
+  private static showError (message: string) {
+    this.$error.text(message).attr("hidden", null);
+  }
+
+  private static clearError () {
+    this.$error.text("").attr("hidden", "hidden");
+  }
+
+  private static clearList () {
+    this.$list.find(".thumbnail").each((_, element) => { PostCache.prune($(element)); });
+    this.$list.empty();
+  }
+}
+
+$(() => {
+  FeaturedPostsPreview.init();
+});
+
+export default FeaturedPostsPreview;

--- a/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
+++ b/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
@@ -1,4 +1,9 @@
 #c-wiki-pages {
+  #a-show #content {
+    container-type: inline-size;
+    container-name: wiki-content;
+  }
+
   .wiki-featured-posts {
     margin: 0.5rem 0 1rem;
 
@@ -7,11 +12,19 @@
       display: flex;
       flex-flow: row wrap;
       gap: 0.5rem;
+
+      @container wiki-content (max-width: 940px) {
+        max-width: 466px;
+      }
     }
 
     // Single featured post: an enlarged "hero" image.
     &.wiki-featured-hero article.thumbnail {
       --thumb-image-size: 380px;
+
+      @include window-smaller-than(30rem) {
+        img { max-width: calc(100vw - 1rem); }
+      }
     }
   }
 

--- a/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
+++ b/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
@@ -53,3 +53,26 @@
     }
   }
 }
+
+#c-wiki-pages #a-new, #c-wiki-pages #a-edit {
+  #wiki_page_featured_posts_string {
+    width: 100%;
+    max-width: 50rem;
+    box-sizing: border-box;
+  }
+
+  #featured-posts-preview {
+    margin: 0.5rem 0 1rem;
+
+    .featured-posts-preview-error {
+      color: palette("text-red");
+      margin-bottom: 0.5rem;
+    }
+
+    .featured-posts-preview-list {
+      display: flex;
+      flex-flow: row wrap;
+      gap: 0.5rem;
+    }
+  }
+}

--- a/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
+++ b/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
@@ -1,4 +1,20 @@
 #c-wiki-pages {
+  .wiki-featured-posts {
+    margin: 0.5rem 0 1rem;
+
+    // Multiple featured posts: a wrapping thumbnail row.
+    &.wiki-featured-row {
+      display: flex;
+      flex-flow: row wrap;
+      gap: 0.5rem;
+    }
+
+    // Single featured post: an enlarged "hero" image.
+    &.wiki-featured-hero article.thumbnail {
+      --thumb-image-size: 380px;
+    }
+  }
+
   .automated-tag-notice {
     max-width: 50rem;
     box-sizing: border-box;

--- a/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
+++ b/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
@@ -1,4 +1,4 @@
-#c-wiki-pages {
+#c-wiki-pages, #c-wiki-page-versions {
   #a-show #content {
     container-type: inline-size;
     container-name: wiki-content;

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -27,10 +27,12 @@ class WikiPage < ApplicationRecord
   validate :validate_rename
   validate :validate_redirect
   validate :validate_not_locked
+  validate :validate_featured_posts
 
   attr_accessor :skip_secondary_validations, :edit_reason
 
   array_attribute :other_names
+  array_attribute :featured_posts, parse: /\d+/, cast: :to_i
   belongs_to_creator
   belongs_to_updater
   has_one :tag, foreign_key: "name", primary_key: "title"
@@ -269,6 +271,26 @@ class WikiPage < ApplicationRecord
     end
   end
 
+  def validate_featured_posts
+    return if featured_posts.blank?
+
+    max = Danbooru.config.wiki_page_max_featured_posts
+    if featured_posts.size > max
+      errors.add(:featured_posts, "cannot have more than #{max} posts")
+      return
+    end
+
+    if featured_posts.uniq.size != featured_posts.size
+      errors.add(:featured_posts, "cannot contain duplicate posts")
+      return
+    end
+
+    missing = featured_posts - Post.where(id: featured_posts).pluck(:id)
+    if missing.any?
+      errors.add(:featured_posts, "contains invalid post IDs: #{missing.join(', ')}")
+    end
+  end
+
   def validate_redirect
     return unless will_save_change_to_parent? && parent.present?
     if WikiPage.find_by(title: parent).blank?
@@ -290,6 +312,7 @@ class WikiPage < ApplicationRecord
     self.body = version.body
     self.parent = version.parent
     self.other_names = version.other_names
+    self.featured_posts = version.featured_posts
   end
 
   def revert_to!(version)
@@ -338,7 +361,7 @@ class WikiPage < ApplicationRecord
   end
 
   def wiki_page_changed?
-    saved_change_to_title? || saved_change_to_body? || saved_change_to_is_locked? || saved_change_to_is_deleted? || saved_change_to_other_names? || saved_change_to_parent?
+    saved_change_to_title? || saved_change_to_body? || saved_change_to_is_locked? || saved_change_to_is_deleted? || saved_change_to_other_names? || saved_change_to_parent? || saved_change_to_featured_posts?
   end
 
   def create_new_version
@@ -351,6 +374,7 @@ class WikiPage < ApplicationRecord
       is_deleted: is_deleted,
       other_names: other_names,
       parent: parent,
+      featured_posts: featured_posts,
       reason: edit_reason,
     )
   end

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -2,6 +2,7 @@
 
 class WikiPageVersion < ApplicationRecord
   array_attribute :other_names
+  array_attribute :featured_posts, parse: /\d+/, cast: :to_i
   belongs_to :wiki_page
   belongs_to_updater
   user_status_counter :wiki_edit_count, foreign_key: :updater_id

--- a/app/views/wiki_page_versions/diff.html.erb
+++ b/app/views/wiki_page_versions/diff.html.erb
@@ -17,7 +17,7 @@
         <div>
           Added featured posts:
           <% @featured_posts_added.each do |post| %>
-            <%= link_to post, "/posts/#{post}" %>
+            <%= link_to post, post_path(post) %>
           <% end %>
         </div>
       <% end %>
@@ -25,7 +25,7 @@
         <div>
           Removed featured posts:
           <% @featured_posts_removed.each do |post| %>
-            <%= link_to post, "/posts/#{post}" %>
+            <%= link_to post, post_path(post) %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/wiki_page_versions/diff.html.erb
+++ b/app/views/wiki_page_versions/diff.html.erb
@@ -12,6 +12,25 @@
       </div>
     <% end %>
 
+    <div class="wiki-featured-diff">
+      <% if @featured_posts_added.any? %>
+        <div>
+          Added featured posts:
+          <% @featured_posts_added.each do |post| %>
+            <%= link_to post, "/posts/#{post}" %>
+          <% end %>
+        </div>
+      <% end %>
+      <% if @featured_posts_removed.any? %>
+        <div>
+          Removed featured posts:
+          <% @featured_posts_removed.each do |post| %>
+            <%= link_to post, "/posts/#{post}" %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
     <div>
       <%= text_diff(@thispage.body, @otherpage.body) %>
     </div>

--- a/app/views/wiki_page_versions/show.html.erb
+++ b/app/views/wiki_page_versions/show.html.erb
@@ -9,6 +9,8 @@
         <div class="wiki-page-redirect"><%= svg_icon(:corner_down_right, width: 12, height: 12) %> Redirects to <%= link_to @wiki_page_version.parent, show_or_new_wiki_pages_path(title: @wiki_page_version.parent) %></div>
       <% end %>
 
+      <%= render partial: "wiki_pages/featured_posts", locals: { wiki_content: @wiki_page_version } %>
+
       <div id="wiki-page-body" class="dtext dtext-container">
         <%= format_text(@wiki_page_version.body) %>
       </div>

--- a/app/views/wiki_pages/_featured_posts.html.erb
+++ b/app/views/wiki_pages/_featured_posts.html.erb
@@ -1,0 +1,14 @@
+<% featured_ids = wiki_content.featured_posts %>
+<% if featured_ids.present? %>
+  <% posts_by_id = Post.where(id: featured_ids).index_by(&:id) %>
+  <% posts = featured_ids.filter_map { |id| posts_by_id[id] } %>
+  <% if posts.any? %>
+    <div id="wiki-featured-posts" class="wiki-featured-posts <%= posts.size == 1 ? "wiki-featured-hero" : "wiki-featured-row" %>">
+      <% if posts.size == 1 %>
+        <%= render(PostThumbnailComponent.new(post: posts.first, show_deleted: true, stats: false, show_samples: true, native: true)) %>
+      <% else %>
+        <%= render(PostThumbnailComponent.with_collection(posts, show_deleted: true, stats: false)) %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/wiki_pages/_featured_posts.html.erb
+++ b/app/views/wiki_pages/_featured_posts.html.erb
@@ -1,3 +1,5 @@
+<%# locals: (wiki_content:) %>
+
 <% featured_ids = wiki_content.featured_posts %>
 <% if featured_ids.present? %>
   <% posts_by_id = Post.where(id: featured_ids).index_by(&:id) %>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -12,6 +12,8 @@
 
     <%= f.input :body, as: :dtext, limit: Danbooru.config.wiki_page_max_size, allow_color: true %>
 
+    <%= f.input :featured_posts_string, label: "Featured posts", hint: "Up to #{Danbooru.config.wiki_page_max_featured_posts} space-separated post IDs shown at the top of the page. A single ID displays as a large hero image; multiple display as a thumbnail row." %>
+
     <% if @wiki_page.new_record? || @wiki_page.tag.present? %>
       <%= f.input :category_id, 
         label: "Tag Category", 

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -14,6 +14,11 @@
 
     <%= f.input :featured_posts_string, label: "Featured posts", hint: "Up to #{Danbooru.config.wiki_page_max_featured_posts} space-separated post IDs shown at the top of the page. A single ID displays as a large hero image; multiple display as a thumbnail row." %>
 
+    <div id="featured-posts-preview" data-max="<%= Danbooru.config.wiki_page_max_featured_posts %>">
+      <div class="featured-posts-preview-error" hidden></div>
+      <div class="featured-posts-preview-list"></div>
+    </div>
+
     <% if @wiki_page.new_record? || @wiki_page.tag.present? %>
       <%= f.input :category_id, 
         label: "Tag Category", 

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -28,6 +28,8 @@
 
       <%= render partial: "automated_tag", locals: { tag: wiki_content.title } %>
 
+      <%= render partial: "featured_posts", locals: { wiki_content: wiki_content } %>
+
       <div id="wiki-page-body" class="dtext-container">
         <% if wiki_content.body.present? %>
           <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>  

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -396,6 +396,10 @@ module Danbooru
       250_000
     end
 
+    def wiki_page_max_featured_posts
+      6
+    end
+
     def user_feedback_max_size
       20_000
     end

--- a/db/migrate/20260707182943_add_featured_posts_to_wiki_pages.rb
+++ b/db/migrate/20260707182943_add_featured_posts_to_wiki_pages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFeaturedPostsToWikiPages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :wiki_pages, :featured_posts, :integer, array: true, default: [], null: false
+    add_column :wiki_page_versions, :featured_posts, :integer, array: true, default: [], null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2980,7 +2980,8 @@ CREATE TABLE public.wiki_page_versions (
     other_names text[] DEFAULT '{}'::text[] NOT NULL,
     is_deleted boolean DEFAULT false NOT NULL,
     reason character varying,
-    parent character varying
+    parent character varying,
+    featured_posts integer[] DEFAULT '{}'::integer[] NOT NULL
 );
 
 
@@ -3019,7 +3020,8 @@ CREATE TABLE public.wiki_pages (
     updater_id integer,
     other_names text[] DEFAULT '{}'::text[] NOT NULL,
     is_deleted boolean DEFAULT false NOT NULL,
-    parent character varying
+    parent character varying,
+    featured_posts integer[] DEFAULT '{}'::integer[] NOT NULL
 );
 
 
@@ -6101,6 +6103,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260707182943'),
 ('20260702120000'),
 ('20260624213023'),
 ('20260622142717'),

--- a/spec/factories/wiki_page_factory.rb
+++ b/spec/factories/wiki_page_factory.rb
@@ -8,8 +8,9 @@ FactoryBot.define do
     body        { "Wiki page body." }
     is_locked   { false }
     is_deleted  { false }
-    parent      { nil }
-    other_names { [] }
+    parent         { nil }
+    other_names    { [] }
+    featured_posts { [] }
 
     factory :locked_wiki_page do
       is_locked { true }

--- a/spec/factories/wiki_page_version_factory.rb
+++ b/spec/factories/wiki_page_version_factory.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     is_locked       { false }
     is_deleted      { false }
     other_names     { [] }
+    featured_posts  { [] }
     updater_ip_addr { "127.0.0.1" }
     reason          { nil }
     parent          { nil }

--- a/spec/models/wiki_page/featured_posts_spec.rb
+++ b/spec/models/wiki_page/featured_posts_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# --------------------------------------------------------------------------- #
+#                        WikiPage Featured Posts                              #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe WikiPage do
+  include_context "as admin"
+
+  # -------------------------------------------------------------------------
+  # Attribute parsing (via array_attribute)
+  # -------------------------------------------------------------------------
+  describe "#featured_posts_string=" do
+    it "parses a space-separated string into an array of integer IDs" do
+      page = build(:wiki_page)
+      page.featured_posts_string = "123 456"
+      expect(page.featured_posts).to eq([123, 456])
+    end
+
+    it "ignores non-numeric noise" do
+      page = build(:wiki_page)
+      page.featured_posts_string = "123, #456 foo"
+      expect(page.featured_posts).to eq([123, 456])
+    end
+  end
+
+  describe "#featured_posts=" do
+    it "accepts an array directly" do
+      page = build(:wiki_page)
+      page.featured_posts = [1, 2, 3]
+      expect(page.featured_posts).to eq([1, 2, 3])
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Validation
+  # -------------------------------------------------------------------------
+  describe "featured_posts validation" do
+    it "accepts a valid list of existing post IDs" do
+      posts = create_list(:post, 2)
+      page = build(:wiki_page, featured_posts: posts.map(&:id))
+      expect(page).to be_valid
+    end
+
+    it "accepts a post that has been deleted" do
+      post = create(:post)
+      post.update_column(:is_deleted, true)
+      page = build(:wiki_page, featured_posts: [post.id])
+      expect(page).to be_valid
+    end
+
+    it "rejects more than the configured maximum" do
+      posts = create_list(:post, Danbooru.config.wiki_page_max_featured_posts + 1)
+      page = build(:wiki_page, featured_posts: posts.map(&:id))
+      expect(page).not_to be_valid
+      expect(page.errors[:featured_posts]).to be_present
+    end
+
+    it "rejects duplicate post IDs" do
+      post = create(:post)
+      page = build(:wiki_page, featured_posts: [post.id, post.id])
+      expect(page).not_to be_valid
+      expect(page.errors[:featured_posts]).to be_present
+    end
+
+    it "rejects nonexistent post IDs" do
+      page = build(:wiki_page, featured_posts: [999_999])
+      expect(page).not_to be_valid
+      expect(page.errors[:featured_posts]).to be_present
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # Versioning
+  # -------------------------------------------------------------------------
+  describe "versioning" do
+    it "records featured_posts in a new version when changed" do
+      posts = create_list(:post, 2)
+      page = create(:wiki_page)
+      expect do
+        page.update(featured_posts: posts.map(&:id))
+      end.to change { page.versions.count }.by(1)
+      expect(page.versions.last.featured_posts).to eq(posts.map(&:id))
+    end
+
+    it "restores featured_posts on revert" do
+      posts = create_list(:post, 2)
+      page = create(:wiki_page, featured_posts: [posts.first.id])
+      original_version = page.versions.last
+
+      page.update(featured_posts: posts.map(&:id))
+      page.revert_to!(original_version)
+
+      expect(page.reload.featured_posts).to eq([posts.first.id])
+    end
+  end
+end

--- a/spec/requests/wiki_pages_controller_spec.rb
+++ b/spec/requests/wiki_pages_controller_spec.rb
@@ -128,6 +128,35 @@ RSpec.describe WikiPagesController do
   end
 
   # ---------------------------------------------------------------------------
+  # GET /wiki_pages/:id — featured posts rendering
+  # ---------------------------------------------------------------------------
+
+  describe "GET /wiki_pages/:id (featured posts)" do
+    it "renders a hero container for a single featured post" do
+      post = create(:post)
+      page = create(:wiki_page, featured_posts: [post.id])
+      get wiki_page_path(page)
+      expect(response.body).to include("wiki-featured-hero")
+    end
+
+    it "renders a thumbnail row for multiple featured posts" do
+      posts = create_list(:post, 3)
+      page = create(:wiki_page, featured_posts: posts.map(&:id))
+      get wiki_page_path(page)
+      expect(response.body).to include("wiki-featured-row")
+    end
+
+    it "still renders a featured post that has been deleted" do
+      post = create(:post)
+      post.update_column(:is_deleted, true)
+      page = create(:wiki_page, featured_posts: [post.id])
+      get wiki_page_path(page)
+      expect(response.body).to include("wiki-featured-hero")
+      expect(response.body).to include("/posts/#{post.id}")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # GET /wiki_pages/new — new
   # ---------------------------------------------------------------------------
 
@@ -217,6 +246,12 @@ RSpec.describe WikiPagesController do
         end.not_to change(WikiPage, :count)
       end
 
+      it "allows setting featured posts" do
+        posts = create_list(:post, 2)
+        post wiki_pages_path, params: { wiki_page: { title: "featured_member_page", body: "body", featured_posts_string: posts.map(&:id).join(" ") } }
+        expect(WikiPage.titled("featured_member_page").featured_posts).to eq(posts.map(&:id))
+      end
+
       # FIXME: Cannot test that members cannot set is_locked or parent by passing
       # those params in the request body, because config/application.rb sets
       # `action_on_unpermitted_parameters = :raise`. Rails raises
@@ -287,6 +322,12 @@ RSpec.describe WikiPagesController do
       it "returns a successful JSON response on success" do
         patch wiki_page_path(wiki_page, format: :json), params: update_params
         expect(response).to be_successful
+      end
+
+      it "updates featured posts" do
+        posts = create_list(:post, 2)
+        patch wiki_page_path(wiki_page), params: { wiki_page: { featured_posts_string: posts.map(&:id).join(" ") } }
+        expect(wiki_page.reload.featured_posts).to eq(posts.map(&:id))
       end
 
       it "returns 403 when trying to update a locked page" do


### PR DESCRIPTION
Replacement for the old way of including a bunch of `thumb #12345` tags on top of the wiki page.
Supports up to 6 posts. If only one post ID is listed, displays its sample – otherwise, it's just a grid of thumbnails.

<img width="480" height="207" alt="image" src="https://github.com/user-attachments/assets/c5ec369c-3b19-42e7-b14c-26e22cbd555f" />
