### PR TITLE
[Bans] Fix ban flags leaking into JSON

### DIFF
--- a/app/blueprints/ban_blueprint.rb
+++ b/app/blueprints/ban_blueprint.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class BanBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :user_id
+  field :banner_id
+  field :reason
+  field :duration
+
+  field :expires_at
+  field :created_at
+  field :updated_at
+end

--- a/app/blueprints/ban_blueprint.rb
+++ b/app/blueprints/ban_blueprint.rb
@@ -6,7 +6,6 @@ class BanBlueprint < Blueprinter::Base
   field :user_id
   field :banner_id
   field :reason
-  field :duration
 
   field :expires_at
   field :created_at

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -18,12 +18,15 @@ class BansController < ApplicationController
     @bans = Ban.search(search_params).paginate(params[:page], :limit => params[:limit])
     respond_with(@bans) do |format|
       format.html { @bans = @bans.includes(:user, :banner) }
+      format.json { render json: BanBlueprint.render(@bans) }
     end
   end
 
   def show
     @ban = Ban.find(params[:id])
-    respond_with(@ban)
+    respond_with(@ban) do |format|
+      format.json { render json: BanBlueprint.render(@ban) }
+    end
   end
 
   def create

--- a/spec/requests/bans_controller_spec.rb
+++ b/spec/requests/bans_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BansController do
   let(:admin)      { create(:admin_user) }
   let(:ban_target) { create(:user) }
   # The factory sets an explicit banner (moderator_user) so no CurrentUser swap is needed.
-  let(:ban) { create(:ban, user: ban_target) }
+  let(:ban)        { create(:ban, user: ban_target) }
 
   # ---------------------------------------------------------------------------
   # GET /bans — index
@@ -32,6 +32,16 @@ RSpec.describe BansController do
       sign_in_as member
       get bans_path
       expect(response).to have_http_status(:ok)
+    end
+
+    it "does not include ban_flags in the JSON response" do
+      ban
+      sign_in_as member
+      get bans_path(format: :json)
+      expect(response).to have_http_status(:ok)
+      first_ban = response.parsed_body.first
+      expect(first_ban).to include("id", "user_id", "banner_id", "reason", "expires_at", "created_at", "updated_at")
+      expect(first_ban).not_to include("ban_flags")
     end
 
     context "with expired and active bans" do
@@ -70,6 +80,12 @@ RSpec.describe BansController do
       get ban_path(ban, format: :json)
       expect(response).to have_http_status(:ok)
       expect(response.parsed_body).to include("id" => ban.id)
+    end
+
+    it "does not include ban_flags in the JSON response" do
+      get ban_path(ban, format: :json)
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).not_to include("ban_flags")
     end
   end
 


### PR DESCRIPTION
Previously, ban flags were exposed in the API output.
This information is not intended to be public.