### PR TITLE
[Posts] Fix karma crediting inconsistencies

### DIFF
--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -40,6 +40,10 @@ class UploadService
     @post.save!
     @post.reload
 
+    # Posts that bypass the review queue never pass through approve!, so karma is credited here instead.
+    # Mirrors the +1 awarded by approve! for queued posts.
+    UserStatus.for_user(@post.uploader_id).update_all("upload_karma = upload_karma + 1") unless @post.is_pending?
+
     upload.update(status: "completed", post_id: @post.id)
 
     @post

--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -50,7 +50,8 @@ class UploadService
         previous_md5 = post.md5
         previous_file_ext = post.file_ext
 
-        previous_pending = post.is_pending? # Drives the replacer's +1 credit (see below).
+        previous_pending = post.is_pending? # Drives the replacer's +1 credit
+        reverting = replacement.status.in?(%w[approved original]) # Drives revert logic
 
         post.md5 = upload.md5
         post.file_ext = upload.file_ext
@@ -85,12 +86,17 @@ class UploadService
           UserStatus.for_user(previous_uploader).update_all("upload_karma = upload_karma - 3")
         end
 
-        # The replacer earns karma only when replacing another user's post, and only once the
-        # post is live: a pending post is worth 0 to its uploader until approval (which pays the
-        # +1 itself), so crediting here as well would double-count. Mirrors the not-pending guard
-        # in UploadService#create_post_from_upload.
+        # The live post's +1 credit follows ownership: previous owner loses it, new one gets it.
+        # Skipped when the post is still pending.
         if replacement.creator_id != previous_uploader && !previous_pending
+          UserStatus.for_user(previous_uploader).update_all("upload_karma = upload_karma - 1")
           UserStatus.for_user(replacement.creator_id).update_all("upload_karma = upload_karma + 1")
+        end
+
+        # Reset-to must revert any penalty that the previous version carried.
+        if reverting
+          retiring = post.replacements.approved.find_by(md5: previous_md5)
+          retiring.toggle_penalize! if retiring&.penalize_uploader_on_approve? && retiring.id != replacement.id
         end
 
         # Invalidate avatar cache

--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -50,6 +50,8 @@ class UploadService
         previous_md5 = post.md5
         previous_file_ext = post.file_ext
 
+        previous_pending = post.is_pending? # Drives the replacer's +1 credit (see below).
+
         post.md5 = upload.md5
         post.file_ext = upload.file_ext
         post.image_width = upload.image_width
@@ -82,8 +84,12 @@ class UploadService
           # Karma penalty for the previous uploader, in step with the penalize counter.
           UserStatus.for_user(previous_uploader).update_all("upload_karma = upload_karma - 3")
         end
-        # The replacer earns karma only when replacing another user's post.
-        if replacement.creator_id != previous_uploader
+
+        # The replacer earns karma only when replacing another user's post, and only once the
+        # post is live: a pending post is worth 0 to its uploader until approval (which pays the
+        # +1 itself), so crediting here as well would double-count. Mirrors the not-pending guard
+        # in UploadService#create_post_from_upload.
+        if replacement.creator_id != previous_uploader && !previous_pending
           UserStatus.for_user(replacement.creator_id).update_all("upload_karma = upload_karma + 1")
         end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1661,6 +1661,9 @@ class Post < ApplicationRecord
         reason = pending_flag.reason
       end
 
+      # Capture whether the post held a +1 upload-karma credit *before* the update below clears it.
+      was_credited = !is_pending?
+
       force_flag = options.fetch(:force, false)
       Post.with_timeout(30_000) do
         transaction do
@@ -1685,10 +1688,15 @@ class Post < ApplicationRecord
       # XXX This must happen *after* the `is_deleted` flag is set to true (issue #3419).
       # We don't care if these fail per-se so they are outside the transaction.
       UserStatus.for_user(uploader_id).update_all("post_deleted_count = post_deleted_count + 1")
-      # Penalize the uploader for a deleted post (includes auto-deletions). Takedowns
-      # pass skip_karma: the removal reflects the artist's wishes, not the uploader's conduct.
+
+      # Penalize the uploader for a deleted post (includes auto-deletions).
+      # A post that had cleared the queue also carried a +1 credit, so deleting it reverses that
+      # credit on top of the -3 penalty (-4 total); a still-pending post never earned the credit,
+      # so it is only the -3 penalty.
+      # Takedowns pass skip_karma: removal reflects the artist's wishes, not the uploader's conduct.
       unless options[:skip_karma]
-        UserStatus.for_user(uploader_id).update_all("upload_karma = upload_karma - 3")
+        penalty = was_credited ? 4 : 3
+        UserStatus.for_user(uploader_id).update_all("upload_karma = upload_karma - #{penalty}")
       end
       give_favorites_to_parent if options[:move_favorites]
       give_post_sets_to_parent if options[:move_favorites]
@@ -1714,8 +1722,6 @@ class Post < ApplicationRecord
         return
       end
 
-      was_approved = approver_id.present?
-
       transaction do
         self.is_deleted = false
         self.is_pending = false
@@ -1730,11 +1736,12 @@ class Post < ApplicationRecord
       User.where(avatar_id: id).pluck(:id).each { |uid| UserAvatarUrlCache.invalidate(uid) }
       UserStatus.for_user(uploader_id).update_all("post_deleted_count = post_deleted_count - 1")
 
-      # Reverse the deletion penalty when the post is restored (symmetric with delete!).
-      # skip_karma restores from a takedown, which never applied the penalty in the first place.
+      # A restored post is always approved (undelete clears is_pending and sets an approver),
+      # so it is always worth +1. delete! drove every deleted post down to -3 (reversing the
+      # +1 credit for posts that had one), so a flat +4 here lands the post back at +1 in every
+      # case. skip_karma restores from a takedown, which never applied the penalty to begin with.
       unless options[:skip_karma]
-        delta = was_approved ? 3 : 4
-        UserStatus.for_user(uploader_id).update_all("upload_karma = upload_karma + #{delta}")
+        UserStatus.for_user(uploader_id).update_all("upload_karma = upload_karma + 4")
       end
     end
 

--- a/spec/jobs/takedown_job_spec.rb
+++ b/spec/jobs/takedown_job_spec.rb
@@ -119,11 +119,12 @@ RSpec.describe TakedownJob do
 
       it "restores karma when reversing a deletion that was not a takedown" do
         post = create(:post, approver: create(:admin_user))
-        # Deleted for an unrelated reason: the -3 penalty was applied and should be reversed.
+        # Deleted for an unrelated reason: the deletion penalty was applied (-4 for this
+        # credited post) and undeletion reverses it with a flat +4.
         post.delete!("inferior quality", force: true)
         takedown = create(:takedown_with_post, post: post)
         expect { perform(takedown) }
-          .to change { post.uploader.user_status.reload.upload_karma }.by(3)
+          .to change { post.uploader.user_status.reload.upload_karma }.by(4)
         expect(post.reload.is_deleted?).to be false
       end
     end

--- a/spec/logical/upload_service/replacer_spec.rb
+++ b/spec/logical/upload_service/replacer_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Exercises the upload-karma side effects of UploadService::Replacer#process!, which are
+# otherwise uncovered: PostReplacement#approve! specs mock the Replacer, and the request specs
+# mock approve!. The file pipeline (Upload creation + processing, storage, sample/iqdb work) is
+# stubbed so the spec isolates the karma bookkeeping.
+RSpec.describe UploadService::Replacer do
+  include_context "as admin"
+
+  let(:uploader)      { create(:user) } # original post uploader / previous uploader
+  let(:replacer_user) { create(:user) } # suggests + owns the replacement
+  let(:post)          { create(:post, uploader: uploader) }
+  let(:storage)       { instance_spy(StorageManager) }
+
+  before do
+    allow(Danbooru.config.custom_configuration).to receive_messages(storage_manager: storage)
+    # Keep post creation off the real storage: skip the AI check and make the thumbnail/AI
+    # file lookups resolve to a (non-existent) string path so callbacks return early.
+    allow(Setting).to receive_messages(automatic_ai_check: false)
+    allow(storage).to receive(:post_file_path).and_return("/tmp/replacer_spec_no_such_file")
+  end
+
+  # Runs the real process! control flow (including its karma updates) with the file machinery
+  # stubbed. The stubbed upload carries the post's own md5/dimensions so md5_changed is false
+  # and the file-cleanup branch is skipped.
+  def process!(replacement, penalize:)
+    upload = build(:upload,
+                   uploader:     replacer_user,
+                   md5:          post.md5,
+                   file_ext:     post.file_ext,
+                   image_width:  post.image_width,
+                   image_height: post.image_height,
+                   file_size:    post.file_size,
+                   tag_string:   post.tag_string)
+    file_stub = instance_double(File, path: "/tmp/replacer_spec_no_such_file")
+    allow(upload).to receive_messages(
+      invalid?: false, is_errored?: false, save!: true, update: true,
+      file: file_stub, is_animated_file?: false, video_duration: nil
+    )
+    allow(upload).to receive(:file=)
+    allow(Upload).to receive(:create).and_return(upload)
+    allow(UploadService::Utils).to receive(:get_file_for_upload).and_return(file_stub)
+    allow(UploadService::Utils).to receive(:process_file)
+    allow(post).to receive(:update_iqdb_async)
+
+    described_class.new(post: post, replacement: replacement).process!(penalize_current_uploader: penalize)
+  end
+
+  context "replacing another user's live post" do
+    let(:replacement) { create(:post_replacement, post: post, creator: replacer_user) }
+
+    it "credits the replacer +1" do
+      expect { process!(replacement, penalize: false) }
+        .to change { replacer_user.user_status.reload.upload_karma }.by(1)
+    end
+
+    it "penalizes the previous uploader -3 when the penalty is set" do
+      expect { process!(replacement, penalize: true) }
+        .to change { uploader.user_status.reload.upload_karma }.by(-3)
+    end
+
+    it "does not penalize the previous uploader when the penalty is not set" do
+      expect { process!(replacement, penalize: false) }
+        .not_to(change { uploader.user_status.reload.upload_karma })
+    end
+
+    it "records the penalty flag and previous uploader so toggle_penalize! reverses symmetrically" do
+      process!(replacement, penalize: true)
+      expect(replacement.reload.penalize_uploader_on_approve).to be true
+      expect(replacement.uploader_id_on_approve).to eq(uploader.id)
+    end
+  end
+
+  context "replacing one's own post" do
+    let(:replacement) { create(:post_replacement, post: post, creator: uploader) }
+
+    it "does not credit the replacer" do
+      expect { process!(replacement, penalize: false) }
+        .not_to(change { uploader.user_status.reload.upload_karma })
+    end
+  end
+
+  context "replacing a post that is still pending" do
+    let(:replacement) { create(:post_replacement, post: post, creator: replacer_user) }
+
+    before { post.update_columns(is_pending: true) }
+
+    it "does not credit the replacer yet (the +1 is paid on the post's approval instead)" do
+      expect { process!(replacement, penalize: false) }
+        .not_to(change { replacer_user.user_status.reload.upload_karma })
+    end
+
+    it "credits the replacer exactly once, on the post's eventual approval" do
+      process!(replacement, penalize: false)
+      expect(post.reload.uploader_id).to eq(replacer_user.id)
+      expect { post.approve! }
+        .to change { replacer_user.user_status.reload.upload_karma }.by(1)
+    end
+  end
+end

--- a/spec/logical/upload_service/replacer_spec.rb
+++ b/spec/logical/upload_service/replacer_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe UploadService::Replacer do
     # file lookups resolve to a (non-existent) string path so callbacks return early.
     allow(Setting).to receive_messages(automatic_ai_check: false)
     allow(storage).to receive(:post_file_path).and_return("/tmp/replacer_spec_no_such_file")
+    # The retired-penalty reversal on reset-to routes through toggle_penalize!, which logs one.
+    allow(PostEvent).to receive(:add)
   end
 
   # Runs the real process! control flow (including its karma updates) with the file machinery
@@ -51,25 +53,87 @@ RSpec.describe UploadService::Replacer do
   context "replacing another user's live post" do
     let(:replacement) { create(:post_replacement, post: post, creator: replacer_user) }
 
-    it "credits the replacer +1" do
+    it "transfers the ownership +1: -1 from the previous owner, +1 to the replacer" do
       expect { process!(replacement, penalize: false) }
-        .to change { replacer_user.user_status.reload.upload_karma }.by(1)
+        .to change { uploader.user_status.reload.upload_karma }.by(-1)
+        .and change { replacer_user.user_status.reload.upload_karma }.by(1)
     end
 
-    it "penalizes the previous uploader -3 when the penalty is set" do
+    it "additionally penalizes the previous owner when penalized (-4 total: -1 transfer, -3 penalty)" do
       expect { process!(replacement, penalize: true) }
-        .to change { uploader.user_status.reload.upload_karma }.by(-3)
+        .to change { uploader.user_status.reload.upload_karma }.by(-4)
     end
 
-    it "does not penalize the previous uploader when the penalty is not set" do
-      expect { process!(replacement, penalize: false) }
-        .not_to(change { uploader.user_status.reload.upload_karma })
+    it "still credits the replacer +1 when penalized" do
+      expect { process!(replacement, penalize: true) }
+        .to change { replacer_user.user_status.reload.upload_karma }.by(1)
     end
 
     it "records the penalty flag and previous uploader so toggle_penalize! reverses symmetrically" do
       process!(replacement, penalize: true)
       expect(replacement.reload.penalize_uploader_on_approve).to be true
       expect(replacement.uploader_id_on_approve).to eq(uploader.id)
+    end
+  end
+
+  context "reset-to (handing ownership back to a previous version)" do
+    # The post is currently owned by replacer_user (their replacement is live); resetting to the
+    # original backup (created by `uploader`) must MOVE the +1 back, not mint a duplicate.
+    let(:original) { create(:original_post_replacement, post: post, creator: uploader, md5: SecureRandom.hex(16)) }
+
+    before { post.update_columns(uploader_id: replacer_user.id) }
+
+    it "transfers the ownership +1 back: -1 from the current owner, +1 to the restored owner" do
+      expect { process!(original, penalize: false) }
+        .to change { replacer_user.user_status.reload.upload_karma }.by(-1)
+        .and change { uploader.user_status.reload.upload_karma }.by(1)
+    end
+
+    context "when the retired replacement had penalized the previous uploader" do
+      # replacer_user's currently-live replacement penalized `uploader` (-3). Reverting to the
+      # original must hand that penalty back, not leave `uploader` stuck -3.
+      let!(:retired) do
+        create(:post_replacement, post: post, creator: replacer_user, status: "approved",
+                                  md5: post.md5, penalize_uploader_on_approve: true,
+                                  uploader_id_on_approve: uploader.id)
+      end
+
+      it "returns the penalty (+3) on top of the ownership +1 (+4 total to the restored uploader)" do
+        expect { process!(original, penalize: false) }
+          .to change { uploader.user_status.reload.upload_karma }.by(4)
+          .and change { replacer_user.user_status.reload.upload_karma }.by(-1)
+      end
+
+      it "clears the penalty flag on the retired replacement" do
+        process!(original, penalize: false)
+        expect(retired.reload.penalize_uploader_on_approve).to be false
+      end
+
+      it "decrements the previous uploader's own_post_replaced_penalize_count" do
+        expect { process!(original, penalize: false) }
+          .to change { uploader.user_status.reload.own_post_replaced_penalize_count }.by(-1)
+      end
+    end
+  end
+
+  context "forward replacement does not reverse an earlier penalty" do
+    # A penalized replacement by replacer_user is currently live (it penalized `uploader`).
+    # A brand-new (pending) replacement by a third user is a forward replace, not a revert,
+    # so `uploader`'s standing -3 must be left in place.
+    let(:third)   { create(:user) }
+    let(:forward) { create(:post_replacement, post: post, creator: third, status: "pending") }
+    let!(:retired) do
+      create(:post_replacement, post: post, creator: replacer_user, status: "approved",
+                                md5: post.md5, penalize_uploader_on_approve: true,
+                                uploader_id_on_approve: uploader.id)
+    end
+
+    before { post.update_columns(uploader_id: replacer_user.id) }
+
+    it "leaves the earlier penalty untouched" do
+      expect { process!(forward, penalize: false) }
+        .not_to(change { uploader.user_status.reload.upload_karma })
+      expect(retired.reload.penalize_uploader_on_approve).to be true
     end
   end
 

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -218,6 +218,18 @@ RSpec.describe UploadService do
         expect { service.create_post_from_upload(upload) }
           .not_to(change { uploader.user_status.reload.upload_karma })
       end
+
+      it "nets +1 across an unlimited-upload user's upload, deletion, and undeletion" do
+        allow(uploader).to receive(:upload_free?).and_return(true)
+        admin = create(:admin_user)
+        expect do
+          post = service.create_post_from_upload(upload)  # +1: bypasses the queue on upload
+          CurrentUser.scoped(admin) do
+            post.delete!("Test reason")                   # -4: deleting a credited post reverses the +1 (-1) plus the -3 penalty
+            post.reload.undelete!                         # +4: a restored post is approved and worth +1 again
+          end
+        end.to change { uploader.user_status.reload.upload_karma }.by(1)
+      end
     end
   end
 

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -198,6 +198,27 @@ RSpec.describe UploadService do
       post = service.create_post_from_upload(upload)
       expect(upload.reload.post_id).to eq(post.id)
     end
+
+    context "upload karma" do
+      it "grants +1 karma when the post bypasses the review queue" do
+        allow(uploader).to receive(:upload_free?).and_return(true)
+        expect { service.create_post_from_upload(upload) }
+          .to change { uploader.user_status.reload.upload_karma }.by(1)
+      end
+
+      it "does not grant karma when the post enters the review queue" do
+        allow(uploader).to receive(:upload_free?).and_return(false)
+        expect { service.create_post_from_upload(upload) }
+          .not_to change { uploader.user_status.reload.upload_karma }
+      end
+
+      it "does not grant karma when upload_as_pending forces the post into the queue" do
+        allow(uploader).to receive(:upload_free?).and_return(true)
+        allow(upload).to receive(:upload_as_pending?).and_return(true)
+        expect { service.create_post_from_upload(upload) }
+          .not_to change { uploader.user_status.reload.upload_karma }
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -209,14 +209,14 @@ RSpec.describe UploadService do
       it "does not grant karma when the post enters the review queue" do
         allow(uploader).to receive(:upload_free?).and_return(false)
         expect { service.create_post_from_upload(upload) }
-          .not_to change { uploader.user_status.reload.upload_karma }
+          .not_to(change { uploader.user_status.reload.upload_karma })
       end
 
       it "does not grant karma when upload_as_pending forces the post into the queue" do
         allow(uploader).to receive(:upload_free?).and_return(true)
         allow(upload).to receive(:upload_as_pending?).and_return(true)
         expect { service.create_post_from_upload(upload) }
-          .not_to change { uploader.user_status.reload.upload_karma }
+          .not_to(change { uploader.user_status.reload.upload_karma })
       end
     end
   end

--- a/spec/models/post/deletion_methods_spec.rb
+++ b/spec/models/post/deletion_methods_spec.rb
@@ -44,8 +44,17 @@ RSpec.describe Post do
         expect(post.errors[:is_status_locked]).to be_present
       end
 
-      it "penalizes the uploader's upload karma by 3" do
+      it "penalizes a credited (non-pending) post's uploader by 4" do
+        # A default post has is_pending == false, so it held a +1 credit: deletion reverses
+        # that credit (-1) on top of the -3 penalty.
         post = create(:post)
+        expect { post.delete!("Test reason") }
+          .to change { post.uploader.user_status.reload.upload_karma }.by(-4)
+      end
+
+      it "penalizes a still-pending post's uploader by only 3" do
+        # A pending post never earned the +1 credit, so only the -3 penalty applies.
+        post = create(:pending_post)
         expect { post.delete!("Test reason") }
           .to change { post.uploader.user_status.reload.upload_karma }.by(-3)
       end
@@ -84,13 +93,15 @@ RSpec.describe Post do
         expect(post.reload.is_pending).to be false
       end
 
-      it "restores the uploader's upload karma by 3 if the post was previously approved" do
+      it "restores the uploader's upload karma by 4 when the deleted post had an approver" do
         post = create(:deleted_post, approver: create(:admin_user))
         expect { post.undelete! }
-          .to change { post.uploader.user_status.reload.upload_karma }.by(3)
+          .to change { post.uploader.user_status.reload.upload_karma }.by(4)
       end
 
-      it "restores the uploader's upload karma by 4 if the post was not previously approved" do
+      it "restores the uploader's upload karma by 4 when the deleted post had no approver" do
+        # Restoring always approves the post (worth +1), and delete! already drove every
+        # deleted post down to -3, so the reversal is a flat +4 regardless of prior state.
         member = create(:user)
         post = create(:deleted_post, uploader: member, approver: nil)
         expect { post.undelete! }
@@ -103,13 +114,22 @@ RSpec.describe Post do
           .not_to(change { post.uploader.user_status.reload.upload_karma })
       end
 
-      it "nets zero upload karma across a delete then undelete, even when karma goes negative" do
+      it "nets zero upload karma across a delete then undelete of a credited post, even when karma goes negative" do
         member = create(:user)
         post = create(:post, uploader: member, approver: create(:admin_user))
         expect do
-          post.delete!("Test reason")
-          post.reload.undelete!
+          post.delete!("Test reason")   # -4
+          post.reload.undelete!         # +4
         end.not_to(change { member.user_status.reload.upload_karma })
+      end
+
+      it "nets +1 across a pending post's delete then undelete (undelete approves it)" do
+        member = create(:user)
+        post = create(:pending_post, uploader: member)
+        expect do
+          post.delete!("Test reason")   # -3 (never earned the +1 credit)
+          post.reload.undelete!         # +4 (restored → approved)
+        end.to change { member.user_status.reload.upload_karma }.by(1)
       end
 
       # FIXME: It definitely does not do this.


### PR DESCRIPTION
Three separate problems here.

First, users with unlimited uploads were not getting credited with karma for uploading posts.
Second, post undeletion over-credited users with unlimited uploads by +1. Or self-approvals, but those are more rare.
Third, reverting replacements would not revert penalties and upload credit cleanly.

This PR fixes all of these.