### PR TITLE
[Posts] Fix compatibility video sample being prioritized too high

### DIFF
--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -95,18 +95,19 @@ class PostPresenter < Presenter
     else
       # original / fit videos
       output = []
+
+      original = @post.video_sample_list[:original]
+      output.push({ # Original first: don't show 1080 variant unless the device can't play it
+        codec: "video/#{@post.file_ext}" + (original.key?(:codec) ? "; codec=#{original[:codec]}" : ""),
+        url: original[:url],
+      })
+
       @post.video_sample_list[:variants].each do |ext, data|
-        output.push({
+        output.push({ # 1080p variant: for compatibility with devices that can't play VP8 / VP9
           codec: "video/#{ext}" + (data.key?(:codec) ? "; codec=#{data[:codec]}" : ""),
           url: data[:url],
         })
       end
-
-      original = @post.video_sample_list[:original]
-      output.push({
-        codec: "video/#{@post.file_ext}" + (original.key?(:codec) ? "; codec=#{original[:codec]}" : ""),
-        url: original[:url],
-      })
 
       output
     end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -89,7 +89,7 @@ class PostPresenter < Presenter
       # sample videos
       sample = @post.video_sample_list[:samples].values.last
       [{
-        codec: "video/mp4#{sample.key?(:codec) ? "; codec=#{sample[:codec]}" : ''}",
+        codec: "video/mp4#{sample.key?(:codec) ? "; codecs=#{sample[:codec]}" : ''}",
         url: sample[:url],
       }]
     else
@@ -98,13 +98,13 @@ class PostPresenter < Presenter
 
       original = @post.video_sample_list[:original]
       output.push({ # Original first: don't show 1080 variant unless the device can't play it
-        codec: "video/#{@post.file_ext}" + (original.key?(:codec) ? "; codec=#{original[:codec]}" : ""),
+        codec: "video/#{@post.file_ext}" + (original.key?(:codec) ? "; codecs=#{original[:codec]}" : ""),
         url: original[:url],
       })
 
       @post.video_sample_list[:variants].each do |ext, data|
         output.push({ # 1080p variant: for compatibility with devices that can't play VP8 / VP9
-          codec: "video/#{ext}" + (data.key?(:codec) ? "; codec=#{data[:codec]}" : ""),
+          codec: "video/#{ext}" + (data.key?(:codec) ? "; codecs=#{data[:codec]}" : ""),
           url: data[:url],
         })
       end


### PR DESCRIPTION
The "variant" is an mp4 version of the original video, downscaled to 1080p.
Its only purpose is to provide some kind of playback for devices that cannot play webm videos.

Therefore, it should be lower than the original in the video `<source>` list.
Also, changed the `codec` values in the mime types to `codecs` – that is the correct parameter name.