### PR TITLE
[Posts] Resolve `flash` tag as `type:swf`

### DIFF
--- a/app/javascript/src/js/components/autocomplete/Constants.ts
+++ b/app/javascript/src/js/components/autocomplete/Constants.ts
@@ -17,6 +17,10 @@ export default class Constants {
     type: ["jpg", "png", "gif", "swf", "webm", "mp4", "webp"], // Consider passing these from the back-end as well
   };
 
+  static readonly FILETYPE_ALIASES: Record<string, string> = {
+    flash: "swf",
+  };
+
   // Precompiled regexes for performance
 
   static readonly TAG_PREFIXES_REGEX = new RegExp("^([" + Constants.TAG_PREFIXES.join("") + "]*)(.*)", "i");

--- a/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
@@ -145,6 +145,12 @@ export default class TagQueryProvider extends Provider<Types.AutocompleteItem> {
     if (!options) return [];
     term = term.trim().toLowerCase();
 
+    // Resolve filetype aliases
+    if (metatag === "filetype" || metatag === "type") {
+      const alias = Constants.FILETYPE_ALIASES[term];
+      if (alias) term = alias;
+    }
+
     return (options as string[])
       .filter(option => !term || option.startsWith(term))
       .map(option => ({

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -11,6 +11,10 @@ module FileMethods
     webp: "webp",
   }.freeze
 
+  FILE_TYPE_ALIASES = {
+    flash: "swf",
+  }.freeze
+
   def is_of_type?(type)
     file_ext == FileMethods::FILE_TYPE[type]
   end

--- a/app/logical/file_methods.rb
+++ b/app/logical/file_methods.rb
@@ -12,7 +12,7 @@ module FileMethods
   }.freeze
 
   FILE_TYPE_ALIASES = {
-    flash: "swf",
+    "flash" => "swf",
   }.freeze
 
   def is_of_type?(type)

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1555,8 +1555,11 @@ class TagQuery
 
   # Checks if a certain tag should be transformed into a metatag, and adds it accordingly if so.
   def intercept_metatag_alias(tag, type)
-    if FileMethods::FILE_TYPE.value?(tag)
-      add_to_query(type, :filetype, tag)
+    filetype = FileMethods::FILE_TYPE_ALIASES[tag]
+    filetype ||= tag if FileMethods::FILE_TYPE.value?(tag)
+
+    if filetype
+      add_to_query(type, :filetype, filetype)
       return true
     end
     nil

--- a/spec/logical/tag_query/content_metatags_spec.rb
+++ b/spec/logical/tag_query/content_metatags_spec.rb
@@ -69,6 +69,12 @@ RSpec.describe TagQuery do
         expect(TagQuery.new("-#{t}")[:filetype_must_not]).to include(t)
       end
     end
+
+    it "resolves filetype aliases" do
+      expect(TagQuery.new("flash")[:filetype]).to include("swf")
+      expect(TagQuery.new("-flash")[:filetype_must_not]).to include("swf")
+      expect(TagQuery.new("~flash")[:filetype_should]).to include("swf")
+    end
   end
 
   describe "source: metatag" do


### PR DESCRIPTION
All filetype tags redirect to their metatag counterparts. For example: `swf` -> `filetype:swf`.
Unfortunately, we also have a `swf -> flash` alias that predates that system. That's causing inconsistencies and strange post count values. It stands to reason that we should outright replace this alias with a similar redirect in the back-end.