### PR TITLE
[PostReplacements] Ensure new replacements receive the `sequence_number`

### DIFF
--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -384,7 +384,7 @@ class PostReplacement < ApplicationRecord
           # Legacy backups can have a higher ID than the replacement it backed up.
           # sequence_number is 0 for the original backup and 1..N for replacements in creation
           # order, so this always anchors the original below its replacements.
-          q.order(sequence_number: :desc)
+          q.order(sequence_number: :desc, id: :desc)
         else
           q.default_order
         end

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -34,6 +34,7 @@ class PostReplacement < ApplicationRecord
   validates :reason, length: { in: 5..150 }, presence: true, on: :create
 
   before_create :create_original_backup
+  before_create :fill_sequence_number
   before_create :set_previous_uploader
   after_create -> { post.update_index }
   before_destroy :remove_files
@@ -95,10 +96,16 @@ class PostReplacement < ApplicationRecord
     @uploader_linked_artists ||= post.artist_tags.filter_map(&:artist).select { |artist| artist.linked_user_id == creator.id }.map(&:name)
   end
 
-  def sequence_number
-    return 0 if status == "original"
-    siblings = PostReplacement.where(post_id: post_id).where.not(status: "original").order(:id).ids
-    1 + siblings.index(id)
+  def self.calculate_sequence_number(post_id)
+    1 + where(post_id: post_id).maximum(:sequence_number).to_i
+  end
+
+  # Runs before_create (after create_original_backup, so the backup already holds
+  # 0) rather than before_validation, so it also fires on the factory's
+  # save!(validate: false) path. The original is numbered by its status marker,
+  # which keeps it in lockstep with the check constraint (status 'original' <=> 0).
+  def fill_sequence_number
+    self.sequence_number = status == "original" ? 0 : self.class.calculate_sequence_number(post_id)
   end
 
   def user_is_not_limited
@@ -374,16 +381,10 @@ class PostReplacement < ApplicationRecord
         if params[:order].present?
           q.apply_basic_order(params)
         elsif params[:post_id].present?
-          # Backups are created before the first replacement, so id DESC already
-          # sorts them last. This pin only matters for legacy posts whose backup
-          # was created afterwards and thus has a higher id; it keeps the backup
-          # anchored below the replacements in that single-post view.
-          q.order(Arel.sql("
-            CASE status
-              WHEN 'original' THEN 0
-              ELSE #{table_name}.id
-            END DESC
-          "))
+          # Legacy backups can have a higher ID than the replacement it backed up.
+          # sequence_number is 0 for the original backup and 1..N for replacements in creation
+          # order, so this always anchors the original below its replacements.
+          q.order(sequence_number: :desc)
         else
           q.default_order
         end

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -381,7 +381,7 @@ class PostReplacement < ApplicationRecord
         if params[:order].present?
           q.apply_basic_order(params)
         elsif params[:post_id].present?
-          # Legacy backups can have a higher ID than the replacement it backed up.
+          # Legacy backup can have a higher ID than the replacement it backed up.
           # sequence_number is 0 for the original backup and 1..N for replacements in creation
           # order, so this always anchors the original below its replacements.
           q.order(sequence_number: :desc, id: :desc)

--- a/db/migrate/20260727195335_enforce_post_replacement_sequence_number.rb
+++ b/db/migrate/20260727195335_enforce_post_replacement_sequence_number.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Important:
+#
+# 139_backfill_replacement_sequence_number.rb MUST be run before this migration,
+# or the NOT NULL constraint will fail.
+
 class EnforcePostReplacementSequenceNumber < ActiveRecord::Migration[8.1]
   def change
     PostReplacement.without_timeout do

--- a/db/migrate/20260727195335_enforce_post_replacement_sequence_number.rb
+++ b/db/migrate/20260727195335_enforce_post_replacement_sequence_number.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class EnforcePostReplacementSequenceNumber < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :post_replacements2, :sequence_number, false
+
+    PostReplacement.without_timeout do
+      add_index :post_replacements2, %i[post_id sequence_number],
+                unique: true,
+                name: :index_post_replacements2_on_post_id_and_sequence_number
+    end
+
+    add_check_constraint :post_replacements2,
+                         "(status = 'original') = (sequence_number = 0)",
+                         name: :post_replacements2_status_original_seq0
+  end
+end

--- a/db/migrate/20260727195335_enforce_post_replacement_sequence_number.rb
+++ b/db/migrate/20260727195335_enforce_post_replacement_sequence_number.rb
@@ -2,16 +2,16 @@
 
 class EnforcePostReplacementSequenceNumber < ActiveRecord::Migration[8.1]
   def change
-    change_column_null :post_replacements2, :sequence_number, false
-
     PostReplacement.without_timeout do
+      change_column_null :post_replacements2, :sequence_number, false
+
       add_index :post_replacements2, %i[post_id sequence_number],
                 unique: true,
                 name: :index_post_replacements2_on_post_id_and_sequence_number
-    end
 
-    add_check_constraint :post_replacements2,
-                         "(status = 'original') = (sequence_number = 0)",
-                         name: :post_replacements2_status_original_seq0
+      add_check_constraint :post_replacements2,
+                           "(status = 'original') = (sequence_number = 0)",
+                           name: :post_replacements2_status_original_seq0
+    end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1763,7 +1763,8 @@ CREATE TABLE public.post_replacements2 (
     protected boolean DEFAULT false NOT NULL,
     uploader_id_on_approve integer,
     penalize_uploader_on_approve boolean,
-    sequence_number integer
+    sequence_number integer NOT NULL,
+    CONSTRAINT post_replacements2_status_original_seq0 CHECK ((((status)::text = 'original'::text) = (sequence_number = 0)))
 );
 
 
@@ -5201,6 +5202,13 @@ CREATE INDEX index_post_replacements2_on_post_id ON public.post_replacements2 US
 
 
 --
+-- Name: index_post_replacements2_on_post_id_and_sequence_number; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_post_replacements2_on_post_id_and_sequence_number ON public.post_replacements2 USING btree (post_id, sequence_number);
+
+
+--
 -- Name: index_post_sets_on_post_ids; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6160,6 +6168,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260727195335'),
 ('20260727191219'),
 ('20260727160104'),
 ('20260713192035'),

--- a/spec/models/post_replacement/instance_methods_spec.rb
+++ b/spec/models/post_replacement/instance_methods_spec.rb
@@ -99,6 +99,12 @@ RSpec.describe PostReplacement do
       second = create(:post_replacement, post: post)
       expect(second.sequence_number).to eq(2)
     end
+
+    it "rejects a second original on the same post (both fill to 0)" do
+      post = create(:post)
+      create(:original_post_replacement, post: post)
+      expect { create(:original_post_replacement, post: post) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
   end
 
   # --------------------------------------------------------------------------

--- a/spec/models/post_replacement/search_spec.rb
+++ b/spec/models/post_replacement/search_spec.rb
@@ -190,6 +190,18 @@ RSpec.describe PostReplacement do
         ids = PostReplacement.search(post_id: post.id.to_s).ids
         expect(ids).to eq([newer.id, older.id, original.id])
       end
+
+      it "stays deterministic across multiple posts (id breaks sequence_number ties)" do
+        post_a = create(:post)
+        post_b = create(:post)
+        a0 = create(:original_post_replacement, post: post_a) # seq 0
+        a1 = make_replacement(post: post_a)                   # seq 1
+        b0 = create(:original_post_replacement, post: post_b) # seq 0
+        b1 = make_replacement(post: post_b)                   # seq 1
+        # sequence_number desc, then id desc: seq-1 rows (b1, a1) then seq-0 rows (b0, a0)
+        ids = PostReplacement.search(post_id: "#{post_a.id},#{post_b.id}").ids
+        expect(ids).to eq([b1.id, a1.id, b0.id, a0.id])
+      end
     end
 
     context "with an explicit order" do


### PR DESCRIPTION
Part 2 of #2327.