### PR TITLE
[Users] Raise upload slot ceiling to 50

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -746,7 +746,7 @@ class User < ApplicationRecord
     end
 
     def upload_slot_ceiling
-      Danbooru.config.upload_slots_base * 2
+      Danbooru.config.upload_slots_base * 5
     end
 
     def upload_slots_pieces


### PR DESCRIPTION
By popular demand.
Apparently, 20 is too low - especially for replacements.