### PR TITLE
 [PostVersions] Cleaner way to hide post versions

### DIFF
--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -29,14 +29,14 @@ class PostVersionsController < ApplicationController
     @post_version = PostVersion.find(params[:id])
     if @post_version.is_hidden?
       flash[:notice] = "Post version #{@post_version.id} is already hidden."
-      redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })
+      redirect_to_versions_for(@post_version)
       return
     end
 
     @post_version.update_columns(is_hidden: true)
     ModAction.log(:post_version_hide, { version: @post_version.version, post_id: @post_version.post_id })
 
-    redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })
+    redirect_to_versions_for(@post_version)
   end
 
   def unhide
@@ -45,13 +45,19 @@ class PostVersionsController < ApplicationController
     @post_version = PostVersion.find(params[:id])
     unless @post_version.is_hidden?
       flash[:notice] = "Post version #{@post_version.id} is not hidden."
-      redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })
+      redirect_to_versions_for(@post_version)
       return
     end
 
     @post_version.update_columns(is_hidden: false)
     ModAction.log(:post_version_unhide, { version: @post_version.version, post_id: @post_version.post_id })
 
-    redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })
+    redirect_to_versions_for(@post_version)
+  end
+
+  private
+
+  def redirect_to_versions_for(post_version)
+    redirect_back fallback_location: post_versions_path(search: { post_id: post_version.post_id })
   end
 end

--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -27,8 +27,7 @@ class PostVersionsController < ApplicationController
     raise User::PrivilegeError unless CurrentUser.is_bd_staff?
 
     @post_version = PostVersion.find(params[:id])
-    @post_version.is_hidden = true
-    @post_version.save!
+    @post_version.update_columns(is_hidden: true)
     ModAction.log(:post_version_hide, { version: @post_version.version, post_id: @post_version.post_id })
 
     redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })
@@ -38,8 +37,7 @@ class PostVersionsController < ApplicationController
     raise User::PrivilegeError unless CurrentUser.is_bd_staff?
 
     @post_version = PostVersion.find(params[:id])
-    @post_version.is_hidden = false
-    @post_version.save!
+    @post_version.update_columns(is_hidden: false)
     ModAction.log(:post_version_unhide, { version: @post_version.version, post_id: @post_version.post_id })
 
     redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })

--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -27,6 +27,12 @@ class PostVersionsController < ApplicationController
     raise User::PrivilegeError unless CurrentUser.is_bd_staff?
 
     @post_version = PostVersion.find(params[:id])
+    if @post_version.is_hidden?
+      flash[:notice] = "Post version #{@post_version.id} is already hidden."
+      redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })
+      return
+    end
+
     @post_version.update_columns(is_hidden: true)
     ModAction.log(:post_version_hide, { version: @post_version.version, post_id: @post_version.post_id })
 
@@ -37,6 +43,12 @@ class PostVersionsController < ApplicationController
     raise User::PrivilegeError unless CurrentUser.is_bd_staff?
 
     @post_version = PostVersion.find(params[:id])
+    unless @post_version.is_hidden?
+      flash[:notice] = "Post version #{@post_version.id} is not hidden."
+      redirect_back fallback_location: post_versions_path(search: { post_id: @post_version.post_id })
+      return
+    end
+
     @post_version.update_columns(is_hidden: false)
     ModAction.log(:post_version_unhide, { version: @post_version.version, post_id: @post_version.post_id })
 

--- a/spec/requests/post_versions_controller_spec.rb
+++ b/spec/requests/post_versions_controller_spec.rb
@@ -143,18 +143,22 @@ RSpec.describe PostVersionsController do
       it "does not change updater_id or updated_at" do
         bv = base_version
         old_updater_id = bv.updater_id
+        old_updater_ip = bv.updater_ip_addr
         old_updated_at = bv.updated_at
         put hide_post_version_path(bv)
         bv.reload
         expect(bv.updater_id).to eq(old_updater_id)
-        expect(bv.updated_at).to eq(old_updated_at)
+        expect(bv.updater_ip_addr).to eq(old_updater_ip)
+        expect(bv.updated_at).to be_within(1.second).of(old_updated_at)
       end
 
       it "returns a flash notice if the post version is already hidden" do
         bv = base_version
         bv.update_columns(is_hidden: true)
-        put hide_post_version_path(bv)
+        expect { put hide_post_version_path(bv) }.not_to change(ModAction, :count)
+        expect(bv.reload.is_hidden).to be true
         expect(flash[:notice]).to eq("Post version #{bv.id} is already hidden.")
+        expect(response).to redirect_to(post_versions_path(search: { post_id: bv.post_id }))
       end
 
       it "logs a post_version_hide ModAction" do
@@ -201,18 +205,22 @@ RSpec.describe PostVersionsController do
       it "does not change updater_id or updated_at" do
         bv = base_version
         old_updater_id = bv.updater_id
+        old_updater_ip = bv.updater_ip_addr
         old_updated_at = bv.updated_at
         put unhide_post_version_path(bv)
         bv.reload
         expect(bv.updater_id).to eq(old_updater_id)
-        expect(bv.updated_at).to eq(old_updated_at)
+        expect(bv.updater_ip_addr).to eq(old_updater_ip)
+        expect(bv.updated_at).to be_within(1.second).of(old_updated_at)
       end
 
       it "returns a flash notice if the post version is not hidden" do
         bv = base_version
         bv.update_columns(is_hidden: false)
-        put unhide_post_version_path(bv)
+        expect { put unhide_post_version_path(bv) }.not_to change(ModAction, :count)
         expect(flash[:notice]).to eq("Post version #{bv.id} is not hidden.")
+        expect(bv.reload.is_hidden).to be false
+        expect(response).to redirect_to(post_versions_path(search: { post_id: bv.post_id }))
       end
 
       it "logs a post_version_unhide ModAction" do

--- a/spec/requests/post_versions_controller_spec.rb
+++ b/spec/requests/post_versions_controller_spec.rb
@@ -140,6 +140,23 @@ RSpec.describe PostVersionsController do
         expect(bv.reload.is_hidden).to be true
       end
 
+      it "does not change updater_id or updated_at" do
+        bv = base_version
+        old_updater_id = bv.updater_id
+        old_updated_at = bv.updated_at
+        put hide_post_version_path(bv)
+        bv.reload
+        expect(bv.updater_id).to eq(old_updater_id)
+        expect(bv.updated_at).to eq(old_updated_at)
+      end
+
+      it "returns a flash notice if the post version is already hidden" do
+        bv = base_version
+        bv.update_columns(is_hidden: true)
+        put hide_post_version_path(bv)
+        expect(flash[:notice]).to eq("Post version #{bv.id} is already hidden.")
+      end
+
       it "logs a post_version_hide ModAction" do
         bv = base_version
         expect { put hide_post_version_path(bv) }.to change(ModAction, :count).by(1)
@@ -179,6 +196,23 @@ RSpec.describe PostVersionsController do
         bv = base_version
         put unhide_post_version_path(bv)
         expect(bv.reload.is_hidden).to be false
+      end
+
+      it "does not change updater_id or updated_at" do
+        bv = base_version
+        old_updater_id = bv.updater_id
+        old_updated_at = bv.updated_at
+        put unhide_post_version_path(bv)
+        bv.reload
+        expect(bv.updater_id).to eq(old_updater_id)
+        expect(bv.updated_at).to eq(old_updated_at)
+      end
+
+      it "returns a flash notice if the post version is not hidden" do
+        bv = base_version
+        bv.update_columns(is_hidden: false)
+        put unhide_post_version_path(bv)
+        expect(flash[:notice]).to eq("Post version #{bv.id} is not hidden.")
       end
 
       it "logs a post_version_unhide ModAction" do


### PR DESCRIPTION
Previous implementation overwritten the previous `updater_id` and `updated_at` values. Irreversibly.

This is a partial fix – ideally, we would surface the name of the staff member who hid the version – but that would require a database migration.
And we don't want a repeat of #1067 / #1073.