### PR TITLE
[UserFeedbacks] Add a staff-only expiry notice

### DIFF
--- a/app/javascript/src/styles/specific/user_feedback.scss
+++ b/app/javascript/src/styles/specific/user_feedback.scss
@@ -42,3 +42,10 @@ div#c-user-feedbacks, div#c-staff-moderator-dashboards .activity-container {
     padding: 0.5em 0;
   }
 }
+
+div#c-user-feedbacks #a-index {
+  .user-feedback-expired {
+    margin-top: 0.5rem;
+    font-weight: bold;
+  }
+}

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -137,7 +137,7 @@ class UserFeedback < ApplicationRecord
   def expires_at
     return nil if category == "positive" || is_deleted? || body =~ /^Banned permanently/
     @expires_at ||= begin
-      is_ban = body =~ /^Banned for \d+/
+      is_ban = body =~ /^Banned for /
       multiplier = if is_ban
                      3
                    elsif category == "negative"

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -134,18 +134,19 @@ class UserFeedback < ApplicationRecord
     deletable_by?(destroyer) && (destroyer.is_admin? || destroyer == creator)
   end
 
-  def is_expired?
-    return false if category == "positive"
-    return false if is_deleted?
+  def expires_at
+    return nil if category == "positive" || is_deleted? || body =~ /^Banned permanently/
+    @expires_at ||= begin
+      is_ban = body =~ /^Banned for \d+/
+      multiplier = if is_ban
+                     3
+                   elsif category == "negative"
+                     2
+                   else
+                     1
+                   end
 
-    return created_at < (Danbooru.config.user_feedback_expires_after * 2).ago if category == "negative"
-    created_at < Danbooru.config.user_feedback_expires_after.ago
-  end
-
-  def expired_on
-    return false unless is_expired?
-
-    return created_at + (Danbooru.config.user_feedback_expires_after * 2) if category == "negative"
-    created_at + Danbooru.config.user_feedback_expires_after
+      created_at + (Danbooru.config.user_feedback_expires_after * multiplier)
+    end
   end
 end

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -133,4 +133,19 @@ class UserFeedback < ApplicationRecord
   def destroyable_by?(destroyer)
     deletable_by?(destroyer) && (destroyer.is_admin? || destroyer == creator)
   end
+
+  def is_expired?
+    return false if category == "positive"
+    return false if is_deleted?
+
+    return created_at < (Danbooru.config.user_feedback_expires_after * 2).ago if category == "negative"
+    created_at < Danbooru.config.user_feedback_expires_after.ago
+  end
+
+  def expired_on
+    return false unless is_expired?
+
+    return created_at + (Danbooru.config.user_feedback_expires_after * 2) if category == "negative"
+    created_at + Danbooru.config.user_feedback_expires_after
+  end
 end

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -137,7 +137,7 @@ class UserFeedback < ApplicationRecord
   def expires_at
     return nil if category == "positive" || is_deleted? || body =~ /^Banned permanently/
     @expires_at ||= begin
-      is_ban = body =~ /^Banned for /
+      is_ban = body =~ /\ABanned for /
       multiplier = if is_ban
                      3
                    elsif category == "negative"

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -28,6 +28,11 @@
               <div class="dtext-container">
                 <%= format_text(feedback.body) %>
               </div>
+              <% if CurrentUser.user.is_staff? && feedback.is_expired? %>
+                <div class="user-feedback-expired">
+                  This feedback has expired on <%= compact_time(feedback.expired_on) %> and may be deleted.
+                </div>
+              <% end %>
               <%= render "application/update_notice", record: feedback %>
             </td>
             <td>

--- a/app/views/user_feedbacks/index.html.erb
+++ b/app/views/user_feedbacks/index.html.erb
@@ -28,9 +28,9 @@
               <div class="dtext-container">
                 <%= format_text(feedback.body) %>
               </div>
-              <% if CurrentUser.user.is_staff? && feedback.is_expired? %>
+              <% if CurrentUser.user.is_staff? && feedback.expires_at && feedback.expires_at < Time.current %>
                 <div class="user-feedback-expired">
-                  This feedback has expired on <%= compact_time(feedback.expired_on) %> and may be deleted.
+                  This feedback expired on <%= compact_time(feedback.expires_at) %> and may be deleted.
                 </div>
               <% end %>
               <%= render "application/update_notice", record: feedback %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -412,6 +412,10 @@ module Danbooru
       10_000
     end
 
+    def user_feedback_expires_after
+      6.months
+    end
+
     def discord_site
     end
 

--- a/spec/models/user_feedback/methods_spec.rb
+++ b/spec/models/user_feedback/methods_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe UserFeedback do
       end
 
       it "returns a future expiration date for negative feedback" do
-        feedback.update(category: "negative", body: "Banned for 7 days")
+        feedback.update(category: "negative", body: "User is a very naughty boy.")
         expect(feedback.expires_at).to be > Time.current
       end
 

--- a/spec/models/user_feedback/methods_spec.rb
+++ b/spec/models/user_feedback/methods_spec.rb
@@ -117,5 +117,51 @@ RSpec.describe UserFeedback do
         expect(target.destroyable_by?(admin)).to be(false)
       end
     end
+
+    # -------------------------------------------------------------------------
+    # #expires_at
+    # -------------------------------------------------------------------------
+    describe "#expires_at" do
+      before do
+        allow(Danbooru.config.custom_configuration).to receive(:user_feedback_expires_after).and_return(3.days)
+      end
+
+      it "returns nil for positive feedback" do
+        feedback.update(category: "positive")
+        expect(feedback.expires_at).to be_nil
+      end
+
+      it "returns nil for deleted feedback" do
+        feedback.update(is_deleted: true)
+        expect(feedback.expires_at).to be_nil
+      end
+
+      it "returns nil for feedback with a body indicating permanent ban" do
+        feedback.update(body: "Banned permanently for violating rules")
+        expect(feedback.expires_at).to be_nil
+      end
+
+      it "returns a future expiration date for negative feedback" do
+        feedback.update(category: "negative", body: "Banned for 7 days")
+        expect(feedback.expires_at).to be > Time.current
+      end
+
+      it "returns a future expiration date for neutral feedback" do
+        feedback.update(category: "neutral", body: "Some neutral feedback")
+        expect(feedback.expires_at).to be > Time.current
+      end
+
+      it "returns an expiration date that is 3 times the default for ban feedback" do
+        feedback.update(category: "negative", body: "Banned for 7 days")
+        expected_expiration = feedback.created_at + (3.days * 3) # 3 times the default
+        expect(feedback.expires_at).to be_within(1.second).of(expected_expiration)
+      end
+
+      it "returns an expiration date that is 2 times the default for negative feedback" do
+        feedback.update(category: "negative", body: "Some negative feedback")
+        expected_expiration = feedback.created_at + (3.days * 2) # 2 times the default
+        expect(feedback.expires_at).to be_within(1.second).of(expected_expiration)
+      end
+    end
   end
 end


### PR DESCRIPTION
Typically, neutral feedback records are removed after 6 months.
Negative records are removed after a year.

This process is manual, and requires staff members to calculate when the feedback is due to be removed.
This PR simplifies this by adding a small notice to older feedback records.

<img width="905" height="254" alt="image" src="https://github.com/user-attachments/assets/a0256016-4d75-459f-9ffb-5529093e464b" />
