### PR TITLE
[Dmails] Prevent DMails from being manipulated by non-owners

### DIFF
--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -20,7 +20,7 @@ class DmailsController < ApplicationController
     check_privilege(@dmail, params[:key])
     respond_with(@dmail) do |format|
       format.html do
-        @dmail.mark_as_read! unless @dmail.is_read
+        @dmail.mark_as_read! if !@dmail.is_read && @dmail.owner_id == CurrentUser.user.id
       end
     end
   end
@@ -57,12 +57,18 @@ class DmailsController < ApplicationController
   def mark_as_read
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
+    check_is_owner(@dmail)
     @dmail.mark_as_read!
+    respond_to do |format|
+      format.html { redirect_to(dmails_path, notice: "Message marked as read") }
+      format.json
+    end
   end
 
   def mark_as_unread
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
+    check_is_owner(@dmail)
     @dmail.mark_as_unread!
     respond_to do |format|
       format.html { redirect_to(dmails_path, notice: "Message marked as unread") }
@@ -86,6 +92,10 @@ class DmailsController < ApplicationController
 
   def check_privilege(dmail, key = nil)
     raise User::PrivilegeError unless dmail.visible_to?(CurrentUser.user, key)
+  end
+
+  def check_is_owner(dmail)
+    raise User::PrivilegeError unless dmail.owner_id == CurrentUser.user.id
   end
 
   def create_params

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -46,6 +46,7 @@ class DmailsController < ApplicationController
   def destroy
     @dmail = Dmail.find(params[:id])
     check_privilege(@dmail)
+    check_is_owner(@dmail)
     @dmail.mark_as_read!
     @dmail.update_column(:is_deleted, true)
     respond_to do |format|

--- a/spec/requests/dmails_controller_spec.rb
+++ b/spec/requests/dmails_controller_spec.rb
@@ -429,13 +429,14 @@ RSpec.describe DmailsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 403 for staff member accessing DMail via a key" do
-      dmail_from_staff = create(:dmail, from: moderator, to: recipient, owner_id: recipient.id)
-      dmail_from_staff.update_columns(is_read: false)
-      sign_in_as janitor
-      put mark_as_read_dmail_path(dmail_from_staff, format: :json)
+    it "returns 403 for a moderator with ticket access" do
+      ticket = create(:ticket, :dmail_type)
+      dmail = Dmail.find(ticket.disp_id)
+      dmail.update_columns(is_read: false)
+      sign_in_as moderator
+      put mark_as_read_dmail_path(dmail, format: :json)
       expect(response).to have_http_status(:forbidden)
-      expect(dmail_from_staff.reload.is_read).to be false
+      expect(dmail.reload.is_read).to be false
     end
   end
 
@@ -471,13 +472,14 @@ RSpec.describe DmailsController do
       expect(response).to have_http_status(:forbidden)
     end
 
-    it "returns 403 for staff member accessing DMail via a key" do
-      dmail_from_staff = create(:dmail, from: moderator, to: recipient, owner_id: recipient.id)
-      dmail_from_staff.update_columns(is_read: true)
-      sign_in_as janitor
-      put mark_as_unread_dmail_path(dmail_from_staff, format: :json)
+    it "returns 403 for a moderator with ticket access" do
+      ticket = create(:ticket, :dmail_type)
+      dmail = Dmail.find(ticket.disp_id)
+      dmail.update_columns(is_read: false)
+      sign_in_as moderator
+      put mark_as_unread_dmail_path(dmail, format: :json)
       expect(response).to have_http_status(:forbidden)
-      expect(dmail_from_staff.reload.is_read).to be true
+      expect(dmail.reload.is_read).to be false
     end
   end
 

--- a/spec/requests/dmails_controller_spec.rb
+++ b/spec/requests/dmails_controller_spec.rb
@@ -267,6 +267,15 @@ RSpec.describe DmailsController do
         get dmail_path(dmail_from_staff), params: { key: dmail_from_staff.generate_key }
         expect(response).to have_http_status(:forbidden)
       end
+
+      it "does not mark the dmail as read when viewed by a non-owner with the correct key" do
+        dmail_from_staff = create(:dmail, from: moderator, to: recipient, owner_id: recipient.id)
+        dmail_from_staff.update_columns(is_read: false)
+        sign_in_as janitor
+        get dmail_path(dmail_from_staff), params: { key: dmail_from_staff.generate_key }
+        expect(response).to have_http_status(:ok)
+        expect(dmail_from_staff.reload.is_read).to be false
+      end
     end
 
     context "staff system access" do
@@ -300,6 +309,17 @@ RSpec.describe DmailsController do
         sign_in_as moderator
         get dmail_path(dmail)
         expect(response).to have_http_status(:ok)
+      end
+
+      it "does not mark the dmail as read when viewed by a moderator via a ticket" do
+        ticket = create(:ticket, :dmail_type)
+        dmail = Dmail.find(ticket.disp_id)
+        dmail.update_columns(is_read: false)
+
+        sign_in_as moderator
+        get dmail_path(dmail)
+        expect(response).to have_http_status(:ok)
+        expect(dmail.reload.is_read).to be false
       end
 
       it "returns 403 for a moderator viewing a dmail without an associated ticket" do
@@ -391,13 +411,11 @@ RSpec.describe DmailsController do
       expect(response).to redirect_to(new_session_path)
     end
 
-    # FIXME: mark_as_read has no HTML template and no explicit respond_with or
-    # redirect, causing ActionController::MissingExactTemplate on HTML requests.
-    # it "marks the dmail as read for the owner (HTML)" do
-    #   sign_in_as recipient
-    #   put mark_as_read_dmail_path(dmail)
-    #   expect(dmail.reload.is_read).to be true
-    # end
+    it "marks the dmail as read for the owner (HTML)" do
+      sign_in_as recipient
+      put mark_as_read_dmail_path(dmail)
+      expect(dmail.reload.is_read).to be true
+    end
 
     it "marks the dmail as read for the owner (JSON)" do
       sign_in_as recipient
@@ -409,6 +427,15 @@ RSpec.describe DmailsController do
       sign_in_as other
       put mark_as_read_dmail_path(dmail, format: :json)
       expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for staff member accessing DMail via a key" do
+      dmail_from_staff = create(:dmail, from: moderator, to: recipient, owner_id: recipient.id)
+      dmail_from_staff.update_columns(is_read: false)
+      sign_in_as janitor
+      put mark_as_read_dmail_path(dmail_from_staff, format: :json)
+      expect(response).to have_http_status(:forbidden)
+      expect(dmail_from_staff.reload.is_read).to be false
     end
   end
 
@@ -442,6 +469,15 @@ RSpec.describe DmailsController do
       sign_in_as other
       put mark_as_unread_dmail_path(dmail, format: :json)
       expect(response).to have_http_status(:forbidden)
+    end
+
+    it "returns 403 for staff member accessing DMail via a key" do
+      dmail_from_staff = create(:dmail, from: moderator, to: recipient, owner_id: recipient.id)
+      dmail_from_staff.update_columns(is_read: true)
+      sign_in_as janitor
+      put mark_as_unread_dmail_path(dmail_from_staff, format: :json)
+      expect(response).to have_http_status(:forbidden)
+      expect(dmail_from_staff.reload.is_read).to be true
     end
   end
 

--- a/spec/requests/dmails_controller_spec.rb
+++ b/spec/requests/dmails_controller_spec.rb
@@ -397,6 +397,15 @@ RSpec.describe DmailsController do
       delete dmail_path(dmail, format: :json)
       expect(response).to have_http_status(:no_content)
     end
+
+    it "returns 403 for a moderator with ticket access" do
+      ticket = create(:ticket, :dmail_type)
+      dmail = Dmail.find(ticket.disp_id)
+      sign_in_as moderator
+      delete dmail_path(dmail, format: :json)
+      expect(response).to have_http_status(:forbidden)
+      expect(dmail.reload.is_deleted).to be false
+    end
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Staff members can share DMails among themselves with a private key.
Previously, nothing prevented third parties from changing the message's "read" status.