### PR TITLE
[Posts] Add an edit reason field to tag scripts

### DIFF
--- a/app/javascript/src/js/pages/post_versions/post_versions.js
+++ b/app/javascript/src/js/pages/post_versions/post_versions.js
@@ -65,6 +65,7 @@ PostVersion.tag_script_selected = function (event) {
   PostVersion.updated = 0;
   let selected_rows = $(".post-version-select:checked").parents(".post-version");
   const script = $("#update-tag-script").val();
+  const reason = $("#update-edit-reason").val();
   if (!script)
     return;
 
@@ -74,7 +75,7 @@ PostVersion.tag_script_selected = function (event) {
     let id = $(row).data("post-id");
 
     promises.push(TaskQueue.add(() => {
-      Post.tagScript(id, script);
+      Post.tagScript(id, script, reason);
 
       toast.message = `${++PostVersion.updated} / ${selected_rows.length} changes applied.`;
     }, { name: "PostVersion.tag_script_selected" }));

--- a/app/javascript/src/js/pages/posts/post_mode_menu.js
+++ b/app/javascript/src/js/pages/posts/post_mode_menu.js
@@ -238,7 +238,7 @@ PostModeMenu.click = function (e) {
     const postTags = $(`article.thumbnail[data-id="${post_id}"]`).first().data("tags").split(" ");
     const tags = new Set(postTags);
     const changes = TagScript.run(tags, tag_script);
-    Post.tagScript(post_id, changes);
+    Post.tagScript(post_id, changes, $("#tag-script-reason").val());
   } else {
     return;
   }

--- a/app/javascript/src/js/pages/posts/posts.js
+++ b/app/javascript/src/js/pages/posts/posts.js
@@ -354,9 +354,9 @@ Post.tag = function (post_id, tags) {
   Post.update(post_id, { "post[old_tag_string]": "", "post[tag_string]": tag_string });
 };
 
-Post.tagScript = function (post_id, tags) {
+Post.tagScript = function (post_id, tags, reason = "") {
   const tag_string = (Array.isArray(tags) ? tags.join(" ") : String(tags));
-  Post.update(post_id, { "post[tag_string_diff]": tag_string });
+  Post.update(post_id, { "post[tag_string_diff]": tag_string, "post[edit_reason]": reason });
 };
 
 Post.getMatchingThumbnails = function (post_id) {

--- a/app/javascript/src/styles/views/posts/index/partials/_mode_menu.scss
+++ b/app/javascript/src/styles/views/posts/index/partials/_mode_menu.scss
@@ -26,10 +26,14 @@ $modes: (
 }
 
 #tag-script-ui {
-  display: flex;
-  margin-top: 0.5em;
-  gap: 0.5em;
-
-  input { flex: 1; }
-  button { padding: 0 0.25em; }
+  display: grid;
+  grid-template-columns: 1fr min-content;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+  
+  #tag-script-field { padding: 0.25rem; }
+  #tag-script-all {
+    grid-column: 2;
+    grid-row: 1 / 3;
+  }
 }

--- a/app/javascript/src/styles/views/posts/show/_show.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.scss
@@ -191,6 +191,7 @@ body.c-posts.a-show-seq {
       margin-top: 0.5em;
 
       #tag-script-field {
+        box-sizing: border-box;
         width: 100%;
       }
 
@@ -200,8 +201,9 @@ body.c-posts.a-show-seq {
         margin-top: 0.5em;
 
         #tag-script-reason {
+          box-sizing: border-box;
+          flex: 1;
           min-width: 0;
-          width: 100%;
         }
       }
     }

--- a/app/javascript/src/styles/views/posts/show/_show.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.scss
@@ -186,27 +186,6 @@ body.c-posts.a-show-seq {
       font-family: $base_font_family;
       font-size: 1.05em;
     }
-
-    #tag-script-ui {
-      margin-top: 0.5em;
-
-      #tag-script-field {
-        box-sizing: border-box;
-        width: 100%;
-      }
-
-      .tag-script-actions {
-        display: flex;
-        gap: 0.5em;
-        margin-top: 0.5em;
-
-        #tag-script-reason {
-          box-sizing: border-box;
-          flex: 1;
-          min-width: 0;
-        }
-      }
-    }
   }
 
   & > .adscape {

--- a/app/javascript/src/styles/views/posts/show/_show.scss
+++ b/app/javascript/src/styles/views/posts/show/_show.scss
@@ -186,6 +186,25 @@ body.c-posts.a-show-seq {
       font-family: $base_font_family;
       font-size: 1.05em;
     }
+
+    #tag-script-ui {
+      margin-top: 0.5em;
+
+      #tag-script-field {
+        width: 100%;
+      }
+
+      .tag-script-actions {
+        display: flex;
+        gap: 0.5em;
+        margin-top: 0.5em;
+
+        #tag-script-reason {
+          min-width: 0;
+          width: 100%;
+        }
+      }
+    }
   }
 
   & > .adscape {

--- a/app/views/post_versions/index.html.erb
+++ b/app/views/post_versions/index.html.erb
@@ -10,6 +10,10 @@
           <label>Tag Script</label>
           <input id="update-tag-script" placeholder="tag script to apply here"/>
         </div>
+        <div class="input">
+          <label>Reason</label>
+          <input id="update-edit-reason" placeholder="reason for the edit"/>
+        </div>
       </div>
     <% end %>
 

--- a/app/views/post_versions/index.html.erb
+++ b/app/views/post_versions/index.html.erb
@@ -12,7 +12,7 @@
         </div>
         <div class="input">
           <label>Reason</label>
-          <input id="update-edit-reason" placeholder="reason for the edit"/>
+          <input id="update-edit-reason" placeholder="reason for the edit" maxlength="250"/>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/partials/index/_mode_menu.html.erb
+++ b/app/views/posts/partials/index/_mode_menu.html.erb
@@ -33,6 +33,7 @@
   <% if CurrentUser.is_privileged? %>
     <span id="tag-script-ui" style="display: none;">
       <input id="tag-script-field" data-autocomplete="tag-edit" placeholder="Enter tag script" style="display: none;"/>
+      <input id="tag-script-reason" placeholder="Reason"/>
       <button id="tag-script-all">All</button>
     </span>
     <input id="quick-mode-reason" placeholder="Reason" style="display: none;"/>

--- a/app/views/posts/partials/index/_mode_menu.html.erb
+++ b/app/views/posts/partials/index/_mode_menu.html.erb
@@ -31,11 +31,13 @@
   </form>
   <select id="set-id" style="display: none; margin-top: 0.5em;"></select>
   <% if CurrentUser.is_privileged? %>
-    <span id="tag-script-ui" style="display: none;">
+    <div id="tag-script-ui" style="display: none;">
       <input id="tag-script-field" data-autocomplete="tag-edit" placeholder="Enter tag script" style="display: none;"/>
-      <input id="tag-script-reason" placeholder="Reason"/>
-      <button id="tag-script-all">All</button>
-    </span>
+      <div class="tag-script-actions">
+        <input id="tag-script-reason" placeholder="Reason" maxlength="250"/>
+        <button id="tag-script-all">All</button>
+      </div>
+    </div>
     <input id="quick-mode-reason" placeholder="Reason" style="display: none;"/>
   <% end %>
 </section>

--- a/app/views/posts/partials/index/_mode_menu.html.erb
+++ b/app/views/posts/partials/index/_mode_menu.html.erb
@@ -33,10 +33,8 @@
   <% if CurrentUser.is_privileged? %>
     <div id="tag-script-ui" style="display: none;">
       <input id="tag-script-field" data-autocomplete="tag-edit" placeholder="Enter tag script" style="display: none;"/>
-      <div class="tag-script-actions">
-        <input id="tag-script-reason" placeholder="Reason" maxlength="250"/>
-        <button id="tag-script-all">All</button>
-      </div>
+      <button id="tag-script-all">All</button>
+      <input id="tag-script-reason" placeholder="Reason" maxlength="250"/>
     </div>
     <input id="quick-mode-reason" placeholder="Reason" style="display: none;"/>
   <% end %>


### PR DESCRIPTION
## Summary

- add an edit reason field to the tag script controls on post index pages
- add the same reason field to the post versions tag script form
- send the reason as `post[edit_reason]` with each tag script update

## Validation

- `npm run lint`
- targeted ESLint on the three changed JavaScript files
- Node regression probe covering the `Post.tagScript` request payload and both UI call paths
- `git diff --check`

The full Docker/Rails suite was not run locally; the repository CI will cover it.

Fixes #1963
