### PR TITLE
[Users] Fix faulty redirect after reauthentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -261,8 +261,18 @@ class ApplicationController < ActionController::Base
     return redirect_to(new_session_path(url: request.fullpath)) if CurrentUser.user.is_logged_out?
     last_authenticated_at = session[:last_authenticated_at]
     if last_authenticated_at.blank? || Time.zone.parse(last_authenticated_at) < 1.hour.ago
-      # Redirect back to the referrer if the request is not a GET.
-      return_to = request.get? ? request.fullpath : URI.parse(request.referer.to_s).path.presence
+      if request.get?
+        return_to = request.fullpath
+      else
+        # If the request is not a GET, we can't redirect back to it after reauthentication.
+        # Redirecting back to the referer is the next best option, although that would lose
+        # any form data and query params.
+        begin
+          return_to = URI.parse(request.referer.to_s).path.presence
+        rescue URI::InvalidURIError
+          return_to = nil
+        end
+      end
       redirect_to(confirm_password_session_path(url: return_to))
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -261,7 +261,9 @@ class ApplicationController < ActionController::Base
     return redirect_to(new_session_path(url: request.fullpath)) if CurrentUser.user.is_logged_out?
     last_authenticated_at = session[:last_authenticated_at]
     if last_authenticated_at.blank? || Time.zone.parse(last_authenticated_at) < 1.hour.ago
-      redirect_to(confirm_password_session_path(url: request.fullpath))
+      # Redirect back to the referrer if the request is not a GET.
+      return_to = request.get? ? request.fullpath : URI.parse(request.referer.to_s).path.presence
+      redirect_to(confirm_password_session_path(url: return_to))
     end
   end
 

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe Staff::UsersController do
 
     it "redirects to the confirm_password page when reauthentication is missing" do
       sign_in_as admin
-      post password_reset_staff_user_path(user)
+      post password_reset_staff_user_path(user), headers: { "HTTP_REFERER" => password_reset_staff_user_path(user) }
       expect(response).to redirect_to(confirm_password_session_path(url: password_reset_staff_user_path(user)))
     end
 

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -566,6 +566,11 @@ RSpec.describe Staff::UsersController do
         post anonymize_staff_user_path(user), headers: { "HTTP_REFERER" => user_path(user) }
         expect(response).to redirect_to(confirm_password_session_path(url: user_path(user)))
       end
+
+      it "redirects to the confirm_password page when the referrer is malformed" do
+        post anonymize_staff_user_path(user), headers: { "HTTP_REFERER" => "http://exa mple.com/foo" }
+        expect(response).to redirect_to(confirm_password_session_path)
+      end
     end
 
     context "as bd_staff with reauthentication" do

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe Staff::UsersController do
     it "returns 302 with an alert for a non-BD-staff admin when the target is staff" do
       staff_user = create(:janitor_user)
       sign_in_as admin, reauthenticated: true
-      post password_reset_staff_user_path(staff_user)
+      post password_reset_staff_user_path(staff_user), params: { admin: { password: "hexerade" } }, headers: { "HTTP_REFERER" => user_path(staff_user) }
       expect(response).to redirect_to(user_path(staff_user))
       expect(flash[:alert]).to eq("Only BD staff can request password resets for staff accounts")
     end

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -554,10 +554,18 @@ RSpec.describe Staff::UsersController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "redirects to the confirm_password page when reauthentication is missing" do
-      sign_in_as bd_staff
-      post anonymize_staff_user_path(user)
-      expect(response).to redirect_to(confirm_password_session_path(url: anonymize_staff_user_path(user)))
+    context "as bd staff without reauthentication" do
+      before { sign_in_as bd_staff }
+
+      it "redirects to the confirm_password page" do
+        post anonymize_staff_user_path(user)
+        expect(response).to redirect_to(confirm_password_session_path)
+      end
+
+      it "redirects to the confirm_password page with the referrer URL" do
+        post anonymize_staff_user_path(user), headers: { "HTTP_REFERER" => user_path(user) }
+        expect(response).to redirect_to(confirm_password_session_path(url: user_path(user)))
+      end
     end
 
     context "as bd_staff with reauthentication" do


### PR DESCRIPTION
If the route gated behind `:requires_reauthentication` expects a POST, the user confirming their password will see error 404.
Reproduction steps go something like this:

1. Go to the `request_password_reset` route 59 minutes after the last authentication.
    No prompt to re-authenticate so far.
2. Wait a few minutes, then reset the password.
    The form POSTs to `password_reset`.
3. Since it's now been over an hour since their last authentication, get the `requires_reauthentication` prompt.
4. After confirming the password, get redirected back to the `password_reset` route.
    Since it's a GET request now, see error 404.

The new approach redirects the user back to their referrer if the original request was not a GET.
Forms may get reset to their defaults, but this is a more user-friendly solution than a 404 either way.