### PR TITLE
[Takedowns] Fix being unable to remove posts

### DIFF
--- a/app/javascript/entrypoints/v_takedowns.ts
+++ b/app/javascript/entrypoints/v_takedowns.ts
@@ -4,6 +4,6 @@ import E621Type from "@/interfaces/E621";
 declare const E621: E621Type;
 
 import "@/pages/takedowns/takedown_editor";
-import "@/pages/takedowns/takedowns";
+import Takedown from "@/pages/takedowns/takedowns";
 
-E621.Registry.register("v_takedowns");
+E621.Registry.register("v_takedowns", { Takedown });


### PR DESCRIPTION
Forgot to export the Takedown class - and nobody noticed.