### PR TITLE
[Misc] Fix a recursive "sign in" link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -185,6 +185,11 @@ module ApplicationHelper
     end
   end
 
+  def safe_new_session_path
+    return new_session_path if request.path == new_session_path
+    new_session_path(url: request.fullpath[0, 2000])
+  end
+
   protected
 
   def nav_link_match(controller, url)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -187,7 +187,11 @@ module ApplicationHelper
 
   def safe_new_session_path
     return new_session_path if request.path == new_session_path
-    new_session_path(url: request.fullpath[0, 2000])
+    url = request.fullpath[0, 2000]
+    path = new_session_path(url: url)
+    max = 2000 + new_session_path(url: "").length
+    return path if path.length <= max
+    new_session_path(url: url[0, url.length - (path.length - max)])
   end
 
   protected

--- a/app/views/layouts/navigation/_navigation.html.erb
+++ b/app/views/layouts/navigation/_navigation.html.erb
@@ -19,7 +19,7 @@
       </span>
     </a>
     <% if CurrentUser.user.is_logged_out? %>
-      <a href="<%= new_session_path(url: request.fullpath) %>" class="simple-avatar nav-controls-profile auth-login-link">
+      <a href="<%= request.path == new_session_path ? new_session_path : new_session_path(url: request.fullpath) %>" class="simple-avatar nav-controls-profile auth-login-link">
         <span class="avatar-name">
           Sign In
         </span>

--- a/app/views/layouts/navigation/_navigation.html.erb
+++ b/app/views/layouts/navigation/_navigation.html.erb
@@ -19,7 +19,7 @@
       </span>
     </a>
     <% if CurrentUser.user.is_logged_out? %>
-      <a href="<%= request.path == new_session_path ? new_session_path : new_session_path(url: request.fullpath[0, 2000]) %>" class="simple-avatar nav-controls-profile auth-login-link">
+      <a href="<%= safe_new_session_path %>" class="simple-avatar nav-controls-profile auth-login-link">
         <span class="avatar-name">
           Sign In
         </span>

--- a/app/views/layouts/navigation/_navigation.html.erb
+++ b/app/views/layouts/navigation/_navigation.html.erb
@@ -19,7 +19,7 @@
       </span>
     </a>
     <% if CurrentUser.user.is_logged_out? %>
-      <a href="<%= request.path == new_session_path ? new_session_path : new_session_path(url: request.fullpath) %>" class="simple-avatar nav-controls-profile auth-login-link">
+      <a href="<%= request.path == new_session_path ? new_session_path : new_session_path(url: request.fullpath[0, 2000]) %>" class="simple-avatar nav-controls-profile auth-login-link">
         <span class="avatar-name">
           Sign In
         </span>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe ApplicationHelper do
 
     context "when the current path is the sign-in page" do
       before do
-        dpath = instance_double(ActionDispatch::Request, path: new_session_path, fullpath: new_session_path)
-        allow(helper).to receive(:request).and_return(dpath)
+        request = instance_double(ActionDispatch::Request, path: new_session_path, fullpath: new_session_path)
+        allow(helper).to receive(:request).and_return(request)
       end
 
       it { is_expected.to eq(new_session_path) }
@@ -66,11 +66,24 @@ RSpec.describe ApplicationHelper do
 
     context "when the current path is not the sign-in page" do
       before do
-        dpath = instance_double(ActionDispatch::Request, path: "/posts", fullpath: "/posts?search[tags]=test")
-        allow(helper).to receive(:request).and_return(dpath)
+        request = instance_double(ActionDispatch::Request, path: "/posts", fullpath: "/posts?search[tags]=test")
+        allow(helper).to receive(:request).and_return(request)
       end
 
       it { is_expected.to eq(new_session_path(url: "/posts?search[tags]=test")) }
+    end
+
+    context "when the current path is longer than 2000 characters" do
+      before do
+        long_path = "/posts?search[tags]=#{'a' * 3000}"
+        request = instance_double(ActionDispatch::Request, path: "/posts", fullpath: long_path)
+        allow(helper).to receive(:request).and_return(request)
+      end
+
+      it "truncates the URL parameter to 2000 characters" do
+        length = 2000 + new_session_path(url: "").length
+        expect(path.length).to be <= length
+      end
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -51,4 +51,26 @@ RSpec.describe ApplicationHelper do
       end
     end
   end
+
+  describe "#safe_new_session_path" do
+    subject(:path) { helper.safe_new_session_path }
+
+    context "when the current path is the sign-in page" do
+      before do
+        dpath = instance_double(ActionDispatch::Request, path: new_session_path, fullpath: new_session_path)
+        allow(helper).to receive(:request).and_return(dpath)
+      end
+
+      it { is_expected.to eq(new_session_path) }
+    end
+
+    context "when the current path is not the sign-in page" do
+      before do
+        dpath = instance_double(ActionDispatch::Request, path: "/posts", fullpath: "/posts?search[tags]=test")
+        allow(helper).to receive(:request).and_return(dpath)
+      end
+
+      it { is_expected.to eq(new_session_path(url: "/posts?search[tags]=test")) }
+    end
+  end
 end


### PR DESCRIPTION
Clicking on the "sign in" link (with JS disabled) while you are already on the sign-in page would grow the URL exponentially.
This PR fixes that.