### PR TITLE
[TagAliases] Remove implication-added tags on undo

### DIFF
--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -208,6 +208,11 @@ class TagAlias < TagRelationship
   # be told apart from one the user put there on purpose. As a consequence,
   # posts with the consequent tag in their locked_tags will have it re-added
   # by apply_locked_tags when they are next saved.
+  #
+  # Tags that processing pulled in through the consequent's implications are
+  # removed along with it (unless another tag on the post still implies them).
+  # A user manually re-adding such a tag between approval and undo is
+  # indistinguishable from the auto-add and gets reverted too.
   def process_undo!(update_topic: true, undoer: nil)
     side_effects = validate_undoable!.undo_data
 
@@ -254,18 +259,19 @@ class TagAlias < TagRelationship
     Thread.current[:skip_post_index_update] = true
     Post.without_timeout do
       tag_rel_undos.where(applied: false).select(&:posts_chunk?).each do |tu|
-        had_consequent = tu.undo_data["with_consequent"].to_set
+        added = tu.undo_data["added"]
         Post.where(id: tu.post_ids).find_each do |post|
           post.with_lock do
             # The post was edited since the alias was processed and no longer
             # carries the consequent tag; don't fight that decision.
             next unless post.tag_array.include?(consequent_name)
+            # Remove whatever of the recorded added set (the consequent plus
+            # the tags its implications pulled in) is still present; a tag
+            # still implied by another tag on the post gets re-added by
+            # normalize_tags during this same save.
+            to_remove = added[post.id.to_s] & post.tag_array
             post.do_not_version_changes = true
-            post.tag_string_diff = if had_consequent.include?(post.id)
-                                     antecedent_name
-                                   else
-                                     "-#{consequent_name} #{antecedent_name}"
-                                   end
+            post.tag_string_diff = (to_remove.map { |tag| "-#{tag}" } << antecedent_name).join(" ")
             post.save
           end
         end
@@ -485,32 +491,52 @@ class TagAlias < TagRelationship
     unapplied.destroy_all
 
     Post.without_timeout do
-      with_ids = []
-      without_ids = []
+      implied = implied_tag_closure
+      added = {}
       Post.sql_raw_tag_match(antecedent_name).find_each do |post|
-        if post.tag_array.include?(consequent_name)
-          with_ids << post.id
-        else
-          without_ids << post.id
-        end
+        # The set the post-save pipeline is about to add: the consequent plus
+        # its implication chain. A post that already carries the consequent
+        # gains nothing — its implications were enforced on an earlier save.
+        added[post.id.to_s] = if post.tag_array.include?(consequent_name)
+                                []
+                              else
+                                ([consequent_name] + implied) - post.tag_array
+                              end
 
-        if with_ids.size + without_ids.size >= POST_LIMIT
-          create_undo_posts_chunk(with_ids, without_ids)
-          with_ids = []
-          without_ids = []
+        if added.size >= POST_LIMIT
+          create_undo_posts_chunk(added)
+          added = {}
         end
       end
-      create_undo_posts_chunk(with_ids, without_ids) if with_ids.any? || without_ids.any?
+      create_undo_posts_chunk(added) if added.any?
       tag_rel_undos.create!(undo_data: undo_side_effects_snapshot)
     end
   end
 
-  def create_undo_posts_chunk(with_ids, without_ids)
+  # Every tag the active implication chain hangs off the consequent, i.e. what
+  # update_posts will auto-add alongside it. Also seeded with the antecedent:
+  # move_aliases_and_implications is about to rewrite its implications onto
+  # the consequent, so they will be live by the time the posts are saved.
+  # Neither seed appears in the result.
+  def implied_tag_closure
+    seen = Set[antecedent_name, consequent_name]
+    result = []
+    children = seen.to_a
+
+    until children.empty?
+      children = TagImplication.active.where(antecedent_name: children).distinct.pluck(:consequent_name) - seen.to_a
+      seen.merge(children)
+      result.concat(children)
+    end
+
+    result
+  end
+
+  def create_undo_posts_chunk(added)
     tag_rel_undos.create!(undo_data: {
-      "version" => 2,
+      "version" => 3,
       "kind" => "posts",
-      "with_consequent" => with_ids,
-      "without_consequent" => without_ids,
+      "added" => added,
     })
   end
 

--- a/app/models/tag_rel_undo.rb
+++ b/app/models/tag_rel_undo.rb
@@ -21,11 +21,7 @@ class TagRelUndo < ApplicationRecord
     if undo_data.is_a?(Array)
       undo_data
     elsif posts_chunk?
-      if undo_data.key?("added")
-        undo_data["added"].keys.map(&:to_i)
-      else
-        undo_data["with_consequent"] + undo_data["without_consequent"]
-      end
+      undo_data["added"].keys.map(&:to_i)
     elsif side_effects?
       []
     else

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe TagAliasFinalizeJob do
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102, 103, 104] })
     end
 
-    it "reads post IDs from v2 posts chunks and ignores side effects records" do
+    it "reads post IDs from posts chunks and ignores side effects records" do
       ta.tag_rel_undos.destroy_all
-      ta.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "with_consequent" => [201], "without_consequent" => [202] })
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "201" => [], "202" => [ta.consequent_name] } })
       ta.tag_rel_undos.create!(undo_data: {
         "version" => 2,
         "kind" => "side_effects",
@@ -44,8 +44,8 @@ RSpec.describe TagAliasFinalizeJob do
       expect(Post.document_store).to have_received(:import).with(query: { id: [201, 202] })
     end
 
-    it "handles a mix of legacy and v2 undo data" do
-      ta.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "with_consequent" => [103], "without_consequent" => [301] })
+    it "handles a mix of legacy and current undo data" do
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "103" => [], "301" => [ta.consequent_name] } })
       described_class.perform_now(ta.id)
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102, 103, 301] })
     end

--- a/spec/models/tag_alias/instance_methods_spec.rb
+++ b/spec/models/tag_alias/instance_methods_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe TagAlias do
       expect(side_effects.undo_data["alias"]).to eq("antecedent_name" => ta.antecedent_name, "consequent_name" => ta.consequent_name)
     end
 
-    it "classifies affected posts by whether they already have the consequent tag" do
+    it "records the consequent as added for posts that lacked it and nothing for posts that had it" do
       ta = create(:tag_alias,
                   antecedent_name: "undo_ant_#{SecureRandom.hex(4)}",
                   consequent_name: "undo_con_#{SecureRandom.hex(4)}")
@@ -82,9 +82,58 @@ RSpec.describe TagAlias do
 
       ta.create_undo_information
 
-      chunk = ta.tag_rel_undos.find(&:posts_chunk?)
-      expect(chunk.undo_data["with_consequent"]).to contain_exactly(with_post.id)
-      expect(chunk.undo_data["without_consequent"]).to contain_exactly(without_post.id)
+      added = ta.tag_rel_undos.find(&:posts_chunk?).undo_data["added"]
+      expect(added.keys).to contain_exactly(with_post.id.to_s, without_post.id.to_s)
+      expect(added[with_post.id.to_s]).to eq([])
+      expect(added[without_post.id.to_s]).to eq([ta.consequent_name])
+    end
+
+    it "includes the consequent's active implication chain in the added set" do
+      ta = create(:tag_alias,
+                  antecedent_name: "chain_ant_#{SecureRandom.hex(4)}",
+                  consequent_name: "chain_con_#{SecureRandom.hex(4)}")
+      b = "chain_b_#{SecureRandom.hex(4)}"
+      d = "chain_d_#{SecureRandom.hex(4)}"
+      create(:active_tag_implication, antecedent_name: ta.consequent_name, consequent_name: b)
+      create(:active_tag_implication, antecedent_name: b, consequent_name: d)
+      create(:tag_implication, antecedent_name: d, consequent_name: "chain_pending_#{SecureRandom.hex(4)}")
+      post = create(:post, tag_string: "#{ta.antecedent_name} other_tag")
+
+      ta.create_undo_information
+
+      added = ta.tag_rel_undos.find(&:posts_chunk?).undo_data["added"]
+      expect(added[post.id.to_s]).to contain_exactly(ta.consequent_name, b, d)
+    end
+
+    it "excludes implied tags the post already carries from the added set" do
+      ta = create(:tag_alias,
+                  antecedent_name: "have_ant_#{SecureRandom.hex(4)}",
+                  consequent_name: "have_con_#{SecureRandom.hex(4)}")
+      b = "have_b_#{SecureRandom.hex(4)}"
+      create(:active_tag_implication, antecedent_name: ta.consequent_name, consequent_name: b)
+      post = create(:post, tag_string: "#{ta.antecedent_name} #{b}")
+
+      ta.create_undo_information
+
+      added = ta.tag_rel_undos.find(&:posts_chunk?).undo_data["added"]
+      expect(added[post.id.to_s]).to eq([ta.consequent_name])
+    end
+
+    it "treats the antecedent's active implications as already moved onto the consequent" do
+      ta = create(:tag_alias,
+                  antecedent_name: "moved_ant_#{SecureRandom.hex(4)}",
+                  consequent_name: "moved_con_#{SecureRandom.hex(4)}")
+      x = "moved_x_#{SecureRandom.hex(4)}"
+      # Created after the post so the post doesn't pick it up on save; by the
+      # time update_posts runs, move_aliases_and_implications will have
+      # rewritten it onto the consequent.
+      post = create(:post, tag_string: "#{ta.antecedent_name} other_tag")
+      create(:active_tag_implication, antecedent_name: ta.antecedent_name, consequent_name: x)
+
+      ta.create_undo_information
+
+      added = ta.tag_rel_undos.find(&:posts_chunk?).undo_data["added"]
+      expect(added[post.id.to_s]).to contain_exactly(ta.consequent_name, x)
     end
 
     it "records the relationships that will be moved" do
@@ -137,7 +186,7 @@ RSpec.describe TagAlias do
                   consequent_name: "retry2_con_#{SecureRandom.hex(4)}")
       # A posts chunk without the side effects record means the previous
       # snapshot attempt died partway through.
-      stale = ta.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "with_consequent" => [], "without_consequent" => [999] })
+      stale = ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "999" => [ta.consequent_name] } })
 
       ta.create_undo_information
 
@@ -216,19 +265,18 @@ RSpec.describe TagAlias do
       ta
     end
 
-    def create_posts_chunk(rel, with_ids: [], without_ids: [])
+    def create_posts_chunk(rel, added: {})
       rel.tag_rel_undos.create!(undo_data: {
-        "version" => 2,
+        "version" => 3,
         "kind" => "posts",
-        "with_consequent" => with_ids,
-        "without_consequent" => without_ids,
+        "added" => added,
       })
     end
 
     it "restores the antecedent and removes the consequent from posts that gained it from the alias" do
       ta = create_pending_undoable_alias
       post = create(:post, tag_string: "#{ta.consequent_name} other_tag")
-      create_posts_chunk(ta, without_ids: [post.id])
+      create_posts_chunk(ta, added: { post.id.to_s => [ta.consequent_name] })
 
       ta.update_posts_undo
 
@@ -239,17 +287,54 @@ RSpec.describe TagAlias do
     it "restores the antecedent but keeps the consequent on posts that had it before the alias" do
       ta = create_pending_undoable_alias
       post = create(:post, tag_string: "#{ta.consequent_name} other_tag")
-      create_posts_chunk(ta, with_ids: [post.id])
+      create_posts_chunk(ta, added: { post.id.to_s => [] })
 
       ta.update_posts_undo
 
       expect(post.reload.tag_string.split).to include(ta.antecedent_name, ta.consequent_name)
     end
 
+    it "removes tags the alias pulled in through implications" do
+      ta = create_pending_undoable_alias
+      b = "undo_imp_#{SecureRandom.hex(4)}"
+      post = create(:post, tag_string: "#{ta.consequent_name} #{b} other_tag")
+      create_posts_chunk(ta, added: { post.id.to_s => [ta.consequent_name, b] })
+
+      ta.update_posts_undo
+
+      expect(post.reload.tag_string.split).to include(ta.antecedent_name, "other_tag")
+      expect(post.reload.tag_string.split).not_to include(ta.consequent_name, b)
+    end
+
+    it "keeps a recorded tag that another tag on the post still implies" do
+      ta = create_pending_undoable_alias
+      b = "undo_keep_#{SecureRandom.hex(4)}"
+      other_src = "undo_src_#{SecureRandom.hex(4)}"
+      create(:active_tag_implication, antecedent_name: other_src, consequent_name: b)
+      post = create(:post, tag_string: "#{ta.consequent_name} #{other_src}")
+      create_posts_chunk(ta, added: { post.id.to_s => [ta.consequent_name, b] })
+
+      ta.update_posts_undo
+
+      expect(post.reload.tag_string.split).to include(ta.antecedent_name, other_src, b)
+      expect(post.reload.tag_string.split).not_to include(ta.consequent_name)
+    end
+
+    it "ignores recorded tags the post no longer carries" do
+      ta = create_pending_undoable_alias
+      post = create(:post, tag_string: "#{ta.consequent_name} other_tag")
+      create_posts_chunk(ta, added: { post.id.to_s => [ta.consequent_name, "undo_gone_#{SecureRandom.hex(4)}"] })
+
+      ta.update_posts_undo
+
+      expect(post.reload.tag_string.split).to include(ta.antecedent_name, "other_tag")
+      expect(post.reload.tag_string.split).not_to include(ta.consequent_name)
+    end
+
     it "leaves posts alone when the consequent tag was removed since the alias was processed" do
       ta = create_pending_undoable_alias
       post = create(:post, tag_string: "other_tag")
-      create_posts_chunk(ta, without_ids: [post.id])
+      create_posts_chunk(ta, added: { post.id.to_s => [ta.consequent_name] })
 
       original_tag_string = post.reload.tag_string
       ta.update_posts_undo

--- a/spec/models/tag_alias/process_methods_spec.rb
+++ b/spec/models/tag_alias/process_methods_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe TagAlias do
     def create_undoable_alias
       ta = create(:active_tag_alias)
       ta.update_columns(approver_id: create(:admin_user).id)
-      ta.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "with_consequent" => [], "without_consequent" => [] })
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => {} })
       ta.tag_rel_undos.create!(undo_data: {
         "version" => 2,
         "kind" => "side_effects",
@@ -165,7 +165,7 @@ RSpec.describe TagAlias do
     it "raises when the side effects record is missing" do
       ta = create(:active_tag_alias)
       ta.update_columns(approver_id: create(:admin_user).id)
-      ta.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "with_consequent" => [], "without_consequent" => [] })
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => {} })
 
       expect { ta.process_undo!(update_topic: false) }.to raise_error(TagAlias::UndoError, /side effects record is missing/)
     end
@@ -192,6 +192,64 @@ RSpec.describe TagAlias do
 
       expect { ta.process_undo!(update_topic: false) }
         .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
+    end
+
+    it "removes tags the consequent's implications added during processing" do
+      ta = create(:tag_alias,
+                  antecedent_name: "e2e_ant_#{SecureRandom.hex(4)}",
+                  consequent_name: "e2e_con_#{SecureRandom.hex(4)}")
+      b = "e2e_b_#{SecureRandom.hex(4)}"
+      create(:active_tag_implication, antecedent_name: ta.consequent_name, consequent_name: b)
+      post = create(:post, tag_string: "#{ta.antecedent_name} other_tag")
+      ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
+
+      ta.process!(update_topic: false)
+      expect(post.reload.tag_string.split).to include(ta.consequent_name, b)
+
+      ta.process_undo!(update_topic: false)
+
+      expect(post.reload.tag_string.split).to include(ta.antecedent_name, "other_tag")
+      expect(post.reload.tag_string.split).not_to include(ta.consequent_name, b)
+    end
+
+    it "keeps an implication-added tag that another tag on the post still implies" do
+      ta = create(:tag_alias,
+                  antecedent_name: "e2e_keep_ant_#{SecureRandom.hex(4)}",
+                  consequent_name: "e2e_keep_con_#{SecureRandom.hex(4)}")
+      b = "e2e_keep_b_#{SecureRandom.hex(4)}"
+      other_src = "e2e_keep_src_#{SecureRandom.hex(4)}"
+      # Both implications are created after the post so it lacks b at snapshot
+      # time and b lands in the recorded added set.
+      post = create(:post, tag_string: "#{ta.antecedent_name} #{other_src}")
+      create(:active_tag_implication, antecedent_name: ta.consequent_name, consequent_name: b)
+      create(:active_tag_implication, antecedent_name: other_src, consequent_name: b)
+      ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
+
+      ta.process!(update_topic: false)
+      expect(post.reload.tag_string.split).to include(ta.consequent_name, b)
+
+      ta.process_undo!(update_topic: false)
+
+      expect(post.reload.tag_string.split).to include(ta.antecedent_name, other_src, b)
+      expect(post.reload.tag_string.split).not_to include(ta.consequent_name)
+    end
+
+    it "leaves implication-added tags alone on posts edited to drop the consequent since processing" do
+      ta = create(:tag_alias,
+                  antecedent_name: "e2e_skip_ant_#{SecureRandom.hex(4)}",
+                  consequent_name: "e2e_skip_con_#{SecureRandom.hex(4)}")
+      b = "e2e_skip_b_#{SecureRandom.hex(4)}"
+      create(:active_tag_implication, antecedent_name: ta.consequent_name, consequent_name: b)
+      post = create(:post, tag_string: "#{ta.antecedent_name} other_tag")
+      ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
+      ta.process!(update_topic: false)
+
+      post.reload.update(tag_string: "other_tag")
+      edited_tag_string = post.reload.tag_string
+
+      ta.process_undo!(update_topic: false)
+
+      expect(post.reload.tag_string).to eq(edited_tag_string)
     end
 
     it "does not call fix_post_count directly" do


### PR DESCRIPTION
Posts gaining the consequent during alias processing also gain its active implication chain via the post-save pipeline.
The previous undo implementation left those tags behind.

This PR records the actually-added set per post (mirroring the implication undo) and removes it on undo, letting `normalize_tags` re-add anything still implied by another tag.

Since the PR with the v2 alias undo information hasn't been deployed yet, this PR has no handling for rows like that.