### PR TITLE
[Misc] Fix inconsistencies between `structure.sql` and the production DB

### DIFF
--- a/db/fixes/140_backfill_legacy_null_columns.rb
+++ b/db/fixes/140_backfill_legacy_null_columns.rb
@@ -58,7 +58,7 @@ module Fixes
       end
     end
 
-    def self.batched_update(conn, table, predicate, assignment, from: nil, join: nil)
+    def self.batched_update(conn, table, predicate, assignment, from: nil, join: nil) # rubocop:disable Metrics/ParameterLists
       total = 0
       loop do
         sql = <<~SQL.squish
@@ -72,7 +72,7 @@ module Fixes
         SQL
         updated = conn.execute(sql).cmd_tuples
         total += updated
-        break if updated.zero?
+        break if updated == 0
 
         puts "#{table}: #{total} rows" unless Rails.env.test?
         sleep(0.1) # bound replica lag / let autovacuum breathe

--- a/db/fixes/140_backfill_legacy_null_columns.rb
+++ b/db/fixes/140_backfill_legacy_null_columns.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# Backfills NULLs in columns that db/structure.sql declares NOT NULL but prod relaxed to fit
+# pre-rewrite data. All NULLs predate 2020-03-05 (the e621ng launch); nothing writes new ones.
+#
+# Fill values, per column:
+# - forum_posts.updater_id / news_updates.updater_id <- creator_id: the old code only
+#   set updater on edit, so NULL means "never edited".
+# - post_versions.updater_id <- 0, tickets.handler_id <- 0: those columns already use
+#   0 as their sentinel (DEFAULT 0). post_versions is updated with raw SQL, so the
+#   OpenSearch index is not touched; stale docs are harmless because NULL and 0 both
+#   resolve to "no user" in updater: searches.
+# - notes.creator_id, note_versions.updater_id, wiki_page_versions.updater_id
+#   <- User.system: 42/210/81 rows from 2007-2016 with no recoverable author.
+# - user_statuses.created_at/updated_at <- users.created_at: launch-day backfill
+#   created ~448k status rows without timestamps.
+#
+# Idempotent: every UPDATE is scoped to IS NULL.
+module Fixes
+  class BackfillLegacyNullColumns
+    BATCH_SIZE = 10_000
+
+    def self.run
+      conn = ApplicationRecord.connection
+      system_user_id = User.system.id
+
+      ApplicationRecord.without_timeout do
+        batched_update(conn, "forum_posts", "updater_id IS NULL", "updater_id = creator_id")
+        batched_update(conn, "post_versions", "updater_id IS NULL", "updater_id = 0")
+
+        puts "news_updates.updater_id: #{conn.execute(<<~SQL.squish).cmd_tuples} rows"
+          UPDATE news_updates SET updater_id = creator_id WHERE updater_id IS NULL
+        SQL
+        puts "tickets.handler_id: #{conn.execute(<<~SQL.squish).cmd_tuples} rows"
+          UPDATE tickets SET handler_id = 0 WHERE handler_id IS NULL
+        SQL
+        puts "notes.creator_id: #{conn.execute(<<~SQL.squish).cmd_tuples} rows"
+          UPDATE notes SET creator_id = #{system_user_id} WHERE creator_id IS NULL
+        SQL
+        puts "note_versions.updater_id: #{conn.execute(<<~SQL.squish).cmd_tuples} rows"
+          UPDATE note_versions SET updater_id = #{system_user_id} WHERE updater_id IS NULL
+        SQL
+        puts "wiki_page_versions.updater_id: #{conn.execute(<<~SQL.squish).cmd_tuples} rows"
+          UPDATE wiki_page_versions SET updater_id = #{system_user_id} WHERE updater_id IS NULL
+        SQL
+
+        # user_name_change_requests.user_id (1 NULL row from 2014) was fixed manually
+        # in prod on 2026-08-12.
+
+        # Two passes: rows missing created_at (fill both from the user's registration
+        # date), then any stragglers missing only updated_at.
+        batched_update(conn, "user_statuses", "user_statuses.created_at IS NULL",
+                       "created_at = u.created_at, updated_at = COALESCE(user_statuses.updated_at, u.created_at)",
+                       from: "users u", join: "u.id = user_statuses.user_id")
+        puts "user_statuses.updated_at stragglers: #{conn.execute(<<~SQL.squish).cmd_tuples} rows"
+          UPDATE user_statuses SET updated_at = created_at WHERE updated_at IS NULL
+        SQL
+      end
+    end
+
+    def self.batched_update(conn, table, predicate, assignment, from: nil, join: nil)
+      total = 0
+      loop do
+        sql = <<~SQL.squish
+          UPDATE #{table} SET #{assignment}
+          #{"FROM #{from}" if from}
+          WHERE #{table}.id IN (
+            SELECT id FROM #{table} WHERE #{predicate} LIMIT #{BATCH_SIZE}
+          )
+          #{"AND #{join}" if join}
+          AND #{predicate}
+        SQL
+        updated = conn.execute(sql).cmd_tuples
+        total += updated
+        break if updated.zero?
+
+        puts "#{table}: #{total} rows" unless Rails.env.test?
+        sleep(0.1) # bound replica lag / let autovacuum breathe
+      end
+      puts "#{table} (#{assignment.split(',').first.strip}): #{total} rows total"
+    end
+  end
+end
+
+Fixes::BackfillLegacyNullColumns.run unless Rails.env.test?

--- a/db/migrate/20260812223229_enforce_not_null_on_legacy_columns.rb
+++ b/db/migrate/20260812223229_enforce_not_null_on_legacy_columns.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Important:
+#
+# 140_backfill_legacy_null_columns.rb MUST be run before this migration,
+# or the NOT NULL constraints will fail.
+# (user_name_change_requests.user_id was already fixed manually in prod, 2026-08-12.)
+#
+# Restores the NOT NULL constraints that db/structure.sql already declares but prod
+# relaxed years ago to fit pre-rewrite data (docs/export/from-db/DRIFT.md). On fresh
+# installs every column is already NOT NULL and each step is a fast no-op.
+#
+
+class EnforceNotNullOnLegacyColumns < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  COLUMNS = {
+    forum_posts: [:updater_id],
+    news_updates: %i[creator_id updater_id],
+    note_versions: [:updater_id],
+    notes: [:creator_id],
+    post_versions: [:updater_id],
+    posts: %i[file_size image_height image_width is_status_locked uploader_id],
+    tickets: %i[handler_id status],
+    user_name_change_requests: [:user_id],
+    user_statuses: %i[created_at updated_at],
+    wiki_page_versions: [:updater_id],
+  }.freeze
+
+  def up
+    ApplicationRecord.without_timeout do
+      # Prod's tickets.status is nullable with no default; structure.sql already has
+      # this default, so it only changes prod.
+      change_column_default :tickets, :status, "pending"
+
+      COLUMNS.each do |table, columns|
+        columns.each { |column| enforce_not_null(table, column) }
+      end
+    end
+  end
+
+  def down
+    # The columns were always NOT NULL in structure.sql; only prod drifted.
+  end
+
+  private
+
+  # Unlike EnforcePostReplacementSequenceNumber, this touches huge tables, so a bare
+  # change_column_null would hold an ACCESS EXCLUSIVE lock for a full-table scan.
+  # Instead:
+  # - add the equivalent CHECK constraint NOT VALID (instant)
+  # - VALIDATE it (only takes a share lock)
+  # - SET NOT NULL
+  # Postgres sees the validated check and skips the scan — and drop the transient check.
+  # Requires disable_ddl_transaction.
+  def enforce_not_null(table, column)
+    constraint = "#{table}_#{column}_not_null"
+    add_check_constraint table, "#{column} IS NOT NULL", name: constraint, validate: false
+    validate_check_constraint table, name: constraint
+    change_column_null table, column, false
+    remove_check_constraint table, name: constraint
+  end
+end

--- a/db/migrate/20260812223255_add_creator_ip_addr_to_notes.rb
+++ b/db/migrate/20260812223255_add_creator_ip_addr_to_notes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Prod has notes.creator_ip_addr (inet NOT NULL) but structure.sql lost it somewhere along the way.
+class AddCreatorIpAddrToNotes < ActiveRecord::Migration[8.1]
+  def up
+    return if column_exists?(:notes, :creator_ip_addr)
+
+    Note.without_timeout do
+      add_column :notes, :creator_ip_addr, :inet
+      execute("UPDATE notes SET creator_ip_addr = '127.0.0.1' WHERE creator_ip_addr IS NULL")
+      change_column_null :notes, :creator_ip_addr, false
+    end
+  end
+
+  def down
+    # Prod always had this column; removing it would discard recorded data.
+  end
+end

--- a/db/migrate/20260812223301_align_id_column_types_with_prod.rb
+++ b/db/migrate/20260812223301_align_id_column_types_with_prod.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Aligns id column types with prod.
+# structure.sql drifted to bigint on 12 tables where prod is integer - none of which will plausibly
+# overflow - and to integer on dmails/uploads where prod is already bigint. Rather than rewriting
+# large prod tables for no benefit, structure.sql adopts prod's types.
+#
+# Guarded by the column's current type, so every statement is a no-op on prod; only
+# databases built from the drifted structure.sql (dev, CI) are converted. Fresh
+# installs get the corrected types from the regenerated structure.sql directly.
+class AlignIdColumnTypesWithProd < ActiveRecord::Migration[8.1]
+  # structure.sql said bigint; prod is integer
+  SHRINK = %i[
+    blips exception_logs forum_categories help_pages post_report_reasons
+    post_sets post_set_maintainers takedowns tag_type_versions tickets
+    upload_whitelists user_statuses
+  ].freeze
+
+  # structure.sql said integer; prod is bigint
+  WIDEN = %i[dmails uploads].freeze
+
+  def up
+    ApplicationRecord.without_timeout do
+      SHRINK.each do |table|
+        change_column table, :id, :integer if id_type(table) == "bigint"
+      end
+      WIDEN.each do |table|
+        change_column table, :id, :bigint if id_type(table) == "integer"
+      end
+    end
+  end
+
+  def down
+    # structure.sql is adopting prod's types; there is no prior state to restore.
+  end
+
+  private
+
+  def id_type(table)
+    connection.columns(table).find { |c| c.name == "id" }.sql_type
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -431,7 +431,7 @@ ALTER SEQUENCE public.bans_id_seq OWNED BY public.bans.id;
 --
 
 CREATE TABLE public.blips (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     creator_ip_addr inet NOT NULL,
     creator_id integer NOT NULL,
     body character varying NOT NULL,
@@ -691,7 +691,7 @@ ALTER SEQUENCE public.dmail_filters_id_seq OWNED BY public.dmail_filters.id;
 --
 
 CREATE TABLE public.dmails (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     owner_id integer NOT NULL,
     from_id integer NOT NULL,
     to_id integer NOT NULL,
@@ -800,7 +800,7 @@ ALTER SEQUENCE public.email_blacklists_id_seq OWNED BY public.email_blacklists.i
 --
 
 CREATE TABLE public.exception_logs (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     class_name character varying NOT NULL,
@@ -869,7 +869,7 @@ ALTER SEQUENCE public.favorites_id_seq OWNED BY public.favorites.id;
 --
 
 CREATE TABLE public.forum_categories (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying NOT NULL,
     description text,
     cat_order integer,
@@ -1082,7 +1082,7 @@ ALTER SEQUENCE public.forum_topics_id_seq OWNED BY public.forum_topics.id;
 --
 
 CREATE TABLE public.help_pages (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     name character varying NOT NULL,
@@ -1304,7 +1304,8 @@ CREATE TABLE public.notes (
     body text NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    version integer DEFAULT 0 NOT NULL
+    version integer DEFAULT 0 NOT NULL,
+    creator_ip_addr inet NOT NULL
 );
 
 
@@ -1792,7 +1793,7 @@ ALTER SEQUENCE public.post_replacements2_id_seq OWNED BY public.post_replacement
 --
 
 CREATE TABLE public.post_report_reasons (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     reason character varying NOT NULL,
@@ -1826,7 +1827,7 @@ ALTER SEQUENCE public.post_report_reasons_id_seq OWNED BY public.post_report_rea
 --
 
 CREATE TABLE public.post_set_maintainers (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     post_set_id integer NOT NULL,
     user_id integer NOT NULL,
     status character varying DEFAULT 'pending'::character varying NOT NULL,
@@ -1859,7 +1860,7 @@ ALTER SEQUENCE public.post_set_maintainers_id_seq OWNED BY public.post_set_maint
 --
 
 CREATE TABLE public.post_sets (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     name character varying NOT NULL,
     shortname character varying NOT NULL,
     description text DEFAULT ''::text NOT NULL,
@@ -2547,7 +2548,7 @@ ALTER SEQUENCE public.tag_rel_undos_id_seq OWNED BY public.tag_rel_undos.id;
 --
 
 CREATE TABLE public.tag_type_versions (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     old_type integer NOT NULL,
@@ -2619,7 +2620,7 @@ ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
 --
 
 CREATE TABLE public.takedowns (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     creator_id integer,
@@ -2663,7 +2664,7 @@ ALTER SEQUENCE public.takedowns_id_seq OWNED BY public.takedowns.id;
 --
 
 CREATE TABLE public.tickets (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     creator_id integer NOT NULL,
     creator_ip_addr inet NOT NULL,
     disp_id integer NOT NULL,
@@ -2704,7 +2705,7 @@ ALTER SEQUENCE public.tickets_id_seq OWNED BY public.tickets.id;
 --
 
 CREATE TABLE public.upload_whitelists (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     note character varying,
     reason character varying,
     allowed boolean DEFAULT true NOT NULL,
@@ -2740,7 +2741,7 @@ ALTER SEQUENCE public.upload_whitelists_id_seq OWNED BY public.upload_whitelists
 --
 
 CREATE TABLE public.uploads (
-    id integer NOT NULL,
+    id bigint NOT NULL,
     source text,
     rating character(1) NOT NULL,
     uploader_id integer NOT NULL,
@@ -2934,7 +2935,7 @@ ALTER SEQUENCE public.user_password_reset_nonces_id_seq OWNED BY public.user_pas
 --
 
 CREATE TABLE public.user_statuses (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     user_id integer NOT NULL,
@@ -6328,6 +6329,9 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260812223301'),
+('20260812223255'),
+('20260812223229'),
 ('20260805155544'),
 ('20260728160704'),
 ('20260727195335'),


### PR DESCRIPTION
First part of #2417.
Fills in missing data and corrects a number of columns.