### PR TITLE
[Sessions] Fix a broken redirect on malformed URL

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,7 +16,7 @@ class SessionsController < ApplicationController
       return
     end
     session_creator = SessionCreator.new(request, session, cookies, sparams[:name], sparams[:password], sparams[:remember].to_s.truthy?)
-    url = sparams[:url] if sparams[:url]&.start_with?("/") && !sparams[:url].start_with?("//")
+    url = url_from(sparams[:url])
 
     case session_creator.authenticate(url: url)
     when :succeeded


### PR DESCRIPTION
For example, attempting to log in from the `https://e621.net/posts/1599045]` page.