### PR TITLE
[Posts] Add a count-only API endpoint

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,9 +3,9 @@
 class PostsController < ApplicationController
   include JsonResponseHelper
 
-  before_action :member_only, except: %i[show show_seq index random]
+  before_action :member_only, except: %i[show show_seq index random count]
   before_action :admin_only, only: [:update_iqdb]
-  before_action :ensure_lockdown_disabled, except: %i[index show show_seq random]
+  before_action :ensure_lockdown_disabled, except: %i[index show show_seq random count]
   respond_to :html, :json
 
   def index
@@ -59,6 +59,19 @@ class PostsController < ApplicationController
         format.atom
       end
     end
+  end
+
+  def count
+    query = tag_query
+    unless query.is_a?(String)
+      render_expected_error(400, "Invalid tags parameter", format: :json)
+      return
+    end
+
+    max_count = (Danbooru.config.max_numbered_pages * Danbooru.config.max_per_page) + 1
+    search = Post.tag_match(query)
+    total = search.count_only(max_count: max_count)
+    render json: { count: total, capped: search.count_capped? }
   end
 
   def show

--- a/app/logical/danbooru/paginator/document_store_extensions.rb
+++ b/app/logical/danbooru/paginator/document_store_extensions.rb
@@ -58,10 +58,17 @@ module Danbooru
         real_count > 0
       end
 
-      def count_only
+      def count_only(max_count: nil)
         search.definition[:body]&.delete(:sort)
-        search.definition.update(from: 0, size: 0, sort: "_doc", _source: false, track_total_hits: true)
+        search.definition.update(from: 0, size: 0, sort: "_doc", _source: false, track_total_hits: max_count || true)
         real_count
+      end
+
+      # Whether the last count was capped by track_total_hits (OpenSearch reports the
+      # total as a lower bound). Reads the same memoized response as real_count.
+      def count_capped?
+        total = response["hits"]["total"]
+        total.respond_to?(:keys) && total["relation"] == "gte"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -334,6 +334,7 @@ Rails.application.routes.draw do
     resources :favorites, controller: "post_favorites", only: %i[index]
     collection do
       get :random
+      get :count
     end
     member do
       get :update_iqdb

--- a/spec/requests/posts_controller_spec.rb
+++ b/spec/requests/posts_controller_spec.rb
@@ -110,6 +110,42 @@ RSpec.describe PostsController do
   end
 
   # ---------------------------------------------------------------------------
+  # GET /posts/count — approximate result count
+  # ---------------------------------------------------------------------------
+
+  describe "GET /posts/count" do
+    # Post.tag_match hits OpenSearch. Stub it so these examples are self-contained
+    # without requiring an indexed search engine.
+    it "returns an approximate count as an anonymous user" do
+      allow(Post).to receive(:tag_match).and_return(double(count_only: 42, count_capped?: false)) # rubocop:disable RSpec/VerifiedDoubles
+
+      get count_posts_path(format: :json), params: { tags: "tagme" }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("count" => 42, "capped" => false)
+    end
+
+    it "flags capped results" do
+      allow(Post).to receive(:tag_match).and_return(double(count_only: 240_001, count_capped?: true)) # rubocop:disable RSpec/VerifiedDoubles
+
+      get count_posts_path(format: :json), params: { tags: "canid" }
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq("count" => 240_001, "capped" => true)
+    end
+
+    it "returns 400 for a non-string tags param" do
+      get count_posts_path(format: :json), params: { tags: { "$eq" => "" } }
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it "returns 422 when the tag limit is exceeded" do
+      allow(Post).to receive(:tag_match).and_raise(TagQuery::CountExceededError)
+
+      get count_posts_path(format: :json), params: { tags: "a b c" }
+      expect(response).to have_http_status(:unprocessable_content)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # GET /posts/:id — show
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
By popular demand.

Adds a `/posts/count.json?tags=<query>` route that returns the number of posts that match the provided tag query string.
Deliberately capped to 240,001- matching the  total number of results returned by the posts#index endpoint.

Similar in spirit to the Danbooru implementation.
https://github.com/danbooru/danbooru/blob/master/app/controllers/counts_controller.rb