### PR TITLE
[Blacklist] Fixes to numerous minor bugs

### DIFF
--- a/app/javascript/src/js/core/DeferredPostLoader.ts
+++ b/app/javascript/src/js/core/DeferredPostLoader.ts
@@ -34,6 +34,7 @@ export default class DeferredPostLoader {
     // However, this lets us populate the Blacklist and render thumbnails with the correct
     // visibility on the first try, instead of rendering them and then updating their visibility.
     E621.Blacklist.loadDeferredPosts(processed);
+    E621.Blacklist.recalculateMatchedPosts();
     E621.Blacklist.updatePostVisibility();
     E621.Blacklist.updateThumbnailStyles();
 

--- a/app/javascript/src/js/core/blacklist/BlacklistWidget.ts
+++ b/app/javascript/src/js/core/blacklist/BlacklistWidget.ts
@@ -136,9 +136,9 @@ export default class BlacklistWidget {
 
       const link = $("<a>")
         .attr("href", "/posts?tags=" + encodeURIComponent(name))
-        .html(name
-          .replace(/_/g, "&#8203;_") // Allow tags to linebreak on underscores
-          .replace(/ -/, " &#8209;"), // Prevent linebreaking on negated tags
+        .text(name
+          .replace(/_/g, "\u200b_")   // zero-width space: allow tags to linebreak on underscores
+          .replace(/ -/g, " \u2011"), // non-breaking hyphen: prevent linebreaking on negated tags
         )
         .on("click", (event) => {
           event.preventDefault();

--- a/app/javascript/src/js/core/blacklist/BlacklistWidget.ts
+++ b/app/javascript/src/js/core/blacklist/BlacklistWidget.ts
@@ -29,6 +29,15 @@ export default class BlacklistWidget {
         for (const widget of this.registry)
           widget.rebuildFilters();
       });
+
+    // Register hotkey for toggling the blacklist
+    if (!BlacklistWidget.isHotkeyRegistered) {
+      BlacklistWidget.isHotkeyRegistered = true;
+      Hotkeys.register("blacklist", () => {
+        if (!this.registry.length) return;
+        this.registry[0].toggleAllFilters();
+      });
+    }
   }
 
   /* ============================== */
@@ -89,18 +98,18 @@ export default class BlacklistWidget {
         E621.Blacklist.updatePostVisibility();
       });
 
-    // Register hotkey for toggling the blacklist
-    // Only register it once - widgets synchronize their state automatically.
-    if (!BlacklistWidget.isHotkeyRegistered) {
-      BlacklistWidget.isHotkeyRegistered = true;
-      Hotkeys.register("blacklist", () => {
-        this.$toggle[0].click();
-      });
-    }
-
     // Filters
     this.$container = this.$wrapper.find(".blacklist-filters");
     this.rebuildFilters();
+  }
+
+  /* ============================== */
+  /* ========= Public API ========= */
+  /* ============================== */
+
+  public toggleAllFilters () {
+    if (!this.$toggle.length) return;
+    this.$toggle[0].click();
   }
 
   /* ============================== */

--- a/app/javascript/src/js/core/blacklist/BlacklistWidget.ts
+++ b/app/javascript/src/js/core/blacklist/BlacklistWidget.ts
@@ -23,8 +23,9 @@ export default class BlacklistWidget {
       this.registry.push(new BlacklistWidget(element as HTMLDivElement));
     });
 
-    $(document).off("e621:blacklist:state-changed")
-      .on("e621:blacklist:state-changed", () => {
+    $(document)
+      .off("e621:blacklist:state-changed.blacklistWidget")
+      .on("e621:blacklist:state-changed.blacklistWidget", () => {
         for (const widget of this.registry)
           widget.rebuildFilters();
       });

--- a/app/javascript/src/js/core/blacklist/CommentBlacklist.ts
+++ b/app/javascript/src/js/core/blacklist/CommentBlacklist.ts
@@ -35,6 +35,11 @@ export default class CommentBlacklist {
     }
   }
 
+  /**
+   * Hides all comments from a given user.
+   * @param attr Data-attribute to match against
+   * @param value Value to match against
+   */
   private static hideComment (attr: "creator" | "creator-id", value: string) {
     value = CSS.escape(value);
     $(`article[data-${attr}="${value}"]`).hide();

--- a/app/javascript/src/js/core/blacklist/CommentBlacklist.ts
+++ b/app/javascript/src/js/core/blacklist/CommentBlacklist.ts
@@ -18,20 +18,25 @@ export default class CommentBlacklist {
       switch (token.type) {
         case "user": {
           if (token.value.startsWith("!")) {
-            $(`article[data-creator-id="${token.value.slice(1)}"]`).hide();
+            CommentBlacklist.hideComment("creator-id", token.value.slice(1));
             continue;
           }
           // falls through
         }
         case "username": {
-          $(`article[data-creator="${token.value}"]`).hide();
+          CommentBlacklist.hideComment("creator", token.value);
           continue;
         }
         case "userid": {
-          $(`article[data-creator-id="${token.value}"]`).hide();
+          CommentBlacklist.hideComment("creator-id", token.value);
           continue;
         }
       }
     }
+  }
+
+  private static hideComment (attr: "creator" | "creator-id", value: string) {
+    value = CSS.escape(value);
+    $(`article[data-${attr}="${value}"]`).hide();
   }
 }

--- a/app/javascript/src/js/core/blacklist/FilterToken.ts
+++ b/app/javascript/src/js/core/blacklist/FilterToken.ts
@@ -22,15 +22,17 @@ export default class FilterToken {
   constructor (raw: string) {
     raw = raw.trim().toLowerCase();
 
-    // Token prefixes
-    // TODO: This REQUIRES the tokens to be formatted properly.
-    // -~ format is not accepted. This may cause issues with the the quick blacklist.
-    // Regular blacklist edits do get fixed server-side.
-    this.optional = raw.startsWith("~");
-    if (this.optional) raw = raw.slice(1);
-
-    this.inverted = raw.startsWith("-");
-    if (this.inverted) raw = raw.slice(1);
+    // Token prefixes: ~ for optional, - for inverted
+    const prefixMatch = raw.match(/^(~|-)+/);
+    if (prefixMatch) {
+      const prefix = prefixMatch[0];
+      this.optional = prefix.includes("~");
+      this.inverted = prefix.includes("-");
+      raw = raw.slice(prefix.length);
+    } else {
+      this.optional = false;
+      this.inverted = false;
+    }
 
     // Get filter type: tag, id, score, rating, etc.
     this.type = FilterUtilities.getFilterType(raw);

--- a/app/javascript/src/js/core/blacklist/FilterUtilities.ts
+++ b/app/javascript/src/js/core/blacklist/FilterUtilities.ts
@@ -175,14 +175,26 @@ export default class FilterUtilities {
 
   /**
    * Takes in a formatted file size string (ex. 5MB) and converts it to bytes
-   * @param {string} input Formatted string, needs to be lower case
+   * @param {string} input Formatted string
    * @returns {number} Filesize, in bytes
    */
   static parseFilesize (input: string): number {
-    if (/^\d+b?$/.test(input)) return parseInt(input);
-    if (/^\d+kb$/.test(input)) return parseInt(input) * 1024;
-    if (/^\d+mb$/.test(input)) return parseInt(input) * 1048576;
-    return 0;
+    const floatMatch = /^([0-9]+(?:\.[0-9]+)?)\s*(b|kb|mb)?$/i;
+
+    const match = input.match(floatMatch);
+    if (!match) return NaN;
+
+    const value = parseFloat(match[1]);
+    switch (match[2]?.toLowerCase()) {
+      case "b":
+        return Math.floor(value);
+      case "kb":
+        return Math.floor(value * 1024);
+      case "mb":
+        return Math.floor(value * 1048576);
+      default:
+        return Math.floor(value);
+    }
   }
 }
 

--- a/app/javascript/src/js/core/blacklist/FilterUtilities.ts
+++ b/app/javascript/src/js/core/blacklist/FilterUtilities.ts
@@ -1,3 +1,4 @@
+import { CachedPost } from "@/models/PostCache";
 import FilterToken from "./FilterToken";
 
 /** Various utilities for the blacklist filters */
@@ -137,15 +138,15 @@ export default class FilterUtilities {
 
   /**
    * Check if the post has the specified tag
-   * @param {any} post
+   * @param {CachedPost} post
    * @param {string} filter
    * @returns true the post has the tag
    */
-  static tagsMatchesFilter (post, filter) {
+  static tagsMatchesFilter (post: CachedPost, filter: string): boolean {
     return post.tags.indexOf(filter) >= 0;
   }
 
-  static wildcardTagMatchesFilter (post, filter) {
+  static wildcardTagMatchesFilter (post: CachedPost, filter: RegExp): boolean {
     for (const one of post.tags)
       if (filter.test(one)) return true;
     return false;
@@ -185,4 +186,4 @@ export default class FilterUtilities {
   }
 }
 
-type FilterTestFunction = (token: FilterToken, post: any) => boolean;
+type FilterTestFunction = (token: FilterToken, post: CachedPost) => boolean;

--- a/app/javascript/src/js/core/blacklist/FilterUtilities.ts
+++ b/app/javascript/src/js/core/blacklist/FilterUtilities.ts
@@ -179,9 +179,7 @@ export default class FilterUtilities {
    * @returns {number} Filesize, in bytes
    */
   static parseFilesize (input: string): number {
-    const floatMatch = /^([0-9]+(?:\.[0-9]+)?)\s*(b|kb|mb)?$/i;
-
-    const match = input.match(floatMatch);
+    const match = input.match(/^([0-9]+(?:\.[0-9]+)?)\s*(b|kb|mb)?$/i);
     if (!match) return NaN;
 
     const value = parseFloat(match[1]);

--- a/app/javascript/src/js/core/blacklist/index.ts
+++ b/app/javascript/src/js/core/blacklist/index.ts
@@ -38,7 +38,9 @@ class Blacklist {
     document.addEventListener("e621:blacklistUpdated", () => {
       this.regenerateFilters();
       this.addPosts(PostCache.sample());
+      this.recalculateMatchedPosts();
       this.updatePostVisibility();
+      this.updateThumbnailStyles();
     });
   }
 
@@ -46,6 +48,7 @@ class Blacklist {
     this.isPostsShow = $("#image-container").length > 0;
 
     this.addPosts($(".blacklistable"));
+    this.recalculateMatchedPosts();
     this.updateThumbnailStyles();
     this.updatePostVisibility();
     $("#blacklisted-hider").remove();
@@ -143,15 +146,22 @@ class Blacklist {
   }
 
   /**
-   * Adds a `filter-matches` class to any thumbnails that match any of the filters,
-   * including disabled ones. Only needs to run after new posts get added to the page.
+   * Recalculates the list of posts that match any of the filters, including disabled ones.
+   * This is used for styling thumbnails that match any filter, even if the filter is disabled.
+   * Should be called after new posts are added to the system, or after filters are updated.
    */
-  public updateThumbnailStyles () {
+  public recalculateMatchedPosts () {
     let allPosts = [];
     for (const filter of Object.values(this.filters))
       allPosts = allPosts.concat(Array.from(filter.matchIDs));
     this.matchedPosts = new Set(allPosts);
+  }
 
+  /**
+   * Adds a `filter-matches` class to any thumbnails that match any of the filters,
+   * including disabled ones. Only needs to run after new posts get added to the page.
+   */
+  public updateThumbnailStyles () {
     $(".filter-matches").removeClass("filter-matches");
     for (const postID of this.matchedPosts)
       PostCache.apply(postID, ($element) => {

--- a/app/javascript/src/js/core/blacklist/index.ts
+++ b/app/javascript/src/js/core/blacklist/index.ts
@@ -76,7 +76,7 @@ class Blacklist {
    * Also applies or removed `blacklist` class wherever necessary.
    */
   public updatePostVisibility () {
-    const oldPosts = [...this.hiddenPosts];
+    const oldPosts = this.hiddenPosts;
     let newPosts = [];
 
     // Tally up the new blacklisted posts
@@ -86,16 +86,14 @@ class Blacklist {
     }
 
     // Calculate diffs
-    // TODO I feel like this could be optimized.
     this.hiddenPosts = new Set(newPosts.filter(n => n));
-    const added = [...this.hiddenPosts].filter((n) => !oldPosts.includes(n));
-    const removed = oldPosts.filter((n) => !this.hiddenPosts.has(n));
+    const added = [...this.hiddenPosts].filter((n) => !oldPosts.has(n));
+    const removed = [...oldPosts].filter((n) => !this.hiddenPosts.has(n));
 
     // Update the UI
     $(document).trigger("e621:blacklist:state-changed");
 
     // Apply / remove classes
-    // TODO: Cache the post elements to avoid repeat lookups
     for (const postID of added)
       PostCache.apply(postID, ($element) => {
         $element.addClass("blacklisted").trigger("blk:hide");


### PR DESCRIPTION
Fixes the following issues:

1. Stop the CommentBlacklist from passing unescaped values to jQuery selectors – previously, malformed values could cause errors.
2. Use `.text` instead of `.html` when building the UI filter list – mostly for cleanliness, deals with a minor self-XSS risk.
3. Cleaner listener rebinding if `BlacklistWidget.initializeAll()` is called multiple times.
4. Reworked `~-` prefix detection when building filters – these prefixes can come in any order now.
5. Reworked added/removed posts calculation in `updatePostVisibility()`
6. Reworked the `parseFilesize()` method to support float values
7. Fixed the `.filter-matches` class not being re-applied to posts when the blacklist changes
8. Reworked hotkey binding to prevent issues if the first blacklist UI section ceases to exist.