### PR TITLE
[Notes] Fix phantom notes showing up when notes have thumbnails in them

### DIFF
--- a/app/javascript/src/js/pages/posts/show/notes.js
+++ b/app/javascript/src/js/pages/posts/show/notes.js
@@ -12,8 +12,9 @@ export default class NoteManager {
     if (container.length == 0) return;
     if (!NoteManager.PermittedFileTypes.includes((container.data("file-ext") + ""))) return;
 
-    // Load notes from the staging area
-    $("#note-staging article").each((_, note) => { Note.fromStaged(note); });
+    // Load notes from the staging area.
+    // Note bodies may contain rendered DText thumbnails, so selector has to be precise
+    $("#note-staging > article.staged-note").each((_, note) => { Note.fromStaged(note); });
 
     // Highlight notes based on URL hash
     this.highlightHashNotes();
@@ -803,6 +804,11 @@ class Note {
     const $staged = $(stagedElement);
     const noteData = stagedElement.dataset;
     const html = $staged.html();
+
+    // Guard against elements that aren't staged notes
+    for (const field of ["id", "x", "y", "width", "height", "body"]) {
+      if (typeof noteData[field] === "undefined") return null;
+    }
 
     return new Note({
       id: noteData.id,

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,1 +1,1 @@
-<article data-width="<%= note.width %>" data-height="<%= note.height %>" data-x="<%= note.x %>" data-y="<%= note.y %>" data-id="<%= note.id %>" data-body="<%= note.body %>"><%= format_text(note.body, allow_color: true) %></article>
+<article class="staged-note" data-width="<%= note.width %>" data-height="<%= note.height %>" data-x="<%= note.x %>" data-y="<%= note.y %>" data-id="<%= note.id %>" data-body="<%= note.body %>"><%= format_text(note.body, allow_color: true) %></article>


### PR DESCRIPTION
DTextPostLoader rendered thumbnails inside the note staging area.
NoteManager then misidentified these thumbnails as more notes.