### PR TITLE
[UI] Fix the avatar menu repeatedly fetching data for blocked users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@
 class UsersController < ApplicationController
   respond_to :html, :json
   skip_before_action :api_check
-  before_action :logged_in_only, only: %i[edit settings upload_limit update]
-  before_action :member_only, only: %i[custom_style avatar_menu]
+  before_action :logged_in_only, only: %i[edit settings upload_limit update avatar_menu]
+  before_action :member_only, only: %i[custom_style]
   before_action :janitor_only, only: %i[toggle_uploads disable_uploads fix_counts toggle_karma_free disable_karma_free]
   before_action :admin_only, only: %i[flush_favorites]
   before_action :check_upload_disable_reason, only: %i[disable_uploads]


### PR DESCRIPTION
`Navigation.ts` pre-fetches the avatar menu data if the `localStorage` cache is empty.
However, the `/users/avatar_menu.json` route will throw error 403 for users lower in rank than a member.
As a result, the script will attempt (and fail) to re-fetch the data on every single page load.

Also applies to users who have not verified their email.