### PR TITLE
[Posts] Always serve full-sized images in "Fit" modes

### DIFF
--- a/app/views/posts/partials/show/content/embedded/_image.html.erb
+++ b/app/views/posts/partials/show/content/embedded/_image.html.erb
@@ -4,17 +4,9 @@
   <% webp = Danbooru.config.webp_previews_enabled? && post.has_sample? %>
   <picture>
     <% if post.has_sample? && initial_size != "original" %>
-      <% if initial_size == "large" %>
-        <%# Sample view: serve the WebP encoding of the sample when available. %>
-        <% if webp %>
-          <source type="image/webp" srcset="<%= post.sample_url(:sample_webp) %>">
-        <% end %>
-      <% else %>
-        <%# fit / fitv: the full original by default, but show sample if the viewport is small enough for it not to matter. %>
-        <% if webp %>
-          <source type="image/webp" media="(max-width: <%= post.sample_width - 1 %>px)" srcset="<%= post.sample_url(:sample_webp) %>">
-        <% end %>
-        <source media="(max-width: <%= post.sample_width - 1 %>px)" srcset="<%= post.sample_url(:sample_jpg) %>">
+      <%# Sample view: serve the WebP encoding of the sample when available. %>
+      <% if initial_size == "large" && webp %>
+        <source type="image/webp" srcset="<%= post.sample_url(:sample_webp) %>">
       <% end %>
     <% end %>
     <%= image_tag(post.presenter.initial_image_url(user), post.presenter.image_attributes) %>


### PR DESCRIPTION
By popular demand.

Previous approach failed to take into account the fact that CSS pixels are different than phone screen's pixels.
That, and the ability to zoom into the page.

Back to the drawing board.