### PR TITLE
[Users] Prevent deletion from resetting the banned users' levels

### DIFF
--- a/app/logical/user_deletion.rb
+++ b/app/logical/user_deletion.rb
@@ -58,7 +58,7 @@ class UserDeletion
       profile_about: "",
       profile_artinfo: "",
       custom_style: "",
-      level: UserLevel::MEMBER,
+      level: [user.level, UserLevel::MEMBER].min, # Keep banned users banned
     )
     AvatarCleanupJob.perform_later(user.id, force: true)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,7 +153,7 @@ class User < ApplicationRecord
 
     def unban!
       self.level = 20
-      save
+      save(validate: false) # Banned users may have malformed data
     end
 
     def ban_expired?

--- a/spec/logical/user_deletion_spec.rb
+++ b/spec/logical/user_deletion_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe UserDeletion do
 
       it "does not change the user's level if they are blocked" do
         user.update_columns(level: UserLevel::BLOCKED)
+        create(:ban, user: user, prevent_login: false) 
         deletion.delete!
         expect(user.reload.level).to eq(UserLevel::BLOCKED)
       end

--- a/spec/logical/user_deletion_spec.rb
+++ b/spec/logical/user_deletion_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe UserDeletion do
 
       it "does not change the user's level if they are blocked" do
         user.update_columns(level: UserLevel::BLOCKED)
-        create(:ban, user: user, prevent_login: false) 
+        create(:ban, user: user, prevent_login: false)
         deletion.delete!
         expect(user.reload.level).to eq(UserLevel::BLOCKED)
       end

--- a/spec/logical/user_deletion_spec.rb
+++ b/spec/logical/user_deletion_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe UserDeletion do
         expect(user.level).to eq(UserLevel::MEMBER)
       end
 
+      it "does not change the user's level if they are blocked" do
+        user.update_columns(level: UserLevel::BLOCKED)
+        deletion.delete!
+        expect(user.reload.level).to eq(UserLevel::BLOCKED)
+      end
+
       it "invalidates the password hash" do
         deletion.delete!
         user.reload


### PR DESCRIPTION
Purely a visual bug - users remained deleted.