### PR TITLE
[Search] Add appeal metatags to search

### DIFF
--- a/app/indexes/post_index.rb
+++ b/app/indexes/post_index.rb
@@ -20,6 +20,8 @@ module PostIndex
           noted_at: { type: "date" },
           flagged_at: { type: "date" },
           deleted_at: { type: "date" },
+          appealed_at: { type: "date" },
+
           id: { type: "integer" },
           up_score: { type: "integer" },
           down_score: { type: "integer" },
@@ -44,6 +46,7 @@ module PostIndex
           parent: { type: "integer" },
           pools: { type: "integer" },
           sets: { type: "integer" },
+
           commenters: { type: "integer" },
           noters: { type: "integer" },
           faves: { type: "integer" },
@@ -54,6 +57,8 @@ module PostIndex
           approver: { type: "integer" },
           deleter: { type: "integer" },
           flagger: { type: "integer" },
+          appealer: { type: "integer" },
+
           width: { type: "integer" },
           height: { type: "integer" },
           mpixels: { type: "float" },
@@ -70,6 +75,7 @@ module PostIndex
           del_reason: { type: "keyword" },
           flag_reason: { type: "keyword" },
           flag_note: { type: "keyword" },
+          appeal_status: { type: "keyword" },
 
           rating_locked: { type: "boolean" },
           note_locked: { type: "boolean" },
@@ -80,6 +86,7 @@ module PostIndex
           has_children: { type: "boolean" },
           has_pending_replacements: { type: "boolean" },
           artverified: { type: "boolean" },
+          has_pending_appeals: { type: "boolean" },
         },
       },
     }
@@ -177,6 +184,7 @@ module PostIndex
           WHERE post_id IN (#{post_ids})
           GROUP BY post_id
         SQL
+        appeal_sql = none # TODO: mm12:feat/search/appeals-data
 
         # Run queries
         conn = ApplicationRecord.connection
@@ -191,6 +199,9 @@ module PostIndex
         flag_reasons     = flags.values.map { |p, fid, fr, fn, fca| [p, fr] }.to_h
         flag_notes       = flags.values.map { |p, fid, fr, fn, fca| [p, fn] }.to_h
         flag_dates       = flags.values.map { |p, fid, fr, fn, fca| [p, fca] }.to_h
+        appealer_ids     = none # TODO: mm12:feat/search/appeals-data
+        appeal_dates     = none # TODO: mm12:feat/search/appeals-data
+        appeal_statuses  = none # TODO: mm12:feat/search/appeals-data
         comment_counts   = conn.execute(comments_sql).values.to_h
         pool_ids         = conn.execute(pools_sql).values.map(&array_parse).to_h
         set_ids          = conn.execute(sets_sql).values.map(&array_parse).to_h
@@ -230,12 +241,16 @@ module PostIndex
             deleter:                  deleter_ids[p.id]    || empty,
             del_reason:               del_reasons[p.id]    || empty,
             deleted_at:               del_dates[p.id],
+            flagged_at:               flag_dates[p.id],
             flagger:                  flagger_ids[p.id]    || empty,
             flag_reason:              flag_reasons[p.id]   || empty,
             flag_note:                flag_notes[p.id]     || empty,
             fav_count:                fav_counts[p.id]     || 0,
-            flagged_at:               flag_dates[p.id],
+            appealer:                 appealer_ids[p.id]   || empty,
+            appeal_statuses:          appeal_statuses[p.id], # TODO: mm12:feat/search/appeals-data
+            appealed_at:              appeal_dates[p.id],
             has_pending_replacements: pending_replacements[p.id],
+            has_pending_appeals:      empty, # TODO: mm12:feat/search/appeals-data
             artverified:              p.tag_array.any? { |tag| verified_artists.key?(tag) && verified_artists[tag] == p.uploader_id },
           }
 
@@ -262,6 +277,9 @@ module PostIndex
     deletion = unless options.key?(:deleter) && options.key?(:del_reason) && options.key?(:deleted_at)
                  ::PostFlag.where(post_id: id, is_resolved: false, is_deletion: true).order(id: :desc).first
                end
+    appeal = unless options.key?(:appealer) && options.key?(:appealed_at)
+               ::Appeal.first # TODO: mm12:feat/search/appeals-data
+             end
 
     {
       created_at:               created_at,
@@ -307,6 +325,7 @@ module PostIndex
       flagger:                  options[:flagger]       || flag&.creator_id,
       flag_reason:              options[:flag_reason]   || flag&.reason&.downcase,
       flag_note:                options[:flag_note]     || flag&.note&.downcase,
+      appealer:                 options[:appealer]      || appealer&.creator_id,
       width:                    image_width,
       height:                   image_height,
       mpixels:                  image_width && image_height ? (image_width.to_f * image_height / 1_000_000).round(2) : 0.0,
@@ -319,6 +338,7 @@ module PostIndex
       file_ext:                 file_ext,
       source:                   source_array,
       description:              description.presence,
+      appeal_status:            none, # TODO: mm12:feat/search/appeals-data
 
       rating_locked:            is_rating_locked,
       note_locked:              is_note_locked,
@@ -328,10 +348,12 @@ module PostIndex
       deleted:                  is_deleted,
       has_children:             has_children,
       has_pending_replacements: options.key?(:has_pending_replacements) ? options[:has_pending_replacements] : replacements.pending.any?,
+      has_pending_appeals:      none, # TODO: mm12:feat/search/appeals-data
       artverified:              options.key?(:artverified) ? options[:artverified] : uploader_linked_artists.any?,
 
       flagged_at:               options.key?(:flagged_at) ? options[:flagged_at] : flag&.created_at,
       deleted_at:               options.key?(:deleted_at) ? options[:deleted_at] : deletion&.created_at,
+      appealed_at:              options.key?(:appealed_at) ? options[:appealed_at] : appeal&.created_at,
     }
   end
 end

--- a/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
@@ -171,6 +171,9 @@ export default class TagQueryProvider extends Provider<Types.AutocompleteItem> {
     switch (metatag) {
       case "user":
       case "approver":
+      case "appealedby":
+      case "appellant":
+      case "appealer":
       case "commenter":
       case "comm":
       case "noter":

--- a/app/logical/elastic_post_query_builder.rb
+++ b/app/logical/elastic_post_query_builder.rb
@@ -137,6 +137,8 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
     "flagged_asc" => [{ flagged_at: { order: :asc, missing: :_last } }, { id: :asc }],
     "deleted" => [{ deleted_at: { order: :desc, missing: :_last } }, { id: :desc }],
     "deleted_asc" => [{ deleted_at: { order: :asc, missing: :_last } }, { id: :asc }],
+    "appealed" => [{ appealed_at: { order: :desc, missing: :_last } }, { id: :desc }],
+    "appealed_asc" => [{ appealed_at: { order: :asc, missing: :_last } }, { id: :asc }],
   }).freeze.each_value(&:freeze)
 
   def build
@@ -278,6 +280,11 @@ class ElasticPostQueryBuilder < ElasticQueryBuilder
 
     if q.include?(:artverified)
       must.push({ term: { artverified: q[:artverified] } })
+    end
+
+    if q.include?(:pending_appeals)
+      # TODO: mm12:feat/search/appeals-data
+      # need staff check!
     end
 
     add_tag_string_search_relation(q[:tags])

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -1517,7 +1517,7 @@ class TagQuery
       when "appealer", "-appealer", "~appealser",
            "appellant", "-appellant", "~appellant",
            "appealedby", "-appealedby", "~appealedby"
-        next unless CurrentUser.is_staff? # TODO: mm12:feat/search/appeals-data
+        next unless CurrentUser.is_staff? # CHECK: mm12:feat/search/appeals-data
         add_to_query(type, :appealer, g2.downcase, wildcard: true)
 
       when "upvote", "-upvote", "~upvote",

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -63,7 +63,7 @@ class TagQuery
 
   # Tags with parsed values of `true` or `false`. See `TagQuery#parse_boolean` for details.
   BOOLEAN_METATAGS = %w[
-    hassource hasdescription isparent ischild hasparent haschild haschildren inpool pending_replacements artverified
+    hassource hasdescription isparent ischild hasparent haschild haschildren inpool pending_replacements artverified has_pending_appeals
   ].freeze
 
   BOOLEAN_METATAG_ALIASES = {
@@ -79,7 +79,7 @@ class TagQuery
     source status pool set fav favoritedby note locked
     upvote votedup upvoted voteup downvote voteddown downvoted votedown voted vote
     width height mpixels ratio filesize duration score favcount date age change tagcount
-    commenter comm noter noteupdater flagreason flagnote flaggedby
+    commenter comm noter noteupdater flagreason flagnote flaggedby appealedby appeal_status
   ].concat(CATEGORY_METATAG_MAP.keys).freeze
 
   METATAGS = %w[md5 order limit child randseed ratinglocked notelocked statuslocked].concat(
@@ -139,7 +139,7 @@ class TagQuery
   # NOTE: The first element (`id`) is the only one whose value is equivalent to the `_asc`-suffixed variant.
   ORDER_INVERTIBLE_ROOTS = %w[
     id score md5 favcount note mpixels filesize tagcount change duration
-    created updated comment comment_bumped aspect_ratio deleted flagged
+    created updated comment comment_bumped aspect_ratio deleted flagged appealed
   ].concat(COUNT_METATAGS, CATEGORY_METATAG_MAP.keys).freeze
 
   # All possible valid values for `order` metatags; used for autocomplete.
@@ -237,10 +237,15 @@ class TagQuery
     flagger -flagger ~flagger
     flagnote -flagnote ~flagnote
     flagreason -flagreason ~flagreason
+    appealedby -appealedby ~appealedby
+    appellant -appellant ~appellant
+    appealer -appealer ~appealer
+    appeal_status -appeal_status ~appeal_status
   ].freeze
 
   OVERRIDE_DELETED_FILTER_ORDERS = %w[
     deleted deleted_desc deleted_asc
+    appealed appealed_desc appealed_desc
   ].freeze
 
   STATUS_VALUES = %w[all any pending modqueue deleted flagged active].freeze
@@ -1484,6 +1489,10 @@ class TagQuery
 
       when "note", "-note", "~note" then add_to_query(type, :note, g2)
 
+      when "appeal_status", "-appeal_status", "~appeal_status"
+        next unless CurrentUser.is_staff?
+        add_to_query(type, :appeal_status, g2) # TODO: mm12:feat/search/appeals-data
+
       when "delreason", "-delreason", "~delreason"
         q[:status] ||= "any" unless q[:status_must_not]
         q[:show_deleted] ||= true
@@ -1504,6 +1513,12 @@ class TagQuery
       when "flagnote", "-flagnote", "~flagnote"
         next unless CurrentUser.is_staff?
         add_to_query(type, :flagnote, g2.downcase, wildcard: true)
+
+      when "appealer", "-appealer", "~appealser",
+           "appellant", "-appellant", "~appellant",
+           "appealedby", "-appealedby", "~appealedby"
+        next unless CurrentUser.is_staff? # TODO: mm12:feat/search/appeals-data
+        add_to_query(type, :appealer, g2.downcase, wildcard: true)
 
       when "upvote", "-upvote", "~upvote",
            "votedup", "-votedup", "~votedup",

--- a/db/fixes/999_1_add_opensearch_appeal_index.rb
+++ b/db/fixes/999_1_add_opensearch_appeal_index.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+client = Post.document_store.client
+client.indices.put_mapping(
+  index: Post.document_store.index_name,
+  body: {
+    properties: {
+      appealed_at:         { type: "date" },
+      appealer:            { type: "integer" },
+      appeal_status:       { type: "keyword" },
+      has_pending_appeals: { type: "boolean" }, # TODO: mm12:feat/search/appeals-data
+    },
+  },
+)

--- a/db/fixes/999_2_add_opensearch_appeal_data.rb
+++ b/db/fixes/999_2_add_opensearch_appeal_data.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "config", "environment"))
+
+client = Post.document_store.client
+conn = ApplicationRecord.connection
+
+Post.find_in_batches(batch_size: 10_000) do |posts| # rubocop:disable Metrics/BlockLength
+  # TODO: mm12:feat/search/appeals-data
+end

--- a/spec/indexes/post_index_spec.rb
+++ b/spec/indexes/post_index_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe PostIndex do
         end
 
         it "returns false when options[:has_pending_appeals] is false, even if a pending replacement exists" do
-          # TODO: mm12:feat/search/appeals-data
+          # CHECK: mm12:feat/search/appeals-data
           appeal = create(:appeal, post: post)
           PostFlag.find(appeal.disp_id).update(post_id: post.id)
           expect(post.as_indexed_json(has_pending_appeals: false)[:has_pending_appeals]).to be false

--- a/spec/indexes/post_index_spec.rb
+++ b/spec/indexes/post_index_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PostIndex do
           tags md5 rating file_ext source description del_reason notes
           rating_locked note_locked status_locked flagged pending
           deleted has_children has_pending_replacements artverified
-          deleted_at flag_note flag_reason flagged_at flagger appellant appealled_at
+          deleted_at flag_note flag_reason flagged_at flagger appealedby appealled_at
         ] + category_count_keys
         expect(indexed.keys).to match_array(expected_keys)
       end

--- a/spec/indexes/post_index_spec.rb
+++ b/spec/indexes/post_index_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PostIndex do
           tags md5 rating file_ext source description del_reason notes
           rating_locked note_locked status_locked flagged pending
           deleted has_children has_pending_replacements artverified
-          deleted_at flag_note flag_reason flagged_at flagger
+          deleted_at flag_note flag_reason flagged_at flagger appellant appealled_at
         ] + category_count_keys
         expect(indexed.keys).to match_array(expected_keys)
       end
@@ -539,6 +539,23 @@ RSpec.describe PostIndex do
 
         it "returns true when the uploader is the linked artist for one of the post's artist tags" do
           expect(verified_post.as_indexed_json[:artverified]).to be true
+        end
+      end
+    end
+
+    describe "has_pending_appeals" do
+      let(:post) { create(:post) }
+
+      context "via options (options.key? pattern)" do
+        it "returns true when options[:has_pending_appeals] is true" do
+          expect(post.as_indexed_json(has_pending_appeals: true)[:has_pending_appeals]).to be true
+        end
+
+        it "returns false when options[:has_pending_appeals] is false, even if a pending replacement exists" do
+          # TODO: mm12:feat/search/appeals-data
+          appeal = create(:appeal, post: post)
+          PostFlag.find(appeal.disp_id).update(post_id: post.id)
+          expect(post.as_indexed_json(has_pending_appeals: false)[:has_pending_appeals]).to be false
         end
       end
     end

--- a/spec/logical/elastic_post_query_builder/array_relations_spec.rb
+++ b/spec/logical/elastic_post_query_builder/array_relations_spec.rb
@@ -44,6 +44,9 @@ RSpec.describe ElasticPostQueryBuilder do
       end
     end
 
+    describe "appeal_status" do # TODO: mm12:feat/search/appeals-data
+    end
+
     describe "source (wildcard)" do
       it "adds a wildcard clause for source:*example.com*" do
         expect(build_query("source:*example.com*").must).to include({ wildcard: { source: "*example.com*" } })
@@ -149,6 +152,9 @@ RSpec.describe ElasticPostQueryBuilder do
       it "adds an exists clause to must for noter:any" do
         expect(build_query("noter:any").must).to include({ exists: { field: :noters } })
       end
+    end
+
+    describe "appealer any/none" do # TODO: mm12:feat/search/appeals-data
     end
 
     describe "source any/none" do

--- a/spec/logical/elastic_post_query_builder/array_relations_spec.rb
+++ b/spec/logical/elastic_post_query_builder/array_relations_spec.rb
@@ -44,7 +44,26 @@ RSpec.describe ElasticPostQueryBuilder do
       end
     end
 
-    describe "appeal_status" do # TODO: mm12:feat/search/appeals-data
+    describe "appeal_status" do # CHECK: mm12:feat/search/appeals-data
+      context "a member user" do
+        it "does not add a term clause for `appeal_staus:pending`" do
+          expect(build_query("appeal_staus:pending").must).to eq(build_query(""))
+        end
+
+        it "does not add a term clause for `-appeal_staus:pending`" do
+          expect(build_query("-appeal_staus:pending").must_not).to eq(build_query(""))
+        end
+      end
+
+      context "a staff user" do # Do we need this? If so, still need to add role context
+        it "adds a `must` term clause for `appeal_staus:pending`" do
+          expect(build_query("appeal_staus:pending").must).to include({ term: { appeal_status: "pending" } })
+        end
+
+        it "adds a `must_not` term clause for `-appeal_staus:pending`" do
+          expect(build_query("-appeal_staus:pending").must_not).to include({ term: { appeal_status: "pending" } })
+        end
+      end
     end
 
     describe "source (wildcard)" do
@@ -154,7 +173,14 @@ RSpec.describe ElasticPostQueryBuilder do
       end
     end
 
-    describe "appealer any/none" do # TODO: mm12:feat/search/appeals-data
+    describe "appealer any/none" do # CHECK: mm12:feat/search/appeals-data - do we need role context here?
+      it "adds an exists clause to must for `appealedby:any`" do
+        expect(build_query("appealedby:any").must).to include({ exists: { field: :appealers } })
+      end
+
+      it "adds an exists clause to must_not for `appealedby:none`" do
+        expect(build_query("appealedby:none").must_not).to include({ exists: { field: :appealers } })
+      end
     end
 
     describe "source any/none" do

--- a/spec/logical/elastic_post_query_builder/boolean_metatags_spec.rb
+++ b/spec/logical/elastic_post_query_builder/boolean_metatags_spec.rb
@@ -70,6 +70,16 @@ RSpec.describe ElasticPostQueryBuilder do
       end
     end
 
+    describe "has_pending_appeals" do # CHECK: mm12:feat/search/appeals-data
+      it "adds a has_pending_appeals:true term for pending_appeals:true" do
+        expect(build_query("pending_appeals:true").must).to include({ term: { has_pending_appeals: true } })
+      end
+
+      it "adds a has_pending_appeals:false term for pending_appeals:false" do
+        expect(build_query("pending_appeals:false").must).to include({ term: { has_pending_appeals: false } })
+      end
+    end
+
     describe "artverified" do
       it "adds an artverified:true term for artverified:true" do
         expect(build_query("artverified:true").must).to include({ term: { artverified: true } })

--- a/spec/logical/elastic_post_query_builder/order_spec.rb
+++ b/spec/logical/elastic_post_query_builder/order_spec.rb
@@ -93,7 +93,16 @@ RSpec.describe ElasticPostQueryBuilder do
     end
   end
 
-  describe "appealed order" do # TODO: mm12:feat/search/appeals-data
+  describe "appealed order" do # CHECK: mm12:feat/search/appeals-data
+    it "sets order from ORDER_TABLE for `order:appealed`" do
+      builder = build_query("order:appealed")
+      expect(builder.order).to eq([{ appealed_at: { order: :desc, missing: :_last } }, { id: :desc }])
+    end
+
+    it "sets order from ORDER_TABLE for `order:appealed_asc`" do
+      builder = build_query("order:appealed_asc")
+      expect(builder.order).to eq([{ appealed_at: { order: :asc, missing: :_last } }, { id: :asc }])
+    end
   end
 
   describe "COUNT_METATAG order pattern" do

--- a/spec/logical/elastic_post_query_builder/order_spec.rb
+++ b/spec/logical/elastic_post_query_builder/order_spec.rb
@@ -93,6 +93,9 @@ RSpec.describe ElasticPostQueryBuilder do
     end
   end
 
+  describe "appealed order" do # TODO: mm12:feat/search/appeals-data
+  end
+
   describe "COUNT_METATAG order pattern" do
     it "orders by comment_count desc for order:comment_count" do
       builder = build_query("order:comment_count")

--- a/spec/logical/tag_query/content_metatags_spec.rb
+++ b/spec/logical/tag_query/content_metatags_spec.rb
@@ -245,9 +245,22 @@ RSpec.describe TagQuery do
     end
   end
 
-  describe "has_pending_appeals" do # TODO: mm12:feat/search/appeals-data
-  end
+  describe "appeal_status" do
+    it "is ignored for non-staff users" do # CHECK: mm12:feat/search/appeals-data
+      tq = TagQuery.new("appeal_status:*")
+      expect(tq[:appeal_status]).to be_nil
+      expect(tq[:appeal_status_must_not]).to be_nil
+      expect(tq[:appeal_status_should]).to be_nil
+    end
 
-  describe "appeal_status" do # TODO: mm12:feat/search/appeals-data
+    it "is parsed for staff users ...." do # CHECK: mm12:feat/search/appeals-data
+      staff = create(:admin_user)
+
+      CurrentUser.scoped(staff) do
+        expect(TagQuery.new("appeal_status:pending")[:appeal_status]).to include("pending")
+        expect(TagQuery.new("-appeal_status:rejected")[:appeal_status]).to include("rejected")
+        expect(TagQuery.new("~appeal_status:approved")[:appeal_status]).to include("approved")
+      end
+    end
   end
 end

--- a/spec/logical/tag_query/content_metatags_spec.rb
+++ b/spec/logical/tag_query/content_metatags_spec.rb
@@ -3,7 +3,8 @@
 require "rails_helper"
 
 # Tests content-filtering metatags: rating:, filetype: (type: alias), source:,
-# md5:, description:, note:, delreason:, deletedby:, flagreason:, and flagnote:.
+# md5:, description:, note:, delreason:, deletedby:, flagreason:, flagnote:,
+# has_pending_appeals:, appeal_status:.
 
 RSpec.describe TagQuery do
   include_context "as member"
@@ -242,5 +243,11 @@ RSpec.describe TagQuery do
         expect(TagQuery.new("~flagnote:Needs*More***Details")[:flagnote_should]).to include("needs*more*details")
       end
     end
+  end
+
+  describe "has_pending_appeals" do # TODO: mm12:feat/search/appeals-data
+  end
+
+  describe "appeal_status" do # TODO: mm12:feat/search/appeals-data
   end
 end

--- a/spec/logical/tag_query/order_metatags_spec.rb
+++ b/spec/logical/tag_query/order_metatags_spec.rb
@@ -106,6 +106,9 @@ RSpec.describe TagQuery do
     it "-order:flagged inverts to flagged_asc" do
       expect(TagQuery.new("-order:flagged")[:order]).to eq("flagged_asc")
     end
+
+    it "-order:appealed inverts to appealed_asc" do # TODO: mm12:feat/search/appeals-data
+    end
   end
 
   describe "randseed: metatag" do

--- a/spec/logical/tag_query/order_metatags_spec.rb
+++ b/spec/logical/tag_query/order_metatags_spec.rb
@@ -107,7 +107,8 @@ RSpec.describe TagQuery do
       expect(TagQuery.new("-order:flagged")[:order]).to eq("flagged_asc")
     end
 
-    it "-order:appealed inverts to appealed_asc" do # TODO: mm12:feat/search/appeals-data
+    it "-order:appealed inverts to appealed_asc" do
+      expect(TagQuery.new("-order:appealed")[:order]).to eq("appealed_asc")
     end
   end
 

--- a/spec/logical/tag_query/status_metatags_spec.rb
+++ b/spec/logical/tag_query/status_metatags_spec.rb
@@ -176,6 +176,12 @@ RSpec.describe TagQuery, type: :model do
                        input: "pending_replacements", expected_key: :pending_replacements,
                        true_value: true, false_value: false
     end
+
+    describe "pending_appeals:" do
+      include_examples "a boolean metatag",
+                       input: "pending_appeals", expected_key: :pending_appeal,
+                       true_value: true, false_value: false
+    end
   end
 
   describe "boolean metatag aliases" do

--- a/spec/logical/tag_query/user_metatags_spec.rb
+++ b/spec/logical/tag_query/user_metatags_spec.rb
@@ -288,6 +288,9 @@ RSpec.describe TagQuery do
     end
   end
 
+  describe "appellant: metatag" do # TODO: mm12:feat/search/appeals-data
+  end
+
   describe "deleted filter helpers with order metatags" do
     it "does not hide deleted posts when order:deleted is present" do
       expect(TagQuery.should_hide_deleted_posts?("aaa bbb order:deleted")).to be(false)

--- a/spec/logical/tag_query/user_metatags_spec.rb
+++ b/spec/logical/tag_query/user_metatags_spec.rb
@@ -288,7 +288,43 @@ RSpec.describe TagQuery do
     end
   end
 
-  describe "appealedby: metatag" do # TODO: mm12:feat/search/appeals-data
+  describe "appealedby: metatag" do # CHECK: mm12:feat/search/appeals-data
+    let!(:appealed_user) { create(:user) }
+
+    it "is ignored for non-staff users" do
+      tq = TagQuery.new("appealedby:#{appealed_user.name}")
+      expect(tq[:appealer]).to be_nil
+      expect(tq[:appealer_must_not]).to be_nil
+      expect(tq[:appealer_should]).to be_nil
+    end
+
+    it "parses username and id forms for staff users" do
+      staff = create(:admin_user)
+
+      CurrentUser.scoped(staff) do
+        expect(TagQuery.new("appealedby:#{appealed_user.name}")[:appealedby]).to include(appealed_user.id)
+        expect(TagQuery.new("appealedby:!#{appealed_user.id}")[:appealedby]).to include(appealed_user.id)
+        expect(TagQuery.new("-appealedby:#{appealed_user.name}")[:appealedby_must_not]).to include(appealed_user.id)
+        expect(TagQuery.new("~appealedby:#{appealed_user.name}")[:appealedby_should]).to include(appealed_user.id)
+      end
+    end
+
+    it "stores -1 for unknown users when staff" do
+      staff = create(:admin_user)
+
+      CurrentUser.scoped(staff) do
+        expect(TagQuery.new("appealedby:missing_user")[:flagger]).to include(-1)
+      end
+    end
+
+    it "stores the current user's ID for appealedby:me when staff" do
+      staff = create(:admin_user)
+
+      CurrentUser.scoped(staff) do
+        tq = TagQuery.new("appealedby:me")
+        expect(tq[:appealedby]).to include(CurrentUser.id)
+      end
+    end
   end
 
   describe "deleted filter helpers with order metatags" do

--- a/spec/logical/tag_query/user_metatags_spec.rb
+++ b/spec/logical/tag_query/user_metatags_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe TagQuery do
     end
   end
 
-  describe "appellant: metatag" do # TODO: mm12:feat/search/appeals-data
+  describe "appealedby: metatag" do # TODO: mm12:feat/search/appeals-data
   end
 
   describe "deleted filter helpers with order metatags" do


### PR DESCRIPTION
Staff request: To be able to search appeals by tags, `artistverified`, `delreason`, etc. 

This is difficult since appeals will handle more models than just postflags. However, adding appeals to the post search index would allow this capability, even if degraded. 
