### PR TITLE
[Users] Rework the karma level display

### DIFF
--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -1,15 +1,19 @@
-<div class="karma-badge">
+<a
+  href="<%= upload_limit_user_path(user) %>"
+  class="karma-badge"
+  title="<%= badge_title %>"
+>
   <div class="karma-badge-title">
-    Karma
+    Level
   </div>
   <div class="karma-badge-outer" style="<%= progress_degree_style %>">
     <div class="karma-badge-inner">
       <div class="karma-badge-level<%= ' karma-badge-level-max' if user.upload_karma_level >= 10 %>">
-        <%= user.upload_karma_level >= 10 ? "S" : user.upload_karma_level %>
+        <%= karma_level %>
       </div>
     </div>
   </div>
   <div class="karma-badge-progress">
-    <%= @user.upload_karma %>
+    <%= user.upload_karma %>
   </div>
-</div>
+</a>

--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -8,7 +8,7 @@
   </div>
   <div class="karma-badge-outer" style="<%= progress_degree_style %>">
     <div class="karma-badge-inner">
-      <div class="karma-badge-level<%= ' karma-badge-level-max' if user.upload_karma_level >= 10 %>">
+      <div class="karma-badge-level<%= " karma-badge-level-max" if user.upload_karma_level >= 10 %>">
         <%= karma_level %>
       </div>
     </div>

--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -1,0 +1,15 @@
+<div class="karma-badge">
+  <div class="karma-badge-title">
+    Karma
+  </div>
+  <div class="karma-badge-outer" style="<%= progress_degree_style %>">
+    <div class="karma-badge-inner">
+      <div class="karma-badge-level<%= ' karma-badge-level-max' if user.upload_karma_level >= 10 %>">
+        <%= user.upload_karma_level >= 10 ? "S" : user.upload_karma_level %>
+      </div>
+    </div>
+  </div>
+  <div class="karma-badge-progress">
+    <%= @user.upload_karma %>
+  </div>
+</div>

--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -8,7 +8,7 @@
   </div>
   <div class="karma-badge-outer" style="<%= progress_degree_style %>">
     <div class="karma-badge-inner">
-      <div class="karma-badge-level<%= " karma-badge-level-max" if user.upload_karma_level >= 10 %>">
+      <div class="karma-badge-level<%= " karma-badge-level-max" if user.upload_karma_level >= user.max_karma_level %>">
         <%= karma_level %>
       </div>
     </div>

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class KarmaBadge < ViewComponent::Base
+  def initialize(user: nil)
+    super()
+    @user = user
+  end
+
+  def render?
+    return false if user.blank?
+    return false if user.upload_karma <= 0
+
+    true
+  end
+
+  private
+
+  attr_reader :user
+
+  def progress_degree
+    return 0 if user.upload_karma_level >= 10
+    (user.upload_karma_percent * 3.6).round
+  end
+
+  def progress_degree_style
+    "background: conic-gradient(var(--color-button-active) #{progress_degree}deg, var(--color-section) 0deg);"
+  end
+end

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -18,12 +18,12 @@ class KarmaBadge < ViewComponent::Base
   attr_reader :user
 
   def karma_level
-    return "S" if user.upload_karma_level >= 10
+    return "S" if user.upload_karma_level >= user.max_karma_level
     user.upload_karma_level
   end
 
   def badge_title
-    if user.upload_karma_level >= 10
+    if user.upload_karma_level >= user.max_karma_level
       return "Upload Karma: #{user.upload_karma} (Level S)"
     end
 
@@ -32,7 +32,7 @@ class KarmaBadge < ViewComponent::Base
   end
 
   def progress_degree
-    return 0 if user.upload_karma_level >= 10
+    return 0 if user.upload_karma_level >= user.max_karma_level
     (user.upload_karma_percent * 3.6).round
   end
 

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -24,7 +24,7 @@ class KarmaBadge < ViewComponent::Base
 
   def badge_title
     if user.upload_karma_level >= 10
-      return "Upload Karma: #{user.upload_karma} / #{user.upload_karma_level * 100} (Level S)"
+      return "Upload Karma: #{user.upload_karma} (Level S)"
     end
 
     next_level = user.upload_karma_level + 1

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -17,6 +17,20 @@ class KarmaBadge < ViewComponent::Base
 
   attr_reader :user
 
+  def karma_level
+    return "S" if user.upload_karma_level >= 10
+    user.upload_karma_level
+  end
+
+  def badge_title
+    if user.upload_karma_level >= 10
+      return "Upload Karma: #{user.upload_karma} / #{user.upload_karma_level * 100} (Level S)"
+    end
+
+    next_level = user.upload_karma_level + 1
+    "Upload Karma: #{user.upload_karma} / #{user.required_karma_for_level(next_level)} (Level #{karma_level})"
+  end
+
   def progress_degree
     return 0 if user.upload_karma_level >= 10
     (user.upload_karma_percent * 3.6).round

--- a/app/javascript/src/styles/base.scss
+++ b/app/javascript/src/styles/base.scss
@@ -39,6 +39,7 @@
 @import "common/user_styles.scss";
 @import "common/voting.scss";
 
+@import "components/karma_badge.scss";
 @import "components/paginator_component.scss";
 @import "components/post_replacement_card_component.scss";
 @import "components/post_thumbnail_component.scss";

--- a/app/javascript/src/styles/components/karma_badge.scss
+++ b/app/javascript/src/styles/components/karma_badge.scss
@@ -44,7 +44,6 @@
     font-family: "Roboto", Verdana, Geneva, sans-serif;
     font-size: 1.5rem;
     font-weight: bold;
-    color: var(--color-link);
 
     &.karma-badge-level-max {
       color: var(--color-button-active);

--- a/app/javascript/src/styles/components/karma_badge.scss
+++ b/app/javascript/src/styles/components/karma_badge.scss
@@ -1,20 +1,20 @@
 .karma-badge {
   display: flex;
   flex-flow: column;
+  align-items: center;
+  justify-content: space-between;
+
   height: 5.5rem;
   width: 3rem;
-  align-items: center;
   overflow: hidden;
-  justify-content: space-between;
 
   & &-title {
     font-family: "Roboto", Verdana, Geneva, sans-serif;
   }
 
   & &-progress {
-    font-family: "Roboto", Verdana, Geneva, sans-serif;
-    color: var(--color-text-muted);
     font-family: monospace;
+    color: themed("color-text-muted");
   }
 
   & &-outer {
@@ -22,22 +22,24 @@
     flex-flow: column;
     width: 3rem;
     height: 3rem;
-    background: var(--color-section);
-    border-radius: 0.25rem;
+    background: themed("color-section");
+    @include st-radius;
   }
 
   & &-inner {
     display: flex;
     flex-flow: column;
+    align-items: center;
+    justify-content: center;
+
     width: 2.75rem;
     height: 2.75rem;
-    margin: 0.125rem;
-    background: var(--color-section-lighten-5);
-    border-radius: 0.25rem;
     overflow: hidden;
-    justify-content: center;
-    align-items: center;
-    box-shadow: inset 0 0 0.5rem var(--color-section-lighten-10);
+    margin: 0.125rem;
+
+    background: themed("color-section-lighten-5");
+    box-shadow: inset 0 0 0.5rem themed("color-section-lighten-10");
+    @include st-radius;
   }
 
   & &-level {
@@ -46,7 +48,7 @@
     font-weight: bold;
 
     &.karma-badge-level-max {
-      color: var(--color-button-active);
+      color: themed("color-button-active");
     }
   }
 }

--- a/app/javascript/src/styles/components/karma_badge.scss
+++ b/app/javascript/src/styles/components/karma_badge.scss
@@ -1,0 +1,53 @@
+.karma-badge {
+  display: flex;
+  flex-flow: column;
+  height: 5.5rem;
+  width: 3rem;
+  align-items: center;
+  overflow: hidden;
+  justify-content: space-between;
+
+  & &-title {
+    font-family: "Roboto", Verdana, Geneva, sans-serif;
+  }
+
+  & &-progress {
+    font-family: "Roboto", Verdana, Geneva, sans-serif;
+    color: var(--color-text-muted);
+    font-family: monospace;
+  }
+
+  & &-outer {
+    display: flex;
+    flex-flow: column;
+    width: 3rem;
+    height: 3rem;
+    background: var(--color-section);
+    border-radius: 0.25rem;
+  }
+
+  & &-inner {
+    display: flex;
+    flex-flow: column;
+    width: 2.75rem;
+    height: 2.75rem;
+    margin: 0.125rem;
+    background: var(--color-section-lighten-5);
+    border-radius: 0.25rem;
+    overflow: hidden;
+    justify-content: center;
+    align-items: center;
+    box-shadow: inset 0 0 0.5rem var(--color-section-lighten-10);
+  }
+
+  & &-level {
+    font-family: "Roboto", Verdana, Geneva, sans-serif;
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: var(--color-link);
+
+    &.karma-badge-level-max {
+      color: var(--color-button-active);
+    }
+  }
+}

--- a/app/javascript/src/styles/views/users/show/partials/_card.scss
+++ b/app/javascript/src/styles/views/users/show/partials/_card.scss
@@ -1,5 +1,15 @@
 $avatar-height: 4.5rem;
 
+.user-header {
+  display: flex;
+  flex-flow: column;
+  gap: 0.5rem;
+
+  @include window-larger-than(30rem) {
+    flex-flow: row;
+  }
+}
+
 .user-card {
   display: grid;
   grid-template-columns: $avatar-height auto min-content;
@@ -8,7 +18,7 @@ $avatar-height: 4.5rem;
 
   background: themed("color-section");
   border-radius: 0.25rem;
-  padding: 0.5rem 0.5rem 0;
+  padding: 0.5rem 0.5rem;
 
   & &-avatar {
     --thumb-image-size: #{$avatar-height};
@@ -16,24 +26,6 @@ $avatar-height: 4.5rem;
 
     article.thumbnail {
       box-shadow: 0 0 0.5rem -0.25rem themed("color-background");
-    }
-
-    .user-card-level {
-      position: absolute;
-      background: themed("color-button-active");
-      color: palette("plain-black");
-      width: 1rem;
-      height: 1rem;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      border-radius: 50%;
-      line-height: 0;
-      font-size: 0.75rem;
-      bottom: -0.25rem;
-      right: -0.25rem;
-      border: 0.125rem solid themed("color-section");
-      font-weight: bold;
     }
   }
 
@@ -84,33 +76,9 @@ $avatar-height: 4.5rem;
       gap: 0.25rem;
     }
   }
+}
 
-  & &-karma {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    position: relative;
-
-    &-percent {
-      position: absolute;
-      line-height: 1rem;
-      font-size: 0.75rem;
-      color: themed("color-text-muted");
-      top: -1rem;
-      right: 1.5rem;
-      font-family: monospace;
-    }
-
-    &-progress {
-      height: 0.125rem;
-      background: themed("color-section-lighten-5");
-      margin: 0 -0.5rem;
-      border-radius: 0 0 0.25rem 0.25rem;
-      overflow: hidden;
-
-      &-bar {
-        background: themed("color-button-active");
-        height: 100%;
-      }
-    }
-  }
+.user-badges {
+  display: flex;
+  justify-content: center;
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -877,9 +877,9 @@ class User < ApplicationRecord
       can_upload_free? || upload_karma_free?
     end
 
-    private
-
     def max_karma_level = 10
+
+    private
 
     def upload_karma_l1 = Danbooru.config.upload_karma_l1_threshold.to_f
     def upload_karma_l10 = Danbooru.config.upload_karma_l10_threshold.to_f

--- a/app/views/users/partials/show/_card.html.erb
+++ b/app/views/users/partials/show/_card.html.erb
@@ -2,11 +2,6 @@
   <div class="user-card">
     <div class="user-card-avatar">
       <%= render AvatarComponent.new(user: @user) %>
-      <% if @user.upload_karma_level > 0 %>
-        <div class="user-card-level">
-          <%= @user.upload_karma_level >= 10 ? "S" : @user.upload_karma_level %>
-        </div>
-      <% end %>
     </div>
     <div class="user-card-info">
       <div class="user-card-name">
@@ -26,18 +21,9 @@
     <div class="user-card-feedback">
       <%= render(UserFeedbackComponent.new(user: @user, style: :badge)) %>
     </div>
-    <div class="user-card-karma">
-      <% if @user.upload_karma > 0 %>
-        <div class="user-card-karma-percent">
-          <%= @user.upload_karma %>
-          <% if @user.upload_karma_level < 10 %>
-            / <%= @user.required_karma_for_level(@user.upload_karma_level + 1) %>
-          <% end %>
-        </div>
-      <% end %>
-      <div class="user-card-karma-progress">
-        <div class="user-card-karma-progress-bar" style="width: <%= @user.upload_karma_percent %>%"></div>
-      </div>
-    </div>
+  </div>
+
+  <div class="user-badges">
+    <%= render KarmaBadge.new(user: @user) %>
   </div>
 </div>

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -39,15 +39,17 @@
     </div>
   <% end %>
 
-  <div class="profile-line">
-    <h4><%= svg_icon(:upload) %> Upload Limit</h4>
-    <span class="profile-line-number">
-      <%= link_to presenter.upload_limit_short, upload_limit_user_path(user) %>
-    </span>
-    <span class="profile-line-extra">
-      Max number of unapproved posts at a time.
-    </span>
-  </div>
+  <% unless user.upload_karma_free? %>
+    <div class="profile-line">
+      <h4><%= svg_icon(:upload) %> Upload Limit</h4>
+      <span class="profile-line-number">
+        <%= link_to presenter.upload_limit_short, upload_limit_user_path(user) %>
+      </span>
+      <span class="profile-line-extra">
+        Max number of unapproved posts at a time.
+      </span>
+    </div>
+  <% end %>
 
   <div class="profile-line">
     <h4><%= svg_icon(:replace) %> Changes</h4>

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -39,7 +39,7 @@
     </div>
   <% end %>
 
-  <% unless user.upload_karma_free? %>
+  <% unless user.upload_free? %>
     <div class="profile-line">
       <h4><%= svg_icon(:upload) %> Upload Limit</h4>
       <span class="profile-line-number">

--- a/spec/components/karma_badge/badge_methods_spec.rb
+++ b/spec/components/karma_badge/badge_methods_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe KarmaBadge do
+  include_context "as member"
+
+  let(:user) { create(:user) }
+
+  before do
+    allow(Danbooru.config.custom_configuration).to receive_messages(
+      upload_karma_l1_threshold: 100,
+      upload_karma_l10_threshold: 10_000,
+    )
+  end
+
+  def component(user = self.user)
+    described_class.new(user: user)
+  end
+
+  def set_karma(target, value)
+    target.user_status.update_columns(upload_karma: value)
+    target.reload
+  end
+
+  describe "#karma_level" do
+    it "returns the numeric level below the maximum" do
+      set_karma(user, Danbooru.config.upload_karma_l1_threshold)
+      expect(component.send(:karma_level)).to eq(1)
+    end
+
+    it "returns S at the maximum level" do
+      set_karma(user, Danbooru.config.upload_karma_l10_threshold)
+      expect(component.send(:karma_level)).to eq("S")
+    end
+  end
+
+  describe "#badge_title" do
+    it "shows progress toward the next level below the maximum" do
+      set_karma(user, Danbooru.config.upload_karma_l1_threshold)
+      required_for_next = user.required_karma_for_level(2)
+      expect(component.send(:badge_title)).to eq("Upload Karma: #{user.upload_karma} / #{required_for_next} (Level 1)")
+    end
+
+    it "shows the S level at the maximum" do
+      set_karma(user, Danbooru.config.upload_karma_l10_threshold)
+      expect(component.send(:badge_title)).to eq("Upload Karma: #{user.upload_karma} (Level S)")
+    end
+  end
+
+  describe "#progress_degree" do
+    it "converts the karma percentage into degrees" do
+      set_karma(user, Danbooru.config.upload_karma_l1_threshold / 2)
+      expect(user.upload_karma_percent).to eq(50)
+      expect(component.send(:progress_degree)).to eq(180)
+    end
+
+    it "returns 0 at the start of a level" do
+      set_karma(user, Danbooru.config.upload_karma_l1_threshold)
+      expect(component.send(:progress_degree)).to eq(0)
+    end
+
+    it "returns 0 at the maximum level" do
+      set_karma(user, Danbooru.config.upload_karma_l10_threshold)
+      expect(component.send(:progress_degree)).to eq(0)
+    end
+  end
+
+  describe "#progress_degree_style" do
+    it "embeds the progress degree in a conic gradient" do
+      set_karma(user, Danbooru.config.upload_karma_l1_threshold / 2)
+      expect(component.send(:progress_degree_style)).to eq(
+        "background: conic-gradient(var(--color-button-active) 180deg, var(--color-section) 0deg);",
+      )
+    end
+  end
+end

--- a/spec/components/karma_badge/render_spec.rb
+++ b/spec/components/karma_badge/render_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe KarmaBadge do
+  include_context "as member"
+
+  let(:user) { create(:user) }
+
+  def component(user = self.user)
+    described_class.new(user: user)
+  end
+
+  def set_karma(target, value)
+    target.user_status.update_columns(upload_karma: value)
+    target.reload
+  end
+
+  describe "#render?" do
+    it "returns false when user is nil" do
+      expect(component(nil).render?).to be false
+    end
+
+    it "returns false for a user with no karma" do
+      expect(component.render?).to be false
+    end
+
+    it "returns false for a user with negative karma" do
+      set_karma(user, -7)
+      expect(component.render?).to be false
+    end
+
+    it "returns true for a user with positive karma" do
+      set_karma(user, 1)
+      expect(component.render?).to be true
+    end
+  end
+end

--- a/spec/components/karma_badge/template_spec.rb
+++ b/spec/components/karma_badge/template_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe KarmaBadge, type: :component do
+  include_context "as member"
+
+  let(:user) { create(:user) }
+
+  before do
+    allow(Danbooru.config.custom_configuration).to receive_messages(
+      upload_karma_l1_threshold: 100,
+      upload_karma_l10_threshold: 10_000,
+    )
+  end
+
+  def set_karma(target, value)
+    target.user_status.update_columns(upload_karma: value)
+    target.reload
+  end
+
+  describe "rendered output" do
+    it "renders a link to the user's upload limit page" do
+      set_karma(user, 50)
+      doc = render_inline(described_class.new(user: user))
+      link = doc.at_css("a.karma-badge")
+      expect(link).to be_present
+      expect(link["href"]).to eq("/users/#{user.id}/upload_limit")
+    end
+
+    it "sets the title to the badge title" do
+      set_karma(user, 50)
+      doc = render_inline(described_class.new(user: user))
+      expect(doc.at_css("a.karma-badge")["title"]).to eq("Upload Karma: 50 / 100 (Level 0)")
+    end
+
+    it "shows the numeric level and karma amount" do
+      set_karma(user, Danbooru.config.upload_karma_l1_threshold)
+      doc = render_inline(described_class.new(user: user))
+      expect(doc.at_css(".karma-badge-level").text.strip).to eq("1")
+      expect(doc.at_css(".karma-badge-progress").text.strip).to eq(user.upload_karma.to_s)
+    end
+
+    it "applies the progress gradient style" do
+      set_karma(user, 50)
+      doc = render_inline(described_class.new(user: user))
+      expect(doc.at_css(".karma-badge-outer")["style"]).to include("180deg")
+    end
+
+    it "shows S with the max level class at the maximum level" do
+      set_karma(user, Danbooru.config.upload_karma_l10_threshold)
+      doc = render_inline(described_class.new(user: user))
+      expect(doc.at_css(".karma-badge-level-max")).to be_present
+      expect(doc.at_css(".karma-badge-level").text.strip).to eq("S")
+    end
+
+    it "does not apply the max level class below the maximum level" do
+      set_karma(user, Danbooru.config.upload_karma_l1_threshold)
+      doc = render_inline(described_class.new(user: user))
+      expect(doc.css(".karma-badge-level-max")).to be_empty
+    end
+
+    it "renders nothing for a user with no karma" do
+      doc = render_inline(described_class.new(user: user))
+      expect(doc.to_html.strip).to be_empty
+    end
+
+    it "renders nothing when user is nil" do
+      doc = render_inline(described_class.new(user: nil))
+      expect(doc.to_html.strip).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Rework the way karma levels are displayed on the profile page.
Rather than build it directly into the profile card, it is now displayed as a separate badge.

<img width="439" height="100" alt="image" src="https://github.com/user-attachments/assets/1a6efbc2-f63c-4e30-b06b-1cb50d3668b1" />
