### PR TITLE
[Wiki] Add table of contents

### DIFF
--- a/app/helpers/wiki_pages_helper.rb
+++ b/app/helpers/wiki_pages_helper.rb
@@ -12,4 +12,8 @@ module WikiPagesHelper
   def wiki_page_alias_and_implication_list(wiki_page)
     render "tags/alias_and_implication_list", tag: wiki_page.tag || Tag.new(name: wiki_page.title)
   end
+
+  def wiki_page_outline(wiki_content, allow_color: true, max_thumbs: 75)
+    WikiTableOfContents.new(format_text(wiki_content.body, allow_color: allow_color, max_thumbs: max_thumbs).to_s)
+  end
 end

--- a/app/javascript/entrypoints/v_wiki-pages_show.ts
+++ b/app/javascript/entrypoints/v_wiki-pages_show.ts
@@ -4,5 +4,6 @@ import E621Type from "@/interfaces/E621";
 declare const E621: E621Type;
 
 import "@/pages/wiki_pages/show/CopyTag";
+import "@/pages/wiki_pages/show/DetailsAnchor";
 
 E621.Registry.register("v_wiki-pages_show");

--- a/app/javascript/src/js/pages/wiki_pages/show/DetailsAnchor.ts
+++ b/app/javascript/src/js/pages/wiki_pages/show/DetailsAnchor.ts
@@ -1,0 +1,32 @@
+// Native expansion of a closed <details> on fragment navigation is inconsistent across
+// browsers, so open the target's <details> ancestors ourselves.
+
+function revealAnchoredDetails (): void {
+  const raw = window.location.hash.slice(1);
+  if (!raw) return;
+
+  let id: string;
+  try {
+    id = decodeURIComponent(raw);
+  } catch {
+    id = raw;
+  }
+
+  const target = document.getElementById(id);
+  if (!target) return;
+
+  let node: HTMLElement | null = target;
+  let opened = false;
+  while (node) {
+    if (node instanceof HTMLDetailsElement && !node.open) {
+      node.open = true;
+      opened = true;
+    }
+    node = node.parentElement;
+  }
+
+  if (opened) target.scrollIntoView({ block: "start" });
+}
+
+$(() => revealAnchoredDetails());
+$(window).on("hashchange.e6.details", revealAnchoredDetails);

--- a/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
+++ b/app/javascript/src/styles/views/wiki_pages/_wiki_pages.scss
@@ -28,6 +28,19 @@
     }
   }
 
+  #wiki-page-toc {
+    li {
+      padding-inline-start: calc(var(--toc-depth, 0) * 0.75rem);
+    }
+
+    a {
+      display: block;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+  }
+
   .automated-tag-notice {
     max-width: 50rem;
     box-sizing: border-box;

--- a/app/logical/wiki_table_of_contents.rb
+++ b/app/logical/wiki_table_of_contents.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "cgi"
+require "strscan"
+
+# Builds the wiki sidebar outline from a rendered DText body. One document-order tree
+# from both headers (<h1-6>, nested by level) and sections (<details>, nested by DOM):
+# sections that follow a header become its children, and a header immediately followed
+# by a same-slug section fold into one node. Ids are injected on headers and section
+# summaries so the outline links land. Author anchors are reused as-is.
+class WikiTableOfContents
+  NAV_GLYPHS = /[\^↑⬆▲⇧]/
+  BACK_TO_TOP = %r{<a\b[^>]*href="#top"[^>]*>.*?</a>}m
+  ANCHOR_ID = /<a\b[^>]*\sid="([^"]*)"/
+  CLOSINGS = ["</summary>", *(1..6).map { |n| "</h#{n}>" }].index_with { |tag| /#{Regexp.escape(tag)}/m }.freeze
+
+  Node = Struct.new(:kind, :level, :text, :slug, :children, keyword_init: true)
+
+  def initialize(html)
+    @html = html.to_s
+    @out = +""
+    @root = Node.new(kind: :root, level: 0, text: nil, slug: nil, children: [])
+    scan
+    merge(@root)
+  end
+
+  def html
+    @out.html_safe # rubocop:disable Rails/OutputSafety -- Already safe DText html
+  end
+
+  def entries
+    @entries ||= [].tap { |list| flatten(@root, -1, list) }
+  end
+
+  private
+
+  def scan
+    scanner = StringScanner.new(@html)
+    stack = [{ frame: :root, level: 0, node: @root }]
+
+    until scanner.eos?
+      if scanner.scan(/(<details\b[^>]*>)(\s*)<summary\b([^>]*)>/m)
+        push_section(stack, scanner[1], scanner[2], scanner[3], read_until(scanner, "</summary>"))
+      elsif scanner.scan(%r{</details>})
+        @out << "</details>"
+        close_section(stack)
+      elsif scanner.scan(/<h([1-6])((?:\s[^>]*)?)>/)
+        level = scanner[1].to_i
+        push_header(stack, level, scanner[2], read_until(scanner, "</h#{level}>"))
+      else
+        @out << (scanner.scan(/[^<]+/) || scanner.getch).to_s
+      end
+    end
+  end
+
+  def read_until(scanner, closing)
+    chunk = scanner.scan_until(CLOSINGS.fetch(closing)) || scanner.rest.tap { scanner.terminate }
+    chunk.delete_suffix(closing)
+  end
+
+  def push_section(stack, open_details, spacing, summary_attrs, inner)
+    label = clean_label(inner)
+    anchor = inner[ANCHOR_ID, 1]
+    slug = anchor.presence || slugify(label)
+
+    summary = if slug.present? && anchor.nil? && summary_attrs.exclude?("id=")
+                %(<summary#{summary_attrs} id="#{slug}">)
+              else
+                "<summary#{summary_attrs}>"
+              end
+    @out << open_details << spacing << summary << inner << "</summary>"
+
+    node = Node.new(kind: :section, level: nil, text: label.presence, slug: slug, children: [])
+    stack.last[:node].children << node
+    stack.push({ frame: :section, level: nil, node: node })
+  end
+
+  def close_section(stack)
+    stack.pop while stack.size > 1 && stack.last[:frame] != :section
+    stack.pop if stack.size > 1
+  end
+
+  def push_header(stack, level, attrs, inner)
+    label = clean_label(inner)
+    anchor = inner[ANCHOR_ID, 1]
+    slug = anchor.presence || slugify(label)
+
+    if slug.present? && anchor.nil? && attrs.exclude?("id=")
+      @out << %(<h#{level}#{attrs} id="#{slug}">) << inner << "</h#{level}>"
+    else
+      @out << "<h#{level}#{attrs}>" << inner << "</h#{level}>"
+    end
+
+    return if slug.blank?
+
+    stack.pop while stack.last[:frame] == :header && stack.last[:level] >= level
+    node = Node.new(kind: :header, level: level, text: label.presence, slug: slug, children: [])
+    stack.last[:node].children << node
+    stack.push({ frame: :header, level: level, node: node })
+  end
+
+  def merge(node)
+    node.children.each { |child| merge(child) }
+    first = node.children.first
+    return unless node.kind == :header && first&.kind == :section && first.slug == node.slug
+
+    node.children = first.children + node.children[1..]
+  end
+
+  def flatten(node, depth, list)
+    list << { depth: depth, slug: node.slug, text: node.text } if node.text
+    node.children.each { |child| flatten(child, depth + 1, list) }
+  end
+
+  def clean_label(inner)
+    text = CGI.unescapeHTML(inner.gsub(BACK_TO_TOP, "").gsub(/<[^>]+>/, ""))
+    text.gsub(/\A(?:\s|#{NAV_GLYPHS})+|(?:\s|#{NAV_GLYPHS})+\z/, "").sub(/:\s*\z/, "")
+  end
+
+  def slugify(text)
+    normalized = text.to_s.downcase
+    to_slug(normalized.gsub(/\s*\([^()]*\)/, "")).presence || to_slug(normalized)
+  end
+
+  def to_slug(text)
+    text.gsub(/[^\p{Alnum}]+/, "-").delete_prefix("-").delete_suffix("-")
+  end
+end

--- a/app/logical/wiki_table_of_contents.rb
+++ b/app/logical/wiki_table_of_contents.rb
@@ -30,7 +30,7 @@ class WikiTableOfContents
   end
 
   def entries
-    @entries ||= [].tap { |list| flatten(@root, -1, list) }
+    @entries ||= [].tap { |list| flatten(@root, 0, list) }
   end
 
   private
@@ -150,7 +150,8 @@ class WikiTableOfContents
 
   def flatten(node, depth, list)
     list << { depth: depth, slug: node.slug, text: node.text } if node.text
-    node.children.each { |child| flatten(child, depth + 1, list) }
+    child_depth = node.text ? depth + 1 : depth
+    node.children.each { |child| flatten(child, child_depth, list) }
   end
 
   def clean_label(inner)

--- a/app/logical/wiki_table_of_contents.rb
+++ b/app/logical/wiki_table_of_contents.rb
@@ -3,11 +3,9 @@
 require "cgi"
 require "strscan"
 
-# Builds the wiki sidebar outline from a rendered DText body. One document-order tree
-# from both headers (<h1-6>, nested by level) and sections (<details>, nested by DOM):
-# sections that follow a header become its children, and a header immediately followed
-# by a same-slug section fold into one node. Ids are injected on headers and section
-# summaries so the outline links land. Author anchors are reused as-is.
+# Turns a rendered DText body into a linkable outline. #html returns the body with an id
+# on every header and section summary, and #entries returns the matching outline, so each
+# entry's slug addresses an element in #html.
 class WikiTableOfContents
   NAV_GLYPHS = /[\^↑⬆▲⇧]/
   BACK_TO_TOP = %r{<a\b[^>]*href="#top"[^>]*>.*?</a>}m
@@ -19,6 +17,9 @@ class WikiTableOfContents
   def initialize(html)
     @html = html.to_s
     @out = +""
+    @used = Set.new
+    # Reserve pre-existing ids first so a generated slug also avoids ones appearing later.
+    @html.scan(/\sid="([^"]*)"/) { |(id)| reserve(id) }
     @root = Node.new(kind: :root, level: 0, text: nil, slug: nil, children: [])
     scan
     merge(@root)
@@ -54,24 +55,36 @@ class WikiTableOfContents
   end
 
   def read_until(scanner, closing)
+    # An unclosed tag consumes the rest of the document.
     chunk = scanner.scan_until(CLOSINGS.fetch(closing)) || scanner.rest.tap { scanner.terminate }
     chunk.delete_suffix(closing)
   end
 
   def push_section(stack, open_details, spacing, summary_attrs, inner)
     label = clean_label(inner)
-    anchor = inner[ANCHOR_ID, 1]
-    slug = anchor.presence || slugify(label)
+    existing = existing_id(inner, summary_attrs)
+    parent = stack.last
 
-    summary = if slug.present? && anchor.nil? && summary_attrs.exclude?("id=")
-                %(<summary#{summary_attrs} id="#{slug}">)
-              else
-                "<summary#{summary_attrs}>"
-              end
+    if existing
+      reserve(existing)
+      slug = existing
+      inject = false
+    elsif (base = slugify(label)).blank?
+      slug = base
+      inject = false
+    elsif merge_partner?(parent, base)
+      slug = parent[:node].slug
+      inject = false
+    else
+      slug = unique_slug(base)
+      inject = true
+    end
+
+    summary = inject ? %(<summary#{summary_attrs} id="#{slug}">) : "<summary#{summary_attrs}>"
     @out << open_details << spacing << summary << inner << "</summary>"
 
     node = Node.new(kind: :section, level: nil, text: label.presence, slug: slug, children: [])
-    stack.last[:node].children << node
+    parent[:node].children << node
     stack.push({ frame: :section, level: nil, node: node })
   end
 
@@ -82,10 +95,14 @@ class WikiTableOfContents
 
   def push_header(stack, level, attrs, inner)
     label = clean_label(inner)
-    anchor = inner[ANCHOR_ID, 1]
-    slug = anchor.presence || slugify(label)
+    existing = existing_id(inner, attrs)
 
-    if slug.present? && anchor.nil? && attrs.exclude?("id=")
+    if existing
+      reserve(existing)
+      slug = existing
+      @out << "<h#{level}#{attrs}>" << inner << "</h#{level}>"
+    elsif (slug = slugify(label)).present?
+      slug = unique_slug(slug)
       @out << %(<h#{level}#{attrs} id="#{slug}">) << inner << "</h#{level}>"
     else
       @out << "<h#{level}#{attrs}>" << inner << "</h#{level}>"
@@ -97,6 +114,30 @@ class WikiTableOfContents
     node = Node.new(kind: :header, level: level, text: label.presence, slug: slug, children: [])
     stack.last[:node].children << node
     stack.push({ frame: :header, level: level, node: node })
+  end
+
+  def existing_id(inner, attrs)
+    (inner[ANCHOR_ID, 1] || attrs[/\sid="([^"]*)"/, 1]).presence
+  end
+
+  # A header directly followed by a same-slug section is one anchor, so they share the id and fold in #merge.
+  def merge_partner?(parent, base)
+    parent[:frame] == :header && parent[:node].children.empty? && parent[:node].slug == base
+  end
+
+  def unique_slug(base)
+    candidate = base
+    suffix = 0
+    while @used.include?(candidate)
+      suffix += 1
+      candidate = "#{base}-#{suffix}"
+    end
+    @used << candidate
+    candidate
+  end
+
+  def reserve(id)
+    @used << id if id.present?
   end
 
   def merge(node)
@@ -117,6 +158,7 @@ class WikiTableOfContents
     text.gsub(/\A(?:\s|#{NAV_GLYPHS})+|(?:\s|#{NAV_GLYPHS})+\z/, "").sub(/:\s*\z/, "")
   end
 
+  # A parenthetical is a disambiguating qualifier, so slug on the bare name unless that empties it.
   def slugify(text)
     normalized = text.to_s.downcase
     to_slug(normalized.gsub(/\s*\([^()]*\)/, "")).presence || to_slug(normalized)

--- a/app/views/wiki_pages/_sidebar.html.erb
+++ b/app/views/wiki_pages/_sidebar.html.erb
@@ -1,4 +1,5 @@
 <aside id="sidebar">
   <%= render partial: "application/blacklist" %>
+  <%= render "wiki_pages/table_of_contents", wiki_outline: local_assigns[:wiki_outline] %>
   <%= render "wiki_pages/recent_changes" %>
 </aside>

--- a/app/views/wiki_pages/_table_of_contents.html.erb
+++ b/app/views/wiki_pages/_table_of_contents.html.erb
@@ -1,0 +1,11 @@
+<% outline = local_assigns[:wiki_outline] %>
+<% if outline && outline.entries.present? %>
+  <section id="wiki-page-toc">
+    <h1>Contents</h1>
+    <ul>
+      <% outline.entries.each do |entry| %>
+        <li style="--toc-depth: <%= [entry[:depth], 6].min %>"><%= link_to entry[:text], "##{entry[:slug]}" %></li>
+      <% end %>
+    </ul>
+  </section>
+<% end %>

--- a/app/views/wiki_pages/show.html.erb
+++ b/app/views/wiki_pages/show.html.erb
@@ -1,7 +1,8 @@
 <% wiki_content = @wiki_redirect.presence || @wiki_page %>
+<% wiki_outline = wiki_content.body.present? ? wiki_page_outline(wiki_content) : nil %>
 <div id="c-wiki-pages">
   <div id="a-show">
-    <%= render "sidebar" %>
+    <%= render "sidebar", wiki_outline: wiki_outline %>
 
     <section id="content">
       <h1 id="wiki-page-title">
@@ -31,8 +32,8 @@
       <%= render partial: "featured_posts", locals: { wiki_content: wiki_content } %>
 
       <div id="wiki-page-body" class="dtext-container">
-        <% if wiki_content.body.present? %>
-          <%= format_text(wiki_content.body, allow_color: true, max_thumbs: 75) %>  
+        <% if wiki_outline %>
+          <%= wiki_outline.html %>
         <% else %>
           <p>This wiki page is empty. <%= link_to "Click here to add details", edit_wiki_page_path(@wiki_page) %>.</p>
         <% end %>

--- a/spec/logical/wiki_table_of_contents_spec.rb
+++ b/spec/logical/wiki_table_of_contents_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WikiTableOfContents do
+  def entries(html)
+    described_class.new(html).entries
+  end
+
+  def rendered(html)
+    described_class.new(html).html
+  end
+
+  def section(title, body = "<div><p>Skarn</p></div>")
+    "<details><summary>#{title}</summary>#{body}</details>"
+  end
+
+  describe "#entries" do
+    describe "headers" do
+      it "extracts a header as an entry" do
+        expect(entries("<h2>Vaelor</h2>")).to eq([{ depth: 0, slug: "vaelor", text: "Vaelor" }])
+      end
+
+      it "nests headers by level" do
+        result = entries("<h1>Vaelor</h1><h2>Draketh</h2>")
+        expect(result.map { |e| [e[:depth], e[:slug]] }).to eq([[0, "vaelor"], [1, "draketh"]])
+      end
+
+      it "uses structural (tree) depth, so a level maps to different depths by position" do
+        result = entries("<h6>Vaelor</h6><h1>Draketh</h1><h6>Ignyr</h6>")
+        expect(result.pluck(:depth)).to eq([0, 0, 1])
+      end
+
+      it "omits a header whose text yields no slug" do
+        expect(entries("<h2>###</h2>")).to eq([])
+      end
+    end
+
+    describe "slugs" do
+      it "lowercases and hyphenates" do
+        expect(entries("<h2>Vaelor Draketh</h2>").first[:slug]).to eq("vaelor-draketh")
+      end
+
+      it "keeps letters of any script" do
+        expect(entries("<h2>Ðrako</h2>").first[:slug]).to eq("ðrako")
+      end
+
+      it "drops a parenthetical qualifier" do
+        expect(entries("<h2>Vaelor (Draketh)</h2>").first[:slug]).to eq("vaelor")
+      end
+
+      it "falls back to the full text when dropping parentheticals empties the slug" do
+        expect(entries("<h2>(Vaelor)</h2>").first).to include(slug: "vaelor", text: "(Vaelor)")
+      end
+    end
+
+    describe "labels" do
+      it "strips a leading or trailing nav glyph but keeps a mid-text one" do
+        expect(entries("<h2>↑ Vaelor</h2>").first[:text]).to eq("Vaelor")
+        expect(entries("<h2>Vaelor ^</h2>").first[:text]).to eq("Vaelor")
+        expect(entries("<h2>Vaelor^Draketh</h2>").first[:text]).to eq("Vaelor^Draketh")
+      end
+
+      it "strips a back-to-top link and a trailing colon" do
+        expect(entries(%(<h2><a href="#top">↑</a> Vaelor:</h2>)).first).to include(slug: "vaelor", text: "Vaelor")
+      end
+
+      it "strips inner markup from the label" do
+        expect(entries("<h2>Vaelor <b>Draketh</b></h2>").first[:text]).to eq("Vaelor Draketh")
+      end
+    end
+
+    describe "author anchors" do
+      it "reuses an author anchor as the slug" do
+        expect(entries(%(<h2>Vaelor <a id="wyrmroost"></a></h2>)).first[:slug]).to eq("wyrmroost")
+      end
+
+      it "does not read data-id as an anchor" do
+        expect(entries(%(<h2>Vaelor <a data-id="123">Draketh</a></h2>)).first[:slug]).to eq("vaelor-draketh")
+      end
+    end
+
+    describe "sections" do
+      it "extracts a section summary as an entry" do
+        expect(entries(section("Emberden")).first).to include(slug: "emberden", text: "Emberden")
+      end
+
+      it "nests a section under a preceding header" do
+        result = entries("<h2>Vaelor</h2>#{section('Emberden')}")
+        expect(result.map { |e| [e[:depth], e[:slug]] }).to eq([[0, "vaelor"], [1, "emberden"]])
+      end
+
+      it "nests sections by DOM depth" do
+        result = entries(section("Emberden", "<div>#{section('Frostmaw')}</div>"))
+        expect(result.map { |e| [e[:depth], e[:slug]] }).to eq([[0, "emberden"], [1, "frostmaw"]])
+      end
+
+      it "merges a header with an immediately following same-slug section" do
+        result = entries("<h2>Emberden</h2>#{section('Emberden', '<div><h3>Draketh</h3></div>')}")
+        expect(result.map { |e| [e[:depth], e[:slug]] }).to eq([[0, "emberden"], [1, "draketh"]])
+      end
+    end
+
+    it "returns nothing for a body with no headers or sections" do
+      expect(entries("<p>Skarn</p>")).to eq([])
+    end
+  end
+
+  describe "#html" do
+    it "injects an id onto a header" do
+      expect(rendered("<h2>Vaelor</h2>")).to eq(%(<h2 id="vaelor">Vaelor</h2>))
+    end
+
+    it "injects an id onto a section summary" do
+      expect(rendered(section("Emberden"))).to include(%(<summary id="emberden">))
+    end
+
+    it "leaves a header untouched when it already carries an author anchor" do
+      html = %(<h2>Vaelor <a id="wyrmroost"></a></h2>)
+      expect(rendered(html)).to eq(html)
+    end
+
+    it "leaves the body byte-identical except for injected ids" do
+      html = %(<h2>Vaelor</h2><p>Skarn &quot;Glimmerscale&quot;  Hoard</p>#{section('Emberden', '<div><p>Cinder</p></div>')})
+      strip_ids = ->(text) { text.gsub(/ id="[^"]*"/, "") }
+      expect(strip_ids.call(rendered(html))).to eq(strip_ids.call(html))
+    end
+  end
+end

--- a/spec/logical/wiki_table_of_contents_spec.rb
+++ b/spec/logical/wiki_table_of_contents_spec.rb
@@ -52,6 +52,35 @@ RSpec.describe WikiTableOfContents do
       it "falls back to the full text when dropping parentheticals empties the slug" do
         expect(entries("<h2>(Vaelor)</h2>").first).to include(slug: "vaelor", text: "(Vaelor)")
       end
+
+      it "suffixes a colliding slug so each entry stays linkable" do
+        expect(entries("<h2>Vaelor</h2><h2>Vaelor</h2>").pluck(:slug)).to eq(%w[vaelor vaelor-1])
+      end
+
+      it "increments the suffix past an existing numbered slug" do
+        result = entries("<h2>Vaelor</h2><h2>Vaelor 1</h2><h2>Vaelor</h2>")
+        expect(result.pluck(:slug)).to eq(%w[vaelor vaelor-1 vaelor-2])
+      end
+
+      it "suffixes a generated slug that collides with an author anchor" do
+        result = entries(%(<h2>Vaelor <a id="vaelor"></a></h2><h2>Vaelor</h2>))
+        expect(result.pluck(:slug)).to eq(%w[vaelor vaelor-1])
+      end
+
+      it "suffixes a generated slug that collides with a later author anchor" do
+        result = entries(%(<h2>Vaelor</h2><h2>Draketh <a id="vaelor"></a></h2>))
+        expect(result.pluck(:slug)).to eq(%w[vaelor-1 vaelor])
+      end
+
+      it "reserves an explicit id attribute so a generated slug avoids it" do
+        result = entries(%(<h2 id="vaelor">Draketh</h2><h2>Vaelor</h2>))
+        expect(result.pluck(:slug)).to eq(%w[vaelor vaelor-1])
+      end
+
+      it "suffixes a section slug that collides with a header" do
+        result = entries("<h2>Vaelor</h2><h3>Draketh</h3>#{section('Vaelor')}")
+        expect(result.pluck(:slug)).to eq(%w[vaelor draketh vaelor-1])
+      end
     end
 
     describe "labels" do
@@ -118,6 +147,10 @@ RSpec.describe WikiTableOfContents do
     it "leaves a header untouched when it already carries an author anchor" do
       html = %(<h2>Vaelor <a id="wyrmroost"></a></h2>)
       expect(rendered(html)).to eq(html)
+    end
+
+    it "injects a suffixed id onto a colliding header" do
+      expect(rendered("<h2>Vaelor</h2><h2>Vaelor</h2>")).to eq(%(<h2 id="vaelor">Vaelor</h2><h2 id="vaelor-1">Vaelor</h2>))
     end
 
     it "leaves the body byte-identical except for injected ids" do


### PR DESCRIPTION
Table of contents implementation for Wikis.

Tries its best to work in the way users already write wikis:
1. Headers and sections are jump points.
2. Links lose trailing parenthesis.
3. An automatic `#top`  always exists, and ▲ and friends are excluded from the links and labels.
4. Header followed by section named the same does not gain a duplicate link.
5. Weirdly nested headers (e.g. starting with h4) are normalized relative to each other.
6. Existing dtext anchors inside headers override the auto-generated one.

Uses a StringScanner instead of a html parser because Nokogiri would reformat the HTML (e.g. transform `&#38;` to `&`) and I didnt like that.

Preview:
<img width="1634" height="1127" alt="image" src="https://github.com/user-attachments/assets/0e33d90d-8079-4e7e-a0d6-f8ca1d1501cd" />

Some articles might look strange after merging this, e.g. e621:cheatsheet uses h6 plus bold to emphasize the tag searches. I believe these should be edited to use just bold later.