### PR TITLE
[UserAlts] Implement an alt account tracking utility

### DIFF
--- a/app/blueprints/user_alt_blueprint.rb
+++ b/app/blueprints/user_alt_blueprint.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Serializes a UserAltFinder candidate for the moderator API. Exposes only
+# evidence DERIVED from IPs (counts, ratios, date ranges, rarity) — never an IP
+# or subnet value in any form. Renders the plain candidate hashes the finder
+# returns.
+class UserAltBlueprint < Blueprinter::Base
+  field :user_id
+  field :score
+  field :handoff
+  field :shared_exact
+  field :shared_subnet
+  field :total_ips
+  field :ratio
+  field :rarest_users
+  field :overlap_first
+  field :overlap_last
+  field :last_co_seen
+  field :concurrent
+  field :deleted
+
+  field :user do |candidate|
+    user = candidate[:user]
+    next nil unless user
+
+    {
+      id: user.id,
+      name: user.name,
+      level_string: user.level_string,
+      created_at: user.created_at,
+    }
+  end
+end

--- a/app/controllers/staff/user_alts_controller.rb
+++ b/app/controllers/staff/user_alts_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Staff
+  # Moderator-accessible alt-account finder. Unlike the admin-only IP tools, its
+  # output never contains IP values — only scores and IP-derived evidence — so
+  # it is gated at moderator rather than admin.
+  class UserAltsController < ApplicationController
+    before_action :moderator_only
+    respond_to :html, :json
+
+    def show
+      @user = User.find(params[:user_id])
+      @finder = UserAltFinder.new(@user)
+      @candidates = @finder.candidates
+      @chains = @finder.chains
+
+      respond_to do |format|
+        format.html
+        format.json { render json: UserAltBlueprint.render_as_hash(@candidates) }
+      end
+    end
+  end
+end

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -44,7 +44,6 @@
 @import "components/user_feedback_component.scss";
 
 @import "views/application/application";
-@import "views/staff/vote_trends";
 @import "views/appeals/appeals";
 @import "views/artists/artists";
 @import "views/auths/auths";
@@ -60,6 +59,8 @@
 @import "views/post_replacements/post_replacements";
 @import "views/posts/posts";
 @import "views/search_trends/search_trends";
+@import "views/staff/user_alts/show";
+@import "views/staff/vote_trends";
 @import "views/staff_files/staff_files";
 @import "views/staff_wikis/staff_wikis";
 @import "views/static/static";

--- a/app/javascript/src/styles/views/staff/user_alts/_show.scss
+++ b/app/javascript/src/styles/views/staff/user_alts/_show.scss
@@ -1,0 +1,6 @@
+#c-staff-user-alts #a-show {
+
+  .user-alt-disclaimer {
+    margin-bottom: 1rem;
+  }
+}

--- a/app/jobs/user_ip_address_backfill_job.rb
+++ b/app/jobs/user_ip_address_backfill_job.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# One-time seed of user_ip_addresses from the existing per-record IP columns,
+# restricted to the retention window. Run once, off-peak. Deliberately NOT
+# idempotent: re-running a source that already completed doubles its hit_count
+# contributions. If a run fails partway, clear user_ip_addresses and start over
+# (the table is fully reconstructible from these sources plus the live writes).
+class UserIpAddressBackfillJob < ApplicationJob
+  queue_as :low_prio
+
+  BATCH_SIZE = 100_000
+
+  # Each source contributes (user, ip, timestamp) tuples. `where` is an extra
+  # predicate on the source, already qualified to the `t` alias below.
+  SOURCES = [
+    { table: "comments",           user: "creator_id",  ip: "creator_ip_addr", ts: "created_at" },
+    # Dmails are stored once per participant and both copies carry from_id /
+    # creator_ip_addr; without this filter every sent dmail counts twice.
+    { table: "dmails",             user: "from_id",     ip: "creator_ip_addr", ts: "created_at", where: "t.owner_id = t.from_id" },
+    { table: "blips",              user: "creator_id",  ip: "creator_ip_addr", ts: "created_at" },
+    { table: "post_flags",         user: "creator_id",  ip: "creator_ip_addr", ts: "created_at" },
+    { table: "posts",              user: "uploader_id", ip: "uploader_ip_addr", ts: "created_at" },
+    { table: "post_votes",         user: "user_id",     ip: "user_ip_addr",    ts: "created_at" },
+    { table: "comment_votes",      user: "user_id",     ip: "user_ip_addr",    ts: "created_at" },
+    { table: "forum_posts",        user: "creator_id",  ip: "creator_ip_addr", ts: "created_at" },
+    { table: "forum_topics",       user: "creator_id",  ip: "creator_ip_addr", ts: "created_at" },
+    { table: "tickets",            user: "creator_id",  ip: "creator_ip_addr", ts: "created_at" },
+    { table: "artist_versions",    user: "updater_id",  ip: "updater_ip_addr", ts: "created_at" },
+    { table: "note_versions",      user: "updater_id",  ip: "updater_ip_addr", ts: "created_at" },
+    { table: "pool_versions",      user: "updater_id",  ip: "updater_ip_addr", ts: "created_at" },
+    # post_versions has no created_at, defaults updater_ip_addr to 127.0.0.1
+    # (dropped by the loopback filter) and updater_id to 0 (dropped by the FK
+    # join to users).
+    { table: "post_versions",      user: "updater_id",  ip: "updater_ip_addr", ts: "updated_at" },
+    { table: "wiki_page_versions", user: "updater_id",  ip: "updater_ip_addr", ts: "created_at" },
+    # A user's last login: one row seen at last_logged_in_at.
+    { table: "users",              user: "id",          ip: "last_ip_addr",    ts: "last_logged_in_at" },
+  ].freeze
+
+  # Private / loopback / link-local ranges to exclude, both families. Cross-family
+  # <<= returns false (verified), so listing v4 and v6 ranges together is safe.
+  NON_PUBLIC_RANGES = %w[
+    10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 127.0.0.0/8 169.254.0.0/16
+    ::1/128 fc00::/7 fe80::/10
+  ].freeze
+
+  def perform
+    cutoff = Danbooru.config.user_ip_retention_period.ago
+    UserIpAddress.without_timeout do
+      SOURCES.each { |source| backfill_source(source, cutoff) }
+    end
+  end
+
+  private
+
+  def connection
+    UserIpAddress.connection
+  end
+
+  def backfill_source(source, cutoff)
+    table = source[:table]
+    max_id = connection.select_value("SELECT MAX(id) FROM #{table}").to_i
+    (0..max_id).step(BATCH_SIZE) do |start_id|
+      connection.execute(batch_sql(source, cutoff, start_id, start_id + BATCH_SIZE))
+    end
+    Rails.logger.info("UserIpAddressBackfillJob: finished #{table} (max_id=#{max_id})")
+  end
+
+  # Aggregates one id-range into user_ip_addresses. ON CONFLICT merges across
+  # batches and across source tables, so batching is safe.
+  def batch_sql(source, cutoff, start_id, end_id)
+    table, user_col, ip_col, ts_col = source.values_at(:table, :user, :ip, :ts)
+    normalized_ip = normalize_ip("t.#{ip_col}")
+    extra = source[:where] ? "AND #{source[:where]}" : ""
+    <<~SQL.squish
+      INSERT INTO user_ip_addresses (user_id, ip_addr, first_seen_at, last_seen_at, hit_count)
+      SELECT uid, nip, MIN(ts), MAX(ts), COUNT(*)
+      FROM (
+        SELECT u.id AS uid, #{normalized_ip} AS nip, t.#{ts_col} AS ts
+        FROM #{table} t
+        INNER JOIN users u ON u.id = t.#{user_col}
+        WHERE t.id >= #{start_id.to_i} AND t.id < #{end_id.to_i}
+          AND t.#{ip_col} IS NOT NULL
+          AND t.#{ts_col} IS NOT NULL
+          AND t.#{ts_col} > #{connection.quote(cutoff)}
+          #{extra}
+      ) s
+      WHERE #{public_only('nip')}
+      GROUP BY uid, nip
+      ON CONFLICT (user_id, ip_addr) DO UPDATE SET
+        first_seen_at = LEAST(user_ip_addresses.first_seen_at, excluded.first_seen_at),
+        last_seen_at  = GREATEST(user_ip_addresses.last_seen_at, excluded.last_seen_at),
+        hit_count     = user_ip_addresses.hit_count + excluded.hit_count
+    SQL
+  end
+
+  # Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d -> a.b.c.d) to match the live
+  # write path, so a client never splits into a mapped and an unmapped identity.
+  def normalize_ip(expr)
+    "CASE WHEN #{expr} <<= inet '::ffff:0:0/96' " \
+      "THEN (inet '0.0.0.0' + (#{expr} - inet '::ffff:0.0.0.0')) " \
+      "ELSE #{expr} END"
+  end
+
+  def public_only(expr)
+    clauses = NON_PUBLIC_RANGES.map { |range| "#{expr} <<= inet '#{range}'" }.join(" OR ")
+    "NOT (#{clauses})"
+  end
+end

--- a/app/jobs/user_ip_address_prune_job.rb
+++ b/app/jobs/user_ip_address_prune_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Daily prune of user_ip_addresses rows unseen for the retention period. This is
+# the sole expiry mechanism for the table; account deletion deliberately leaves
+# rows behind (the delete-and-re-register evasion pattern depends on them), so
+# the prune applies uniformly to active and deleted accounts.
+class UserIpAddressPruneJob < ApplicationJob
+  queue_as :low_prio
+
+  def perform
+    UserIpAddress.without_timeout do
+      UserIpAddress
+        .where(last_seen_at: ...Danbooru.config.user_ip_retention_period.ago)
+        .in_batches(load: false)
+        .delete_all
+    end
+  end
+end

--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -33,6 +33,9 @@ class SessionLoader
       load_remember_token
     end
 
+    # Record the IP for everyone, including attempted logins from banned users.
+    UserIpTracker.track!(CurrentUser.user, CurrentUser.ip_addr)
+
     CurrentUser.user.unban! if CurrentUser.user.ban_expired?
     if CurrentUser.user.is_restricted?
       recent_ban = CurrentUser.user.recent_ban

--- a/app/logical/user_alt_finder.rb
+++ b/app/logical/user_alt_finder.rb
@@ -95,12 +95,18 @@ class UserAltFinder
 
   # --- data collection (all against user_ip_addresses) ----------------------
 
+  # Every candidate-side query is scoped to the same window as the target
+  # footprint, so the ratio's numerator and denominator (and rarity) stay
+  # consistent even when unpruned stale rows exist or `window:` is narrowed.
+  def within_window
+    UserIpAddress.where(last_seen_at: @cutoff..)
+  end
+
   # { ip_string => { first:, last:, hits:, subnet: <cidr string> } }, capped to
   # the most-recently-seen rows.
   def collect_target_ips(user_id)
-    rows = UserIpAddress
+    rows = within_window
            .where(user_id: user_id)
-           .where(last_seen_at: @cutoff..)
            .order(last_seen_at: :desc)
            .limit(target_ip_cap)
            .pluck(:ip_addr, :subnet, :first_seen_at, :last_seen_at, :hit_count)
@@ -123,7 +129,7 @@ class UserAltFinder
   # (value, user_id) indexes. Keyed by canonical string.
   def distinct_user_counts(column, values)
     return {} if values.empty?
-    UserIpAddress.where(column => values)
+    within_window.where(column => values)
                  .group(column).distinct.count(:user_id)
                  .transform_keys { |k| canonical(column, k) }
   end
@@ -132,7 +138,7 @@ class UserAltFinder
   # value). Keyed by canonical string.
   def match_rows(column, values, target_id)
     return {} if values.empty?
-    rows = UserIpAddress.where(column => values).where.not(user_id: target_id)
+    rows = within_window.where(column => values).where.not(user_id: target_id)
                         .pluck(:user_id, column, :first_seen_at, :last_seen_at, :hit_count)
     result = Hash.new { |h, k| h[k] = [] }
     rows.each do |uid, value, first, last, hits|
@@ -200,7 +206,7 @@ class UserAltFinder
   # Overlap ratio + handoff check for the shortlist, then the final score.
   def finalize(shortlist, target)
     users = User.where(id: shortlist.pluck(:user_id)).index_by(&:id)
-    totals = shortlist.any? ? UserIpAddress.where(user_id: shortlist.pluck(:user_id)).group(:user_id).count : {}
+    totals = shortlist.any? ? within_window.where(user_id: shortlist.pluck(:user_id)).group(:user_id).count : {}
 
     shortlist.each do |c|
       c[:user] = users[c[:user_id]]

--- a/app/logical/user_alt_finder.rb
+++ b/app/logical/user_alt_finder.rb
@@ -165,6 +165,9 @@ class UserAltFinder
     data[:exact_rows].each do |r|
       next if data[:crowded_ips].include?(r[:value])
       e = evidence(r[:value], data[:target_ips][r[:value]], r, data[:users_per_ip][r[:value]], weight_exact)
+      # The subnet this exact IP sits in, so the subnet loop below can dedupe
+      # against it (a candidate's own row always matches its containing subnet).
+      e[:subnet] = subnet_cidr_for_ip(r[:value])
       e[:asn_group] = asn_group_for(r[:value], asn_map)
       e[:asn] = asn_map[r[:value]]
       by_user[r[:user_id]][:exact] << e
@@ -173,7 +176,8 @@ class UserAltFinder
     data[:subnet_rows].each do |r|
       subnet = r[:value]
       next if data[:crowded_subnets].include?(subnet)
-      # Skip if this candidate already matched an exact IP inside the subnet.
+      # Skip if this candidate already matched an exact IP inside the subnet:
+      # that network is already counted, more strongly, as exact evidence.
       next if by_user.key?(r[:user_id]) && by_user[r[:user_id]][:exact].any? { |e| e[:subnet] == subnet }
       e = evidence(subnet, data[:target_subnets][subnet], r, data[:users_per_subnet][subnet], subnet_weight(subnet))
       e[:subnet] = subnet

--- a/app/logical/user_alt_finder.rb
+++ b/app/logical/user_alt_finder.rb
@@ -1,0 +1,334 @@
+# frozen_string_literal: true
+
+# Given a target user, ranks candidate alt accounts by shared-network evidence
+# drawn from the user_ip_addresses aggregate table. Never exposes IP values;
+# callers receive scores and IP-derived evidence only.
+#
+# Scoring, per shared value x (exact IP, or subnet):
+#   contribution = rarity × proximity × dwell × confidence × weight
+#
+# contributions are grouped per ASN (siblings add log2 weight, crowded pools are
+# sqrt-discounted), the top-5 groups summed into evidence, then
+#   score = evidence × (0.3 + 0.7·√ratio) + handoff_bonus
+# normalized to 0-100 against a configured saturation point.
+class UserAltFinder
+  DWELL_FULL_DAYS    = 14.0
+  ASN_SIBLING_WEIGHT = 0.15
+  ASN_CROWD_FREE     = 10
+  TOP_K              = 5
+  RATIO_FLOOR        = 0.3
+  HANDOFF_DAYS       = 14.0
+  HANDOFF_BONUS      = 1.5
+  CHAIN_MIN_SCORE    = 2.0   # displayed-score threshold for chain expansion
+  CHAIN_FANOUT       = 3     # at most this many direct candidates expanded
+  CHAIN_RESULTS      = 3     # indirect candidates surfaced per expanded base
+
+  def initialize(user, window: nil, chain: true)
+    @user = user
+    @cutoff = (window || Danbooru.config.user_ip_retention_period).ago
+    @chain = chain
+  end
+
+  # Direct candidates, highest score first.
+  def candidates
+    analysis[:candidates]
+  end
+
+  # [{ via: <direct candidate>, candidates: [<indirect candidate>, ...] }].
+  # Evasion chains (A -> B -> C, where A and C never shared an IP) are invisible to a
+  # single-hop lookup; each base is re-analyzed and its fresh matches surfaced.
+  def chains
+    return @chains if defined?(@chains)
+    @chains = @chain ? build_chains : []
+  end
+
+  private
+
+  def analysis
+    @analysis ||= analyze(@user)
+  end
+
+  def build_chains
+    known = [@user.id] + analysis[:candidates].pluck(:user_id)
+    bases = analysis[:candidates].select { |c| c[:score] >= CHAIN_MIN_SCORE }.first(CHAIN_FANOUT)
+    bases.filter_map do |base|
+      next unless base[:user]
+      indirect = analyze(base[:user])[:candidates]
+                 .reject { |c| known.include?(c[:user_id]) }
+                 .first(CHAIN_RESULTS)
+      { via: base, candidates: indirect } if indirect.any?
+    end
+  end
+
+  # Full pipeline for one user: collect the target's footprint, measure rarity,
+  # drop crowded values, join survivors, score. Reused per chain hop.
+  def analyze(target)
+    target_ips = collect_target_ips(target.id)
+    return empty_result if target_ips.empty?
+
+    target_subnets = aggregate_subnets(target_ips)
+    ip_keys = target_ips.keys
+    subnet_keys = target_subnets.keys
+
+    users_per_ip = distinct_user_counts(:ip_addr, ip_keys)
+    users_per_subnet = distinct_user_counts(:subnet, subnet_keys)
+    crowded_ips = users_per_ip.select { |_, n| n > max_users_per_ip }.keys.to_set
+    crowded_subnets = users_per_subnet.select { |_, n| n > max_users_per_subnet }.keys.to_set
+
+    exact_rows = match_rows(:ip_addr, ip_keys, target.id)
+    subnet_rows = match_rows(:subnet, subnet_keys, target.id)
+
+    asn_map = resolve_asns(ip_keys, subnet_keys)
+
+    score_candidates(
+      target: target, target_ips: target_ips, target_subnets: target_subnets,
+      exact_rows: exact_rows, subnet_rows: subnet_rows,
+      users_per_ip: users_per_ip, users_per_subnet: users_per_subnet,
+      crowded_ips: crowded_ips, crowded_subnets: crowded_subnets,
+      asn_map: asn_map, co_users_per_asn: count_co_users_per_asn(exact_rows, subnet_rows, asn_map)
+    )
+  end
+
+  def empty_result
+    { candidates: [] }
+  end
+
+  # --- data collection (all against user_ip_addresses) ----------------------
+
+  # { ip_string => { first:, last:, hits:, subnet: <cidr string> } }, capped to
+  # the most-recently-seen rows.
+  def collect_target_ips(user_id)
+    rows = UserIpAddress
+           .where(user_id: user_id)
+           .where(last_seen_at: @cutoff..)
+           .order(last_seen_at: :desc)
+           .limit(target_ip_cap)
+           .pluck(:ip_addr, :subnet, :first_seen_at, :last_seen_at, :hit_count)
+    rows.each_with_object({}) do |(ip, subnet, first, last, hits), acc|
+      acc[ip.to_s] = { first: first, last: last, hits: hits, subnet: cidr(subnet) }
+    end
+  end
+
+  # { subnet_cidr => { first:, last:, hits: } } aggregated from the target's IPs.
+  def aggregate_subnets(target_ips)
+    target_ips.each_with_object({}) do |(_ip, v), acc|
+      entry = acc[v[:subnet]] ||= { first: v[:first], last: v[:last], hits: 0 }
+      entry[:first] = [entry[:first], v[:first]].min
+      entry[:last]  = [entry[:last], v[:last]].max
+      entry[:hits] += v[:hits]
+    end
+  end
+
+  # COUNT(DISTINCT user_id) grouped by the value — index-only on the composite
+  # (value, user_id) indexes. Keyed by canonical string.
+  def distinct_user_counts(column, values)
+    return {} if values.empty?
+    UserIpAddress.where(column => values)
+                 .group(column).distinct.count(:user_id)
+                 .transform_keys { |k| canonical(column, k) }
+  end
+
+  # Other users' rows on the target's values. Merges to one entry per (user,
+  # value). Keyed by canonical string.
+  def match_rows(column, values, target_id)
+    return {} if values.empty?
+    rows = UserIpAddress.where(column => values).where.not(user_id: target_id)
+                        .pluck(:user_id, column, :first_seen_at, :last_seen_at, :hit_count)
+    result = Hash.new { |h, k| h[k] = [] }
+    rows.each do |uid, value, first, last, hits|
+      result[[uid, canonical(column, value)]] << { first: first, last: last, hits: hits }
+    end
+    result.map do |(uid, value), entries|
+      { user_id: uid, value: value,
+        first: entries.pluck(:first).min, last: entries.pluck(:last).max,
+        hits: entries.sum { |e| e[:hits] }, }
+    end
+  end
+
+  # Distinct co-users per ASN across ALL the target's matches (including
+  # crowd-dropped values) — the pool-vs-residential discriminator.
+  def count_co_users_per_asn(exact_rows, subnet_rows, asn_map)
+    co_users = Hash.new { |h, k| h[k] = Set.new }
+    exact_rows.each { |r| co_users[asn_group_for(r[:value], asn_map)] << r[:user_id] }
+    subnet_rows.each { |r| co_users[asn_group_for(r[:value], asn_map)] << r[:user_id] }
+    co_users.transform_values(&:size)
+  end
+
+  # --- scoring --------------------------------------------------------------
+
+  # `data` carries everything analyze() computed (target, footprint, match rows,
+  # rarity counts, crowded sets, asn_map, co_users_per_asn).
+  def score_candidates(data)
+    by_user = Hash.new { |h, k| h[k] = { exact: [], subnet: [] } }
+    asn_map = data[:asn_map]
+
+    data[:exact_rows].each do |r|
+      next if data[:crowded_ips].include?(r[:value])
+      e = evidence(r[:value], data[:target_ips][r[:value]], r, data[:users_per_ip][r[:value]], weight_exact)
+      e[:asn_group] = asn_group_for(r[:value], asn_map)
+      e[:asn] = asn_map[r[:value]]
+      by_user[r[:user_id]][:exact] << e
+    end
+
+    data[:subnet_rows].each do |r|
+      subnet = r[:value]
+      next if data[:crowded_subnets].include?(subnet)
+      # Skip if this candidate already matched an exact IP inside the subnet.
+      next if by_user.key?(r[:user_id]) && by_user[r[:user_id]][:exact].any? { |e| e[:subnet] == subnet }
+      e = evidence(subnet, data[:target_subnets][subnet], r, data[:users_per_subnet][subnet], subnet_weight(subnet))
+      e[:subnet] = subnet
+      e[:asn_group] = asn_group_for(subnet, asn_map)
+      e[:asn] = asn_map[subnet]
+      by_user[r[:user_id]][:subnet] << e
+    end
+
+    prelim = by_user.filter_map do |uid, ev|
+      all = (ev[:exact] + ev[:subnet]).sort_by { |e| -e[:contribution] }
+      groups = build_groups(all, data[:co_users_per_asn])
+      evidence_sum = groups.first(TOP_K).sum { |g| g[:contribution] }
+      { user_id: uid, evidence_sum: evidence_sum, exact: ev[:exact], subnet: ev[:subnet], all: all, groups: groups } if evidence_sum > 0
+    end
+
+    shortlist = prelim.sort_by { |c| -c[:evidence_sum] }.first(candidate_cap)
+    finalize(shortlist, data[:target])
+  end
+
+  # Overlap ratio + handoff check for the shortlist, then the final score.
+  def finalize(shortlist, target)
+    users = User.where(id: shortlist.pluck(:user_id)).index_by(&:id)
+    totals = shortlist.any? ? UserIpAddress.where(user_id: shortlist.pluck(:user_id)).group(:user_id).count : {}
+
+    shortlist.each do |c|
+      c[:user] = users[c[:user_id]]
+      shared = c[:exact].size
+      c[:total_ips] = [totals[c[:user_id]] || shared, shared].max
+      ratio = shared > 0 ? shared.to_f / c[:total_ips] : 0.0
+      ratio_factor = RATIO_FLOOR + ((1 - RATIO_FLOOR) * Math.sqrt([ratio, 1.0].min))
+      c[:handoff] = c[:user] ? handoff?(target, c[:user], c[:exact]) : false
+      raw = (c[:evidence_sum] * ratio_factor) + (c[:handoff] ? HANDOFF_BONUS : 0)
+      c[:score] = [100.0 * raw / saturation, 100.0].min.round(1)
+      annotate_display!(c)
+    end
+
+    { candidates: shortlist.reject { |c| c[:user].nil? }.sort_by { |c| -c[:score] } }
+  end
+
+  # Fields the view/blueprint read; never includes IP or subnet values.
+  def annotate_display!(candidate)
+    all = candidate[:all]
+    candidate[:shared_exact] = candidate[:exact].size
+    candidate[:shared_subnet] = candidate[:subnet].size
+    candidate[:asn_groups] = candidate[:groups].size
+    candidate[:pool_discounted] = candidate[:groups].count { |g| g[:crowd_factor] < 1.0 }
+    candidate[:rarest_users] = all.pluck(:n_users).min
+    candidate[:ratio] = candidate[:total_ips] > 0 ? (candidate[:shared_exact].to_f / candidate[:total_ips]) : 0.0
+    candidate[:last_co_seen] = all.map { |e| [e[:mine][:last], e[:theirs][:last]].min }.max
+    # Span of shared-value activity across both accounts (always a valid range;
+    # the concurrent flag says whether their windows actually overlapped).
+    candidate[:overlap_first] = all.flat_map { |e| [e[:mine][:first], e[:theirs][:first]] }.min
+    candidate[:overlap_last] = all.flat_map { |e| [e[:mine][:last], e[:theirs][:last]] }.max
+    candidate[:concurrent] = all.any? { |e| e[:mine][:first] <= e[:theirs][:last] && e[:theirs][:first] <= e[:mine][:last] }
+    candidate[:deleted] = deleted?(candidate[:user])
+  end
+
+  def evidence(value, mine, theirs, n_users, weight)
+    rarity = 1.0 / Math.log2(1 + n_users)
+    gap_days = [([mine[:first], theirs[:first]].max - [mine[:last], theirs[:last]].min) / 1.day, 0.0].max
+    prox = 0.5**(gap_days / proximity_half_life)
+    spans = [mine, theirs].map { |w| (w[:last] - w[:first]) / 1.day }
+    dwell = 0.5 + (0.5 * [spans.min / DWELL_FULL_DAYS, 1.0].min)
+    conf = (0.4 + (0.3 * Math.log10(1 + [mine[:hits], theirs[:hits]].min))).clamp(0.0, 1.0)
+    { value: value, n_users: n_users, mine: mine, theirs: theirs,
+      contribution: rarity * prox * dwell * conf * weight, }
+  end
+
+  # One evidence unit per ASN: best member carries it, siblings add log2 weight,
+  # crowded ASNs (pool infrastructure) get a sqrt-tapered discount.
+  def build_groups(evidence_items, co_users_per_asn)
+    groups = evidence_items.group_by { |e| e[:asn_group] }.map do |group, items|
+      best = items.first # arrive sorted by contribution desc
+      collapsed = best[:contribution] * (1 + (ASN_SIBLING_WEIGHT * Math.log2(items.size)))
+      crowd = asn_crowd_factor(co_users_per_asn[group] || 2)
+      { group: group, size: items.size, best: best, crowd_factor: crowd, contribution: collapsed * crowd }
+    end
+    groups.sort_by { |g| -g[:contribution] }
+  end
+
+  def asn_crowd_factor(count)
+    count <= ASN_CROWD_FREE ? 1.0 : Math.sqrt(ASN_CROWD_FREE.to_f / count)
+  end
+
+  # A fresh account taking over a shared IP: the later usage window starts within
+  # HANDOFF_DAYS of the earlier one ending, AND that later account was itself
+  # created within HANDOFF_DAYS of the handoff. Symmetric in the two accounts.
+  def handoff?(target_user, cand_user, shared_exact)
+    shared_exact.any? do |e|
+      a = e[:mine]
+      b = e[:theirs]
+      early, late, late_user = a[:first] <= b[:first] ? [a, b, cand_user] : [b, a, target_user]
+      gap_days = (late[:first] - early[:last]) / 1.day
+      next false unless gap_days.between?(-1.0, HANDOFF_DAYS)
+      ((late_user.created_at - early[:last]).abs / 1.day) <= HANDOFF_DAYS
+    end
+  end
+
+  # --- ASN helpers ----------------------------------------------------------
+
+  # { value_key => { asn:, name:, country: } | nil }. Empty (ASN grouping off)
+  # when asn_ranges is missing/empty; unresolved values fall back to their own
+  # subnet so they never merge across providers.
+  def resolve_asns(ip_keys, subnet_keys)
+    return {} unless AsnRange.table_exists? && AsnRange.exists?
+    subnet_bases = subnet_keys.index_with { |k| IPAddr.new(k).to_s }
+    raw = AsnRange.lookup(ip_keys + subnet_bases.values)
+    map = {}
+    ip_keys.each { |ip| map[ip] = raw[IPAddr.new(ip).to_s] }
+    subnet_bases.each { |cidr, base| map[cidr] = raw[base] }
+    map
+  end
+
+  def asn_group_for(value, asn_map)
+    info = asn_map[value]
+    return "AS#{info[:asn]}" if info
+    value.include?("/") ? value : subnet_cidr_for_ip(value)
+  end
+
+  # --- small helpers --------------------------------------------------------
+
+  # Canonical string key for a value read back from the DB (IPAddr or string).
+  # Subnets keep their prefix so /24 and /64 stay distinct from host addresses.
+  def canonical(column, value)
+    column == :subnet ? cidr(value) : IPAddr.new(value.to_s).to_s
+  end
+
+  def cidr(ipaddr)
+    ip = ipaddr.is_a?(IPAddr) ? ipaddr : IPAddr.new(ipaddr.to_s)
+    "#{ip}/#{ip.prefix}"
+  end
+
+  def subnet_cidr_for_ip(ip_string)
+    addr = IPAddr.new(ip_string)
+    mask = addr.ipv4? ? 24 : 64
+    "#{addr.mask(mask)}/#{mask}"
+  end
+
+  def subnet_weight(subnet_cidr)
+    IPAddr.new(subnet_cidr).ipv4? ? weight_subnet_v4 : weight_subnet_v6
+  end
+
+  def deleted?(user)
+    user&.name&.match?(/\Auser_#{user.id}~*\z/)
+  end
+
+  # --- config accessors -----------------------------------------------------
+
+  def max_users_per_ip     = Danbooru.config.alt_finder_max_users_per_ip
+  def max_users_per_subnet = Danbooru.config.alt_finder_max_users_per_subnet
+  def weight_exact         = Danbooru.config.alt_finder_weight_exact
+  def weight_subnet_v6     = Danbooru.config.alt_finder_weight_subnet_v6
+  def weight_subnet_v4     = Danbooru.config.alt_finder_weight_subnet_v4
+  def proximity_half_life  = Danbooru.config.alt_finder_proximity_half_life_days
+  def saturation           = Danbooru.config.alt_finder_score_saturation
+  def target_ip_cap        = Danbooru.config.alt_finder_target_ip_cap
+  def candidate_cap        = Danbooru.config.alt_finder_candidate_cap
+end

--- a/app/logical/user_alt_finder.rb
+++ b/app/logical/user_alt_finder.rb
@@ -320,8 +320,10 @@ class UserAltFinder
     IPAddr.new(subnet_cidr).ipv4? ? weight_subnet_v4 : weight_subnet_v6
   end
 
+  # Soft-deleted accounts are renamed by UserDeletion#calculate_final_name to
+  # "user_{id}", or "user_{id}_{n}" when that base name collides.
   def deleted?(user)
-    user&.name&.match?(/\Auser_#{user.id}~*\z/)
+    user&.name&.match?(/\Auser_#{user.id}(_\d+)?\z/)
   end
 
   # --- config accessors -----------------------------------------------------

--- a/app/logical/user_ip_tracker.rb
+++ b/app/logical/user_ip_tracker.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Records which IP addresses a user is seen using, one debounced upsert per
+# (user, ip) per hour. Feeds UserAltFinder. Called from SessionLoader on every
+# authenticated request; any failure is swallowed so tracking can never break
+# request processing.
+module UserIpTracker
+  DEBOUNCE = 1.hour
+
+  def self.track!(user, ip_addr)
+    return unless Danbooru.config.enable_user_ip_tracking?
+    return if user.nil? || user.is_anonymous?
+
+    # Normalize IPv4-mapped IPv6 (::ffff:a.b.c.d -> a.b.c.d): the mapped form
+    # has family() = 6, so its /64 would be ::/64 (one bucket for every mapped
+    # address) and as an exact inet it does not equal its plain v4 form,
+    # splitting one client into two identities. Skip non-public addresses
+    # entirely, matching AsnRange.lookup.
+    ip = IPAddr.new(ip_addr.to_s).native
+    return if ip.private? || ip.loopback? || ip.link_local?
+
+    ip_string = ip.to_s
+    cache_key = "user_ip:#{user.id}:#{ip_string}"
+    return if Cache.fetch(cache_key)
+
+    Cache.write(cache_key, true, expires_in: DEBOUNCE)
+
+    now = Time.now
+    UserIpAddress.upsert(
+      { user_id: user.id, ip_addr: ip_string, first_seen_at: now, last_seen_at: now },
+      unique_by: %i[user_id ip_addr],
+      on_duplicate: Arel.sql(
+        "last_seen_at = excluded.last_seen_at, hit_count = user_ip_addresses.hit_count + 1",
+      ),
+    )
+  rescue StandardError => e
+    DanbooruLogger.log(e)
+    nil
+  end
+end

--- a/app/models/user_ip_address.rb
+++ b/app/models/user_ip_address.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UserIpAddress < ApplicationRecord
+  belongs_to :user
+
+  def hidden_attributes
+    super + %i[subnet]
+  end
+end

--- a/app/views/staff/user_alts/_candidate.html.erb
+++ b/app/views/staff/user_alts/_candidate.html.erb
@@ -1,0 +1,25 @@
+<tr class="<%= "user-deleted" if candidate[:deleted] %>">
+  <td>
+    <%= link_to_user candidate[:user] %>
+    <span class="user-alt-meta">(<%= candidate[:user].level_string %>, joined <%= compact_date candidate[:user].created_at %>)</span>
+    <% if candidate[:deleted] %><span class="text-red text-bold">[DELETED]</span><% end %>
+  </td>
+  <td class="user-alt-score"><%= candidate[:score] %></td>
+  <td>
+    <% if candidate[:handoff] %>
+      <span class="text-red text-bold" title="A fresh account took over a shared IP within days of the other's last use there.">
+        yes
+      </span>
+    <% end %>
+  </td>
+  <td><%= candidate[:shared_exact] %> exact, <%= candidate[:shared_subnet] %> subnet-only</td>
+  <td>shares <%= candidate[:shared_exact] %> of their <%= candidate[:total_ips] %></td>
+  <td>least-shared: <%= candidate[:rarest_users] %> users</td>
+  <td>
+    <% if candidate[:overlap_first] && candidate[:overlap_last] %>
+      <%= compact_date candidate[:overlap_first] %> &ndash; <%= compact_date candidate[:overlap_last] %>
+    <% end %>
+    <%= candidate[:concurrent] ? "concurrent" : "sequential" %>
+  </td>
+  <td><%= time_ago_in_words_tagged candidate[:last_co_seen], compact: true %></td>
+</tr>

--- a/app/views/staff/user_alts/show.html.erb
+++ b/app/views/staff/user_alts/show.html.erb
@@ -1,0 +1,62 @@
+<div id="c-staff-user-alts">
+  <div id="a-show">
+    <h1>Alt candidates for <%= link_to_user @user %></h1>
+
+    <div class="user-alt-disclaimer notice notice-info">
+      A high score is <strong>shared-network evidence, not proof</strong>.<br />
+      Households, dorms, and shared computers produce genuine high scores for distinct people.<br />
+      A score justifies opening an investigation / escalation to an admin &ndash; it does not justify a ban by itself.
+    </div>
+
+    <% if @candidates.empty? %>
+      <p>No candidates found for this user within the retention window.</p>
+    <% else %>
+      <table class="striped">
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Score</th>
+            <th>Handoff</th>
+            <th>Shared IPs</th>
+            <th>Overlap ratio</th>
+            <th>Rarity</th>
+            <th>Overlap</th>
+            <th>Last co-seen</th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: "candidate", collection: @candidates, as: :candidate %>
+        </tbody>
+      </table>
+    <% end %>
+
+    <% if @chains.any? %>
+      <h2>Chain expansion</h2>
+      <p class="user-alt-meta">
+        Potential evasion chains.<br />
+        Each new alt shares an IP only with its immediate predecessor, so the ends have no direct edge.<br />
+        These are the strong matches of the top direct candidates.
+      </p>
+      <% @chains.each do |chain| %>
+        <h3><%= link_to_user chain[:via][:user] %> &rarr; via &rarr; <%= @user.name %> <span class="user-alt-meta">(<%= chain[:via][:score] %>)</span></h3>
+        <table class="striped">
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Score</th>
+              <th>Handoff</th>
+              <th>Shared IPs</th>
+              <th>Overlap ratio</th>
+              <th>Rarity</th>
+              <th>Overlap</th>
+              <th>Last co-seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= render partial: "candidate", collection: chain[:candidates], as: :candidate %>
+          </tbody>
+        </table>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/partials/show/_staff_info.html.erb
+++ b/app/views/users/partials/show/_staff_info.html.erb
@@ -60,6 +60,11 @@
       <span>
         <%= link_to "Cleanup Page", staff_user_cleanup_path(user) %>
       </span>
+
+      <h4>Alt Accounts</h4>
+      <span>
+        <%= link_to "Find Alts", staff_user_alts_path(user_id: user.id) %>
+      </span>
     <% end %>
 
     <% if CurrentUser.is_admin? %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -761,6 +761,73 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
       true
     end
 
+    # Kill switch for the per-request IP tracking that feeds the alt-account
+    # finder (UserIpTracker). Turning this off stops the write path without a
+    # revert deploy; existing rows are untouched.
+    def enable_user_ip_tracking?
+      true
+    end
+
+    # Rows in user_ip_addresses unseen for this long are pruned daily. Also the
+    # window the one-time backfill imports from. The sole expiry mechanism for
+    # that table (account deletion deliberately leaves rows behind).
+    def user_ip_retention_period
+      2.years
+    end
+
+    # UserAltFinder tuning. These are informed starting values and MUST be
+    # validated/tuned against the real aggregate table before moderators rely
+    # on the scores.
+    #
+    # Exact IPs shared by more distinct users than this are dropped as
+    # institutional/CGNAT noise before joining; likewise subnets past
+    # alt_finder_max_users_per_subnet.
+    def alt_finder_max_users_per_ip
+      50
+    end
+
+    def alt_finder_max_users_per_subnet
+      200
+    end
+
+    # Relative weight of each kind of shared value. An IPv6 /64 is delegated
+    # per-customer (near-exact signal); an IPv4 /24 is a whole ISP neighborhood
+    # (should only ever nudge a score).
+    def alt_finder_weight_exact
+      1.0
+    end
+
+    def alt_finder_weight_subnet_v6
+      0.8
+    end
+
+    def alt_finder_weight_subnet_v4
+      0.2
+    end
+
+    # Half-life (in days) of the proximity decay applied to the gap between the
+    # two users' usage windows on a shared value. Concurrent use scores full.
+    def alt_finder_proximity_half_life_days
+      120
+    end
+
+    # Raw score that maps to a displayed 100 (values above saturate at 100).
+    # Mirrors the validated prototype (script/alt_finder_prototype.rb): a lone
+    # handoff bonus of 1.5 lands ~75, strong real alts ~82-85.
+    def alt_finder_score_saturation
+      2.0
+    end
+
+    # Cap on how many of the target's most-recently-seen IPs are considered,
+    # and how many candidates advance to the (per-candidate) shortlist pass.
+    def alt_finder_target_ip_cap
+      500
+    end
+
+    def alt_finder_candidate_cap
+      50
+    end
+
     def iqdb_server
     end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -55,6 +55,12 @@ Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
       "queue" => "low_prio",
       "description" => "Reset IQDB concurrent request counter to recover from worker crashes",
     },
+    "UserIpAddressPruneJob" => {
+      "cron" => "0 2 * * *", # Every day at 2:00 AM
+      "class" => "UserIpAddressPruneJob",
+      "queue" => "low_prio",
+      "description" => "Prune user IP address rows unseen for the retention period",
+    },
   }
 
   Sidekiq::Cron::Job.load_from_hash schedule

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
     # Previously under /moderator/
     resource :moderator_dashboard, only: %i[show], controller: "moderator_dashboards"
     resource :post_diff, only: %i[show]
+    resource :user_alts, only: %i[show]
     resources :ip_addrs, only: %i[index] do
       collection do
         get :export

--- a/db/migrate/20260728160704_create_user_ip_addresses.rb
+++ b/db/migrate/20260728160704_create_user_ip_addresses.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateUserIpAddresses < ActiveRecord::Migration[8.1]
+  def change
+    # Timestamps are domain columns (first_seen_at/last_seen_at), not created/updated_at.
+    create_table :user_ip_addresses do |t| # rubocop:disable Rails/CreateTableWithTimestamps
+      t.references :user, null: false, foreign_key: true
+      t.inet :ip_addr, null: false
+      # Masked network, maintained by the database so it can never drift from
+      # ip_addr: /24 for IPv4, /64 for IPv6.
+      t.virtual :subnet, type: :inet, stored: true, null: false, as: <<~SQL.squish
+        CASE WHEN family(ip_addr) = 4
+             THEN network(set_masklen(ip_addr, 24))
+             ELSE network(set_masklen(ip_addr, 64))
+        END
+      SQL
+      t.datetime :first_seen_at, null: false
+      t.datetime :last_seen_at, null: false
+      t.integer :hit_count, null: false, default: 1
+    end
+
+    # Doubles as the "all IPs of user X" lookup and the upsert conflict target.
+    add_index :user_ip_addresses, %i[user_id ip_addr], unique: true
+    # user_id trails the value so COUNT(DISTINCT user_id) GROUP BY value stays
+    # index-only on crowded values (CGNAT/VPN pools).
+    add_index :user_ip_addresses, %i[ip_addr user_id]
+    add_index :user_ip_addresses, %i[subnet user_id]
+    add_index :user_ip_addresses, :last_seen_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2821,6 +2821,44 @@ ALTER SEQUENCE public.user_feedback_id_seq OWNED BY public.user_feedback.id;
 
 
 --
+-- Name: user_ip_addresses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_ip_addresses (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    ip_addr inet NOT NULL,
+    subnet inet GENERATED ALWAYS AS (
+CASE
+    WHEN (family(ip_addr) = 4) THEN network(set_masklen(ip_addr, 24))
+    ELSE network(set_masklen(ip_addr, 64))
+END) STORED NOT NULL,
+    first_seen_at timestamp(6) without time zone NOT NULL,
+    last_seen_at timestamp(6) without time zone NOT NULL,
+    hit_count integer DEFAULT 1 NOT NULL
+);
+
+
+--
+-- Name: user_ip_addresses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_ip_addresses_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_ip_addresses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_ip_addresses_id_seq OWNED BY public.user_ip_addresses.id;
+
+
+--
 -- Name: user_name_change_requests; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3593,6 +3631,13 @@ ALTER TABLE ONLY public.user_feedback ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: user_ip_addresses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_ip_addresses ALTER COLUMN id SET DEFAULT nextval('public.user_ip_addresses_id_seq'::regclass);
+
+
+--
 -- Name: user_name_change_requests id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4234,6 +4279,14 @@ ALTER TABLE ONLY public.uploads
 
 ALTER TABLE ONLY public.user_feedback
     ADD CONSTRAINT user_feedback_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_ip_addresses user_ip_addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_ip_addresses
+    ADD CONSTRAINT user_ip_addresses_pkey PRIMARY KEY (id);
 
 
 --
@@ -5700,6 +5753,41 @@ CREATE INDEX index_user_feedback_on_user_id ON public.user_feedback USING btree 
 
 
 --
+-- Name: index_user_ip_addresses_on_ip_addr_and_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_ip_addresses_on_ip_addr_and_user_id ON public.user_ip_addresses USING btree (ip_addr, user_id);
+
+
+--
+-- Name: index_user_ip_addresses_on_last_seen_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_ip_addresses_on_last_seen_at ON public.user_ip_addresses USING btree (last_seen_at);
+
+
+--
+-- Name: index_user_ip_addresses_on_subnet_and_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_ip_addresses_on_subnet_and_user_id ON public.user_ip_addresses USING btree (subnet, user_id);
+
+
+--
+-- Name: index_user_ip_addresses_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_ip_addresses_on_user_id ON public.user_ip_addresses USING btree (user_id);
+
+
+--
+-- Name: index_user_ip_addresses_on_user_id_and_ip_addr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_user_ip_addresses_on_user_id_and_ip_addr ON public.user_ip_addresses USING btree (user_id, ip_addr);
+
+
+--
 -- Name: index_user_lower_email; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5994,6 +6082,14 @@ ALTER TABLE ONLY public.appeals
 
 
 --
+-- Name: user_ip_addresses fk_rails_5ea8388355; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_ip_addresses
+    ADD CONSTRAINT fk_rails_5ea8388355 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: oauth_access_tokens fk_rails_732cb83ab7; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -6168,6 +6264,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260728160704'),
 ('20260727195335'),
 ('20260727191219'),
 ('20260727160104'),

--- a/spec/factories/user_ip_address_factory.rb
+++ b/spec/factories/user_ip_address_factory.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "faker"
+
+FactoryBot.define do
+  factory :user_ip_address do
+    user
+    ip_addr { Faker::Internet.ip_v4_address }
+    first_seen_at { Time.now - 1.day }
+    last_seen_at { Time.now }
+    hit_count { 1 }
+    # subnet is a stored generated column; never set it.
+  end
+end

--- a/spec/jobs/user_ip_address_backfill_job_spec.rb
+++ b/spec/jobs/user_ip_address_backfill_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserIpAddressBackfillJob do
+  include_context "as admin"
+
+  let(:user) { create(:user) }
+
+  # NOTE: FactoryBot cascades (posts, the users themselves) carry their own IP
+  # columns, so the job legitimately seeds rows for them too. These specs assert
+  # on specific controlled IP values rather than on total counts.
+
+  it "aggregates hit_count across a source table's rows" do
+    # Post created outside the user's IP scope (as admin, at 127.0.0.1), so only
+    # the two comments contribute the 203.0.113.10 evidence.
+    post = create(:post)
+    CurrentUser.scoped(user, "203.0.113.10") do
+      create(:comment, post: post)
+      create(:comment, post: post)
+    end
+
+    described_class.perform_now
+    row = UserIpAddress.find_by(user_id: user.id, ip_addr: "203.0.113.10")
+    expect(row).to be_present
+    expect(row.hit_count).to eq(2)
+    expect(row.subnet.to_s).to eq("203.0.113.0")
+  end
+
+  it "counts each dmail once despite the per-mailbox copies" do
+    recipient = create(:user)
+    CurrentUser.scoped(user, "203.0.113.20") do
+      Dmail.create_split(from_id: user.id, to_id: recipient.id, title: "t", body: "b",
+                         bypass_limits: true, no_email_notification: true)
+    end
+    # Sanity: the split really did create both mailbox copies.
+    expect(Dmail.where(from_id: user.id).count).to eq(2)
+
+    described_class.perform_now
+    row = UserIpAddress.find_by(user_id: user.id, ip_addr: "203.0.113.20")
+    expect(row.hit_count).to eq(1)
+  end
+
+  it "excludes loopback addresses" do
+    create(:user, last_ip_addr: "127.0.0.1", last_logged_in_at: 1.day.ago)
+    described_class.perform_now
+    expect(UserIpAddress.where(ip_addr: "127.0.0.1")).to be_empty
+  end
+
+  it "ignores rows outside the retention window" do
+    create(:user, last_ip_addr: "203.0.113.30", last_logged_in_at: 3.years.ago)
+    described_class.perform_now
+    expect(UserIpAddress.find_by(ip_addr: "203.0.113.30")).to be_nil
+  end
+end

--- a/spec/jobs/user_ip_address_prune_job_spec.rb
+++ b/spec/jobs/user_ip_address_prune_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserIpAddressPruneJob do
+  include_context "as admin"
+
+  let(:user) { create(:user) }
+
+  it "deletes rows unseen past the retention period and keeps recent ones" do
+    stale = create(:user_ip_address, user: user, ip_addr: "203.0.113.1",
+                                     last_seen_at: 3.years.ago, first_seen_at: 3.years.ago)
+    fresh = create(:user_ip_address, user: user, ip_addr: "203.0.113.2",
+                                     last_seen_at: 1.day.ago, first_seen_at: 1.day.ago)
+
+    expect { described_class.perform_now }.to change(UserIpAddress, :count).by(-1)
+    expect(UserIpAddress.exists?(fresh.id)).to be(true)
+    expect(UserIpAddress.exists?(stale.id)).to be(false)
+  end
+
+  it "honors a configured retention period" do
+    allow(Danbooru.config.custom_configuration).to receive(:user_ip_retention_period).and_return(30.days)
+    old = create(:user_ip_address, user: user, ip_addr: "203.0.113.3",
+                                   last_seen_at: 60.days.ago, first_seen_at: 60.days.ago)
+
+    expect { described_class.perform_now }.to change { UserIpAddress.exists?(old.id) }.from(true).to(false)
+  end
+end

--- a/spec/logical/user_alt_finder_spec.rb
+++ b/spec/logical/user_alt_finder_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserAltFinder do
+  include_context "as admin"
+
+  let(:now) { Time.now }
+
+  # A shared window wide enough for full dwell weight and overlapping enough for
+  # full proximity, so scores land in a realistic band.
+  def seen(user, ip, first: 40.days.ago, last: 2.days.ago, hits: 10)
+    create(:user_ip_address, user: user, ip_addr: ip, first_seen_at: first, last_seen_at: last, hit_count: hits)
+  end
+
+  describe "#candidates" do
+    it "ranks an exact-IP alt above a subnet-only stranger" do
+      target   = create(:user)
+      alt      = create(:user)
+      stranger = create(:user)
+
+      seen(target, "203.0.113.10")
+      seen(alt, "203.0.113.10")            # exact IP shared with target
+      seen(target, "198.51.100.5")
+      seen(stranger, "198.51.100.200")     # same /24 as the target only
+
+      candidates = described_class.new(target).candidates
+      ids = candidates.pluck(:user_id)
+
+      expect(ids).to include(alt.id, stranger.id)
+      expect(candidates.first[:user_id]).to eq(alt.id)
+
+      alt_score = candidates.find { |c| c[:user_id] == alt.id }[:score]
+      stranger_score = candidates.find { |c| c[:user_id] == stranger.id }[:score]
+      expect(alt_score).to be > stranger_score
+    end
+
+    it "drops values shared by more than the crowded cutoffs" do
+      # Users colliding on one exact IP necessarily share its /24 too, so both
+      # cutoffs must be lowered for the collision to be fully discarded.
+      allow(Danbooru.config.custom_configuration).to receive_messages(alt_finder_max_users_per_ip: 2, alt_finder_max_users_per_subnet: 2)
+      target = create(:user)
+      crowd = create_list(:user, 3)
+
+      seen(target, "203.0.113.50")
+      crowd.each { |u| seen(u, "203.0.113.50") } # 4 distinct users on this IP/subnet (> 2)
+
+      ids = described_class.new(target).candidates.pluck(:user_id)
+      expect(ids).not_to include(*crowd.map(&:id))
+    end
+
+    it "includes deleted accounts, flagged as such" do
+      target = create(:user)
+      alt = create(:user)
+      alt.update_columns(name: "user_#{alt.id}")
+
+      seen(target, "203.0.113.60")
+      seen(alt, "203.0.113.60")
+
+      candidate = described_class.new(target).candidates.find { |c| c[:user_id] == alt.id }
+      expect(candidate).to be_present
+      expect(candidate[:deleted]).to be(true)
+    end
+
+    it "flags the handoff pattern" do
+      target = create(:user, created_at: 90.days.ago)
+      # A fresh account that took over the IP right after the target left it.
+      alt = create(:user, created_at: 6.days.ago)
+
+      seen(target, "203.0.113.70", first: 40.days.ago, last: 8.days.ago)
+      seen(alt, "203.0.113.70", first: 5.days.ago, last: 1.day.ago)
+
+      candidate = described_class.new(target).candidates.find { |c| c[:user_id] == alt.id }
+      expect(candidate[:handoff]).to be(true)
+    end
+  end
+
+  describe "#chains" do
+    it "surfaces an indirect account reachable only through a shared predecessor" do
+      a = create(:user)
+      b = create(:user)
+      c = create(:user)
+
+      seen(a, "203.0.113.10")   # A <-> B on this IP
+      seen(b, "203.0.113.10")
+      seen(b, "198.51.100.10")  # B <-> C on a different IP
+      seen(c, "198.51.100.10")
+
+      finder = described_class.new(a)
+      direct_ids = finder.candidates.pluck(:user_id)
+      expect(direct_ids).to include(b.id)
+      expect(direct_ids).not_to include(c.id) # A and C never shared an IP
+
+      via_b = finder.chains.find { |chain| chain[:via][:user_id] == b.id }
+      expect(via_b).to be_present
+      expect(via_b[:candidates].pluck(:user_id)).to include(c.id)
+    end
+  end
+end

--- a/spec/logical/user_alt_finder_spec.rb
+++ b/spec/logical/user_alt_finder_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe UserAltFinder do
       expect(candidate[:deleted]).to be(true)
     end
 
+    it "flags collision-renamed deleted accounts (user_{id}_{n})" do
+      target = create(:user)
+      alt = create(:user)
+      alt.update_columns(name: "user_#{alt.id}_1")
+
+      seen(target, "203.0.113.65")
+      seen(alt, "203.0.113.65")
+
+      candidate = described_class.new(target).candidates.find { |c| c[:user_id] == alt.id }
+      expect(candidate[:deleted]).to be(true)
+    end
+
     it "does not double-count an exact match's own subnet as subnet-only evidence" do
       target = create(:user)
       alt = create(:user)

--- a/spec/logical/user_alt_finder_spec.rb
+++ b/spec/logical/user_alt_finder_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe UserAltFinder do
       expect(candidate[:deleted]).to be(true)
     end
 
+    it "does not double-count an exact match's own subnet as subnet-only evidence" do
+      target = create(:user)
+      alt = create(:user)
+
+      # The two accounts share exactly one IP and nothing else. Its /24 is not
+      # separate evidence — the exact match already covers that network.
+      seen(target, "203.0.113.80")
+      seen(alt, "203.0.113.80")
+
+      candidate = described_class.new(target).candidates.find { |c| c[:user_id] == alt.id }
+      expect(candidate[:shared_exact]).to eq(1)
+      expect(candidate[:shared_subnet]).to eq(0)
+    end
+
     it "flags the handoff pattern" do
       target = create(:user, created_at: 90.days.ago)
       # A fresh account that took over the IP right after the target left it.

--- a/spec/logical/user_alt_finder_spec.rb
+++ b/spec/logical/user_alt_finder_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe UserAltFinder do
       expect(candidate[:shared_subnet]).to eq(0)
     end
 
+    it "measures the candidate's IP total within the same window as the target" do
+      target = create(:user)
+      alt = create(:user)
+      seen(target, "203.0.113.90")
+      seen(alt, "203.0.113.90") # recent shared IP, inside the window
+      # A stale row beyond the retention window that the prune job hasn't reached
+      # yet must not inflate the ratio denominator.
+      create(:user_ip_address, user: alt, ip_addr: "198.51.100.90",
+                               first_seen_at: 4.years.ago, last_seen_at: 3.years.ago)
+
+      candidate = described_class.new(target).candidates.find { |c| c[:user_id] == alt.id }
+      expect(candidate[:total_ips]).to eq(1)
+    end
+
     it "flags the handoff pattern" do
       target = create(:user, created_at: 90.days.ago)
       # A fresh account that took over the IP right after the target left it.

--- a/spec/logical/user_ip_tracker_spec.rb
+++ b/spec/logical/user_ip_tracker_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserIpTracker do
+  include_context "as member"
+
+  let(:user) { create(:user) }
+
+  # The test env cache is a memory_store (see config/initializers/cache_store.rb),
+  # so the hourly debounce is live. Cases that exercise the upsert's conflict
+  # path stub Cache.fetch to bypass it.
+
+  describe ".track!" do
+    it "inserts a row for a public IP" do
+      expect { described_class.track!(user, "203.0.113.7") }
+        .to change(UserIpAddress, :count).by(1)
+      record = UserIpAddress.last
+      expect(record.user_id).to eq(user.id)
+      expect(record.ip_addr.to_s).to eq("203.0.113.7")
+      expect(record.hit_count).to eq(1)
+    end
+
+    it "increments hit_count and keeps one row on a repeat (debounce bypassed)" do
+      described_class.track!(user, "203.0.113.7")
+      # Clear the debounce key so the second call reaches the upsert's conflict path.
+      Cache.delete("user_ip:#{user.id}:203.0.113.7")
+      expect { described_class.track!(user, "203.0.113.7") }
+        .not_to change(UserIpAddress, :count)
+      expect(UserIpAddress.last.hit_count).to eq(2)
+    end
+
+    it "debounces a repeat within the window, leaving hit_count untouched" do
+      described_class.track!(user, "203.0.113.7")
+      expect { described_class.track!(user, "203.0.113.7") }
+        .not_to change(UserIpAddress, :count)
+      expect(UserIpAddress.last.hit_count).to eq(1)
+    end
+
+    it "skips anonymous users" do
+      expect { described_class.track!(User.anonymous, "203.0.113.7") }
+        .not_to change(UserIpAddress, :count)
+    end
+
+    it "skips when the kill switch is off" do
+      allow(Danbooru.config.custom_configuration).to receive(:enable_user_ip_tracking?).and_return(false)
+      expect { described_class.track!(user, "203.0.113.7") }
+        .not_to change(UserIpAddress, :count)
+    end
+
+    it "skips private, loopback, and link-local addresses" do
+      %w[127.0.0.1 10.0.0.5 192.168.1.1 169.254.1.1 ::1].each do |ip|
+        expect { described_class.track!(user, ip) }
+          .not_to change(UserIpAddress, :count), "expected #{ip} to be skipped"
+      end
+    end
+
+    it "normalizes IPv4-mapped IPv6 to the plain v4 address" do
+      described_class.track!(user, "::ffff:203.0.113.7")
+      expect(UserIpAddress.last.ip_addr.to_s).to eq("203.0.113.7")
+    end
+
+    it "swallows errors so tracking can never break the request" do
+      allow(UserIpAddress).to receive(:upsert).and_raise(ActiveRecord::StatementInvalid, "boom")
+      allow(DanbooruLogger).to receive(:log)
+      expect { described_class.track!(user, "203.0.113.7") }.not_to raise_error
+      expect(DanbooruLogger).to have_received(:log)
+    end
+  end
+end

--- a/spec/models/user_ip_address_spec.rb
+++ b/spec/models/user_ip_address_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserIpAddress do
+  include_context "as member"
+
+  let(:user) { create(:user) }
+
+  describe "the generated subnet column" do
+    it "masks IPv4 to a /24" do
+      record = create(:user_ip_address, user: user, ip_addr: "203.0.113.77")
+      expect(record.reload.subnet.to_s).to eq("203.0.113.0")
+      expect(record.subnet.prefix).to eq(24)
+    end
+
+    it "masks IPv6 to a /64" do
+      record = create(:user_ip_address, user: user, ip_addr: "2001:db8:abcd:1234:aaaa:bbbb:cccc:dddd")
+      expect(record.reload.subnet.to_s).to eq("2001:db8:abcd:1234::")
+      expect(record.subnet.prefix).to eq(64)
+    end
+  end
+
+  describe "uniqueness" do
+    it "rejects a duplicate (user_id, ip_addr) at the database level" do
+      create(:user_ip_address, user: user, ip_addr: "203.0.113.77")
+      expect do
+        create(:user_ip_address, user: user, ip_addr: "203.0.113.77")
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    it "allows the same IP for different users" do
+      other = create(:user)
+      create(:user_ip_address, user: user, ip_addr: "203.0.113.77")
+      expect do
+        create(:user_ip_address, user: other, ip_addr: "203.0.113.77")
+      end.to change(described_class, :count).by(1)
+    end
+  end
+
+  describe "#hidden_attributes" do
+    it "hides both ip_addr and the derived subnet from JSON" do
+      record = create(:user_ip_address, user: user, ip_addr: "203.0.113.77")
+      json = record.as_json
+      expect(json).not_to have_key("ip_addr")
+      expect(json).not_to have_key("subnet")
+    end
+  end
+end

--- a/spec/requests/staff/user_alts_controller_spec.rb
+++ b/spec/requests/staff/user_alts_controller_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Staff::UserAltsController do
+  include_context "as admin"
+
+  let(:moderator) { create(:moderator_user) }
+  let(:member)    { create(:user) }
+  let(:target)    { create(:user) }
+
+  describe "GET /staff/user_alts" do
+    it "redirects anonymous to the login page" do
+      get staff_user_alts_path(user_id: target.id)
+      expect(response).to redirect_to(new_session_path(url: staff_user_alts_path(user_id: target.id)))
+    end
+
+    it "returns 403 for a member" do
+      sign_in_as member
+      get staff_user_alts_path(user_id: target.id)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as a moderator" do
+      before { sign_in_as moderator }
+
+      it "returns 200" do
+        get staff_user_alts_path(user_id: target.id)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "renders the HTML results table with candidates present" do
+        alt = create(:user)
+        create(:user_ip_address, user: target, ip_addr: "203.0.113.40",
+                                 first_seen_at: 30.days.ago, last_seen_at: 2.days.ago, hit_count: 10)
+        create(:user_ip_address, user: alt, ip_addr: "203.0.113.40",
+                                 first_seen_at: 5.days.ago, last_seen_at: 1.day.ago, hit_count: 8)
+
+        get staff_user_alts_path(user_id: target.id)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(user_path(alt)) # candidate row rendered
+        expect(response.body).not_to include("203.0.113")
+      end
+
+      it "renders candidates without exposing any IP or subnet value in JSON" do
+        alt = create(:user)
+        create(:user_ip_address, user: target, ip_addr: "203.0.113.40",
+                                 first_seen_at: 30.days.ago, last_seen_at: 2.days.ago, hit_count: 10)
+        create(:user_ip_address, user: alt, ip_addr: "203.0.113.40",
+                                 first_seen_at: 5.days.ago, last_seen_at: 1.day.ago, hit_count: 8)
+
+        get staff_user_alts_path(user_id: target.id, format: :json)
+        expect(response).to have_http_status(:ok)
+
+        body = response.parsed_body
+        expect(body).to be_an(Array)
+        expect(body.pluck("user_id")).to include(alt.id)
+        body.each do |candidate|
+          expect(candidate).not_to have_key("ip_addr")
+          expect(candidate).not_to have_key("subnet")
+          expect(candidate["user"]).not_to have_key("ip_addr")
+        end
+        # No IP octet leaks anywhere in the payload.
+        expect(response.body).not_to include("203.0.113")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Moderators notably don't have access to user IPs, which makes finding alts almost impossible.
Having to poke an admin every time you suspect someone of ban evading is also not ideal.
Besides, the IP search tools are fascinatingly terrible.

This PR adds a single aggregate table `user_ip_addresses`, unique on `(user_id, ip_addr)`.
It's populated by one hook in SessionLoader on every authenticated request, debounced through Memcached.

A similarity search then takes a user ID, and returns candidate alts ranked by a score built from shared IPs and subnets.
This utility is accessible to moderators.