### PR TITLE
[Users] Log staff password resets

### DIFF
--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -107,6 +107,7 @@ module Staff
       end
 
       @user.update_columns(password_hash: "", bcrypt_password_hash: "*AC*") if params.dig(:admin, :invalidate_old_password)&.truthy?
+      ModAction.log(:password_reset, { user_id: @user.id, invalidated: params.dig(:admin, :invalidate_old_password)&.truthy? || false })
 
       @reset_key = UserPasswordResetNonce.create(user_id: @user.id)
     end

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -106,10 +106,10 @@ module Staff
         return redirect_to user_path(@user), alert: "Only BD staff can request password resets for staff accounts"
       end
 
-      @user.update_columns(password_hash: "", bcrypt_password_hash: "*AC*") if params.dig(:admin, :invalidate_old_password)&.truthy?
-      ModAction.log(:password_reset, { user_id: @user.id, invalidated: params.dig(:admin, :invalidate_old_password)&.truthy? || false })
-
+      invalidate_old_password = params.dig(:admin, :invalidate_old_password)&.truthy? || false
+      @user.update_columns(password_hash: "", bcrypt_password_hash: "*AC*") if invalidate_old_password
       @reset_key = UserPasswordResetNonce.create(user_id: @user.id)
+      ModAction.log(:password_reset, { user_id: @user.id, invalidated: invalidate_old_password })
     end
 
     def totp_reset

--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -174,6 +174,12 @@ class ModActionDecorator < ApplicationDecorator
       "Edited blacklist of #{user}"
     when "totp_reset"
       "Removed two-factor authentication from #{user}"
+    when "password_reset"
+      if vals["invalidated"]
+        "Reset password for #{user} and invalidated their old password"
+      else
+        "Reset password for #{user}"
+      end
     when "user_text_change"
       "Changed profile text of #{user}"
     when "user_custom_title_change"

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -100,6 +100,7 @@ class ModAction < ApplicationRecord
     user_level_change: { user_id: :integer, level: :string, level_was: :string },
     user_name_change: { user_id: :integer },
     totp_reset: { user_id: :integer },
+    password_reset: { user_id: :integer, invalidated: :boolean },
     user_delete: { user_id: :integer },
     user_ban: { user_id: :integer, duration: :integer, reason: :string },
     user_ban_update: { user_id: :integer, ban_id: :integer, expires_at: :datetime, expires_at_was: :datetime, reason: :string, reason_was: :string },
@@ -127,6 +128,7 @@ class ModAction < ApplicationRecord
     staff_file_create staff_file_update staff_file_delete
     ip_ban_create ip_ban_delete
     post_version_hide post_version_unhide
+    totp_reset password_reset
   ].freeze
 
   KnownActionKeys = KnownActions.keys.freeze

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -414,6 +414,18 @@ RSpec.describe Staff::UsersController do
         end.to change(UserPasswordResetNonce, :count).by(1)
       end
 
+      it "logs a password_reset ModAction" do
+        expect do
+          post password_reset_staff_user_path(user)
+        end.to change(ModAction.where(action: "password_reset"), :count).by(1)
+        expect(ModAction.last[:values]).to include("user_id" => user.id, "invalidated" => false)
+
+        expect do
+          post password_reset_staff_user_path(user), params: { admin: { invalidate_old_password: "1" } }
+        end.to change(ModAction.where(action: "password_reset"), :count).by(1)
+        expect(ModAction.last[:values]).to include("user_id" => user.id, "invalidated" => true)
+      end
+
       it "invalidates the old password when invalidate_old_password is truthy" do
         post password_reset_staff_user_path(user), params: {
           admin: { invalidate_old_password: "1" },


### PR DESCRIPTION
2FA staff reset is already logged, although the mod action was exposed for some reason.
It stands to reason that password resets should be logged as well.