### PR TITLE
[TagImplications] Rework the undo functionality

### DIFF
--- a/app/decorators/mod_action_decorator.rb
+++ b/app/decorators/mod_action_decorator.rb
@@ -371,6 +371,8 @@ class ModActionDecorator < ApplicationDecorator
       else
         "Updated tag implication #{vals['implication_desc']}\n#{vals['change_desc']}"
       end
+    when "tag_implication_undo"
+      "Undid tag implication #{vals['implication_desc']}"
 
       ### BURs ###
 

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -11,10 +11,16 @@ class TagImplicationFinalizeJob < ApplicationJob
   def perform(implication_id, reindex_tag_name)
     ti = TagImplication.find_by(id: implication_id)
     return unless ti
+
+    # Posts edited since processing may no longer match the tag query but
+    # still need reindexing after an undo; the undo rows enumerate them.
+    post_ids = ti.tag_rel_undos.flat_map(&:post_ids).uniq
+
     Post.without_timeout do
       Post.document_store.import(
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", reindex_tag_name],
       )
+      Post.document_store.import(query: { id: post_ids }) if post_ids.any?
 
       # Post counts may have drifted out of sync, or may have been inaccurate
       # due to legacy data. Recalculate them to ensure they are correct.

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -8,13 +8,15 @@ class TagImplicationFinalizeJob < ApplicationJob
     [args[0]]
   end
 
-  def perform(implication_id, reindex_tag_name)
+  def perform(implication_id, reindex_tag_name, undo: false)
     ti = TagImplication.find_by(id: implication_id)
     return unless ti
 
     # Posts edited since processing may no longer match the tag query but
-    # still need reindexing after an undo; the undo rows enumerate them.
-    post_ids = ti.tag_rel_undos.flat_map(&:post_ids).uniq
+    # still need reindexing after an undo; the undo rows enumerate them. On
+    # the approval path they all still match the tag query, so this would
+    # only reimport the same documents.
+    post_ids = undo ? ti.tag_rel_undos.flat_map(&:post_ids).uniq : []
 
     Post.without_timeout do
       Post.document_store.import(

--- a/app/jobs/tag_implication_undo_job.rb
+++ b/app/jobs/tag_implication_undo_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class TagImplicationUndoJob < ApplicationJob
+  queue_as :tags
+  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+
+  # These conditions never self-heal, so retrying is pointless; tell the
+  # undoer what happened instead.
+  discard_on TagImplication::UndoError do |job, error|
+    implication_id, _update_topic, undoer_id = job.arguments
+    next if undoer_id.blank?
+
+    Dmail.create_automated(
+      to_id: undoer_id,
+      title: "Tag implication ##{implication_id} could not be undone",
+      body: "The undo of \"tag implication ##{implication_id}\":/tag_implications/#{implication_id} was rejected: #{error.message}",
+    )
+  end
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(*args)
+    ti = TagImplication.find(args[0])
+    undoer = User.find_by(id: args[2])
+    ti.process_undo!(update_topic: args[1], undoer: undoer)
+  end
+end

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -76,6 +76,7 @@ class ModAction < ApplicationRecord
     tag_alias_undo: { alias_id: :integer, alias_desc: :string },
     tag_implication_create: { implication_id: :integer, implication_desc: :string },
     tag_implication_update: { implication_id: :integer, implication_desc: :string, change_desc: :string },
+    tag_implication_undo: { implication_id: :integer, implication_desc: :string },
     ticket_claim: { ticket_id: :integer },
     ticket_unclaim: { ticket_id: :integer },
     ticket_update: { ticket_id: :integer, status: :string, response: :string, status_was: :string, response_was: :string },

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class TagAlias < TagRelationship
-  # Raised when an undo is refused for a reason that will not go away on its
-  # own; TagAliasUndoJob discards instead of retrying when it sees this.
-  class UndoError < StandardError; end
-
   has_many :tag_rel_undos, as: :tag_rel
 
   after_save :create_mod_action

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -324,7 +324,7 @@ class TagImplication < TagRelationship
           tu.update!(applied: true)
         end
       end
-      TagImplicationFinalizeJob.perform_later(id, antecedent_name)
+      TagImplicationFinalizeJob.perform_later(id, antecedent_name, undo: true)
     ensure
       Thread.current[:skip_post_index_update] = false
     end

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -168,22 +168,44 @@ class TagImplication < TagRelationship
     end
 
     def create_undo_information
+      # process! retries from the top on failure, so this can run more than once.
+      # A completed snapshot (the side effects record is created last) must be
+      # kept, not rebuilt: it describes the pre-implication state, which the
+      # failed attempt's mutations may have already partially destroyed. An
+      # incomplete snapshot means no mutations have happened yet, so rebuilding
+      # is safe.
+      unapplied = tag_rel_undos.where(applied: false)
+      return if unapplied.any?(&:side_effects?)
+      unapplied.destroy_all
+
       Post.without_timeout do
-        post_info = {}
+        added = {}
         Post.sql_raw_tag_match(antecedent_name).find_each do |post|
           next if post.tag_array.include?(consequent_name)
-          post_info[post.id.to_s] = post.tag_string
+          # descendant_names is the consequent plus its full active implication
+          # chain — the set the post-save pipeline is about to add.
+          added[post.id.to_s] = descendant_names - post.tag_array
 
-          if post_info.size >= TagRelationship::POST_LIMIT
-            tag_rel_undos.create!(undo_data: post_info)
-            post_info = {}
+          if added.size >= TagRelationship::POST_LIMIT
+            create_undo_posts_chunk(added)
+            added = {}
           end
         end
-
-        if post_info.any?
-          tag_rel_undos.create!(undo_data: post_info)
-        end
+        create_undo_posts_chunk(added) if added.any?
+        tag_rel_undos.create!(undo_data: {
+          "version" => 2,
+          "kind" => "side_effects",
+          "implication" => { "antecedent_name" => antecedent_name, "consequent_name" => consequent_name },
+        })
       end
+    end
+
+    def create_undo_posts_chunk(added)
+      tag_rel_undos.create!(undo_data: {
+        "version" => 2,
+        "kind" => "posts",
+        "added" => added,
+      })
     end
 
     def approve!(approver: CurrentUser.user, update_topic: true)
@@ -192,14 +214,22 @@ class TagImplication < TagRelationship
       TagImplicationJob.perform_later(id, update_topic)
     end
 
+    def undo!(undoer: CurrentUser.user, update_topic: true)
+      TagImplicationUndoJob.perform_later(id, update_topic, undoer.id)
+    end
+
     def reject!(update_topic: true)
       update(status: "deleted")
       invalidate_cached_descendants
       forum_updater.update(reject_message(CurrentUser.user), "REJECTED") if update_topic
     end
 
+    def mod_action_description
+      %Q("tag implication ##{id}":[#{Rails.application.routes.url_helpers.tag_implication_path(self)}]: [[#{antecedent_name}]] -> [[#{consequent_name}]])
+    end
+
     def create_mod_action
-      implication = %Q("tag implication ##{id}":[#{Rails.application.routes.url_helpers.tag_implication_path(self)}]: [[#{antecedent_name}]] -> [[#{consequent_name}]])
+      implication = mod_action_description
 
       if previously_new_record?
         ModAction.log(:tag_implication_create, {implication_id: id, implication_desc: implication})
@@ -232,32 +262,66 @@ class TagImplication < TagRelationship
       )
     end
 
-    def process_undo!(update_topic: true)
-      unless valid?
-        raise errors.full_messages.join("; ")
-      end
+    def process_undo!(update_topic: true, undoer: nil)
+      validate_undoable!
 
-      CurrentUser.scoped(approver) do
-        update(status: "pending")
+      CurrentUser.scoped(undoer || approver) do
+        update!(status: "pending")
+        invalidate_cached_descendants
         update_posts_undo
         forum_updater.update(retirement_message, "UNDONE") if update_topic
+        ModAction.log(:tag_implication_undo, { implication_id: id, implication_desc: mod_action_description })
       end
-      tag_rel_undos.update_all(applied: true)
+      tag_rel_undos.where(applied: false).update_all(applied: true)
+    end
+
+    # Returns the side effects record on success.
+    def validate_undoable!
+      unless valid?
+        raise TagRelationship::UndoError, errors.full_messages.join("; ")
+      end
+      # "pending" is allowed so a retried job can resume an undo that failed
+      # partway through; a never-processed pending implication has no unapplied
+      # undo rows and is refused below.
+      unless is_active? || is_errored? || is_pending?
+        raise TagRelationship::UndoError, "This tag implication cannot be undone while it is \"#{status}\"; if a processing job died, set the status to an error first."
+      end
+
+      undos = tag_rel_undos.where(applied: false).order(:id).to_a
+      raise TagRelationship::UndoError, "No unapplied undo information exists for this tag implication." if undos.empty?
+      raise TagRelationship::UndoError, "This tag implication cannot be undone: its undo data predates undo support." if undos.any?(&:legacy?)
+
+      side_effects = undos.find(&:side_effects?)
+      raise TagRelationship::UndoError, "This tag implication cannot be undone: the side effects record is missing from its undo data." if side_effects.nil?
+
+      recorded = side_effects.undo_data["implication"]
+      if recorded["antecedent_name"] != antecedent_name || recorded["consequent_name"] != consequent_name
+        raise TagRelationship::UndoError, "This tag implication cannot be undone: it was #{recorded['antecedent_name']} -> #{recorded['consequent_name']} when processed, but is now #{antecedent_name} -> #{consequent_name}."
+      end
+
+      side_effects
     end
 
     def update_posts_undo
       Thread.current[:skip_post_index_update] = true
       Post.without_timeout do
-        tag_rel_undos.where(applied: false).each do |tu|
-          Post.where(id: tu.undo_data.keys).find_each do |post|
-            post.do_not_version_changes = true
-            if TagQuery.scan(tu.undo_data[post.id.to_s]).include?(consequent_name)
-              Rails.logger.info("[TIU] Skipping post that already contains target tag.")
-              next
+        tag_rel_undos.where(applied: false).select(&:posts_chunk?).each do |tu|
+          added = tu.undo_data["added"]
+          Post.where(id: tu.post_ids).find_each do |post|
+            post.with_lock do
+              # Only remove what is still there; a tag removed since was a
+              # deliberate edit, and one that is still implied by another
+              # active implication (or locked) gets re-added by normalize_tags
+              # during this same save. This implication is already pending, so
+              # its own tags stay removed.
+              to_remove = added[post.id.to_s] & post.tag_array
+              next if to_remove.empty?
+              post.do_not_version_changes = true
+              post.tag_string_diff = to_remove.map { |tag| "-#{tag}" }.join(" ")
+              post.save
             end
-            post.tag_string_diff = "-#{consequent_name}"
-            post.save
           end
+          tu.update!(applied: true)
         end
       end
       TagImplicationFinalizeJob.perform_later(id, antecedent_name)

--- a/app/models/tag_rel_undo.rb
+++ b/app/models/tag_rel_undo.rb
@@ -3,9 +3,10 @@
 class TagRelUndo < ApplicationRecord
   belongs_to :tag_rel, polymorphic: true
 
-  # Original TagAlias / TagNukeJob format: a flat array of post ids.
+  # Formats that predate undo support: the TagAlias / TagNukeJob flat array of
+  # post ids, and the TagImplication { post_id => tag_string } hash.
   def legacy?
-    undo_data.is_a?(Array)
+    undo_data.is_a?(Array) || (undo_data.is_a?(Hash) && !undo_data.key?("kind"))
   end
 
   def posts_chunk?
@@ -17,14 +18,18 @@ class TagRelUndo < ApplicationRecord
   end
 
   def post_ids
-    if legacy?
+    if undo_data.is_a?(Array)
       undo_data
     elsif posts_chunk?
-      undo_data["with_consequent"] + undo_data["without_consequent"]
+      if undo_data.key?("added")
+        undo_data["added"].keys.map(&:to_i)
+      else
+        undo_data["with_consequent"] + undo_data["without_consequent"]
+      end
     elsif side_effects?
       []
     else
-      # TagImplication format: { post_id => tag_string }
+      # Legacy TagImplication format: { post_id => tag_string }
       undo_data.keys.map(&:to_i)
     end
   end

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -3,6 +3,10 @@
 class TagRelationship < ApplicationRecord
   self.abstract_class = true
 
+  # Raised when an undo is refused for a reason that will not go away on its
+  # own; the undo jobs discard instead of retrying when they see this.
+  class UndoError < StandardError; end
+
   POST_LIMIT = 10_000
   SUPPORT_HARD_CODED = true
 

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -35,5 +35,19 @@ RSpec.describe TagImplicationFinalizeJob do
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ti.antecedent_name],
       )
     end
+
+    it "also reindexes the posts enumerated by the undo rows" do
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "101" => ["species_b"] } })
+      ti.tag_rel_undos.create!(undo_data: { "102" => "char_a species_b" })
+
+      described_class.perform_now(ti.id, ti.antecedent_name)
+
+      expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102] })
+    end
+
+    it "does not reindex by id when no undo rows exist" do
+      described_class.perform_now(ti.id, ti.antecedent_name)
+      expect(Post.document_store).not_to have_received(:import).with(query: hash_including(:id))
+    end
   end
 end

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -36,17 +36,25 @@ RSpec.describe TagImplicationFinalizeJob do
       )
     end
 
-    it "also reindexes the posts enumerated by the undo rows" do
+    it "also reindexes the posts enumerated by the undo rows when called for an undo" do
       ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "101" => ["species_b"] } })
       ti.tag_rel_undos.create!(undo_data: { "102" => "char_a species_b" })
 
-      described_class.perform_now(ti.id, ti.antecedent_name)
+      described_class.perform_now(ti.id, ti.antecedent_name, undo: true)
 
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102] })
     end
 
+    it "does not reindex by id on the approval path even when undo rows exist" do
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "101" => ["species_b"] } })
+
+      described_class.perform_now(ti.id, ti.consequent_name)
+
+      expect(Post.document_store).not_to have_received(:import).with(query: hash_including(:id))
+    end
+
     it "does not reindex by id when no undo rows exist" do
-      described_class.perform_now(ti.id, ti.antecedent_name)
+      described_class.perform_now(ti.id, ti.antecedent_name, undo: true)
       expect(Post.document_store).not_to have_received(:import).with(query: hash_including(:id))
     end
   end

--- a/spec/jobs/tag_implication_undo_job_spec.rb
+++ b/spec/jobs/tag_implication_undo_job_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TagImplicationUndoJob do
+  include_context "as admin"
+
+  describe "#perform" do
+    let(:tag_implication) { create(:tag_implication) }
+
+    it "calls process_undo! on the tag implication with the undoer" do
+      undoer = create(:admin_user)
+      allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
+      allow(tag_implication).to receive(:process_undo!)
+      described_class.perform_now(tag_implication.id, false, undoer.id)
+      expect(tag_implication).to have_received(:process_undo!).with(update_topic: false, undoer: undoer)
+    end
+
+    it "passes a nil undoer when none was recorded" do
+      allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
+      allow(tag_implication).to receive(:process_undo!)
+      described_class.perform_now(tag_implication.id, false)
+      expect(tag_implication).to have_received(:process_undo!).with(update_topic: false, undoer: nil)
+    end
+
+    it "discards and dmails the undoer when the undo is permanently impossible" do
+      undoer = create(:admin_user)
+      allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
+      allow(tag_implication).to receive(:process_undo!).and_raise(TagImplication::UndoError, "some permanent problem")
+
+      expect { described_class.perform_now(tag_implication.id, false, undoer.id) }
+        .to change { Dmail.where(to_id: undoer.id, owner_id: undoer.id).count }.by(1)
+
+      dmail = Dmail.where(to_id: undoer.id, owner_id: undoer.id).last
+      expect(dmail.body).to include("some permanent problem")
+    end
+
+    it "discards without notifying when no undoer was recorded" do
+      allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
+      allow(tag_implication).to receive(:process_undo!).and_raise(TagImplication::UndoError, "some permanent problem")
+
+      expect { described_class.perform_now(tag_implication.id, false) }.not_to change(Dmail, :count)
+    end
+  end
+
+  describe ".lock_args" do
+    it "locks on the tag implication id only" do
+      expect(described_class.lock_args([123, true, 456])).to eq([123])
+    end
+  end
+end

--- a/spec/models/tag_implication/approval_methods_spec.rb
+++ b/spec/models/tag_implication/approval_methods_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 # ---------------------------------------------------------------------------
 # TagImplication::ApprovalMethods
 #
-# Covers: approve!, process!, create_undo_information, update_posts,
+# Covers: approve!, undo!, process!, create_undo_information, update_posts,
 #         process_undo!, update_posts_undo, forum_updater
 # ---------------------------------------------------------------------------
 
@@ -89,14 +89,39 @@ RSpec.describe TagImplication do
   # #create_undo_information
   # ---------------------------------------------------------------------------
   describe "#create_undo_information" do
-    it "captures matching post tag strings in the undo record" do
+    it "records the predicted added tags for matching posts in a posts chunk" do
       ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
       post = create(:post, tag_string: "char_a")
       ti.update_columns(status: "active")
 
       ti.create_undo_information
 
-      expect(ti.tag_rel_undos.last.undo_data).to include(post.id.to_s => "char_a")
+      chunk = ti.tag_rel_undos.find(&:posts_chunk?)
+      expect(chunk.undo_data["added"]).to eq(post.id.to_s => ["species_b"])
+    end
+
+    it "records the full descendant chain, not just the direct consequent" do
+      create(:active_tag_implication, antecedent_name: "species_b", consequent_name: "species_c")
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      post = create(:post, tag_string: "char_a")
+      ti.update_columns(status: "active")
+
+      ti.create_undo_information
+
+      chunk = ti.tag_rel_undos.find(&:posts_chunk?)
+      expect(chunk.undo_data["added"][post.id.to_s]).to match_array(%w[species_b species_c])
+    end
+
+    it "excludes tags the post already carries from the added set" do
+      create(:active_tag_implication, antecedent_name: "species_b", consequent_name: "species_c")
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      post = create(:post, tag_string: "char_a species_c")
+      ti.update_columns(status: "active")
+
+      ti.create_undo_information
+
+      chunk = ti.tag_rel_undos.find(&:posts_chunk?)
+      expect(chunk.undo_data["added"][post.id.to_s]).to eq(["species_b"])
     end
 
     it "skips posts that already contain the consequent" do
@@ -108,14 +133,47 @@ RSpec.describe TagImplication do
 
       ti.create_undo_information
 
-      recorded_ids = ti.tag_rel_undos.flat_map { |u| u.undo_data.keys.map(&:to_i) }
+      recorded_ids = ti.tag_rel_undos.flat_map(&:post_ids)
       expect(recorded_ids).not_to include(post.id)
     end
 
-    it "does not create an undo record when no posts match" do
+    it "creates the side effects record last, recording the names at process time" do
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      create(:post, tag_string: "char_a")
+      ti.update_columns(status: "active")
+
+      ti.create_undo_information
+
+      side_effects = ti.tag_rel_undos.order(:id).last
+      expect(side_effects.side_effects?).to be(true)
+      expect(side_effects.undo_data["implication"]).to eq("antecedent_name" => "char_a", "consequent_name" => "species_b")
+    end
+
+    it "creates only the side effects record when no posts match" do
       ti = create(:active_tag_implication)
 
-      expect { ti.create_undo_information }.not_to change(ti.tag_rel_undos, :count)
+      expect { ti.create_undo_information }.to change(ti.tag_rel_undos, :count).by(1)
+      expect(ti.tag_rel_undos.last.side_effects?).to be(true)
+    end
+
+    it "keeps a completed snapshot when run again" do
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      create(:post, tag_string: "char_a")
+      ti.update_columns(status: "active")
+      ti.create_undo_information
+
+      expect { ti.create_undo_information }.not_to(change { ti.tag_rel_undos.order(:id).pluck(:id) })
+    end
+
+    it "destroys and rebuilds an incomplete snapshot" do
+      ti = create(:active_tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      stale = ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "123" => ["species_b"] } })
+
+      ti.create_undo_information
+
+      expect(TagRelUndo.exists?(stale.id)).to be(false)
+      expect(ti.tag_rel_undos.count).to eq(1)
+      expect(ti.tag_rel_undos.last.side_effects?).to be(true)
     end
   end
 
@@ -147,9 +205,20 @@ RSpec.describe TagImplication do
   # #process_undo!
   # ---------------------------------------------------------------------------
   describe "#process_undo!" do
-    it "resets status to pending" do
+    def create_undoable_implication
       ti = create(:active_tag_implication)
       ti.update_columns(approver_id: create(:admin_user).id)
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
+      ti.tag_rel_undos.create!(undo_data: {
+        "version" => 2,
+        "kind" => "side_effects",
+        "implication" => { "antecedent_name" => ti.antecedent_name, "consequent_name" => ti.consequent_name },
+      })
+      ti
+    end
+
+    it "resets status to pending" do
+      ti = create_undoable_implication
 
       ti.process_undo!(update_topic: false)
 
@@ -157,24 +226,110 @@ RSpec.describe TagImplication do
     end
 
     it "marks all tag_rel_undos as applied" do
-      ti = create(:active_tag_implication)
-      ti.update_columns(approver_id: create(:admin_user).id)
-      ti.tag_rel_undos.create!(undo_data: {})
+      ti = create_undoable_implication
 
       ti.process_undo!(update_topic: false)
 
       expect(ti.tag_rel_undos.where(applied: false).count).to eq(0)
     end
 
-    it "raises when the implication fails validation" do
-      ti = create(:active_tag_implication)
-      ti.update_columns(approver_id: create(:admin_user).id)
+    it "logs a tag_implication_undo mod action" do
+      ti = create_undoable_implication
+
+      expect { ti.process_undo!(update_topic: false) }
+        .to change { ModAction.where(action: "tag_implication_undo").count }.by(1)
+    end
+
+    it "attributes the undo to the undoer, not the original approver" do
+      ti = create_undoable_implication
+      undoer = create(:admin_user)
+
+      ti.process_undo!(update_topic: false, undoer: undoer)
+
+      expect(ModAction.where(action: "tag_implication_undo").last.creator_id).to eq(undoer.id)
+    end
+
+    it "falls back to the original approver when no undoer is given" do
+      ti = create_undoable_implication
+
+      ti.process_undo!(update_topic: false)
+
+      expect(ModAction.where(action: "tag_implication_undo").last.creator_id).to eq(ti.approver_id)
+    end
+
+    it "calls invalidate_cached_descendants" do
+      ti = create_undoable_implication
+      allow(ti).to receive(:invalidate_cached_descendants)
+
+      ti.process_undo!(update_topic: false)
+
+      expect(ti).to have_received(:invalidate_cached_descendants)
+    end
+
+    it "raises when the implication is invalid" do
+      ti = create_undoable_implication
       allow(ti).to receive_messages(
         valid?: false,
         errors: instance_double(ActiveModel::Errors, full_messages: ["something is wrong"]),
       )
 
-      expect { ti.process_undo!(update_topic: false) }.to raise_error(RuntimeError, /something is wrong/)
+      expect { ti.process_undo!(update_topic: false) }.to raise_error(TagImplication::UndoError, /something is wrong/)
+    end
+
+    it "raises when the implication is queued or processing" do
+      ti = create_undoable_implication
+      ti.update_columns(status: "queued")
+
+      expect { ti.process_undo!(update_topic: false) }.to raise_error(TagImplication::UndoError, /cannot be undone while it is/)
+    end
+
+    it "resumes an undo that was interrupted after the status was set to pending" do
+      ti = create_undoable_implication
+      ti.update_columns(status: "pending")
+
+      ti.process_undo!(update_topic: false)
+
+      expect(ti.reload.status).to eq("pending")
+      expect(ti.tag_rel_undos.where(applied: false).count).to eq(0)
+    end
+
+    it "raises when no unapplied undo information exists" do
+      ti = create(:active_tag_implication)
+      ti.update_columns(approver_id: create(:admin_user).id)
+
+      expect { ti.process_undo!(update_topic: false) }.to raise_error(TagImplication::UndoError, /No unapplied undo information/)
+    end
+
+    it "raises when the undo data is in the legacy array format" do
+      ti = create(:active_tag_implication)
+      ti.update_columns(approver_id: create(:admin_user).id)
+      ti.tag_rel_undos.create!(undo_data: [123, 456])
+
+      expect { ti.process_undo!(update_topic: false) }.to raise_error(TagImplication::UndoError, /predates undo support/)
+    end
+
+    it "raises when the undo data is in the legacy tag string format" do
+      ti = create(:active_tag_implication)
+      ti.update_columns(approver_id: create(:admin_user).id)
+      ti.tag_rel_undos.create!(undo_data: { "123" => "char_a" })
+
+      expect { ti.process_undo!(update_topic: false) }.to raise_error(TagImplication::UndoError, /predates undo support/)
+    end
+
+    it "raises when the side effects record is missing" do
+      ti = create(:active_tag_implication)
+      ti.update_columns(approver_id: create(:admin_user).id)
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
+
+      expect { ti.process_undo!(update_topic: false) }.to raise_error(TagImplication::UndoError, /side effects record is missing/)
+    end
+
+    it "raises when the implication was rewritten by an alias after being processed" do
+      ti = create_undoable_implication
+      # Simulate an alias b -> c moving this one from a -> b to a -> c.
+      ti.update_columns(consequent_name: "moved_con_#{SecureRandom.hex(4)}")
+
+      expect { ti.process_undo!(update_topic: false) }.to raise_error(TagImplication::UndoError, /is now #{ti.antecedent_name} -> #{ti.consequent_name}/)
     end
   end
 
@@ -182,40 +337,73 @@ RSpec.describe TagImplication do
   # #update_posts_undo
   # ---------------------------------------------------------------------------
   describe "#update_posts_undo" do
-    it "removes the consequent tag from posts that did not originally have it" do
-      ti = create(:active_tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+    it "removes the recorded added tags from posts that still carry them" do
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
       post = create(:post, tag_string: "char_a species_b")
-      # Deactivate so the implication won't re-apply the tag during post save
-      ti.update_columns(status: "pending")
-      # undo_data records what tags the post had before the implication was applied
-      # (only char_a, not species_b), so species_b should be removed
-      ti.tag_rel_undos.create!(undo_data: { post.id.to_s => "char_a" }, applied: false)
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { post.id.to_s => ["species_b"] } })
 
       ti.update_posts_undo
 
-      expect(post.reload.tag_string.split).not_to include("species_b")
+      expect(post.reload.tag_array).not_to include("species_b")
+    end
+
+    it "skips posts that no longer carry any of the recorded tags" do
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      post = create(:post, tag_string: "char_a")
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { post.id.to_s => ["species_b"] } })
+
+      expect { ti.update_posts_undo }.not_to(change { post.reload.updated_at })
+    end
+
+    it "removes only the recorded tags that are still present" do
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      post = create(:post, tag_string: "char_a species_b")
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { post.id.to_s => %w[species_b species_c] } })
+
+      ti.update_posts_undo
+
+      expect(post.reload.tag_array).to eq(["char_a"])
+    end
+
+    it "leaves a tag in place that is still implied by another active implication" do
+      create(:active_tag_implication, antecedent_name: "other_char", consequent_name: "species_b")
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      post = create(:post, tag_string: "char_a other_char species_b")
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { post.id.to_s => ["species_b"] } })
+
+      ti.update_posts_undo
+
+      # The removal is re-applied by normalize_tags during the same save
+      # because other_char still implies species_b.
+      expect(post.reload.tag_array).to include("species_b")
+    end
+
+    it "marks the posts chunk as applied" do
+      ti = create(:tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
+      chunk = ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
+
+      ti.update_posts_undo
+
+      expect(chunk.reload.applied).to be(true)
     end
 
     it "enqueues TagImplicationFinalizeJob with antecedent_name" do
-      ti = create(:active_tag_implication)
-      ti.update_columns(status: "pending")
-      ti.tag_rel_undos.create!(undo_data: {})
+      ti = create(:tag_implication)
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
 
       expect { ti.update_posts_undo }
         .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name)
     end
+  end
 
-    it "skips posts where the consequent was already in the original tag string" do
-      ti = create(:active_tag_implication, antecedent_name: "char_a", consequent_name: "species_b")
-      post = create(:post, tag_string: "char_a species_b")
-      ti.update_columns(status: "pending")
-      # undo_data includes species_b in original tag string — post should not be modified
-      ti.tag_rel_undos.create!(undo_data: { post.id.to_s => "char_a species_b" }, applied: false)
+  # ---------------------------------------------------------------------------
+  # #undo!
+  # ---------------------------------------------------------------------------
+  describe "#undo!" do
+    it "enqueues TagImplicationUndoJob with the undoing user" do
+      ti = create(:active_tag_implication)
 
-      original_tag_string = post.reload.tag_string
-      ti.update_posts_undo
-
-      expect(post.reload.tag_string).to eq(original_tag_string)
+      expect { ti.undo! }.to have_enqueued_job(TagImplicationUndoJob).with(ti.id, true, CurrentUser.user.id)
     end
   end
 

--- a/spec/models/tag_implication/approval_methods_spec.rb
+++ b/spec/models/tag_implication/approval_methods_spec.rb
@@ -387,12 +387,12 @@ RSpec.describe TagImplication do
       expect(chunk.reload.applied).to be(true)
     end
 
-    it "enqueues TagImplicationFinalizeJob with antecedent_name" do
+    it "enqueues TagImplicationFinalizeJob with antecedent_name and the undo flag" do
       ti = create(:tag_implication)
       ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
 
       expect { ti.update_posts_undo }
-        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name)
+        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name, undo: true)
     end
   end
 


### PR DESCRIPTION
Follow-up to #2406.
Updated the undo process to be more in line with the alias undo. Takes into account the actually-added tag set, to minimize the manual cleanup after a bad implication chain is created.
This functionality is deliberately not surfaced into the UI yet - that will be in another PR.