### PR TITLE
[PostReplacements] Add a persistent sequence number

### DIFF
--- a/db/fixes/139_backfill_replacement_sequence_number.rb
+++ b/db/fixes/139_backfill_replacement_sequence_number.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Backfills sequence_number on post_replacements2.
+# Establishes the invariant 0 = the original backup, 1..N = replacements in creation (id) order
+# within each post.
+#
+# Two set-based UPDATEs, not per-row Ruby. The original is numbered by status, so a legacy
+# "misordered" backup (higher id than the replacement it backed up) still sorts first.
+# 0 is reserved for the original, so posts without one simply start at 1.
+# Idempotent: the assignment is deterministic, so re-running yields the same result.
+#
+# Run only while replacement creation is frozen so no new NULL rows appear mid-run.
+module Fixes
+  class BackfillReplacementSequenceNumber
+    def self.run
+      conn = PostReplacement.connection
+
+      PostReplacement.without_timeout do
+        originals = conn.execute(<<~SQL.squish).cmd_tuples
+          UPDATE post_replacements2 SET sequence_number = 0 WHERE status = 'original'
+        SQL
+
+        replacements = conn.execute(<<~SQL.squish).cmd_tuples
+          UPDATE post_replacements2 pr SET sequence_number = sub.rn
+          FROM (
+            SELECT id, row_number() OVER (PARTITION BY post_id ORDER BY id) AS rn
+            FROM post_replacements2 WHERE status <> 'original'
+          ) sub
+          WHERE pr.id = sub.id
+        SQL
+
+        puts "Backfilled sequence_number: #{originals} originals (0), #{replacements} replacements (1..N)"
+      end
+    end
+  end
+end
+
+Fixes::BackfillReplacementSequenceNumber.run

--- a/db/migrate/20260727191219_add_sequence_number_to_post_replacements.rb
+++ b/db/migrate/20260727191219_add_sequence_number_to_post_replacements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSequenceNumberToPostReplacements < ActiveRecord::Migration[8.1]
+  def change
+    add_column :post_replacements2, :sequence_number, :integer, null: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1762,7 +1762,8 @@ CREATE TABLE public.post_replacements2 (
     reason character varying NOT NULL,
     protected boolean DEFAULT false NOT NULL,
     uploader_id_on_approve integer,
-    penalize_uploader_on_approve boolean
+    penalize_uploader_on_approve boolean,
+    sequence_number integer
 );
 
 
@@ -6159,6 +6160,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260727191219'),
 ('20260727160104'),
 ('20260713192035'),
 ('20260707182943'),


### PR DESCRIPTION
Part 1 of the replacement schema rework.
Previously, the sequence number was calculated on the fly - which was janky and also inconsistent.
Now it's stored in the database and automatically incremented.