### PR TITLE
[ModActions] Add missing artist_delete

### DIFF
--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -7,6 +7,7 @@ class ModAction < ApplicationRecord
 
   KnownActions = {
     admin_user_delete: { user_id: :integer },
+    artist_delete: { artist_id: :integer, artist_name: :string },
     artist_page_rename: { old_name: :string, new_name: :string },
     artist_page_lock: { artist_page: :string },
     artist_page_unlock: { artist_page: :string },


### PR DESCRIPTION
The mod action sanitation is skipped for admins, and since most of the tests are run as admins, these kinds of bugs aren't being caught by the tests (I don't think the sanitation code isn't even tested).