### PR TITLE
[Misc] Prevent offclick menus from closing on autocomplete selection

### DIFF
--- a/app/javascript/src/js/utility/Offclick.ts
+++ b/app/javascript/src/js/utility/Offclick.ts
@@ -23,7 +23,9 @@ export default class Offclick {
 
         if (target.closest(entry.menuSelector).length > 0 // Click inside the menu
             || target.is(entry.buttonSelector) // Click the button itself
-            || target.parents(entry.buttonSelector).length > 0) // Click inside one of the button's children
+            || target.parents(entry.buttonSelector).length > 0 // Click inside one of the button's children
+            || target.parents("ul.ui-autocomplete-dropdown").length > 0 // Click inside an autocomplete dropdown
+          )
           continue;
 
         entry.callback();

--- a/app/javascript/src/js/utility/Offclick.ts
+++ b/app/javascript/src/js/utility/Offclick.ts
@@ -25,7 +25,7 @@ export default class Offclick {
             || target.is(entry.buttonSelector) // Click the button itself
             || target.parents(entry.buttonSelector).length > 0 // Click inside one of the button's children
             || target.parents("ul.ui-autocomplete-dropdown").length > 0 // Click inside an autocomplete dropdown
-          )
+        )
           continue;
 
         entry.callback();

--- a/app/javascript/src/js/utility/Offclick.ts
+++ b/app/javascript/src/js/utility/Offclick.ts
@@ -24,7 +24,7 @@ export default class Offclick {
         if (target.closest(entry.menuSelector).length > 0 // Click inside the menu
             || target.is(entry.buttonSelector) // Click the button itself
             || target.parents(entry.buttonSelector).length > 0 // Click inside one of the button's children
-            || target.parents("ul.ui-autocomplete-dropdown").length > 0 // Click inside an autocomplete dropdown
+            || target.closest("ul.ui-autocomplete-dropdown").length > 0 // Click inside an autocomplete dropdown
         )
           continue;
 


### PR DESCRIPTION
Autocomplete selections are rendered outside of the element they are attached to.
This means that Offclick will treat tapping on a selection as clicking outside the target element.

Most noticeable on mobile.
1. Go to the `/users/` page.
2. Open the hamburger menu.
3. Start typing something into search.
4. Select an autocomplete suggestion
5. Have the hamburger menu close on you.