### PR TITLE
[Users] Add back a manual "unlimited uploads" account flag

### DIFF
--- a/app/blueprints/user_include_blueprint.rb
+++ b/app/blueprints/user_include_blueprint.rb
@@ -22,7 +22,7 @@ class UserIncludeBlueprint < Blueprinter::Base
   field :can do |user|
     {
       approve_posts: user.can_approve_posts?,
-      upload_free: user.upload_karma_free?,
+      upload_free: user.upload_free?,
     }
   end
 

--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -65,7 +65,7 @@ class UploadService
       p.is_animated = animated
       p.duration = upload.video_duration(upload.file.path, animated: animated)
 
-      if !upload.uploader.upload_karma_free? || (!upload.uploader.can_approve_posts? && p.avoid_posting_tags.any?) || upload.upload_as_pending?
+      if !upload.uploader.upload_free? || (!upload.uploader.can_approve_posts? && p.avoid_posting_tags.any?) || upload.upload_as_pending?
         p.is_pending = true
       end
     end

--- a/app/logical/user_promotion.rb
+++ b/app/logical/user_promotion.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserPromotion
-  attr_reader :user, :promoter, :new_level, :options, :old_can_approve_posts, :old_no_flagging, :old_replacements_beta, :old_tag_warden, :old_raised_favorite_limit
+  attr_reader :user, :promoter, :new_level, :options, :old_can_approve_posts, :old_can_upload_free, :old_no_flagging, :old_replacements_beta, :old_tag_warden, :old_raised_favorite_limit
 
   def initialize(user, promoter, new_level, options = {})
     @user = user
@@ -14,6 +14,7 @@ class UserPromotion
     validate
 
     @old_can_approve_posts = user.can_approve_posts?
+    @old_can_upload_free = user.can_upload_free?
     @old_no_flagging = user.no_flagging?
     @old_replacements_beta = user.replacements_beta?
     @old_tag_warden = user.tag_warden?
@@ -23,6 +24,10 @@ class UserPromotion
 
     if options.key?(:can_approve_posts)
       user.can_approve_posts = options[:can_approve_posts]
+    end
+
+    if options.key?(:can_upload_free)
+      user.can_upload_free = options[:can_upload_free]
     end
 
     if options.key?(:tag_warden)
@@ -64,6 +69,7 @@ class UserPromotion
     removed = []
 
     flag_check(added, removed, "can_approve_posts", "approve posts")
+    flag_check(added, removed, "can_upload_free", "unlimited uploads")
     flag_check(added, removed, "no_flagging", "flag ban")
     flag_check(added, removed, "replacements_beta", "replacements beta")
     flag_check(added, removed, "tag_warden", "tag warden")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
   # ================================================================================================#
   # The following flags have corresponding database indexes:                                        #
   # * can_approve_posts                                                                             #
+  # * can_upload_free                                                                               #
   # ================================================================================================#
 
   # ================================================================================================#
@@ -32,6 +33,7 @@ class User < ApplicationRecord
   # * _no_feedback -> no_uploading                                                                  #
   # * _is_banned -> tag_warden                                                                      #
   # * _disable_post_tooltips -> no_karma_free                                                       #
+  # * _can_upload_free -> can_upload_free (reinstated, same meaning)                                #
   # ================================================================================================#
 
   BOOLEAN_ATTRIBUTES = %w[
@@ -51,7 +53,7 @@ class User < ApplicationRecord
     enable_auto_complete
     _has_saved_searches
     can_approve_posts
-    _can_upload_free
+    can_upload_free
     _disable_cropped_thumbnails
     _disable_mobile_gestures
     enable_safe_mode
@@ -703,7 +705,7 @@ class User < ApplicationRecord
         :REJ_UPLOAD_DISABLED
       elsif hourly_upload_limit <= 0 && !Danbooru.config.disable_throttles?
         :REJ_UPLOAD_HOURLY
-      elsif upload_karma_free?
+      elsif upload_free?
         true
       elsif can_approve_posts?
         true
@@ -867,6 +869,14 @@ class User < ApplicationRecord
       upload_karma_level >= Danbooru.config.upload_karma_free_threshold
     end
 
+    # Effective queue bypass. The staff bypass-ban (no_karma_free) beats the manual
+    # staff grant (can_upload_free), which works even when
+    # upload_karma_free_threshold is nil (karma auto-bypass disabled site-wide).
+    def upload_free?
+      return false if no_karma_free?
+      can_upload_free? || upload_karma_free?
+    end
+
     private
 
     def max_karma_level = 10
@@ -886,7 +896,7 @@ class User < ApplicationRecord
       list = super + %i[
         id created_at name level base_upload_limit upload_karma upload_karma_free?
         post_upload_count post_update_count note_update_count
-        is_banned can_approve_posts
+        is_banned can_approve_posts can_upload_free
         level_string avatar_id is_verified?
         has_cropped_avatar?
       ]
@@ -898,7 +908,7 @@ class User < ApplicationRecord
           is_banned receive_email_notifications
           enable_keyboard_navigation enable_privacy_mode
           style_usernames enable_auto_complete
-          can_approve_posts
+          can_approve_posts can_upload_free
           enable_safe_mode
           disable_responsive_mode no_flagging disable_user_dmails
           enable_compact_uploader replacements_beta forum_notification_dot
@@ -1119,7 +1129,7 @@ class User < ApplicationRecord
       include_mask = 0
       exclude_mask = 0
 
-      %i[can_approve_posts].each do |x|
+      %i[can_approve_posts can_upload_free].each do |x|
         next if params[x].blank?
         attr_idx = BOOLEAN_ATTRIBUTES.index(x.to_s)
         next if attr_idx.nil?

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -35,6 +35,10 @@ class UserPresenter
       permissions << "approve posts"
     end
 
+    if user.can_upload_free?
+      permissions << "unrestricted uploads"
+    end
+
     if user.replacements_beta?
       permissions << "replacements beta"
     end
@@ -59,7 +63,7 @@ class UserPresenter
   end
 
   def upload_limit(template)
-    if user.upload_karma_free?
+    if user.upload_free?
       return "none"
     end
 
@@ -73,7 +77,7 @@ class UserPresenter
 
   def upload_limit_short
     return "0 / 0" if user.no_uploading?
-    return "none" if user.upload_karma_free?
+    return "none" if user.upload_free?
     "#{user.upload_slots} / #{user.upload_slots_max}"
   end
 

--- a/app/views/staff/users/edit.html.erb
+++ b/app/views/staff/users/edit.html.erb
@@ -41,6 +41,11 @@
       <% end %>
 
       <div class="input">
+        <label for="user_can_upload_free" class="optional">Unrestricted Uploads</label>
+        <%= select(:user, :can_upload_free, [["Yes", true], ["No", false]]) %>
+      </div>
+
+      <div class="input">
         <label for="user_tag_warden" class="optional">Tag Warden</label>
         <%= select(:user, :tag_warden, [["Yes", true], ["No", false]]) %>
       </div>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -18,7 +18,7 @@
     data-recent-tags="<%= html_escape(CurrentUser.presenter.recent_tags_with_types.to_json) %>"
     data-allow-locked-tags="<%= CurrentUser.is_admin? %>"
     data-allow-rating-lock="<%= CurrentUser.is_privileged? %>"
-    data-allow-upload-as-pending="<%= CurrentUser.upload_karma_free? %>"
+    data-allow-upload-as-pending="<%= CurrentUser.upload_free? %>"
     data-max-file-size="<%= Danbooru.config.max_file_size %>"
     data-max-file-size-map="<%= html_escape(Danbooru.config.max_file_sizes.to_json) %>"
     data-verified-artist-tags="<%= html_escape(CurrentUser.user.artists.pluck(:name).to_json) %>"
@@ -28,7 +28,7 @@
       Your ability to upload posts had been manually disabled by a staff member.<br />
       If you believe that this was done in error, <%= link_to "contact an admin", show_or_new_wiki_pages_path(title: "e621:staff") %> to have this situation resolved.
     </div>
-  <% elsif (!CurrentUser.upload_karma_free? && CurrentUser.upload_slots <= 5) || CurrentUser.post_upload_throttle <= 5 %>
+  <% elsif (!CurrentUser.upload_free? && CurrentUser.upload_slots <= 5) || CurrentUser.post_upload_throttle <= 5 %>
     <% @limit_pieces = CurrentUser.upload_slots_pieces %>
     <div id="post-uploads-remaining" class="box-section section<% if [CurrentUser.upload_slots, CurrentUser.post_upload_throttle].min <= 0 %> background-red<% end %>">
       <p>

--- a/app/views/users/_search.html.erb
+++ b/app/views/users/_search.html.erb
@@ -12,6 +12,7 @@
   <%= f.input :max_level, collection: User.level_hash.to_a, include_blank: "Any" %>
 
   <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
+  <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
 
   <%= f.input :order, collection: [["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]], include_blank: "Join Date" %>
 <% end %>

--- a/app/views/users/partials/show/_staff_info.html.erb
+++ b/app/views/users/partials/show/_staff_info.html.erb
@@ -43,6 +43,9 @@
         <% else %>
           <%= link_to "Enabled", toggle_uploads_user_path(user) %>
         <% end %>
+        <% if user.can_upload_free? %>
+          | <span class="text-bold" title="Unrestricted uploads manually granted by an admin. Change via the staff edit page.">Unrestricted</span>
+        <% end %>
         <% if !Danbooru.config.upload_karma_free_threshold.nil? && (user.upload_karma_level >= Danbooru.config.upload_karma_free_threshold || user.no_karma_free) %>
           | 
           <% if user.no_karma_free %>

--- a/app/views/users/upload_limit.html.erb
+++ b/app/views/users/upload_limit.html.erb
@@ -36,8 +36,11 @@
         <% end %>
       </p>
 
-      <% if @user.upload_karma_free? %>
+      <% if @user.upload_free? %>
         <p><%= is_current_user ? "Your" : "This user's" %> uploads bypass the review queue and are posted directly as approved.</p>
+        <% if @user.can_upload_free? && !@user.upload_karma_free? %>
+          <p>This ability was manually granted by a staff member<%= karma_threshold_enabled ? ", independent of upload karma" : "" %>.</p>
+        <% end %>
       <% else %>
         <p>
           <%= is_current_user ? "You" : link_to_user(@user) %> currently
@@ -125,7 +128,7 @@
       </p>
       <ul>
         <li>Remaining hourly uploads: <%= CurrentUser.hourly_upload_limit %></li>
-        <% unless CurrentUser.upload_karma_free? || CurrentUser.is_privileged? %>
+        <% unless CurrentUser.upload_free? || CurrentUser.is_privileged? %>
           <li>Remaining hourly tag edits: <%= CurrentUser.post_edit_limit %></li>
         <% end %>
       </ul>

--- a/spec/blueprints/user_include_blueprint_spec.rb
+++ b/spec/blueprints/user_include_blueprint_spec.rb
@@ -34,7 +34,23 @@ RSpec.describe UserIncludeBlueprint do
 
     it "reflects the user's permissions" do
       expect(result[:can][:approve_posts]).to eq(user.can_approve_posts?)
-      expect(result[:can][:upload_free]).to eq(user.upload_karma_free?)
+      expect(result[:can][:upload_free]).to eq(user.upload_free?)
+    end
+
+    context "when the user has a manual unlimited-uploads grant" do
+      let(:user) { create(:user, can_upload_free: true) }
+
+      it "serializes upload_free as true" do
+        expect(result[:can][:upload_free]).to be true
+      end
+    end
+
+    context "when a manual grantee is bypass-banned" do
+      let(:user) { create(:user, can_upload_free: true, no_karma_free: true) }
+
+      it "serializes upload_free as false" do
+        expect(result[:can][:upload_free]).to be false
+      end
     end
   end
 

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -279,7 +279,7 @@ RSpec.describe UploadService do
 
     context "is_pending? logic" do
       it "marks post as pending when uploader is below the karma free threshold" do
-        allow(upload.uploader).to receive(:upload_karma_free?).and_return(false)
+        allow(upload.uploader).to receive(:upload_free?).and_return(false)
         expect(service.convert_to_post(upload).is_pending).to be true
       end
 
@@ -287,21 +287,35 @@ RSpec.describe UploadService do
         artist = create(:artist)
         create(:avoid_posting, artist: artist)
         upload.tag_string = artist.name
-        allow(upload.uploader).to receive_messages(upload_karma_free?: true, can_approve_posts?: false)
+        allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: false)
         expect(service.convert_to_post(upload).is_pending).to be true
       end
 
       it "marks post as pending when upload_as_pending? is true" do
-        allow(upload.uploader).to receive_messages(upload_karma_free?: true, can_approve_posts?: true)
+        allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: true)
         allow(upload).to receive(:upload_as_pending?).and_return(true)
         expect(service.convert_to_post(upload).is_pending).to be true
       end
 
       it "does not mark post as pending when no pending conditions apply" do
-        allow(upload.uploader).to receive_messages(upload_karma_free?: true, can_approve_posts?: true)
+        allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: true)
         allow(upload).to receive(:upload_as_pending?).and_return(false)
         # upload.tag_string is "tagme" which has no artist tags, so avoid_posting_tags is []
         expect(service.convert_to_post(upload).is_pending).to be false
+      end
+
+      it "does not mark post as pending for a manual grantee even when karma bypass is disabled" do
+        allow(Danbooru.config.custom_configuration).to receive(:upload_karma_free_threshold).and_return(nil)
+        upload.uploader.update(can_upload_free: true)
+        expect(service.convert_to_post(upload).is_pending).to be false
+      end
+
+      it "marks post as pending for a manual grantee with avoid_posting tags who cannot approve" do
+        artist = create(:artist)
+        create(:avoid_posting, artist: artist)
+        upload.tag_string = artist.name
+        upload.uploader.update(can_upload_free: true)
+        expect(service.convert_to_post(upload).is_pending).to be true
       end
     end
 

--- a/spec/models/user/karma_methods_spec.rb
+++ b/spec/models/user/karma_methods_spec.rb
@@ -145,5 +145,43 @@ RSpec.describe User do
       user.no_karma_free = true
       expect(user.upload_karma_free?).to be false
     end
+
+    it "is not affected by the manual can_upload_free grant" do
+      user.can_upload_free = true
+      expect(user.upload_karma_free?).to be false
+    end
+  end
+
+  # -------------------------------------------------------------------------
+  # #upload_free?
+  # -------------------------------------------------------------------------
+  describe "#upload_free?" do
+    let(:upload_free_karma_threshold) { user.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) }
+
+    it "is false for a user with no karma and no grant" do
+      expect(user.upload_free?).to be false
+    end
+
+    it "is true with the manual grant and zero karma" do
+      user.can_upload_free = true
+      expect(user.upload_free?).to be true
+    end
+
+    it "is true with the manual grant when the threshold is nil" do
+      allow(Danbooru.config.custom_configuration).to receive(:upload_karma_free_threshold).and_return(nil)
+      user.can_upload_free = true
+      expect(user.upload_free?).to be true
+    end
+
+    it "is false when no_karma_free is set even with the manual grant" do
+      user.can_upload_free = true
+      user.no_karma_free = true
+      expect(user.upload_free?).to be false
+    end
+
+    it "is true via earned karma without the manual grant" do
+      set_karma(user, upload_free_karma_threshold)
+      expect(user.upload_free?).to be true
+    end
   end
 end

--- a/spec/models/user/upload_methods_spec.rb
+++ b/spec/models/user/upload_methods_spec.rb
@@ -76,5 +76,27 @@ RSpec.describe User do
       member.reload
       expect(member.can_upload_with_reason).to eq(:REJ_UPLOAD_LIMIT)
     end
+
+    it "allows a manual grantee to bypass the queue with zero slots" do
+      member = create(:user, can_upload_free: true)
+      member.user_status.update_columns(post_replacement_rejected_count: 100)
+      member.reload
+      expect(member.can_upload_with_reason).to be true
+    end
+
+    it "allows a manual grantee when the karma threshold is nil" do
+      allow(Danbooru.config.custom_configuration).to receive(:upload_karma_free_threshold).and_return(nil)
+      member = create(:user, can_upload_free: true)
+      member.user_status.update_columns(post_replacement_rejected_count: 100)
+      member.reload
+      expect(member.can_upload_with_reason).to be true
+    end
+
+    it "returns :REJ_UPLOAD_LIMIT for a granted-but-banned user who is out of slots" do
+      member = create(:user, can_upload_free: true, no_karma_free: true)
+      member.user_status.update_columns(post_replacement_rejected_count: 100)
+      member.reload
+      expect(member.can_upload_with_reason).to eq(:REJ_UPLOAD_LIMIT)
+    end
   end
 end

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -154,6 +154,27 @@ RSpec.describe Staff::UsersController do
         end.not_to(change { ModAction.where(action: "user_karma_change").count })
       end
 
+      it "grants can_upload_free and logs a user_flags_change ModAction" do
+        patch staff_user_path(user), params: { user: { level: user.level, can_upload_free: "true" } }
+        expect(user.reload.can_upload_free?).to be true
+        mod = ModAction.where(action: "user_flags_change").last
+        expect(mod[:values]).to include("user_id" => user.id, "added" => ["unlimited uploads"], "removed" => [])
+      end
+
+      it "revokes can_upload_free and logs a user_flags_change ModAction" do
+        target = create(:user, can_upload_free: true)
+        patch staff_user_path(target), params: { user: { level: target.level, can_upload_free: "false" } }
+        expect(target.reload.can_upload_free?).to be false
+        mod = ModAction.where(action: "user_flags_change").last
+        expect(mod[:values]).to include("user_id" => target.id, "added" => [], "removed" => ["unlimited uploads"])
+      end
+
+      it "does not log user_flags_change when can_upload_free is unchanged" do
+        expect do
+          patch staff_user_path(user), params: { user: { level: user.level, can_upload_free: "false" } }
+        end.not_to(change { ModAction.where(action: "user_flags_change").count })
+      end
+
       it "creates a UserNameChangeRequest when a new name is given" do
         expect do
           patch staff_user_path(user), params: { user: { profile_about: "x", name: "brand_new_name_abc" } }


### PR DESCRIPTION
By popular demand.

Allows users to bypass the approval queue without meeting the karma requirements.
Especially useful for sites that don't have the karma threshold enabled for that.