### PR TITLE
[BUR] Fix potential stale cache issues

### DIFF
--- a/app/helpers/bulk_update_requests_helper.rb
+++ b/app/helpers/bulk_update_requests_helper.rb
@@ -75,7 +75,7 @@ module BulkUpdateRequestsHelper
   end
 
   def script_with_line_breaks(bur, with_decorations:)
-    cache_key = "#{CurrentUser.is_admin? ? 'mod' : ''}#{with_decorations ? 'color' : ''}#{bur.updated_at}"
+    cache_key = "#{CurrentUser.is_admin? ? 'mod' : ''}#{with_decorations ? 'color' : ''}#{bur.cache_key_with_version}"
     Cache.fetch(cache_key, expires_in: 1.hour) do
       script_tokenized = BulkUpdateRequestImporter.tokenize(bur.script)
       script_tags = collect_script_tags(script_tokenized)


### PR DESCRIPTION
BUR scripts were cached with purely the `updated_at` value.
Multiple BURs updated within the same second would therefore clash.