### PR TITLE
[Misc] Restrict `post_tags_match` to members only

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -160,7 +160,8 @@ class CommentsController < ApplicationController
   end
 
   def search_params
-    permitted_params = %i[body_matches post_id post_tags_match creator_name creator_id post_note_updater_name post_note_updater_id poster_id poster_name is_sticky do_not_bump_post order advanced_search]
+    permitted_params = %i[body_matches post_id creator_name creator_id post_note_updater_name post_note_updater_id poster_id poster_name is_sticky do_not_bump_post order advanced_search]
+    permitted_params += %i[post_tags_match] if CurrentUser.is_member?
     permitted_params += %i[is_hidden] if CurrentUser.is_staff?
     permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -63,6 +63,14 @@ class NotesController < ApplicationController
 
   private
 
+  def search_params
+    # creator_id/creator_name and post_note_updater_id/post_note_updater_name
+    # are special cased in the model search function
+    permitted_params = %i[body_matches is_active post_id creator_id creator_name post_note_updater_id post_note_updater_name]
+    permitted_params += %i[post_tags_match] if CurrentUser.is_member?
+    permit_search_params permitted_params
+  end
+
   def note_params(context)
     permitted_params = %i[x y width height body]
     permitted_params += %i[post_id html_id] if context == :create

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -66,7 +66,7 @@ class NotesController < ApplicationController
   def search_params
     # creator_id/creator_name and post_note_updater_id/post_note_updater_name
     # are special cased in the model search function
-    permitted_params = %i[body_matches is_active post_id creator_id creator_name post_note_updater_id post_note_updater_name]
+    permitted_params = %i[body_matches is_active post_id creator_id creator_name post_note_updater_id post_note_updater_name order]
     permitted_params += %i[post_tags_match] if CurrentUser.is_member?
     permit_search_params permitted_params
   end

--- a/app/controllers/post_approvals_controller.rb
+++ b/app/controllers/post_approvals_controller.rb
@@ -4,7 +4,8 @@ class PostApprovalsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @post_approvals = PostApproval.includes(:post, :user).search(search_params).paginate(params[:page], limit: params[:limit])
+    @search_params = search_params
+    @post_approvals = PostApproval.includes(:post, :user).search(@search_params).paginate(params[:page], limit: params[:limit])
     Post.preload_stats!(@post_approvals.map(&:post))
     respond_with(@post_approvals)
   end
@@ -13,7 +14,7 @@ class PostApprovalsController < ApplicationController
 
   def search_params
     # user_id and user_name are special cased in the model search function
-    permitted_params = %i[user_id user_name post_id]
+    permitted_params = %i[user_id user_name post_id order]
     permitted_params += %i[post_tags_match] if CurrentUser.is_member?
     permit_search_params permitted_params
   end

--- a/app/controllers/post_approvals_controller.rb
+++ b/app/controllers/post_approvals_controller.rb
@@ -8,4 +8,13 @@ class PostApprovalsController < ApplicationController
     Post.preload_stats!(@post_approvals.map(&:post))
     respond_with(@post_approvals)
   end
+
+  private
+
+  def search_params
+    # user_id and user_name are special cased in the model search function
+    permitted_params = %i[user_id user_name post_id]
+    permitted_params += %i[post_tags_match] if CurrentUser.is_member?
+    permit_search_params permitted_params
+  end
 end

--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -63,7 +63,8 @@ class PostFlagsController < ApplicationController
 
   def search_params
     # creator_id and creator_name are special cased in the model search function
-    permitted_params = %i[reason_matches creator_id creator_name post_id post_tags_match type is_resolved]
+    permitted_params = %i[reason_matches creator_id creator_name post_id type is_resolved]
+    permitted_params += %i[post_tags_match] if CurrentUser.is_member?
     permitted_params += %i[note] if CurrentUser.is_staff?
     permitted_params += %i[ip_addr] if CurrentUser.is_admin?
     permit_search_params permitted_params

--- a/app/views/comments/_search.html.erb
+++ b/app/views/comments/_search.html.erb
@@ -2,7 +2,7 @@
   <%= hidden_field_tag "group_by", "comment", id: "group_by_full" %>
   <%= f.user :creator, label: "Commenter" %>
   <%= f.input :body_matches, label: "Body" %>
-  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
+  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" if CurrentUser.user.is_member? %>
   <%= f.user :post_note_updater, label: "Post Note Updater", hide_unless_value: true %>
   <%= f.user :poster, label: "Post Uploader", hide_unless_value: true %>
   <% if CurrentUser.is_admin? %>

--- a/app/views/notes/_search.html.erb
+++ b/app/views/notes/_search.html.erb
@@ -3,6 +3,6 @@
   <%= f.user :creator, label: "Author" %>
   <%= f.user :post_note_updater, label: "Post Note Updater" %>
   <%= f.input :post_id, label: "Post #"%>
-  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
+  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" if CurrentUser.user.is_member? %>
   <%= f.input :is_active, label: "Status", collection: [["Active", "true"], ["Deleted", "false"]], :include_blank => true %>
 <% end %>

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -5,7 +5,7 @@
 
     <%= form_search(path: post_approvals_path) do |f| %>
       <%= f.user :user, label: "Approver" %>
-      <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
+      <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" if CurrentUser.user.is_member? %>
     <% end %>
 
     <table class="striped">

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -24,7 +24,7 @@
 
             <td>
               <%= link_to_user post_approval.user %>
-              <%= link_to "»", post_approvals_path(search: params[:search].merge(user_name: post_approval.user.name)) %>
+              <%= link_to "»", post_approvals_path(search: @search_params.merge(user_name: post_approval.user.name)) %>
               <br><%= time_ago_in_words_tagged  post_approval.created_at %>
             </td>
           </tr>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -1,6 +1,6 @@
 <%= form_search(path: post_flags_path) do |f| %>
   <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches" %>
-  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" %>
+  <%= f.input :post_tags_match, label: "Tags", autocomplete: "tag-query" if CurrentUser.user.is_member? %>
   <%= f.input :post_id, label: "Post ID" %>
   <%= f.input :type, collection: [
     ["Flag", "flag"],

--- a/spec/requests/comments_controller_spec.rb
+++ b/spec/requests/comments_controller_spec.rb
@@ -78,6 +78,19 @@ RSpec.describe CommentsController do
         expect(response).to have_http_status(:unprocessable_content)
       end
     end
+
+    describe "post_tags_match search param" do
+      it "returns 403 for anonymous — param is not permitted" do
+        get comments_path(format: :json, search: { post_tags_match: "tag1 tag2" })
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "is accepted for members without raising an error" do
+        sign_in_as member
+        get comments_path(format: :json, search: { post_tags_match: "tag1 tag2" })
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/requests/notes_controller_spec.rb
+++ b/spec/requests/notes_controller_spec.rb
@@ -50,6 +50,17 @@ RSpec.describe NotesController do
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to be_an(Array)
     end
+
+    it "redirects anonymous users to login if post_tags_match is used" do
+      get notes_path(search: { post_tags_match: "tag" })
+      expect(response).to redirect_to(new_session_path(url: notes_path(search: { post_tags_match: "tag" })))
+    end
+
+    it "accepts the post_tags_match search param as a member without error" do
+      sign_in_as creator
+      get notes_path(search: { post_tags_match: "tag" })
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/requests/post_approvals_controller_spec.rb
+++ b/spec/requests/post_approvals_controller_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe PostApprovalsController do
       expect(response.parsed_body).to be_an(Array)
     end
 
+    it "renders the HTML index with a search param and existing approvals" do
+      create(:post_approval)
+      get post_approvals_path(search: { post_id: "1" })
+      expect(response).to have_http_status(:ok)
+    end
+
     it "orders results newest first by default" do
       older = create(:post_approval)
       newer = create(:post_approval)

--- a/spec/requests/post_approvals_controller_spec.rb
+++ b/spec/requests/post_approvals_controller_spec.rb
@@ -70,5 +70,16 @@ RSpec.describe PostApprovalsController do
       get post_approvals_path(format: :json, limit: 2)
       expect(response.parsed_body.length).to eq(2)
     end
+
+    it "redirects anonymous users to login if post_tags_match is used" do
+      get post_approvals_path(search: { post_tags_match: "tag" })
+      expect(response).to redirect_to(new_session_path(url: post_approvals_path(search: { post_tags_match: "tag" })))
+    end
+
+    it "accepts the post_tags_match search param as a member without error" do
+      sign_in_as member
+      get post_approvals_path(search: { post_tags_match: "tag" })
+      expect(response).to have_http_status(:ok)
+    end
   end
 end

--- a/spec/requests/post_flags_controller_spec.rb
+++ b/spec/requests/post_flags_controller_spec.rb
@@ -70,6 +70,17 @@ RSpec.describe PostFlagsController do
       get post_flags_path(search: { ip_addr: "127.0.0.1" })
       expect(response).to have_http_status(:ok)
     end
+
+    it "redirects anonymous users to login if post_tag_match is used" do
+      get post_flags_path(search: { post_tags_match: "tag" })
+      expect(response).to redirect_to(new_session_path(url: post_flags_path(search: { post_tags_match: "tag" })))
+    end
+
+    it "accepts the post_tags_match search param as a member without error" do
+      sign_in_as member
+      get post_flags_path(search: { post_tags_match: "tag" })
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Layering up OpenSearch-backed search on top of another query is a bit too heavy for unauthenticated use.
The `/post_flags` route was utilized in a DDoS attack, but this pattern appears in other controllers too.

Restricted the `post_tags_match` search to members and above for the following controllers:
- PostFlags
- PostApprovals
- Comments
- Notes