### PR TITLE
[Stats] Fix "former staff_users" in json, and include all levels in html

### DIFF
--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -45,7 +45,7 @@ class StatsUpdater
 
     stats[:total_users] = User.count
     UserLevel::MAPPING.each do |name, level|
-      stats[:"#{name.downcase.gsub(' ', '_')}_users"] = User.where(level: level).count
+      stats[:"#{UserLevel.normalize(name)}_users"] = User.where(level: level).count
     end
     stats[:unactivated_users] = User.where.not(email_verification_key: nil).count
     stats[:total_dmails] = Dmail.maximum("id").to_i / 2

--- a/app/logical/stats_updater.rb
+++ b/app/logical/stats_updater.rb
@@ -45,7 +45,7 @@ class StatsUpdater
 
     stats[:total_users] = User.count
     UserLevel::MAPPING.each do |name, level|
-      stats[:"#{name.downcase}_users"] = User.where(level: level).count
+      stats[:"#{name.downcase.gsub(' ', '_')}_users"] = User.where(level: level).count
     end
     stats[:unactivated_users] = User.where.not(email_verification_key: nil).count
     stats[:total_dmails] = Dmail.maximum("id").to_i / 2

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -53,15 +53,12 @@
       %>
 
       <%= render "percentage_table", header_title: "Users", data: [
-          ["User count", "total_users"],
+          ["Total users", "total_users"],
           ["Active users (3 months)", "active_users", "total_users"],
           ["Unactivated users", "unactivated_users", "total_users"],
-          ["Banned users", "blocked_users", "total_users"],
-          ["Members", "member_users", "total_users"],
-          ["Privileged users", "privileged_users", "total_users"],
-          ["Janitors", "janitor_users", "total_users"],
-          ["Moderators", "moderator_users", "total_users"],
-          ["Admins", "admin_users", "total_users"],
+          *UserLevel::MAPPING.keys.map do |level|
+            ["#{level} users", "#{level.downcase.gsub(' ', '_')}_users", "total_users"]
+          end,
           ["Dmails sent", "total_dmails"],
         ]
       %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -57,7 +57,7 @@
           ["Active users (3 months)", "active_users", "total_users"],
           ["Unactivated users", "unactivated_users", "total_users"],
           *UserLevel::MAPPING.keys.map do |level|
-            ["#{level} users", "#{level.downcase.gsub(' ', '_')}_users", "total_users"]
+            ["#{level} users", "#{UserLevel.normalize(level)}_users", "total_users"]
           end,
           ["Dmails sent", "total_dmails"],
         ]

--- a/spec/logical/stats_updater_spec.rb
+++ b/spec/logical/stats_updater_spec.rb
@@ -30,5 +30,16 @@ RSpec.describe StatsUpdater do
       expect(raw).to be_present
       expect(JSON.parse(raw, symbolize_names: true)[:started]).to be_present
     end
+
+    it "correctly normalizes user level names" do
+      described_class.run!
+      raw = Cache.redis.get("e6stats")
+      expect(raw).to be_present
+      stats = JSON.parse(raw, symbolize_names: true)
+      UserLevel::MAPPING.each do |name, level|
+        normalized_name = UserLevel.normalize(name)
+        expect(stats[:"#{normalized_name}_users"]).to eq(User.where(level: level).count)
+      end
+    end
   end
 end


### PR DESCRIPTION
As with everywhere else in the site, former staff here mistakenly included the space. I also modified the html to include all levels. This does currently include anonymous, I left it just for simplicity's sake.
<sub>[On an unrelated note, we do actually have an anonymous user, for some reason](https://e621.net/users/673727)</sub>