### PR TITLE
[ForumPosts] Add an API endpoint for forum post votes

### DIFF
--- a/app/controllers/forum_post_votes_controller.rb
+++ b/app/controllers/forum_post_votes_controller.rb
@@ -10,6 +10,11 @@ class ForumPostVotesController < ApplicationController
   before_action :ensure_no_vote_on_own_post, only: [:create]
   before_action :ensure_lockdown_disabled
 
+  def show
+    @forum_post_votes = @forum_post.votes.includes(:creator)
+    respond_with(@forum_post_votes)
+  end
+
   def create
     @forum_post_vote = @forum_post.votes.create(forum_post_vote_params)
     raise User::PrivilegeError, @forum_post_vote.errors.full_messages.join("; ") unless @forum_post_vote.errors.empty?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -248,7 +248,7 @@ Rails.application.routes.draw do
   resources :db_exports, only: %i[index]
   resources :favorites, only: %i[index create destroy]
   resources :forum_posts do
-    resource :votes, controller: "forum_post_votes"
+    resource :votes, controller: "forum_post_votes", only: %i[show create destroy]
     member do
       post :hide
       post :unhide

--- a/spec/requests/forum_post_votes_controller_spec.rb
+++ b/spec/requests/forum_post_votes_controller_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe ForumPostVotesController do
       post forum_post_votes_path(forum_post_id: forum_post.id, format: :json), params: { forum_post_vote: { score: 1 } }
       expect(response).to have_http_status(:forbidden)
     end
+
+    it "return 403 when trying to get votes" do
+      sign_in_as posting_user
+      get forum_post_votes_path(forum_post_id: forum_post.id, format: :json)
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 
   context "with an already accepted tag change request" do
@@ -71,6 +77,17 @@ RSpec.describe ForumPostVotesController do
         end.to change(ForumPostVote, :count).by(-1)
         expect(ForumPostVote.count).to be(0)
       end
+    end
+
+    it "returns the votes" do
+      CurrentUser.scoped(user2) do
+        forum_post.votes.create(score: 1)
+      end
+
+      sign_in_as user2
+      get forum_post_votes_path(forum_post_id: forum_post.id, format: :json)
+      expect(response).to have_http_status(:success)
+      expect(response.parsed_body.first["score"]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
It seems like it was literally not possible to fetch forum post votes before.