### PR TITLE
[Misc] Ensure that sidekiq-cron prunes removed/renamed jobs

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -105,7 +105,7 @@ Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
     },
   }
 
-  Sidekiq::Cron::Job.load_from_hash schedule
+  Sidekiq::Cron::Job.load_from_hash! schedule, source: "schedule"
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
Previous approach was a bit of a footgun - sidekiq-cron would load new jobs, but wouldn't unload the removed/renamed ones.