### PR TITLE
[PostReplacements] Separate the lockdown toggle from the "uploads" one

### DIFF
--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -5,7 +5,7 @@ class PostReplacementsController < ApplicationController
   before_action :member_only, only: %i[create new]
   before_action :approver_only, only: %i[approve reject promote toggle_penalize]
   before_action :admin_only, only: [:destroy]
-  before_action :ensure_uploads_enabled, only: %i[new create]
+  before_action :ensure_replacements_enabled, only: %i[new create]
 
   content_security_policy only: [:new] do |p|
     p.img_src :self, :data, :blob, "*"
@@ -146,7 +146,7 @@ class PostReplacementsController < ApplicationController
     params.require(:post_replacement).permit(:replacement_url, :replacement_file, :reason, :source, :as_pending)
   end
 
-  def ensure_uploads_enabled
-    access_denied if Security::Lockdown.uploads_disabled? || CurrentUser.user.level < Security::Lockdown.uploads_min_level
+  def ensure_replacements_enabled
+    access_denied if Security::Lockdown.post_replacements_disabled? || CurrentUser.user.level < Security::Lockdown.uploads_min_level
   end
 end

--- a/app/controllers/staff/security_controller.rb
+++ b/app/controllers/staff/security_controller.rb
@@ -9,19 +9,20 @@ module Staff
     end
 
     def panic
-      Security::Lockdown.uploads_disabled   = "1"
-      Security::Lockdown.pools_disabled     = "1"
-      Security::Lockdown.post_sets_disabled = "1"
+      Security::Lockdown.uploads_disabled           = "1"
+      Security::Lockdown.post_replacements_disabled = "1"
+      Security::Lockdown.pools_disabled             = "1"
+      Security::Lockdown.post_sets_disabled         = "1"
 
-      Security::Lockdown.comments_disabled  = "1"
-      Security::Lockdown.forums_disabled    = "1"
-      Security::Lockdown.blips_disabled     = "1"
+      Security::Lockdown.comments_disabled          = "1"
+      Security::Lockdown.forums_disabled            = "1"
+      Security::Lockdown.blips_disabled             = "1"
 
-      Security::Lockdown.aiburs_disabled    = "1"
-      Security::Lockdown.favorites_disabled = "1"
-      Security::Lockdown.votes_disabled     = "1"
+      Security::Lockdown.aiburs_disabled            = "1"
+      Security::Lockdown.favorites_disabled         = "1"
+      Security::Lockdown.votes_disabled             = "1"
 
-      Security::Lockdown.takedowns_disabled = "1"
+      Security::Lockdown.takedowns_disabled         = "1"
 
       StaffAuditLog.log(:lockdown_panic, CurrentUser.user)
       redirect_to staff_security_index_path
@@ -31,6 +32,7 @@ module Staff
       params = lockdown_params
 
       Security::Lockdown.uploads_disabled = params[:uploads] if params[:uploads].present?
+      Security::Lockdown.post_replacements_disabled = params[:post_replacements] if params[:post_replacements].present?
       Security::Lockdown.pools_disabled = params[:pools] if params[:pools].present?
       Security::Lockdown.post_sets_disabled = params[:post_sets] if params[:post_sets].present?
 
@@ -78,7 +80,7 @@ module Staff
     end
 
     def lockdown_params
-      permitted_params = %i[uploads pools post_sets comments forums blips aiburs favorites votes takedowns]
+      permitted_params = %i[uploads post_replacements pools post_sets comments forums blips aiburs favorites votes takedowns]
       params.fetch(:lockdown, {}).permit(permitted_params)
     end
 

--- a/app/logical/security/lockdown.rb
+++ b/app/logical/security/lockdown.rb
@@ -11,6 +11,14 @@ module Security
       Setting.uploads_disabled = state == "1"
     end
 
+    def self.post_replacements_disabled?
+      Setting.post_replacements_disabled?
+    end
+
+    def self.post_replacements_disabled=(state)
+      Setting.post_replacements_disabled = state == "1"
+    end
+
     def self.pools_disabled?
       Setting.pools_disabled?
     end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -4,16 +4,17 @@ class Setting < RailsSettings::Base
   cache_prefix { "v1" }
 
   scope :lockdown do
-    field :uploads_disabled,    type: :boolean, default: false
-    field :pools_disabled,      type: :boolean, default: false
-    field :post_sets_disabled,  type: :boolean, default: false
-    field :comments_disabled,   type: :boolean, default: false
-    field :forums_disabled,     type: :boolean, default: false
-    field :blips_disabled,      type: :boolean, default: false
-    field :aiburs_disabled,     type: :boolean, default: false
-    field :favorites_disabled,  type: :boolean, default: false
-    field :votes_disabled,      type: :boolean, default: false
-    field :takedowns_disabled,  type: :boolean, default: false
+    field :uploads_disabled,           type: :boolean, default: false
+    field :post_replacements_disabled, type: :boolean, default: false
+    field :pools_disabled,             type: :boolean, default: false
+    field :post_sets_disabled,         type: :boolean, default: false
+    field :comments_disabled,          type: :boolean, default: false
+    field :forums_disabled,            type: :boolean, default: false
+    field :blips_disabled,             type: :boolean, default: false
+    field :aiburs_disabled,            type: :boolean, default: false
+    field :favorites_disabled,         type: :boolean, default: false
+    field :votes_disabled,             type: :boolean, default: false
+    field :takedowns_disabled,         type: :boolean, default: false
   end
 
   scope :limits do

--- a/app/views/staff/security/index.html.erb
+++ b/app/views/staff/security/index.html.erb
@@ -11,6 +11,7 @@
 
       <%= custom_form_for(:lockdown, url: enact_staff_security_index_path, method: :put, html: { class: "lockdown-form" }) do |f| %>
         <%= f.input :uploads, as: :boolean, label: "Uploads", input_html: { checked: Security::Lockdown.uploads_disabled? ? "checked" : "" } %>
+        <%= f.input :post_replacements, as: :boolean, label: "Post Replacements", input_html: { checked: Security::Lockdown.post_replacements_disabled? ? "checked" : "" } %>
         <%= f.input :pools, as: :boolean, label: "Pools", input_html: { checked: Security::Lockdown.pools_disabled? ? "checked" : "" } %>
         <%= f.input :post_sets, as: :boolean, label: "Post Sets", input_html: { checked: Security::Lockdown.post_sets_disabled? ? "checked" : "" } %>
         <br />

--- a/spec/models/setting/defaults_spec.rb
+++ b/spec/models/setting/defaults_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Setting do
     # -------------------------------------------------------------------------
     describe "lockdown" do
       it { expect(Setting.uploads_disabled).to be(false) }
+      it { expect(Setting.post_replacements_disabled).to be(false) }
       it { expect(Setting.pools_disabled).to be(false) }
       it { expect(Setting.post_sets_disabled).to be(false) }
       it { expect(Setting.comments_disabled).to be(false) }

--- a/spec/requests/post_replacements_controller_spec.rb
+++ b/spec/requests/post_replacements_controller_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe PostReplacementsController do
       expect(response).to have_http_status(:ok)
     end
 
-    context "when uploads are disabled" do
-      before { allow(Security::Lockdown).to receive(:uploads_disabled?).and_return(true) }
+    context "when post replacements are disabled" do
+      before { allow(Security::Lockdown).to receive(:post_replacements_disabled?).and_return(true) }
 
       it "returns 403 for a janitor" do
         sign_in_as replacer
@@ -110,8 +110,8 @@ RSpec.describe PostReplacementsController do
       expect(response.parsed_body["message"]).to be_present
     end
 
-    context "when uploads are disabled" do
-      before { allow(Security::Lockdown).to receive(:uploads_disabled?).and_return(true) }
+    context "when post replacements are disabled" do
+      before { allow(Security::Lockdown).to receive(:post_replacements_disabled?).and_return(true) }
 
       it "returns 403 for a replacer" do
         sign_in_as replacer
@@ -367,11 +367,11 @@ RSpec.describe PostReplacementsController do
   end
 
   # ---------------------------------------------------------------------------
-  # Upload lockdown behaviour — cross-cutting
+  # Replacement lockdown behaviour — cross-cutting
   # ---------------------------------------------------------------------------
 
-  describe "upload lockdown behaviour" do
-    before { allow(Security::Lockdown).to receive(:uploads_disabled?).and_return(true) }
+  describe "replacement lockdown behaviour" do
+    before { allow(Security::Lockdown).to receive(:post_replacements_disabled?).and_return(true) }
 
     it "returns 403 for GET /post_replacements/new even for a janitor" do
       sign_in_as replacer
@@ -385,8 +385,15 @@ RSpec.describe PostReplacementsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "still serves GET /post_replacements (index) when uploads are disabled" do
+    it "still serves GET /post_replacements (index) when replacements are disabled" do
       get post_replacements_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not gate replacements on the uploads toggle" do
+      allow(Security::Lockdown).to receive_messages(post_replacements_disabled?: false, uploads_disabled?: true)
+      sign_in_as replacer
+      get new_post_replacement_path(post_id: post_record.id)
       expect(response).to have_http_status(:ok)
     end
   end

--- a/spec/requests/staff/security_controller_spec.rb
+++ b/spec/requests/staff/security_controller_spec.rb
@@ -63,6 +63,11 @@ RSpec.describe Staff::SecurityController do
         expect(Security::Lockdown.uploads_disabled?).to be true
       end
 
+      it "disables post replacements" do
+        put panic_staff_security_index_path
+        expect(Security::Lockdown.post_replacements_disabled?).to be true
+      end
+
       it "disables pools" do
         put panic_staff_security_index_path
         expect(Security::Lockdown.pools_disabled?).to be true
@@ -148,6 +153,17 @@ RSpec.describe Staff::SecurityController do
         Security::Lockdown.uploads_disabled = "1"
         put enact_staff_security_index_path, params: { lockdown: { uploads: "0" } }
         expect(Security::Lockdown.uploads_disabled?).to be false
+      end
+
+      it "enables post replacements lockdown when the post_replacements param is '1'" do
+        put enact_staff_security_index_path, params: { lockdown: { post_replacements: "1" } }
+        expect(Security::Lockdown.post_replacements_disabled?).to be true
+      end
+
+      it "disables post replacements lockdown when the post_replacements param is '0'" do
+        Security::Lockdown.post_replacements_disabled = "1"
+        put enact_staff_security_index_path, params: { lockdown: { post_replacements: "0" } }
+        expect(Security::Lockdown.post_replacements_disabled?).to be false
       end
 
       it "does not change pools lockdown when pools param is absent" do


### PR DESCRIPTION
The replacements previously piggy-backed off the `uploads_disabled` in the Lockdown menu.
That is somewhat inconvenient, especially now as we are looking to take the takedowns out of beta.

This PR adds a separate toggle for post replacements.