### PR TITLE
[Stats] Add `updated_at` field & coerce stringified floats

### DIFF
--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -3,7 +3,7 @@
 class StatsUpdater
   def self.run!
     stats = {}
-    stats[:started] = Post.find(Post.minimum("id")).created_at
+    stats[:started] = Post.find_by(id: Post.minimum("id"))&.created_at || Time.now
 
     daily_average = ->(total) do
       (total / ((Time.now - stats[:started]) / (60 * 60 * 24))).round
@@ -11,7 +11,7 @@ class StatsUpdater
 
     ### Posts ###
 
-    stats[:total_posts] = Post.maximum("id") || 0
+    stats[:total_posts] = Post.maximum("id").to_i
     stats[:active_posts] = Post.tag_match("status:active").count_only
     stats[:deleted_posts] = Post.tag_match("status:deleted").count_only
     stats[:existing_posts] = stats[:active_posts] + stats[:deleted_posts]
@@ -24,8 +24,8 @@ class StatsUpdater
     stats[:private_sets] = PostSet.where(is_public: false).count
     stats[:total_sets] = stats[:public_sets] + stats[:private_sets]
 
-    stats[:average_posts_per_pool] = Pool.average(Arel.sql("cardinality(post_ids)")).to_f
-    stats[:average_posts_per_set] = PostSet.average(Arel.sql("cardinality(post_ids)")).to_f
+    stats[:average_posts_per_pool] = Pool.average("cardinality(post_ids)").to_f
+    stats[:average_posts_per_set] = PostSet.average("cardinality(post_ids)").to_f
 
     stats[:safe_posts] = Post.tag_match("rating:s", always_show_deleted: true).count_only
     stats[:questionable_posts] = Post.tag_match("rating:q", always_show_deleted: true).count_only
@@ -48,13 +48,13 @@ class StatsUpdater
       stats[:"#{name.downcase}_users"] = User.where(level: level).count
     end
     stats[:unactivated_users] = User.where.not(email_verification_key: nil).count
-    stats[:total_dmails] = (Dmail.maximum("id") || 0) / 2
+    stats[:total_dmails] = Dmail.maximum("id").to_i / 2
     stats[:average_registrations_per_day] = daily_average.call(stats[:total_users])
     stats[:active_users] = User.where("last_logged_in_at >= ?", 3.months.ago).count
 
     ### Comments ###
 
-    stats[:total_comments] = Comment.maximum("id") || 0
+    stats[:total_comments] = Comment.maximum("id").to_i
     stats[:active_comments] = Comment.where(is_hidden: false).count
     stats[:hidden_comments] = Comment.where(is_hidden: true).count
     stats[:deleted_comments] = stats[:total_comments] - (stats[:active_comments] + stats[:hidden_comments])
@@ -63,14 +63,14 @@ class StatsUpdater
     ### Forum posts ###
 
     stats[:total_forum_threads] = ForumTopic.count
-    stats[:total_forum_posts] = ForumPost.maximum("id") || 0
+    stats[:total_forum_posts] = ForumPost.maximum("id").to_i
     stats[:average_posts_per_thread] = 0
     stats[:average_posts_per_thread] = (stats[:total_forum_posts] / stats[:total_forum_threads]).round if stats[:total_forum_threads] > 0
     stats[:average_forum_posts_per_day] = daily_average.call(stats[:total_forum_posts])
 
     ### Blips ###
 
-    stats[:total_blips] = Blip.maximum("id") || 0
+    stats[:total_blips] = Blip.maximum("id").to_i
     stats[:active_blips] = Blip.where(is_deleted: false).count
     stats[:deleted_blips] = Blip.where(is_deleted: true).count
     stats[:destroyed_blips] = stats[:total_blips] - (stats[:active_blips] + stats[:deleted_blips])
@@ -83,7 +83,7 @@ class StatsUpdater
       stats[:"#{cat}_tags"] = Tag.where(category: TagCategory::MAPPING[cat]).count
     end
 
-    stats[:updated_at] = Time.zone.now
+    stats[:updated_at] = Time.now
     Cache.redis.set("e6stats", stats.to_json)
   end
 end

--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -83,6 +83,7 @@ class StatsUpdater
       stats[:"#{cat}_tags"] = Tag.where(category: TagCategory::MAPPING[cat]).count
     end
 
+    stats[:updated_at] = Time.zone.now
     Cache.redis.set("e6stats", stats.to_json)
   end
 end

--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -24,8 +24,8 @@ class StatsUpdater
     stats[:private_sets] = PostSet.where(is_public: false).count
     stats[:total_sets] = stats[:public_sets] + stats[:private_sets]
 
-    stats[:average_posts_per_pool] = Pool.average(Arel.sql("cardinality(post_ids)")) || 0
-    stats[:average_posts_per_set] = PostSet.average(Arel.sql("cardinality(post_ids)")) || 0
+    stats[:average_posts_per_pool] = Pool.average(Arel.sql("cardinality(post_ids)")).to_f
+    stats[:average_posts_per_set] = PostSet.average(Arel.sql("cardinality(post_ids)")).to_f
 
     stats[:safe_posts] = Post.tag_match("rating:s", always_show_deleted: true).count_only
     stats[:questionable_posts] = Post.tag_match("rating:q", always_show_deleted: true).count_only
@@ -37,7 +37,7 @@ class StatsUpdater
     stats[:swf_posts] = Post.tag_match("type:swf", always_show_deleted: true).count_only
     stats[:webm_posts] = Post.tag_match("type:webm", always_show_deleted: true).count_only
     stats[:mp4_posts] = Post.tag_match("type:mp4", always_show_deleted: true).count_only
-    stats[:average_file_size] = Post.average("file_size")
+    stats[:average_file_size] = Post.average("file_size").to_f
     stats[:total_file_size] = Post.sum("file_size")
     stats[:average_posts_per_day] = daily_average.call(stats[:total_posts])
 

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,6 +1,11 @@
 <div id="c-stats">
   <div id="a-index">
-    <p>Refreshed once a day.</p>
+    <p>
+      Refreshed once a day.
+      <% if @stats["updated_at"].present? %>
+        Last updated at <%= compact_time(DateTime.parse(@stats["updated_at"])) %>.
+      <% end %>
+    </p>
     <div class="stats-column">
       <%= render "stats_table", header_title: "Site", data: [
           ["Started", compact_time(DateTime.parse(@stats["started"]))],

--- a/spec/logical/stats_updater_spec.rb
+++ b/spec/logical/stats_updater_spec.rb
@@ -6,14 +6,29 @@ RSpec.describe StatsUpdater do
   include_context "as member"
 
   describe ".run!" do
-    before { create(:post) }
+    context "with no posts" do
+      it "completes without error" do
+        expect { described_class.run! }.not_to raise_error
+      end
+    end
 
-    it "completes without error and writes stats to Redis" do
+    context "with posts" do
+      before { create(:post) }
+
+      it "completes without error and writes stats to Redis" do
+        described_class.run!
+        raw = Cache.redis.get("e6stats")
+        expect(raw).to be_present
+        stats = JSON.parse(raw, symbolize_names: true)
+        expect(stats[:total_posts]).to be >= 1
+      end
+    end
+
+    it "sets the last run time" do
       described_class.run!
       raw = Cache.redis.get("e6stats")
       expect(raw).to be_present
-      stats = JSON.parse(raw, symbolize_names: true)
-      expect(stats[:total_posts]).to be >= 1
+      expect(JSON.parse(raw, symbolize_names: true)[:started]).to be_present
     end
   end
 end


### PR DESCRIPTION
* Add an `updated_at` property to the stats, returned in both the JSON and shown in the UI
* Fix some fields returning strings rather than parsed floats (the averages)
* Replace the `|| 0` instances with an explicit `.to_i` call
* Modify the `:started` key to function with 0 posts present