### PR TITLE
[Appeals] Don't use a default status for pending appeals

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -134,9 +134,7 @@ class AppealsController < ApplicationController
   end
 
   def update_appeal_params
-    permitted = params.require(:appeal).permit(%i[response status send_update_dmail])
-    permitted.delete(:status) if permitted[:status].blank?
-    permitted
+    params.require(:appeal).permit(%i[response status send_update_dmail])
   end
 
   def search_params

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -134,7 +134,9 @@ class AppealsController < ApplicationController
   end
 
   def update_appeal_params
-    params.require(:appeal).permit(%i[response status send_update_dmail])
+    permitted = params.require(:appeal).permit(%i[response status send_update_dmail])
+    permitted.delete(:status) if permitted[:status].blank?
+    permitted
   end
 
   def search_params

--- a/app/javascript/entrypoints/v_appeals.ts
+++ b/app/javascript/entrypoints/v_appeals.ts
@@ -1,0 +1,8 @@
+// appeals
+
+import E621Type from "@/interfaces/E621";
+declare const E621: E621Type;
+
+import "@/pages/appeals/Appeals";
+
+E621.Registry.register("v_appeals");

--- a/app/javascript/src/js/pages/appeals/Appeals.ts
+++ b/app/javascript/src/js/pages/appeals/Appeals.ts
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const status = document.getElementById("appeal_status") as HTMLSelectElement | null;
+  const submit = document.getElementById("appeal-display-submit-button") as HTMLButtonElement | null;
+  if (status && submit) {
+    status.addEventListener("change", () => submit.disabled = (status.value === ""));
+  }
+});

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -14,7 +14,7 @@ class Appeal < ApplicationRecord
   validates :reason, presence: true
   validates :reason, length: { minimum: 2, maximum: Danbooru.config.ticket_max_size }
   validates :response, length: { minimum: 2, maximum: Danbooru.config.dmail_max_size }, on: :update
-  enum :status, %i[pending partial approved rejected].index_with(&:to_s)
+  enum :status, %i[pending partial approved rejected].index_with(&:to_s), validate: true
   after_create :push_pubsub_create
   after_update :push_pubsub_update_notification
   after_update :log_update

--- a/app/views/appeals/show.html.erb
+++ b/app/views/appeals/show.html.erb
@@ -4,7 +4,7 @@
     <div class="section appeal-display-header">
       <h3><%= @appeal.type_title %> Appeal</h3>
     </div>
-    
+
     <%= render partial: "appeals/types/#{@appeal.qtype}" %>
 
     <div class="appeal-display-report">
@@ -67,7 +67,7 @@
       <% end %>
     <% end %>
 
-    
+
     <div class="appeal-display-section appeal-display-info">
       <div class="appeal-display-info-entry">
         <b>Status:</b>
@@ -122,15 +122,18 @@
 
   <% if @appeal.can_handle? %>
     <%= custom_form_for(@appeal, html: { class: "appeal-display-response" }) do |f| %>
-      <%= f.input :status, collection: [%w[Approved approved], %w[Investigating partial], %w[Rejected rejected]], selected: @appeal.status || "approved" %>
+      <% current_status = @appeal.status.presence || "pending" %>
+      <% is_pending_status = current_status == "pending" %>
+      <%= f.input :status, collection: [%w[Approved approved], %w[Investigating partial], %w[Rejected rejected]],
+        include_blank: is_pending_status, selected: is_pending_status ? "" : current_status %>
       <% unless @appeal.pending? %>
         <%= f.input :send_update_dmail, label: "Send update DMail", as: :boolean, hint: "A DMail is always sent if the status is changed" %>
       <% end %>
-      
+
       <%= f.input :response, as: :dtext, limit: Danbooru.config.dmail_max_size, allow_color: false %>
 
       <%= tag.input name: "force_claim", type: "hidden", value: params[:force_claim] %>
-      <%= f.button :submit, "Submit" %>
+      <%= f.button :submit, "Submit", id: "appeal-display-submit-button", disabled: is_pending_status %>
     <% end %>
   <% end %>
 </div></div>

--- a/spec/requests/appeals_controller_spec.rb
+++ b/spec/requests/appeals_controller_spec.rb
@@ -207,6 +207,20 @@ RSpec.describe AppealsController do
         expect(appeal.reload.response).to eq("Approved, the flag was incorrect.")
       end
 
+      it "updates the appeal response only if the status is empty" do
+        patch appeal_path(appeal), params: { appeal: { response: "Still pending.", status: "" } }
+        expect(response).not_to have_http_status(:internal_server_error)
+        expect(appeal.reload.status).to eq("pending")
+        expect(appeal.reload.response).to eq("Still pending.")
+      end
+
+      it "fails gracefully if the status is invalid" do
+        patch appeal_path(appeal), params: { appeal: { response: "Favourite animal?", status: "leopard" } }
+        expect(response).to have_http_status(:not_acceptable)
+        expect(appeal.reload.status).to eq("pending")
+        expect(appeal.reload.response).to eq("")
+      end
+
       context "when the appeal is already claimed by another janitor" do
         let(:other_janitor) { create(:janitor_user) }
 

--- a/spec/requests/appeals_controller_spec.rb
+++ b/spec/requests/appeals_controller_spec.rb
@@ -207,11 +207,11 @@ RSpec.describe AppealsController do
         expect(appeal.reload.response).to eq("Approved, the flag was incorrect.")
       end
 
-      it "updates the appeal response only if the status is empty" do
+      it "fails gracefully if the status is empty" do
         patch appeal_path(appeal), params: { appeal: { response: "Still pending.", status: "" } }
-        expect(response).not_to have_http_status(:internal_server_error)
+        expect(response).to have_http_status(:not_acceptable)
         expect(appeal.reload.status).to eq("pending")
-        expect(appeal.reload.response).to eq("Still pending.")
+        expect(appeal.reload.response).to eq("")
       end
 
       it "fails gracefully if the status is invalid" do


### PR DESCRIPTION
Too easy to forget to pick the right status before submitting. Defaults to blank in the select, and the submit button is disabled until you pick a valid status.