### PR TITLE
[Misc] Fix discord reports time outs

### DIFF
--- a/app/controllers/staff/discord_reports_controller.rb
+++ b/app/controllers/staff/discord_reports_controller.rb
@@ -5,9 +5,11 @@ module Staff
     before_action :admin_only
 
     def index
-      @janitor_report = DiscordReport::JanitorStats.new.report(update_cache: false)
-      @moderator_report = DiscordReport::ModeratorStats.new.report(update_cache: false)
-      @aibur_report = DiscordReport::AiburStats.new.report(update_cache: false)
+      User.without_timeout do
+        @janitor_report = DiscordReport::JanitorStats.new.report(update_cache: false)
+        @moderator_report = DiscordReport::ModeratorStats.new.report(update_cache: false)
+        @aibur_report = DiscordReport::AiburStats.new.report(update_cache: false)
+      end
     end
   end
 end

--- a/app/jobs/discord_reports_job.rb
+++ b/app/jobs/discord_reports_job.rb
@@ -15,10 +15,12 @@ class DiscordReportsJob < ApplicationJob
   ].freeze
 
   def perform
-    REPORTS.each do |report|
-      report.new.run!
-    rescue StandardError => e
-      DanbooruLogger.log(e)
+    User.without_timeout do
+      REPORTS.each do |report|
+        report.new.run!
+      rescue StandardError => e
+        DanbooruLogger.log(e)
+      end
     end
   end
 end


### PR DESCRIPTION
The discord reports are not time-sensitive, they can take as long as they need to.