### PR TITLE
[Wiki] Strip outline labels with the sanitizer

### DIFF
--- a/app/logical/wiki_table_of_contents.rb
+++ b/app/logical/wiki_table_of_contents.rb
@@ -155,7 +155,7 @@ class WikiTableOfContents
   end
 
   def clean_label(inner)
-    text = CGI.unescapeHTML(inner.gsub(BACK_TO_TOP, "").gsub(/<[^>]+>/, ""))
+    text = CGI.unescapeHTML(ApplicationController.helpers.strip_tags(inner.gsub(BACK_TO_TOP, "")))
     text.gsub(/\A(?:\s|#{NAV_GLYPHS})+|(?:\s|#{NAV_GLYPHS})+\z/, "").sub(/:\s*\z/, "")
   end
 

--- a/spec/logical/wiki_table_of_contents_spec.rb
+++ b/spec/logical/wiki_table_of_contents_spec.rb
@@ -97,6 +97,10 @@ RSpec.describe WikiTableOfContents do
       it "strips inner markup from the label" do
         expect(entries("<h2>Vaelor <b>Draketh</b></h2>").first[:text]).to eq("Vaelor Draketh")
       end
+
+      it "strips inner markup carrying a bracket in an attribute" do
+        expect(entries(%(<h2><span title="Vaelor > Draketh">Ignyr</span></h2>)).first[:text]).to eq("Ignyr")
+      end
     end
 
     describe "author anchors" do


### PR DESCRIPTION
This does not improve security because this text is never directly placed in html but this will satisfy the warning.