### PR TITLE
[TagRelationships] Add UI for the alias and relationship undo actions

### DIFF
--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -47,6 +47,13 @@ class TagAliasesController < ApplicationController
     respond_with(@tag_alias, location: tag_alias_path(@tag_alias))
   end
 
+  def undo
+    @tag_alias = TagAlias.find(params[:id])
+    return access_denied unless @tag_alias.undoable_by?(CurrentUser.user)
+    @tag_alias.undo!(undoer: CurrentUser.user)
+    respond_with(@tag_alias, location: tag_alias_path(@tag_alias))
+  end
+
   private
 
   def tag_alias_params

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -47,6 +47,13 @@ class TagImplicationsController < ApplicationController
     respond_with(@tag_implication, location: tag_implication_path(@tag_implication))
   end
 
+  def undo
+    @tag_implication = TagImplication.find(params[:id])
+    return access_denied unless @tag_implication.undoable_by?(CurrentUser.user)
+    @tag_implication.undo!(undoer: CurrentUser.user)
+    respond_with(@tag_implication, location: tag_implication_path(@tag_implication))
+  end
+
   private
 
   def tag_implication_params

--- a/app/javascript/src/js/pages/tag_aliases/tag_relationships.js
+++ b/app/javascript/src/js/pages/tag_aliases/tag_relationships.js
@@ -46,6 +46,30 @@ class TagRelationships {
       E621.Toast.alert(`Failed to reject ${human}.`);
     });
   }
+
+  static undo (e) {
+    e.preventDefault();
+    const $e = $(e.target);
+    const parent = $e.parents(".tag-relationship");
+    const route = parent.data("relationship-route");
+    const human = parent.data("relationship-human");
+    const id = parent.data("relationship-id");
+    const postCount = $e.data("undoPostCount");
+
+    if (!confirm(`Are you sure you want to undo this ${human}? This will modify approximately ${postCount} posts.`)) {
+      return;
+    }
+
+    $.ajax({
+      url: `/${route}/${id}/undo.json`,
+      type: "POST",
+      dataType: "json",
+    }).done(function () {
+      E621.Toast.notice(`Undo of ${human} queued.`);
+    }).fail(function () {
+      E621.Toast.alert(`Failed to undo ${human}.`);
+    });
+  }
 }
 
 $(document).ready(function () {
@@ -54,6 +78,9 @@ $(document).ready(function () {
   });
   $(".tag-relationship-reject").on("click", e => {
     TagRelationships.reject(e);
+  });
+  $(".tag-relationship-undo").on("click", e => {
+    TagRelationships.undo(e);
   });
 });
 

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -240,11 +240,13 @@ class TagAlias < TagRelationship
       raise UndoError, "This tag alias cannot be undone while it is \"#{status}\"; if a processing job died, set the status to an error first."
     end
 
-    undos = tag_rel_undos.where(applied: false).order(:id).to_a
-    raise UndoError, "No unapplied undo information exists for this tag alias." if undos.empty?
-    raise UndoError, "This tag alias cannot be undone: its undo data predates undo support." if undos.any?(&:legacy?)
+    # Filtered in SQL so the posts chunks are never loaded into Ruby; only the
+    # small side effects record is materialized.
+    undos = tag_rel_undos.unapplied
+    raise UndoError, "No unapplied undo information exists for this tag alias." unless undos.exists?
+    raise UndoError, "This tag alias cannot be undone: its undo data predates undo support." if undos.legacy_format.exists?
 
-    side_effects = undos.find(&:side_effects?)
+    side_effects = undos.side_effects_records.order(:id).first
     raise UndoError, "This tag alias cannot be undone: the side effects record is missing from its undo data." if side_effects.nil?
 
     recorded = side_effects.undo_data["alias"]

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -287,11 +287,13 @@ class TagImplication < TagRelationship
         raise TagRelationship::UndoError, "This tag implication cannot be undone while it is \"#{status}\"; if a processing job died, set the status to an error first."
       end
 
-      undos = tag_rel_undos.where(applied: false).order(:id).to_a
-      raise TagRelationship::UndoError, "No unapplied undo information exists for this tag implication." if undos.empty?
-      raise TagRelationship::UndoError, "This tag implication cannot be undone: its undo data predates undo support." if undos.any?(&:legacy?)
+      # Filtered in SQL so the posts chunks are never loaded into Ruby; only
+      # the small side effects record is materialized.
+      undos = tag_rel_undos.unapplied
+      raise TagRelationship::UndoError, "No unapplied undo information exists for this tag implication." unless undos.exists?
+      raise TagRelationship::UndoError, "This tag implication cannot be undone: its undo data predates undo support." if undos.legacy_format.exists?
 
-      side_effects = undos.find(&:side_effects?)
+      side_effects = undos.side_effects_records.order(:id).first
       raise TagRelationship::UndoError, "This tag implication cannot be undone: the side effects record is missing from its undo data." if side_effects.nil?
 
       recorded = side_effects.undo_data["implication"]

--- a/app/models/tag_rel_undo.rb
+++ b/app/models/tag_rel_undo.rb
@@ -3,6 +3,14 @@
 class TagRelUndo < ApplicationRecord
   belongs_to :tag_rel, polymorphic: true
 
+  scope :unapplied, -> { where(applied: false) }
+  # SQL mirrors of the predicates below, so callers can filter without pulling
+  # the (potentially multi-megabyte) undo_data JSON into Ruby. A JSON-null
+  # "kind" counts as legacy here but not in #legacy?; no writer produces that.
+  scope :legacy_format, -> { where("json_typeof(undo_data) = 'array' OR (json_typeof(undo_data) = 'object' AND undo_data->>'kind' IS NULL)") }
+  scope :posts_chunks, -> { where("json_typeof(undo_data) = 'object' AND undo_data->>'kind' = 'posts'") }
+  scope :side_effects_records, -> { where("json_typeof(undo_data) = 'object' AND undo_data->>'kind' = 'side_effects'") }
+
   # Formats that predate undo support: the TagAlias / TagNukeJob flat array of
   # post ids, and the TagImplication { post_id => tag_string } hash.
   def legacy?

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -102,8 +102,7 @@ class TagRelationship < ApplicationRecord
   # Posts affected by an undo, for the confirmation prompt. Counted in SQL
   # so the potentially large posts chunks are never loaded into Ruby.
   def undo_post_count
-    tag_rel_undos.where(applied: false)
-                 .where("json_typeof(undo_data) = 'object' AND undo_data->>'kind' = 'posts'")
+    tag_rel_undos.unapplied.posts_chunks
                  .sum(Arel.sql("(SELECT count(*) FROM json_object_keys(undo_data -> 'added'))"))
                  .to_i
   end

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -90,6 +90,24 @@ class TagRelationship < ApplicationRecord
     is_pending? && user.is_admin?
   end
 
+  # Non-raising mirror of validate_undoable! for UI gating.
+  def undoable_by?(user)
+    return false unless user.is_admin?
+    validate_undoable!
+    true
+  rescue UndoError
+    false
+  end
+
+  # Posts affected by an undo, for the confirmation prompt. Counted in SQL
+  # so the potentially large posts chunks are never loaded into Ruby.
+  def undo_post_count
+    tag_rel_undos.where(applied: false)
+                 .where("json_typeof(undo_data) = 'object' AND undo_data->>'kind' = 'posts'")
+                 .sum(Arel.sql("(SELECT count(*) FROM json_object_keys(undo_data -> 'added'))"))
+                 .to_i
+  end
+
   module SearchMethods
     def name_matches(name)
       name = name.downcase.strip.to_escaped_for_sql_like

--- a/app/views/tag_aliases/show.html.erb
+++ b/app/views/tag_aliases/show.html.erb
@@ -27,7 +27,7 @@
 
       <li>
         <strong>Commands</strong>
-        <%= render "tag_relationships/command_buttons", tag_relation: @tag_alias, with_show_link: false %>
+        <%= render "tag_relationships/command_buttons", tag_relation: @tag_alias, with_show_link: false, show_undo: true %>
       </li>
 
       <% if @tag_alias.consequent_tag&.artist&.is_dnp? || @tag_alias.antecedent_tag&.artist&.is_dnp? %>

--- a/app/views/tag_implications/show.html.erb
+++ b/app/views/tag_implications/show.html.erb
@@ -15,7 +15,7 @@
 
       <li>
         <strong>Commands</strong>
-        <%= render "tag_relationships/command_buttons", tag_relation: @tag_implication, with_show_link: false %>
+        <%= render "tag_relationships/command_buttons", tag_relation: @tag_implication, with_show_link: false, show_undo: true %>
       </li>
 
       <% if @tag_implication.consequent_tag&.artist&.is_dnp? || @tag_implication.antecedent_tag&.artist&.is_dnp? %>

--- a/app/views/tag_relationships/_command_buttons.html.erb
+++ b/app/views/tag_relationships/_command_buttons.html.erb
@@ -11,6 +11,9 @@
   <% if tag_relation.deletable_by?(CurrentUser.user) %>
     <% links.push link_to("Reject", "#", class: "tag-relationship-reject") %>
   <% end %>
+  <% if local_assigns.fetch(:show_undo, false) && tag_relation.undoable_by?(CurrentUser.user) %>
+    <% links.push link_to("Undo", "#", class: "tag-relationship-undo", data: { undo_post_count: tag_relation.undo_post_count }) %>
+  <% end %>
   <% if tag_relation.editable_by?(CurrentUser.user) %>
     <% links.push link_to("Edit", action: "edit", controller: "/#{tag_relation.model_name.route_key}", id: tag_relation.id) %>
     <% links.push link_to("Flip", send("#{tag_relation.model_name.route_key.singularize}_path", id: tag_relation.id, "#{tag_relation.model_name.route_key.singularize}": { antecedent_name: tag_relation.consequent_name, consequent_name: tag_relation.antecedent_name }), method: :patch) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -399,12 +399,14 @@ Rails.application.routes.draw do
   resources :tag_aliases do
     member do
       post :approve
+      post :undo
     end
   end
   resource :tag_alias_request, only: %i[new create]
   resources :tag_implications do
     member do
       post :approve
+      post :undo
     end
   end
   resource :tag_implication_request, only: %i[new create]

--- a/spec/models/tag_alias/undo_methods_spec.rb
+++ b/spec/models/tag_alias/undo_methods_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TagAlias do
+  include_context "as admin"
+
+  let(:admin)  { create(:admin_user) }
+  let(:member) { create(:user) }
+
+  def create_undoable_alias
+    ta = create(:active_tag_alias)
+    ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "1" => %w[tag_a], "2" => %w[tag_b] } })
+    ta.tag_rel_undos.create!(undo_data: {
+      "version" => 2,
+      "kind" => "side_effects",
+      "alias" => { "antecedent_name" => ta.antecedent_name, "consequent_name" => ta.consequent_name },
+      "relationships" => [],
+      "category_change" => nil,
+      "artist_change" => nil,
+    })
+    ta
+  end
+
+  # ---------------------------------------------------------------------------
+  # #undoable_by?
+  # ---------------------------------------------------------------------------
+
+  describe "#undoable_by?" do
+    it "returns true for an admin when the alias is undoable" do
+      expect(create_undoable_alias.undoable_by?(admin)).to be(true)
+    end
+
+    it "returns false for a non-admin even when the alias is undoable" do
+      expect(create_undoable_alias.undoable_by?(member)).to be(false)
+    end
+
+    it "returns false when the alias is queued" do
+      ta = create_undoable_alias
+      ta.update_columns(status: "queued")
+      expect(ta.undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when the alias is processing" do
+      ta = create_undoable_alias
+      ta.update_columns(status: "processing")
+      expect(ta.undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when the alias is deleted" do
+      ta = create_undoable_alias
+      ta.update_columns(status: "deleted")
+      expect(ta.undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when no undo information exists" do
+      expect(create(:active_tag_alias).undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when all undo information is already applied" do
+      ta = create_undoable_alias
+      ta.tag_rel_undos.update_all(applied: true)
+      expect(ta.undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when the undo data is in the legacy format" do
+      ta = create(:active_tag_alias)
+      ta.tag_rel_undos.create!(undo_data: [[1, 2], [3]])
+      expect(ta.undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when the side effects record is missing" do
+      ta = create(:active_tag_alias)
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => {} })
+      expect(ta.undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when the alias was rewritten after processing" do
+      ta = create_undoable_alias
+      ta.update_columns(consequent_name: "rewritten_tag")
+      expect(ta.undoable_by?(admin)).to be(false)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #undo_post_count
+  # ---------------------------------------------------------------------------
+
+  describe "#undo_post_count" do
+    it "sums the post counts across all unapplied posts chunks" do
+      ta = create_undoable_alias
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "3" => %w[tag_c] } })
+      expect(ta.undo_post_count).to eq(3)
+    end
+
+    it "ignores applied chunks" do
+      ta = create_undoable_alias
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "3" => %w[tag_c] } }, applied: true)
+      expect(ta.undo_post_count).to eq(2)
+    end
+
+    it "ignores side effects and legacy records" do
+      ta = create_undoable_alias
+      ta.tag_rel_undos.create!(undo_data: [[4, 5], [6]])
+      expect(ta.undo_post_count).to eq(2)
+    end
+
+    it "returns 0 when no undo information exists" do
+      expect(create(:active_tag_alias).undo_post_count).to eq(0)
+    end
+  end
+end

--- a/spec/models/tag_implication/undo_methods_spec.rb
+++ b/spec/models/tag_implication/undo_methods_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TagImplication do
+  include_context "as admin"
+
+  let(:admin)  { create(:admin_user) }
+  let(:member) { create(:user) }
+
+  def create_undoable_implication
+    ti = create(:active_tag_implication)
+    ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "1" => %w[tag_a], "2" => %w[tag_b] } })
+    ti.tag_rel_undos.create!(undo_data: {
+      "version" => 2,
+      "kind" => "side_effects",
+      "implication" => { "antecedent_name" => ti.antecedent_name, "consequent_name" => ti.consequent_name },
+    })
+    ti
+  end
+
+  describe "#undoable_by?" do
+    it "returns true for an admin when the implication is undoable" do
+      expect(create_undoable_implication.undoable_by?(admin)).to be(true)
+    end
+
+    it "returns false for a non-admin even when the implication is undoable" do
+      expect(create_undoable_implication.undoable_by?(member)).to be(false)
+    end
+
+    it "returns false when no undo information exists" do
+      expect(create(:active_tag_implication).undoable_by?(admin)).to be(false)
+    end
+
+    it "returns false when the side effects record is missing" do
+      ti = create(:active_tag_implication)
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
+      expect(ti.undoable_by?(admin)).to be(false)
+    end
+  end
+
+  describe "#undo_post_count" do
+    it "sums the post counts across all unapplied posts chunks" do
+      ti = create_undoable_implication
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "3" => %w[tag_c] } })
+      expect(ti.undo_post_count).to eq(3)
+    end
+
+    it "ignores applied chunks and non-posts records" do
+      ti = create_undoable_implication
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "3" => %w[tag_c] } }, applied: true)
+      expect(ti.undo_post_count).to eq(2)
+    end
+
+    it "returns 0 when no undo information exists" do
+      expect(create(:active_tag_implication).undo_post_count).to eq(0)
+    end
+  end
+end

--- a/spec/models/tag_rel_undo_spec.rb
+++ b/spec/models/tag_rel_undo_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TagRelUndo do
+  include_context "as admin"
+
+  # One row per known undo_data format, so the SQL scopes can be checked
+  # against the Ruby predicates they mirror.
+  let(:parent) { create(:active_tag_alias) }
+  let!(:legacy_array)       { parent.tag_rel_undos.create!(undo_data: [1, 2, 3]) }
+  let!(:legacy_implication) { parent.tag_rel_undos.create!(undo_data: { "1" => "tag_a tag_b" }) }
+  let!(:posts_chunk)        { parent.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "1" => %w[tag_a] } }) }
+  let!(:side_effects)       { parent.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "side_effects", "alias" => {} }) }
+
+  describe ".legacy_format" do
+    it "matches exactly the rows where #legacy? is true" do
+      expect(described_class.legacy_format).to match_array(described_class.all.select(&:legacy?))
+      expect(described_class.legacy_format).to contain_exactly(legacy_array, legacy_implication)
+    end
+  end
+
+  describe ".posts_chunks" do
+    it "matches exactly the rows where #posts_chunk? is true" do
+      expect(described_class.posts_chunks).to match_array(described_class.all.select(&:posts_chunk?))
+      expect(described_class.posts_chunks).to contain_exactly(posts_chunk)
+    end
+  end
+
+  describe ".side_effects_records" do
+    it "matches exactly the rows where #side_effects? is true" do
+      expect(described_class.side_effects_records).to match_array(described_class.all.select(&:side_effects?))
+      expect(described_class.side_effects_records).to contain_exactly(side_effects)
+    end
+  end
+
+  describe ".unapplied" do
+    it "excludes applied rows" do
+      posts_chunk.update!(applied: true)
+      expect(described_class.unapplied).to contain_exactly(legacy_array, legacy_implication, side_effects)
+    end
+  end
+end

--- a/spec/requests/tag_aliases_controller_spec.rb
+++ b/spec/requests/tag_aliases_controller_spec.rb
@@ -272,4 +272,73 @@ RSpec.describe TagAliasesController do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # POST /tag_aliases/:id/undo — undo (admin_only)
+  # ---------------------------------------------------------------------------
+
+  describe "POST /tag_aliases/:id/undo" do
+    let(:undoable_alias) do
+      ta = create(:active_tag_alias)
+      ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => {} })
+      ta.tag_rel_undos.create!(undo_data: {
+        "version" => 2,
+        "kind" => "side_effects",
+        "alias" => { "antecedent_name" => ta.antecedent_name, "consequent_name" => ta.consequent_name },
+        "relationships" => [],
+        "category_change" => nil,
+        "artist_change" => nil,
+      })
+      ta
+    end
+
+    context "as anonymous" do
+      it "redirects HTML to the login page" do
+        post undo_tag_alias_path(undoable_alias)
+        expect(response).to redirect_to(new_session_path)
+      end
+
+      it "returns 403 for JSON" do
+        post undo_tag_alias_path(undoable_alias, format: :json)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    it "returns 403 for a member" do
+      sign_in_as member
+      post undo_tag_alias_path(undoable_alias)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as admin undoing an undoable alias" do
+      before { sign_in_as admin }
+
+      it "enqueues TagAliasUndoJob attributed to the admin" do
+        expect { post undo_tag_alias_path(undoable_alias) }
+          .to have_enqueued_job(TagAliasUndoJob).with(undoable_alias.id, true, admin.id)
+      end
+
+      it "redirects to the tag alias page" do
+        post undo_tag_alias_path(undoable_alias)
+        expect(response).to redirect_to(tag_alias_path(undoable_alias))
+      end
+
+      it "returns 2xx for JSON" do
+        post undo_tag_alias_path(undoable_alias, format: :json)
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "as admin undoing a non-undoable alias" do
+      let(:active_alias) { create(:active_tag_alias) }
+
+      before { sign_in_as admin }
+
+      it "returns 403 and enqueues no job" do
+        expect { post undo_tag_alias_path(active_alias) }
+          .not_to have_enqueued_job(TagAliasUndoJob)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/requests/tag_implications_controller_spec.rb
+++ b/spec/requests/tag_implications_controller_spec.rb
@@ -206,4 +206,48 @@ RSpec.describe TagImplicationsController do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # POST /tag_implications/:id/undo — undo (admin_only)
+  # ---------------------------------------------------------------------------
+
+  describe "POST /tag_implications/:id/undo" do
+    let(:undoable_implication) do
+      ti = create(:active_tag_implication)
+      ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
+      ti.tag_rel_undos.create!(undo_data: {
+        "version" => 2,
+        "kind" => "side_effects",
+        "implication" => { "antecedent_name" => ti.antecedent_name, "consequent_name" => ti.consequent_name },
+      })
+      ti
+    end
+
+    it "redirects anonymous to the login page" do
+      post undo_tag_implication_path(undoable_implication)
+      expect(response).to redirect_to(new_session_path)
+    end
+
+    it "returns 403 for a member" do
+      sign_in_as member
+      post undo_tag_implication_path(undoable_implication)
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    context "as an admin" do
+      before { sign_in_as admin }
+
+      it "enqueues TagImplicationUndoJob attributed to the admin and redirects to show" do
+        expect { post undo_tag_implication_path(undoable_implication) }
+          .to have_enqueued_job(TagImplicationUndoJob).with(undoable_implication.id, true, admin.id)
+        expect(response).to redirect_to(tag_implication_path(undoable_implication))
+      end
+
+      it "returns 403 and enqueues no job when the implication is not undoable" do
+        expect { post undo_tag_implication_path(active_implication) }
+          .not_to have_enqueued_job(TagImplicationUndoJob)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds `undoable_by?`/`undo_post_count` to TagRelationship, undo controller actions and routes, an Undo command button on the show pages with a post-count confirmation, and the matching JS handler.
Admin-only, like the approval.

Final part of #2406, #2407, #2408.