### PR TITLE
[PostReplacements] Expand the current replacement card by default

### DIFF
--- a/app/components/post_replacement_card_component.rb
+++ b/app/components/post_replacement_card_component.rb
@@ -13,12 +13,12 @@ class PostReplacementCardComponent < ViewComponent::Base
   }.freeze
 
   # timeline: draw the status dot + rail affordance (index). false for ticket embeds.
-  # expanded: override the open/closed default. nil => open iff pending.
+  # expanded: override the open/closed default. nil => open iff pending or current.
   def initialize(post_replacement:, timeline: false, expanded: nil, actions: true)
     super()
     @replacement = post_replacement
     @timeline = timeline
-    @expanded = expanded.nil? ? post_replacement.is_pending? : expanded
+    @expanded = expanded.nil? ? (post_replacement.is_pending? || post_replacement.is_current?) : expanded
     @actions = actions
     @user = CurrentUser.user
   end

--- a/spec/components/post_replacement_card_component/render_spec.rb
+++ b/spec/components/post_replacement_card_component/render_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe PostReplacementCardComponent, type: :component do
       expect(doc.at_css(".replacement-card.is-expanded")).to be_present
     end
 
+    it "expands the current (md5 matches the post) replacement" do
+      doc = render_card(create(:approved_post_replacement, post: post_record, md5: post_record.md5))
+      expect(doc.at_css(".replacement-card.is-expanded")).to be_present
+    end
+
     it "collapses non-pending replacements" do
       doc = render_card(create(:approved_post_replacement, post: post_record))
       expect(doc.at_css(".replacement-card.is-expanded")).to be_nil


### PR DESCRIPTION
By demand from the staff team.
Apparently, they want to look at the post's sources, and see the large image.