### PR TITLE
[Users] Raise favorite limit to 100k and rework override logic

### DIFF
--- a/app/logical/user_promotion.rb
+++ b/app/logical/user_promotion.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserPromotion
-  attr_reader :user, :promoter, :new_level, :options, :old_can_approve_posts, :old_can_upload_free, :old_no_flagging, :old_replacements_beta, :old_tag_warden
+  attr_reader :user, :promoter, :new_level, :options, :old_can_approve_posts, :old_can_upload_free, :old_no_flagging, :old_replacements_beta, :old_tag_warden, :old_raised_favorite_limit
 
   def initialize(user, promoter, new_level, options = {})
     @user = user
@@ -18,6 +18,7 @@ class UserPromotion
     @old_no_flagging = user.no_flagging?
     @old_replacements_beta = user.replacements_beta?
     @old_tag_warden = user.tag_warden?
+    @old_raised_favorite_limit = user.raised_favorite_limit?
 
     user.level = new_level
 
@@ -39,6 +40,10 @@ class UserPromotion
 
     if options.key?(:replacements_beta)
       user.replacements_beta = options[:replacements_beta]
+    end
+
+    if options.key?(:raised_favorite_limit)
+      user.raised_favorite_limit = options[:raised_favorite_limit]
     end
 
     create_mod_actions
@@ -68,6 +73,7 @@ class UserPromotion
     flag_check(added, removed, "no_flagging", "flag ban")
     flag_check(added, removed, "replacements_beta", "replacements beta")
     flag_check(added, removed, "tag_warden", "tag warden")
+    flag_check(added, removed, "raised_favorite_limit", "raised favorite limit")
 
     if added.any? || removed.any?
       ModAction.log(:user_flags_change, { user_id: user.id, added: added, removed: removed })

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,7 +35,7 @@ class User < ApplicationRecord
   # ================================================================================================#
 
   BOOLEAN_ATTRIBUTES = %w[
-    _show_avatars
+    raised_favorite_limit
     _blacklist_avatars
     blacklist_users
     description_collapsed_initially
@@ -755,7 +755,8 @@ class User < ApplicationRecord
     end
 
     def favorite_limit
-      Danbooru.config.legacy_favorite_limit.fetch(id, 80_000)
+      return (Danbooru.config.default_favorite_limit * 2) if raised_favorite_limit?
+      Danbooru.config.default_favorite_limit
     end
 
     def api_regen_multiplier

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -47,6 +47,10 @@ class UserPresenter
       permissions << "tag warden"
     end
 
+    if user.raised_favorite_limit?
+      permissions << "raised favorite limit"
+    end
+
     permissions.join(", ")
   end
 

--- a/app/views/staff/users/edit.html.erb
+++ b/app/views/staff/users/edit.html.erb
@@ -58,6 +58,12 @@
         <label for="user_replacements_beta" class="optional">Replacements Beta</label>
         <%= select(:user, :replacements_beta, [["Yes", true], ["No", false]]) %>
       </div>
+
+      <div class="input">
+        <label for="user_raised_favorite_limit" class="optional">Raised Favorite Limit</label>
+        <%= select(:user, :raised_favorite_limit, [["Yes", true], ["No", false]]) %>
+      </div>
+
       <%= f.button :submit, value: "Update" %>
     <% end %>
   </div>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -76,11 +76,8 @@ module Danbooru
       false
     end
 
-    # Prevent new users from going above 80k while allowing those currently above
-    # it to continue adding new favorites with the old limit.
-    # { 123 => 200_000 }
-    def legacy_favorite_limit
-      {}
+    def default_favorite_limit
+      100_000
     end
 
     # Set the default level, permissions, and other settings for new users here.

--- a/spec/logical/favorite_manager_spec.rb
+++ b/spec/logical/favorite_manager_spec.rb
@@ -26,16 +26,29 @@ RSpec.describe FavoriteManager do
 
     describe "favorite limit" do
       before do
-        allow(user).to receive_messages(favorite_limit: 0, favorite_count: 0)
+        allow(Danbooru.config.custom_configuration).to receive_messages(default_favorite_limit: 1)
+        allow(user).to receive_messages(favorite_count: 0)
+      end
+
+      it "does not raise an error when the user is below their limit" do
+        expect { FavoriteManager.add!(user: user, post: post) }.not_to raise_error
       end
 
       it "raises Favorite::Error when the user is at their limit" do
+        allow(user).to receive_messages(favorite_count: 1)
         expect { FavoriteManager.add!(user: user, post: post) }
           .to raise_error(Favorite::Error, /only keep up to/)
       end
 
       it "bypasses the limit when force: true" do
         expect { FavoriteManager.add!(user: user, post: post, force: true) }
+          .not_to raise_error
+      end
+
+      it "respects the raised favorite limit flag" do
+        allow(user).to receive_messages(raised_favorite_limit?: true, favorite_count: 1)
+        expect(user.favorite_limit).to eq(2)
+        expect { FavoriteManager.add!(user: user, post: post) }
           .not_to raise_error
       end
     end


### PR DESCRIPTION
Raised the favorites limit from 80k to 100k.
Previous concerns about performance and the favorites table becoming statistically unbalanced proved to be negligible in testing at production-like scale.

Additionally, retired the `legacy_favorite_limit` config option.
An account flag makes it more clear why someone may have more favorites than what the limit would normally allow.
A number of users listed there in prod have their custom limit set to less than 100k – the rest will have to have the new `raised_favorite_limit` flag set manually.