### PR TITLE
[PostReplacements] Make "current" replacement more clear

### DIFF
--- a/app/components/post_replacement_card_component.html.erb
+++ b/app/components/post_replacement_card_component.html.erb
@@ -1,6 +1,6 @@
 <div
   id="replacement-<%= replacement.id %>"
-  class="replacement-card is-<%= status_variant %><%= " is-expanded" if @expanded %><%= " has-timeline" if @timeline %>"
+  class="<%= card_classes %>"
   data-replacement-id="<%= replacement.id %>"
   role="group"
   aria-labelledby="replacement-<%= replacement.id %>-title"

--- a/app/components/post_replacement_card_component.rb
+++ b/app/components/post_replacement_card_component.rb
@@ -44,6 +44,17 @@ class PostReplacementCardComponent < ViewComponent::Base
     end
   end
 
+  def card_classes
+    classes = ["replacement-card"]
+
+    classes << "is-#{status_variant}" if status_variant.present?
+    classes << "is-current" if replacement.is_current?
+    classes << "is-expanded" if @expanded
+    classes << "has-timeline" if @timeline
+
+    classes.join(" ")
+  end
+
   def highlighted_tags
     return [] unless replacement.is_pending?
 

--- a/app/javascript/src/js/pages/post_replacements/post_replacement.js
+++ b/app/javascript/src/js/pages/post_replacements/post_replacement.js
@@ -61,6 +61,7 @@ PostReplacement.approve = function (id, penalize_current_uploader) {
   })
     .done((html) => {
       E621.Toast.notice("Replacement approved.");
+      $(".is-current").removeClass("is-current");
       replace_row($row, html);
     })
     .fail((data) => {

--- a/app/javascript/src/styles/components/post_replacement_card_component.scss
+++ b/app/javascript/src/styles/components/post_replacement_card_component.scss
@@ -58,8 +58,12 @@ $replacement-variants: (
     display: flex;
     justify-content: center;
     align-items: center;
+  }
 
-    &.is-current{
+  &.is-current {
+    border-color: palette("background-gold");
+
+    .replacement-dot {
       outline: 2px solid themed("color-section");
 
       &::before {
@@ -127,12 +131,12 @@ $replacement-variants: (
   height: 100%;
   border-top: 1px solid themed("color-section");
   background-color: transparent;
-  padding: 0.5rem 0;
 
   img {
     max-width: 256px;
     max-height: 256px;
-    padding: 0.5rem 0;
+    padding: 0.5rem;
+    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
<img width="1331" height="424" alt="image" src="https://github.com/user-attachments/assets/8de98e0c-d715-44d3-8403-1e026fc87386" />
