### PR TITLE
[Misc] Allow assuming SSL in development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -45,6 +45,9 @@
 # HOST_GID=
 # DOCKER_USER=e621ng
 
+# When running behind an SSL-terminating reverse proxy, you may want to set this to true
+# RAILS_ASSUME_SSL=true
+
 # discord: Starts the discord integration to join users to a discord server.
 #          The application must have its OAuth2 redirect URI set to ${JOINER_BASE_URL}/callback.
 #          You also need to fill out all the JOINER_* environment variables below.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,6 +77,8 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   # Disable request forgery protection to simplify local development.
   config.action_controller.allow_forgery_protection = ENV.fetch("DISABLE_CSRF_PROTECTION", "true") == "true"
+
+  # Treat all requests as HTTPS, for dev setups behind an SSL-terminating reverse proxy.
   config.assume_ssl = ENV.fetch("RAILS_ASSUME_SSL", "false") == "true"
 
   config.hosts << "e621ng.local"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,6 +77,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   # Disable request forgery protection to simplify local development.
   config.action_controller.allow_forgery_protection = ENV.fetch("DISABLE_CSRF_PROTECTION", "true") == "true"
+  config.assume_ssl = ENV.fetch("RAILS_ASSUME_SSL", "false") == "true"
 
   config.hosts << "e621ng.local"
 


### PR DESCRIPTION
Adds an opt-in `RAILS_ASSUME_SSL` setting for development.

Useful when running e621ng behind a reverse proxy that handles HTTPS, where Rails otherwise sees the backend request as HTTP and can reject requests due to an origin mismatch.

Disabled by default, so existing dev setups are unchanged.

Tested behind Caddy.