### PR TITLE
[Users] Add search and sort options for upload karma

### DIFF
--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -8,7 +8,7 @@
   </div>
   <div class="karma-badge-outer" style="<%= progress_degree_style %>">
     <div class="karma-badge-inner">
-      <div class="karma-badge-level<%= " karma-badge-level-max" if user.upload_karma_level >= user.max_karma_level %>">
+      <div class="karma-badge-level<%= " karma-badge-level-max" if user.upload_karma_level >= User.max_karma_level %>">
         <%= karma_level %>
       </div>
     </div>

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -18,21 +18,21 @@ class KarmaBadge < ViewComponent::Base
   attr_reader :user
 
   def karma_level
-    return "S" if user.upload_karma_level >= user.max_karma_level
+    return "S" if user.upload_karma_level >= User.max_karma_level
     user.upload_karma_level
   end
 
   def badge_title
-    if user.upload_karma_level >= user.max_karma_level
+    if user.upload_karma_level >= User.max_karma_level
       return "Upload Karma: #{user.upload_karma} (Level S)"
     end
 
     next_level = user.upload_karma_level + 1
-    "Upload Karma: #{user.upload_karma} / #{user.required_karma_for_level(next_level)} (Level #{karma_level})"
+    "Upload Karma: #{user.upload_karma} / #{User.required_karma_for_level(next_level)} (Level #{karma_level})"
   end
 
   def progress_degree
-    return 0 if user.upload_karma_level >= user.max_karma_level
+    return 0 if user.upload_karma_level >= User.max_karma_level
     (user.upload_karma_percent * 3.6).round
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -340,6 +340,7 @@ class UsersController < ApplicationController
 
   def search_params
     permitted_params = %i[name_matches about_me avatar_id level min_level max_level can_approve_posts can_upload_free order]
+    permitted_params += %i[can_karma_free] unless Danbooru.config.upload_karma_free_threshold.nil?
     permitted_params += %i[ip_addr email_matches] if CurrentUser.is_admin?
     permit_search_params permitted_params
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -851,23 +851,14 @@ class User < ApplicationRecord
     end
 
     def upload_karma_level
-      # Calculated from the `upload_karma` column. Threshold values pulled from the config file.
-      return 0 if upload_karma < Danbooru.config.upload_karma_l1_threshold
-      level = (Math.log10(upload_karma / upload_karma_l1) * upload_karma_scale).floor + 1
-      [level, max_karma_level].min
-    end
-
-    def required_karma_for_level(level)
-      level = level.to_i
-      return 0 if level <= 0
-      (upload_karma_l1 * (10**((level - 1) / upload_karma_scale))).ceil
+      User.level_from_karma(upload_karma)
     end
 
     def upload_karma_percent
       level = upload_karma_level
-      return 0 if level >= max_karma_level
-      current_level_karma = required_karma_for_level(level)
-      next_level_karma = required_karma_for_level(level + 1)
+      return 0 if level >= User.max_karma_level
+      current_level_karma = User.required_karma_for_level(level)
+      next_level_karma = User.required_karma_for_level(level + 1)
 
       # Ensure we don't divide by zero
       return 100 if next_level_karma == current_level_karma
@@ -889,6 +880,21 @@ class User < ApplicationRecord
       return false if no_karma_free?
       can_upload_free? || upload_karma_free?
     end
+  end
+
+  module GlobalKarmaMethods
+    def required_karma_for_level(level)
+      level = level.to_i
+      return 0 if level <= 0
+      (upload_karma_l1 * (10**((level - 1) / upload_karma_scale))).ceil
+    end
+
+    def level_from_karma(karma)
+      # Calculated from the `upload_karma` column. Threshold values pulled from the config file.
+      return 0 if karma < upload_karma_l1
+      level = (Math.log10(karma / upload_karma_l1) * upload_karma_scale).floor + 1
+      [level, User.max_karma_level].min
+    end
 
     def max_karma_level = 10
 
@@ -896,7 +902,7 @@ class User < ApplicationRecord
 
     def upload_karma_l1 = Danbooru.config.upload_karma_l1_threshold.to_f
     def upload_karma_l10 = Danbooru.config.upload_karma_l10_threshold.to_f
-    def upload_karma_scale = (max_karma_level - 1) / Math.log10(upload_karma_l10 / upload_karma_l1)
+    def upload_karma_scale = (User.max_karma_level - 1) / Math.log10(upload_karma_l10 / upload_karma_l1)
   end
 
   module ApiMethods
@@ -1163,11 +1169,12 @@ class User < ApplicationRecord
         q = q.where("(bit_prefs & :mask) = 0", mask: exclude_mask)
       end
 
-      if params[:can_karma_free].present?
+      if params[:can_karma_free].present? && Danbooru.config.upload_karma_free_threshold.present?
+        required_karma = User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold)
         if params[:can_karma_free].to_s.truthy?
-          q = q.joins(:user_status).where("user_statuses.upload_karma >= ?", Danbooru.config.upload_karma_free_threshold)
+          q = q.joins(:user_status).where("user_statuses.upload_karma >= ?", required_karma)
         elsif params[:can_karma_free].to_s.falsy?
-          q = q.joins(:user_status).where("user_statuses.upload_karma < ?", Danbooru.config.upload_karma_free_threshold)
+          q = q.joins(:user_status).where("user_statuses.upload_karma < ?", required_karma)
         end
       end
 
@@ -1217,6 +1224,7 @@ class User < ApplicationRecord
   include CountMethods
   extend SearchMethods
   extend ThrottleMethods
+  extend GlobalKarmaMethods
 
   def has_mail?
     unread_dmail_count > 0

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1163,8 +1163,16 @@ class User < ApplicationRecord
         q = q.where("(bit_prefs & :mask) = 0", mask: exclude_mask)
       end
 
+      if params[:can_karma_free].present?
+        if params[:can_karma_free].to_s.truthy?
+          q = q.joins(:user_status).where("user_statuses.upload_karma >= ?", Danbooru.config.upload_karma_free_threshold)
+        elsif params[:can_karma_free].to_s.falsy?
+          q = q.joins(:user_status).where("user_statuses.upload_karma < ?", Danbooru.config.upload_karma_free_threshold)
+        end
+      end
+
       # Check if the join is necessary
-      if params[:order].present? && %w[post_upload_count note_count post_update_count].include?(params[:order])
+      if params[:order].present? && %w[post_upload_count note_count post_update_count upload_karma].include?(params[:order])
         q = q.joins(:user_status)
       end
 
@@ -1177,6 +1185,8 @@ class User < ApplicationRecord
         q = q.order("user_statuses.note_count desc")
       when "post_update_count"
         q = q.order("user_statuses.post_update_count desc")
+      when "upload_karma"
+        q = q.order("user_statuses.upload_karma desc")
       else
         q = q.apply_basic_order(params)
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -893,7 +893,7 @@ class User < ApplicationRecord
       # Calculated from the `upload_karma` column. Threshold values pulled from the config file.
       return 0 if karma < upload_karma_l1
       level = (Math.log10(karma / upload_karma_l1) * upload_karma_scale).floor + 1
-      [level, User.max_karma_level].min
+      [level, max_karma_level].min
     end
 
     def max_karma_level = 10

--- a/app/views/users/_search.html.erb
+++ b/app/views/users/_search.html.erb
@@ -14,5 +14,9 @@
   <%= f.input :can_approve_posts, label: "Approver?", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
   <%= f.input :can_upload_free, label: "Unrestricted uploads?", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
 
-  <%= f.input :order, collection: [["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]], include_blank: "Join Date" %>
+  <% unless Danbooru.config.upload_karma_free_threshold.nil? %>
+    <%= f.input :can_karma_free, label: "Karma approval bypass?", collection: [%w[Yes true], %w[No false]], include_blank: "Any" %>
+  <% end %>
+
+  <%= f.input :order, collection: [["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"], ["Upload karma", "upload_karma"]], include_blank: "Join Date" %>
 <% end %>

--- a/app/views/users/upload_limit.html.erb
+++ b/app/views/users/upload_limit.html.erb
@@ -2,7 +2,7 @@
 
   <% pieces = @user.upload_slots_pieces %>
   <% karma_threshold_enabled = !Danbooru.config.upload_karma_free_threshold.nil? %>
-  <% karma_threshold = karma_threshold_enabled ? @user.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) : nil %>
+  <% karma_threshold = karma_threshold_enabled ? User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) : nil %>
   <% is_current_user = @user.id == CurrentUser.id %>
 
   <!-- Header -->

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ admin = User.find_or_create_by!(name: "admin") do |user|
   user.is_bd_auditor = true
 end
 
-required_karma = admin.required_karma_for_level(Danbooru.config.upload_karma_free_threshold)
+required_karma = User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold)
 if !required_karma.nil? && admin.upload_karma < required_karma
   admin.upload_karma = required_karma
   admin.save!

--- a/spec/components/karma_badge/badge_methods_spec.rb
+++ b/spec/components/karma_badge/badge_methods_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe KarmaBadge do
   describe "#badge_title" do
     it "shows progress toward the next level below the maximum" do
       set_karma(user, Danbooru.config.upload_karma_l1_threshold)
-      required_for_next = user.required_karma_for_level(2)
+      required_for_next = User.required_karma_for_level(2)
       expect(component.send(:badge_title)).to eq("Upload Karma: #{user.upload_karma} / #{required_for_next} (Level 1)")
     end
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -95,7 +95,7 @@ FactoryBot.define do
     factory :unlimited_uploads_user do
       # Karma above the free threshold bypasses the review queue.
       after(:create) do |user|
-        threshold = user.required_karma_for_level(Danbooru.config.upload_karma_free_threshold)
+        threshold = User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold)
         user.user_status.update_columns(upload_karma: threshold + 1)
       end
     end

--- a/spec/models/user/karma_methods_spec.rb
+++ b/spec/models/user/karma_methods_spec.rb
@@ -89,10 +89,10 @@ RSpec.describe User do
   # -------------------------------------------------------------------------
   describe "#required_karma_for_level" do
     it "returns the required karma for a given level" do
-      expect(user.required_karma_for_level(-1)).to eq(0)
-      expect(user.required_karma_for_level(0)).to eq(0)
-      expect(user.required_karma_for_level(1)).to eq(Danbooru.config.upload_karma_l1_threshold)
-      expect(user.required_karma_for_level(10)).to eq(Danbooru.config.upload_karma_l10_threshold)
+      expect(User.required_karma_for_level(-1)).to eq(0)
+      expect(User.required_karma_for_level(0)).to eq(0)
+      expect(User.required_karma_for_level(1)).to eq(Danbooru.config.upload_karma_l1_threshold)
+      expect(User.required_karma_for_level(10)).to eq(Danbooru.config.upload_karma_l10_threshold)
     end
   end
 
@@ -101,8 +101,8 @@ RSpec.describe User do
   # -------------------------------------------------------------------------
   describe "#upload_karma_percent" do
     it "returns the percentage of progress toward the next level" do
-      required_for_level_one = user.required_karma_for_level(1)
-      required_for_level_two = user.required_karma_for_level(2)
+      required_for_level_one = User.required_karma_for_level(1)
+      required_for_level_two = User.required_karma_for_level(2)
 
       set_karma(user, 0)
       expect(user.upload_karma_percent).to eq(0)
@@ -130,7 +130,7 @@ RSpec.describe User do
   # #upload_karma_free?
   # -------------------------------------------------------------------------
   describe "#upload_karma_free?" do
-    let(:upload_free_karma_threshold) { user.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) }
+    let(:upload_free_karma_threshold) { User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) }
 
     it "is false below the threshold" do
       set_karma(user, upload_free_karma_threshold - 1)
@@ -164,7 +164,7 @@ RSpec.describe User do
   # #upload_free?
   # -------------------------------------------------------------------------
   describe "#upload_free?" do
-    let(:upload_free_karma_threshold) { user.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) }
+    let(:upload_free_karma_threshold) { User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) }
 
     it "is false for a user with no karma and no grant" do
       expect(user.upload_free?).to be false

--- a/spec/models/user/karma_methods_spec.rb
+++ b/spec/models/user/karma_methods_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe User do
   end
 
   # -------------------------------------------------------------------------
-  # #required_karma_for_level
+  # .required_karma_for_level
   # -------------------------------------------------------------------------
   describe "#required_karma_for_level" do
     it "returns the required karma for a given level" do

--- a/spec/models/user/upload_methods_spec.rb
+++ b/spec/models/user/upload_methods_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe User do
       # zero out the user's upload slots so that the only reason they can upload is their karma level
       member.user_status.update_columns(post_replacement_rejected_count: 100)
 
-      set_karma(member, user.required_karma_for_level(Danbooru.config.upload_karma_free_threshold))
+      set_karma(member, User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold))
       expect(member.can_upload_with_reason).to be true
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,7 +99,7 @@ RSpec.configure do |config|
       user.is_bd_auditor = true
     end
     # Karma above the free threshold so seeded staff uploads bypass the review queue.
-    admin.user_status.update_columns(upload_karma: admin.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) + 1000)
+    admin.user_status.update_columns(upload_karma: User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) + 1000)
 
     system_user = User.find_or_create_by!(name: Danbooru.config.system_user) do |user|
       user.password = "ae3n4oie2n3oi4en23oie4noienaorshtaioresnt"
@@ -109,7 +109,7 @@ RSpec.configure do |config|
       user.can_approve_posts = true
       user.level = UserLevel::JANITOR
     end
-    system_user.user_status.update_columns(upload_karma: system_user.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) + 1000)
+    system_user.user_status.update_columns(upload_karma: User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold) + 1000)
 
     ForumCategory.find_or_create_by!(name: "Tag Alias and Implication Suggestions") do |category|
       category.can_view = 0


### PR DESCRIPTION
Added a way to find users who have unlimited uploads enabled via reaching the necessary karma level.
Disabled if the configuration disables that functionality.

Added a way to order users by their upload karma as well.