### PR TITLE
[TagCategories] Use a separate mapping for the internal (symbol) names

### DIFF
--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -52,6 +52,21 @@ class TagCategory
     8 => "lore",
   }.freeze
 
+  # This mapping is used specifically for the `Tag.categories` members.
+  # It defines the names of the internal symbols, not of the actual categories.
+  # This allows different category names without needing to change all the symbols.
+  ENUM_MAPPING = {
+    0 => "general",
+    1 => "artist",
+    2 => "contributor",
+    3 => "copyright",
+    4 => "character",
+    5 => "species",
+    6 => "invalid",
+    7 => "meta",
+    8 => "lore",
+  }.freeze
+
   SHORT_NAME_MAPPING = {
     "gen" => "general",
     "art" => "artist",

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -21,7 +21,7 @@ class Tag < ApplicationRecord
   attr_accessor :from_wiki
 
   class CategoryMapping
-    TagCategory::REVERSE_MAPPING.each do |value, category|
+    TagCategory::ENUM_MAPPING.each do |value, category|
       define_method(category) do
         value
       end

--- a/spec/models/tag/category_methods_spec.rb
+++ b/spec/models/tag/category_methods_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Tag do
     subject(:mapping) { Tag.categories }
 
     it "exposes a method for each category returning the correct ID" do
-      TagCategory::REVERSE_MAPPING.each do |id, name|
+      TagCategory::ENUM_MAPPING.each do |id, name|
         expect(mapping.public_send(name)).to eq(id),
                                              "expected Tag.categories.#{name} to return #{id}"
       end

--- a/spec/models/tag/category_methods_spec.rb
+++ b/spec/models/tag/category_methods_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Tag do
       end
     end
 
+    it "ensures that ENUM_MAPPING and REVERSE_MAPPING keys match" do
+      expect(TagCategory::ENUM_MAPPING.keys).to match_array(TagCategory::REVERSE_MAPPING.keys)
+    end
+
     describe "#value_for" do
       let(:sample_id)   { TagCategory::REVERSE_MAPPING.keys.first }
       let(:sample_name) { TagCategory::REVERSE_MAPPING.values.first }


### PR DESCRIPTION
That way you can rename a category without needing to change all uses of the `Tag.categories` member. Will be most useful for *that fork*.