### PR TITLE
[Stats] Enable JSON

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class StatsController < ApplicationController
-  respond_to :html
+  respond_to :html, :json
 
   def index
     @stats = JSON.parse(Cache.redis.get("e6stats") || "{}")
+    respond_with(@stats)
   end
 end

--- a/spec/requests/stats_controller_spec.rb
+++ b/spec/requests/stats_controller_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe StatsController do
   end
 
   describe "GET /stats" do
-    it "returns 406 when JSON format is requested" do
+    it "returns 200 when JSON format is requested" do
       get stats_path(format: :json)
-      expect(response).to have_http_status(:not_acceptable)
+      expect(response).to have_http_status(:ok)
     end
 
     # FIXME: When Redis returns nil, @stats is {} and the view raises in two


### PR DESCRIPTION
I don't see a reason serving the stats as json wouldn't be beneficial, it's a single cache lookup and nothing else.