### PR TITLE
[PostReplacements] Minor tweaks to the image info section

### DIFF
--- a/app/components/post_replacement_card_component.html.erb
+++ b/app/components/post_replacement_card_component.html.erb
@@ -58,9 +58,11 @@
         <div class="replacement-field-label">Image info</div>
         <div class="replacement-field-value">
           <%= svg_icon(:circle_check_small, title: "This is the current version", height: 13.5, width: 13.5, class: "inline-icons") if replacement.is_current? %>
-          <% if replacement.is_pending? %>New: <% end %><%= replacement.image_width %>x<%= replacement.image_height %> <%= replacement.file_ext %> (<%= replacement.file_size.to_fs(:human_size, precision: 5) %><% if replacement.is_video? %>, <%= post.duration %>s<% end %>)
           <% if replacement.is_pending? %>
-            <br>Old: <%= post.image_width %>x<%= post.image_height %> <%= post.file_ext %> (<%= post.file_size.to_fs(:human_size, precision: 5) %><% if post.is_video? %>, <%= post.duration %>s<% end %>)
+            New: <%= file_details(replacement) %>
+            <br>Old: <%= file_details(post) %>
+          <% else %>
+            <%= file_details(replacement) %>
           <% end %>
         </div>
       </div>

--- a/app/components/post_replacement_card_component.rb
+++ b/app/components/post_replacement_card_component.rb
@@ -73,6 +73,16 @@ class PostReplacementCardComponent < ViewComponent::Base
     replacement.is_backup? ? "Backup created at" : "Created at"
   end
 
+  # "WIDTHxHEIGHT ext (size, DURATIONs)" for either the replacement or the post.
+  # Replacements don't store a duration; the post's only describes a replacement's
+  # file when that replacement is current, so it's omitted otherwise.
+  def file_details(record)
+    details = "#{record.image_width}x#{record.image_height} #{record.file_ext} "
+    details += "(#{record.file_size.to_fs(:human_size, precision: 5)}"
+    details += ", #{post.duration}s" if record.is_video? && (record == post || replacement.is_current?)
+    "#{details})"
+  end
+
   def show_status_changed_at?
     replacement.updated_at != replacement.created_at
   end


### PR DESCRIPTION
Restructured the "image info" section to be a bit less messy.
Disabled the "duration" display unless the replacement is current - otherwise, it could be misleading.