### PR TITLE
[Users] Add a way to clean up deprecated bitflag values

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,14 @@ class User < ApplicationRecord
   include Danbooru::HasBitFlags
   has_bit_flags BOOLEAN_ATTRIBUTES, field: "bit_prefs"
 
+  # Combined bitmask of every deprecated (underscore-prefixed) boolean attribute.
+  # Derived from the naming convention so it stays correct as flags are deprecated.
+  def self.deprecated_bit_prefs_mask
+    BOOLEAN_ATTRIBUTES.each_index.sum do |i|
+      BOOLEAN_ATTRIBUTES[i].start_with?("_") ? (1 << i) : 0
+    end
+  end
+
   attr_accessor :password, :old_password, :validate_email_format, :is_admin_edit
 
   after_initialize :initialize_attributes, if: :new_record?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,8 +73,8 @@ class User < ApplicationRecord
   # Combined bitmask of every deprecated (underscore-prefixed) boolean attribute.
   # Derived from the naming convention so it stays correct as flags are deprecated.
   def self.deprecated_bit_prefs_mask
-    BOOLEAN_ATTRIBUTES.each_index.sum do |i|
-      BOOLEAN_ATTRIBUTES[i].start_with?("_") ? (1 << i) : 0
+    BOOLEAN_ATTRIBUTES.each_with_index.sum do |attr, i|
+      attr.start_with?("_") ? (1 << i) : 0
     end
   end
 

--- a/db/fixes/138_clear_deprecated_user_bitflags.rb
+++ b/db/fixes/138_clear_deprecated_user_bitflags.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Fixes
+  class ZeroDeprecatedUserBitflags
+    def self.run
+      mask = User.deprecated_bit_prefs_mask
+      processed = 0
+      User.without_timeout do
+        User.where("bit_prefs & ? != 0", mask).in_batches(of: 10_000) do |batch|
+          processed += batch.size
+          batch.update_all(["bit_prefs = bit_prefs & ~?::bigint", mask])
+          sleep(0.1) # bound replica lag / let autovacuum breathe; ~140 batches
+
+          puts "Processed #{processed} users"
+        end
+      end
+    end
+  end
+end
+
+Fixes::ZeroDeprecatedUserBitflags.run

--- a/db/fixes/138_zero_deprecated_user_bitflags.rb
+++ b/db/fixes/138_zero_deprecated_user_bitflags.rb
@@ -9,13 +9,13 @@ module Fixes
         User.where("bit_prefs & ? != 0", mask).in_batches(of: 10_000) do |batch|
           processed += batch.size
           batch.update_all(["bit_prefs = bit_prefs & ~?::bigint", mask])
-          sleep(0.1) # bound replica lag / let autovacuum breathe; ~140 batches
+          sleep(0.1) # bound replica lag / let autovacuum breathe
 
-          puts "Processed #{processed} users"
+          puts "Processed #{processed} users" unless Rails.env.test?
         end
       end
     end
   end
 end
 
-Fixes::ZeroDeprecatedUserBitflags.run
+Fixes::ZeroDeprecatedUserBitflags.run unless Rails.env.test?

--- a/spec/models/user/bit_prefs_spec.rb
+++ b/spec/models/user/bit_prefs_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/fixes/138_clear_deprecated_user_bitflags.rb")
+
+# --------------------------------------------------------------------------- #
+#                          User deprecated bit_prefs                          #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe User do
+  before do
+    CurrentUser.user = create(:user)
+    CurrentUser.ip_addr = "127.0.0.1"
+  end
+
+  after do
+    CurrentUser.user = nil
+    CurrentUser.ip_addr = nil
+  end
+
+  describe ".deprecated_bit_prefs_mask" do
+    it "is the OR of every underscore-prefixed flag and nothing else" do
+      deprecated, live = User::BOOLEAN_ATTRIBUTES.partition { |a| a.start_with?("_") }
+      expected = deprecated.sum { |a| User.flag_value_for(a) }
+
+      expect(User.deprecated_bit_prefs_mask).to eq(expected)
+      live.each do |flag|
+        expect(User.deprecated_bit_prefs_mask & User.flag_value_for(flag)).to eq(0)
+      end
+    end
+  end
+
+  describe "ZeroDeprecatedUserBitflags fixer script" do
+    subject(:run_migration) { Fixes::ZeroDeprecatedUserBitflags.run }
+
+    let(:mask) { User.deprecated_bit_prefs_mask }
+
+    it "clears a deprecated bit while preserving a live flag on the same user" do
+      user = create(:user)
+      user.update_columns(bit_prefs: User.flag_value_for("_show_avatars") | User.flag_value_for("enable_safe_mode"))
+
+      run_migration
+
+      user.reload
+      expect(user._show_avatars).to be false
+      expect(user.enable_safe_mode).to be true
+    end
+
+    it "leaves a user with no deprecated bits unchanged" do
+      user = create(:user)
+      user.update_columns(bit_prefs: User.flag_value_for("enable_safe_mode"))
+
+      expect { run_migration }.not_to(change { user.reload.bit_prefs })
+    end
+
+    it "is idempotent" do
+      user = create(:user)
+      user.update_columns(bit_prefs: User.flag_value_for("_show_avatars"))
+
+      run_migration
+      cleaned = user.reload.bit_prefs
+      run_migration
+
+      expect(user.reload.bit_prefs).to eq(cleaned)
+      expect(user.bit_prefs & mask).to eq(0)
+    end
+  end
+end

--- a/spec/models/user/bit_prefs_spec.rb
+++ b/spec/models/user/bit_prefs_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require Rails.root.join("db/fixes/138_clear_deprecated_user_bitflags.rb")
+require Rails.root.join("db/fixes/138_zero_deprecated_user_bitflags.rb")
 
 # --------------------------------------------------------------------------- #
 #                          User deprecated bit_prefs                          #
@@ -34,28 +34,31 @@ RSpec.describe User do
     subject(:run_migration) { Fixes::ZeroDeprecatedUserBitflags.run }
 
     let(:mask) { User.deprecated_bit_prefs_mask }
+    let(:deprecated_flag) { User::BOOLEAN_ATTRIBUTES.find { |a| a.start_with?("_") } }
+    let(:live_flag) { User::BOOLEAN_ATTRIBUTES.find { |a| !a.start_with?("_") } }
 
     it "clears a deprecated bit while preserving a live flag on the same user" do
       user = create(:user)
-      user.update_columns(bit_prefs: User.flag_value_for("_show_avatars") | User.flag_value_for("enable_safe_mode"))
+      user.update_columns(bit_prefs: User.flag_value_for(deprecated_flag) | User.flag_value_for(live_flag))
 
       run_migration
 
       user.reload
-      expect(user._show_avatars).to be false
-      expect(user.enable_safe_mode).to be true
+      expect(user.send(deprecated_flag)).to be false
+      expect(user.send(live_flag)).to be true
     end
 
     it "leaves a user with no deprecated bits unchanged" do
       user = create(:user)
-      user.update_columns(bit_prefs: User.flag_value_for("enable_safe_mode"))
+
+      user.update_columns(bit_prefs: User.flag_value_for(live_flag))
 
       expect { run_migration }.not_to(change { user.reload.bit_prefs })
     end
 
     it "is idempotent" do
       user = create(:user)
-      user.update_columns(bit_prefs: User.flag_value_for("_show_avatars"))
+      user.update_columns(bit_prefs: User.flag_value_for(deprecated_flag))
 
       run_migration
       cleaned = user.reload.bit_prefs


### PR DESCRIPTION
Bit flags weren't properly removed from existing user accounts before, which could cause issues if those flags were reused later down the line.
This fixer script handles the cleanup process. It will need to be re-run every time a bitflag gets deprecated.