### PR TITLE
[Users] Add PostReplacement count to stats

### DIFF
--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -76,6 +76,7 @@ class UploadService
           penalize_uploader_on_approve: penalize_current_uploader.to_s.truthy?,
         })
 
+        UserStatus.for_user(CurrentUser.id).update_all("post_replacement_submitted_count = post_replacement_submitted_count + 1")
         UserStatus.for_user(previous_uploader).update_all("own_post_replaced_count = own_post_replaced_count + 1")
         if penalize_current_uploader.to_s.truthy?
           UserStatus.for_user(previous_uploader).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count + 1")

--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -76,7 +76,6 @@ class UploadService
           penalize_uploader_on_approve: penalize_current_uploader.to_s.truthy?,
         })
 
-        UserStatus.for_user(CurrentUser.id).update_all("post_replacement_submitted_count = post_replacement_submitted_count + 1")
         UserStatus.for_user(previous_uploader).update_all("own_post_replaced_count = own_post_replaced_count + 1")
         if penalize_current_uploader.to_s.truthy?
           UserStatus.for_user(previous_uploader).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count + 1")

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -336,7 +336,10 @@ class PostReplacement < ApplicationRecord
 
         q = q.attribute_exact_matches(:file_ext, params[:file_ext])
         q = q.attribute_exact_matches(:md5, params[:md5])
-        q = q.attribute_exact_matches(:status, params[:status])
+
+        if params[:status].present?
+          q = params[:status].to_s == ("submitted") ? q.where.not(status: "original") : q.attribute_exact_matches(:status, params[:status])
+        end
 
         q = q.where_user(:creator_id, :creator, params)
         q = q.where_user(:approver_id, :approver, params)
@@ -399,6 +402,10 @@ class PostReplacement < ApplicationRecord
 
       def for_user(id)
         where(creator_id: id.to_i)
+      end
+
+      def submitted
+        where.not(status: "original")
       end
 
       def for_uploader_on_approve(id)

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -340,7 +340,7 @@ class PostReplacement < ApplicationRecord
         q = q.attribute_exact_matches(:md5, params[:md5])
 
         if params[:status].present?
-          q = params[:status].to_s == ("submitted") ? q.where.not(status: "original") : q.attribute_exact_matches(:status, params[:status])
+          q = params[:status].to_s == ("submitted") ? q.submitted : q.attribute_exact_matches(:status, params[:status])
         end
 
         q = q.where_user(:creator_id, :creator, params)

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -36,8 +36,10 @@ class PostReplacement < ApplicationRecord
   before_create :create_original_backup
   before_create :set_previous_uploader
   after_create -> { post.update_index }
+  after_create :increment_user_replacement_count
   before_destroy :remove_files
   after_destroy -> { post.update_index }
+  after_destroy :decrement_user_replacement_count
 
   TAGS_TO_REMOVE_AFTER_ACCEPT = ["better_version_at_source"].freeze
   HIGHLIGHTED_TAGS = %w[better_version_at_source avoid_posting conditional_dnp].freeze
@@ -435,6 +437,16 @@ class PostReplacement < ApplicationRecord
       self.penalize_uploader_on_approve = false
     end
     self.uploader_on_approve = User.find_by(id: uploader)
+  end
+
+  def increment_user_replacement_count
+    return if status == "original"
+    UserStatus.for_user(CurrentUser.id).update_all("post_replacement_submitted_count = post_replacement_submitted_count + 1")
+  end
+
+  def decrement_user_replacement_count
+    return if status == "original"
+    UserStatus.for_user(CurrentUser.id).update_all("post_replacement_submitted_count = post_replacement_submitted_count - 1")
   end
 
   def original_file_visible_to?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -962,6 +962,10 @@ class User < ApplicationRecord
       user_status&.own_post_replaced_penalize_count || 0
     end
 
+    def post_replacement_submitted_count
+      user_status&.post_replacement_submitted_count || 0
+    end
+
     def refresh_counts!
       self.class.without_timeout do
         UserStatus.where(user_id: id).update_all(
@@ -973,6 +977,7 @@ class User < ApplicationRecord
           own_post_replaced_count: PostReplacement.for_uploader_on_approve(id).count,
           own_post_replaced_penalize_count: PostReplacement.penalized.for_uploader_on_approve(id).count,
           post_replacement_rejected_count: post_replacements.rejected.count,
+          post_replacement_submitted_count: PostReplacement.for_user(id).submitted.count,
         )
       end
     end

--- a/app/views/post_replacements/_search.html.erb
+++ b/app/views/post_replacements/_search.html.erb
@@ -4,7 +4,7 @@
   <%= f.user :creator %>
   <%= f.user :approver, label: "Handler" %>
   <%= f.user %i[uploader_name_on_approve uploader_id_on_approve], label: "Original Uploader" %>
-  <%= f.input :status, collection: ["pending", "rejected", "approved", "promoted", "original"], include_blank: "Any" %>
+  <%= f.input :status, collection: ["pending", "rejected", "approved", "promoted", "original", "submitted"], include_blank: "Any" %>
   <%= f.input :file_ext, collection: FileMethods::FILE_TYPE, include_blank: "Any", label: "File Type" %>
   <%= f.input :reason, label: "Reason" %>
   <%= f.input :file_name, label: "File Name" %>

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -81,13 +81,19 @@
         </a>
       <% end %>
 
+      <% if user.post_replacement_submitted_count != 0 %>
+        <a href="<%= post_replacements_path(search: { creator_id: user.id, status: "submitted" }) %>" class="entry">
+          <h5><%= user.post_replacement_submitted_count %></h5>
+          <span>Image</span>
+        </a>
+      <% end %>
+
       <% if user.note_version_count != 0 %>
         <a href="<%= note_versions_path(search: { updater_id: user.id }) %>" class="entry">
           <h5><%= user.note_version_count %></h5>
           <span>Note</span>
         </a>
       <% end %>
-
     </span>
   </div>
 

--- a/db/fixes/999_user_status_post_replacement_count.rb
+++ b/db/fixes/999_user_status_post_replacement_count.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+User.find_each do |user|
+  UserStatus.for_user(user.id).update_all(post_replacement_submitted_count: PostReplacement.where(creator_id: user.id).where.not(status: "original").count)
+end

--- a/db/migrate/20260715181809_add_submitted_replacements_count_to_user_statuses.rb
+++ b/db/migrate/20260715181809_add_submitted_replacements_count_to_user_statuses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSubmittedReplacementsCountToUserStatuses < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_statuses, :post_replacement_submitted_count, :integer
+  end
+end

--- a/db/migrate/20260715181809_add_submitted_replacements_count_to_user_statuses.rb
+++ b/db/migrate/20260715181809_add_submitted_replacements_count_to_user_statuses.rb
@@ -2,6 +2,6 @@
 
 class AddSubmittedReplacementsCountToUserStatuses < ActiveRecord::Migration[8.1]
   def change
-    add_column :user_statuses, :post_replacement_submitted_count, :integer
+    add_column :user_statuses, :post_replacement_submitted_count, :integer, null: false, default: 0
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2882,7 +2882,8 @@ CREATE TABLE public.user_statuses (
     own_post_replaced_penalize_count integer DEFAULT 0,
     post_replacement_rejected_count integer DEFAULT 0,
     ticket_count integer DEFAULT 0 NOT NULL,
-    appeal_count integer DEFAULT 0 NOT NULL
+    appeal_count integer DEFAULT 0 NOT NULL,
+    post_replacement_submitted_count integer
 );
 
 
@@ -6103,6 +6104,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260715181809'),
 ('20260707182943'),
 ('20260702120000'),
 ('20260624213023'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6105,7 +6105,6 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260715181809'),
-('20260714184832'),
 ('20260707182943'),
 ('20260702120000'),
 ('20260624213023'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2883,7 +2883,7 @@ CREATE TABLE public.user_statuses (
     post_replacement_rejected_count integer DEFAULT 0,
     ticket_count integer DEFAULT 0 NOT NULL,
     appeal_count integer DEFAULT 0 NOT NULL,
-    post_replacement_submitted_count integer
+    post_replacement_submitted_count integer DEFAULT 0 NOT NULL
 );
 
 
@@ -6105,6 +6105,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20260715181809'),
+('20260714184832'),
 ('20260707182943'),
 ('20260702120000'),
 ('20260624213023'),

--- a/spec/models/post_replacement/instance_methods_spec.rb
+++ b/spec/models/post_replacement/instance_methods_spec.rb
@@ -166,4 +166,87 @@ RSpec.describe PostReplacement do
       expect(replacement.promoted_id).to eq(promoted_post.id)
     end
   end
+
+  # --------------------------------------------------------------------------
+  # #increment_user_replacement_count
+  # --------------------------------------------------------------------------
+  describe "#increment_user_replacement_count" do
+    let(:user_status_relation) { instance_double(ActiveRecord::Relation) }
+
+    before do
+      allow(CurrentUser).to receive(:id).and_return(123)
+      allow(UserStatus).to receive(:for_user).with(123).and_return(user_status_relation)
+      allow(user_status_relation).to receive(:update_all)
+    end
+
+    it "increments UserStatus item 'post_replacement_submitted_count'" do
+      post_replacement = build(:post_replacement, status: "pending")
+
+      post_replacement.increment_user_replacement_count
+
+      expect(UserStatus).to have_received(:for_user).with(123)
+      expect(user_status_relation).to have_received(:update_all)
+    end
+
+    it "is called on create of pending" do
+      post_replacement = build(:post_replacement, status: "pending")
+
+      # Skip validations so we don't trigger external URL fetching during callback tests
+      post_replacement.save(validate: false)
+
+      expect(user_status_relation).to have_received(:update_all).once
+    end
+
+    it "is not called on create of original" do
+      post_replacement = build(:post_replacement, status: "original")
+
+      post_replacement.save(validate: false)
+
+      expect(UserStatus).not_to have_received(:for_user)
+      expect(user_status_relation).not_to have_received(:update_all)
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # #decrement_user_replacement_count
+  # --------------------------------------------------------------------------
+  describe "#decrement_user_replacement_count" do
+    let(:user_status_relation) { instance_double(ActiveRecord::Relation) }
+
+    before do
+      allow(CurrentUser).to receive(:id).and_return(123)
+      allow(UserStatus).to receive(:for_user).with(123).and_return(user_status_relation)
+      allow(user_status_relation).to receive(:update_all)
+    end
+
+    it "decrements UserStatus item 'post_replacement_submitted_count'" do
+      post_replacement = build(:post_replacement, status: "pending")
+
+      post_replacement.decrement_user_replacement_count
+
+      expect(UserStatus).to have_received(:for_user).with(123)
+      expect(user_status_relation).to have_received(:update_all)
+    end
+
+    it "is called on destroy of non-original" do
+      post_replacement = build(:post_replacement, status: "pending")
+
+      # Prevent the creation callback from hitting update_all
+      allow(post_replacement).to receive(:decrement_user_replacement_count)
+      post_replacement.save(validate: false)
+
+      post_replacement.destroy!
+
+      expect(user_status_relation).to have_received(:update_all).once
+    end
+
+    it "is not called on destroy of original" do
+      post_replacement = build(:post_replacement, status: "original")
+      post_replacement.save(validate: false)
+
+      post_replacement.destroy!
+
+      expect(user_status_relation).not_to have_received(:update_all)
+    end
+  end
 end


### PR DESCRIPTION
  * Add PostReplacement count to stats
    * Labeled as image
    * Counts `submitted` replacements (non-original)
    * Stored in UserStatus
    * Links to PostReplacement search for user's `submitted` replacements
  * Add `submitted` search to PostReplacements
    * Intercept the `status` attribute check, use `where.not(status: original)` if submitted, otherwise use the existing search method.
    * Add `submitted` option to search partial
  * Add helpers for `UserStatus` updates
    * Add a db migration to add the `post_replacement_submitted_count` column to `UserStatus`
    * Add a db fix to populate the column (mostly copied from the ticket count fix)
    * Add incrementer to the `replacer`

Notes:
  * UserStatus has no tests as of current, so none are included.
  * Behavior on destory of replacements is unaccounted for
  * There may be unrealized optimizations that can be made to the DB calls.

Feedback on UI appreciated. 

<img width="245" height="186" alt="image" src="https://github.com/user-attachments/assets/54948ea9-b434-402d-8c50-1beeb8b009f3" />


<img width="397" height="559" alt="image" src="https://github.com/user-attachments/assets/7f048f42-01b1-41df-b49f-8d0771aeacac" />
