### PR TITLE
[Posts] Fix an error caused by catastrophic backtracking in tag groups

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,6 +152,10 @@ class ApplicationController < ActionController::Base
       render_expected_error(410, exception.message)
     when TagQuery::CountExceededError, TagQuery::DepthExceededError, TagQuery::InvalidTagError, ParseValue::InvalidDateError
       render_expected_error(422, exception.message)
+    when Regexp::TimeoutError
+      # See TagQuery.group_depth_exceeded?
+      # Show a cheap 422 for a malformed/abusive search that blows up a regex.
+      render_expected_error(422, "Your query was too complex to process. Try simplifying it.")
     when FeatureUnavailable
       render_expected_error(400, "This feature isn't available")
     when PG::ConnectionBad

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -597,6 +597,23 @@ class TagQuery
     end
   end
 
+  # Cheap, linear guard against catastrophic backtracking in `REGEX_TOKENIZE`.
+  def self.group_depth_exceeded?(tag_str)
+    str = tag_str.to_s
+    # Reaching depth `DEPTH_LIMIT + 1` needs at least that many `(` + whitespace pairs.
+    return false if str.length < (DEPTH_LIMIT + 1) * 2
+    str = str.gsub(TagQuery::REGEX_ANY_QUOTED_METATAG, "") if str.include?(':"')
+    depth = 0
+    str.scan(/\((?=\s)|(?<=\s)\)/) do |paren|
+      if paren == "("
+        return true if (depth += 1) > DEPTH_LIMIT
+      elsif depth > 0
+        depth -= 1
+      end
+    end
+    false
+  end
+
   # Iterates through tokens, returning each tokens' `MatchData` in accordance with
   # `TagQuery::REGEX_TOKENIZE`.
   # ### Parameters
@@ -621,6 +638,13 @@ class TagQuery
       return []
     end
     tag_str = tag_str.to_s.unicode_normalize(:nfc).strip
+    # Reject pathologically-nested group parentheses before they reach `REGEX_TOKENIZE`, where
+    # they'd cause catastrophic backtracking. Only checked at the top level; sub-strings passed to
+    # recursive calls are already one level shallower.
+    if depth == 0 && TagQuery.group_depth_exceeded?(tag_str)
+      raise DepthExceededError if kwargs[:error_on_depth_exceeded]
+      return []
+    end
     results = []
     # OPTIMIZE: Candidate for early exit
     # return results if tag_str.blank?
@@ -687,6 +711,12 @@ class TagQuery
     return [] if tag_str.blank? || /\A[-~]?\(\s+\)\z/.match?(tag_str)
     # Quick and dirty optimization: If it can't contain any groups, use a simpler tokenizer.
     return TagQuery.send(kwargs[:segregate_metatags] ? :scan_light : :scan, tag_str, **kwargs) unless REGEX_HAS_GROUP.match?(tag_str)
+    # Reject pathologically-nested group parentheses before they reach `REGEX_TOKENIZE` below,
+    # where they'd cause catastrophic backtracking. Only checked at the top level; recursive calls
+    # receive sub-strings that are already one level shallower.
+    if depth == 0 && TagQuery.group_depth_exceeded?(tag_str)
+      return error_on_depth_exceeded ? (raise DepthExceededError) : []
+    end
     # If this query is composed of 1 top-level group with no modifiers, convert to ungrouped.
     # TODO: Check if regex catches nested groups & quoted metatag groups
     if SETTINGS[:EARLY_SCAN_SEARCH_CHECK] && tag_str.start_with?("(") && tag_str.end_with?(")")

--- a/app/logical/tag_query.rb
+++ b/app/logical/tag_query.rb
@@ -597,15 +597,27 @@ class TagQuery
     end
   end
 
-  # Cheap, linear guard against catastrophic backtracking in `REGEX_TOKENIZE`.
+  # Cheap, linear guard against catastrophic backtracking in `REGEX_TOKENIZE`, whose recursive
+  # group subpattern blows up on deeply-nested group parentheses (especially unbalanced ones like
+  # `( ( ( ( a ) )`) before `Regexp.timeout` aborts the match. The `DEPTH_LIMIT` recursion guards
+  # run too late — the blowup is inside a single regex match.
+  #
+  # Walks the string once, tracking net group nesting depth, and returns `true` once it passes
+  # `DEPTH_LIMIT` so callers can reject the query before running the regex. Only genuine group
+  # delimiters count (see `REGEX_GROUP_DELIMITER`): a `(` embedded in a tag (`:(`, `foo(`) is
+  # ignored, and quoted metatags are stripped first since the tokenizer matches those atomically.
+  # A group opener (whitespace-delimited `(`, optional `-`/`~` prefix, followed by whitespace —
+  # matching the tokenizer's `\(\s+`) or a group closer (`)` preceded by whitespace).
+  REGEX_GROUP_DELIMITER = /(?<=\s|\A)[-~]?\((?=\s)|(?<=\s)\)(?=\s|\z)/
+
   def self.group_depth_exceeded?(tag_str)
     str = tag_str.to_s
     # Reaching depth `DEPTH_LIMIT + 1` needs at least that many `(` + whitespace pairs.
     return false if str.length < (DEPTH_LIMIT + 1) * 2
     str = str.gsub(TagQuery::REGEX_ANY_QUOTED_METATAG, "") if str.include?(':"')
     depth = 0
-    str.scan(/\((?=\s)|(?<=\s)\)/) do |paren|
-      if paren == "("
+    str.scan(REGEX_GROUP_DELIMITER) do |delimiter|
+      if delimiter.end_with?("(")
         return true if (depth += 1) > DEPTH_LIMIT
       elsif depth > 0
         depth -= 1

--- a/spec/logical/tag_query/error_handling_spec.rb
+++ b/spec/logical/tag_query/error_handling_spec.rb
@@ -127,6 +127,11 @@ RSpec.describe TagQuery, type: :model do
       it "flags prefixed group openers (-( / ~()" do
         expect(TagQuery.group_depth_exceeded?("#{'-( ' * 11}a")).to be(true)
       end
+
+      it "flags prefixed group openers past DEPTH_LIMIT" do
+        expect(TagQuery.group_depth_exceeded?("#{'-( ' * 15}a")).to be(true)
+        expect(TagQuery.group_depth_exceeded?("#{'~( ' * 15}a")).to be(true)
+      end
     end
 
     it "processes the emoticon query without error (not a false positive)" do

--- a/spec/logical/tag_query/error_handling_spec.rb
+++ b/spec/logical/tag_query/error_handling_spec.rb
@@ -87,6 +87,75 @@ RSpec.describe TagQuery, type: :model do
     end
   end
 
+  # Regression: a malformed search of deeply-nested, unbalanced group parentheses
+  # (e.g. "( ( ( ... ( a ) )") drove REGEX_TOKENIZE into catastrophic backtracking,
+  # producing Regexp::TimeoutError 500s in production. scan_search / match_tokens now
+  # reject over-deep nesting with a cheap linear pre-check before the regex runs.
+  describe "deeply-nested group parenthesis guard (ReDoS)" do
+    # The reported abusive query: many unbalanced opening parens.
+    let(:redos_query) { "#{'( ' * 28}a ) )" }
+
+    describe ".group_depth_exceeded?" do
+      it "flags unbalanced deeply-nested parentheses" do
+        expect(TagQuery.group_depth_exceeded?(redos_query)).to be(true)
+      end
+
+      it "flags balanced nesting past DEPTH_LIMIT" do
+        expect(TagQuery.group_depth_exceeded?("#{'( ' * 11}tag#{' )' * 11}")).to be(true)
+      end
+
+      it "does not flag nesting within DEPTH_LIMIT" do
+        expect(TagQuery.group_depth_exceeded?("#{'( ' * 10}tag#{' )' * 10}")).to be(false)
+      end
+
+      it "does not flag many balanced sibling groups" do
+        many_siblings = Array.new(100) { |i| "( tag#{i} )" }.join(" ")
+        expect(TagQuery.group_depth_exceeded?(many_siblings)).to be(false)
+      end
+
+      it "does not flag parentheses inside tags or quoted metatags" do
+        expect(TagQuery.group_depth_exceeded?("boris_(noborhood) cat")).to be(false)
+        expect(TagQuery.group_depth_exceeded?('source:"http://x/( ( ( ( ( ( ( ( ( ( ( (" cat')).to be(false)
+      end
+    end
+
+    it "raises DepthExceededError instead of hanging on the abusive query" do
+      # error_on_depth_exceeded mirrors the PostSets::Post call path.
+      expect do
+        TagQuery.scan_search(redos_query, error_on_depth_exceeded: true)
+      end.to raise_error(TagQuery::DepthExceededError)
+    end
+
+    it "returns quickly rather than backtracking, even under a strict Regexp timeout" do
+      # Without the pre-check this backtracks for ~1s and raises Regexp::TimeoutError;
+      # with it, the query is rejected up front and no timeout is hit.
+      previous = Regexp.timeout
+      Regexp.timeout = 0.5
+      begin
+        expect do
+          TagQuery.scan_search(redos_query, error_on_depth_exceeded: true)
+        end.to raise_error(TagQuery::DepthExceededError)
+      ensure
+        Regexp.timeout = previous
+      end
+    end
+
+    it "does not blow up the regex on the full TagQuery.new parse path" do
+      # TagQuery.new's default path degrades gracefully (error_on_depth_exceeded: false),
+      # so it must not raise Regexp::TimeoutError under a strict timeout — the abusive query
+      # is dropped up front rather than driving the tokenizer into catastrophic backtracking.
+      previous = Regexp.timeout
+      Regexp.timeout = 0.5
+      begin
+        expect do
+          TagQuery.new(redos_query, resolve_aliases: false)
+        end.not_to raise_error
+      ensure
+        Regexp.timeout = previous
+      end
+    end
+  end
+
   describe TagQuery::InvalidTagError do
     it "is a StandardError" do
       expect(TagQuery::InvalidTagError.new).to be_a(StandardError)

--- a/spec/logical/tag_query/error_handling_spec.rb
+++ b/spec/logical/tag_query/error_handling_spec.rb
@@ -117,6 +117,23 @@ RSpec.describe TagQuery, type: :model do
         expect(TagQuery.group_depth_exceeded?("boris_(noborhood) cat")).to be(false)
         expect(TagQuery.group_depth_exceeded?('source:"http://x/( ( ( ( ( ( ( ( ( ( ( (" cat')).to be(false)
       end
+
+      it "does not flag tags that merely end in '(' (e.g. emoticons)" do
+        # A `(` embedded in a tag is not a group opener, so 11+ such tags must not trip the guard.
+        expect(TagQuery.group_depth_exceeded?("#{':( ' * 11}a )")).to be(false)
+        expect(TagQuery.group_depth_exceeded?(Array.new(12) { |i| "foo#{i}(" }.join(" "))).to be(false)
+      end
+
+      it "flags prefixed group openers (-( / ~()" do
+        expect(TagQuery.group_depth_exceeded?("#{'-( ' * 11}a")).to be(true)
+      end
+    end
+
+    it "processes the emoticon query without error (not a false positive)" do
+      # ":( :( ... a )" is not deeply-nested groups; it must scan normally, not raise.
+      expect do
+        TagQuery.scan_search("#{':( ' * 11}a )", error_on_depth_exceeded: true)
+      end.not_to raise_error
     end
 
     it "raises DepthExceededError instead of hanging on the abusive query" do


### PR DESCRIPTION
See: https://e621.net/staff/exceptions/5680364

```
Regexp::TimeoutError
regexp match timeout

app/logical/tag_query.rb:702:in `match'
app/logical/tag_query.rb:702:in `scan_search'
app/logical/post_sets/post.rb:15:in `initialize'
app/controllers/posts_controller.rb:29:in `new'
app/controllers/posts_controller.rb:29:in `index'
app/controllers/application_controller.rb:246:in `set_time_zone'
lib/middleware/parameter_sanitizer.rb:39:in `call'
```

```
{
  "params": {
    "tags": "( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( ( a ) )",
    "controller": "posts",
    "action": "index"
  }
}
```