### PR TITLE
[Misc] Rework the post auto-approval conditions

### DIFF
--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -73,10 +73,13 @@ class UploadService
     end
   end
 
+  private
+
   def should_set_pending?(upload, post)
-    return true unless upload.uploader.upload_free? || upload.uploader.can_approve_posts?
     return true if upload.upload_as_pending?
-    return true if post.avoid_posting_tags.any? && !upload.uploader.can_approve_posts?
+    return false if upload.uploader.can_approve_posts?
+    return true unless upload.uploader.upload_free?
+    return true if post.avoid_posting_tags.any?
     false
   end
 end

--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -69,9 +69,14 @@ class UploadService
       p.is_animated = animated
       p.duration = upload.video_duration(upload.file.path, animated: animated)
 
-      if !upload.uploader.upload_free? || (!upload.uploader.can_approve_posts? && p.avoid_posting_tags.any?) || upload.upload_as_pending?
-        p.is_pending = true
-      end
+      p.is_pending = true if should_set_pending?(upload, p)
     end
+  end
+
+  def should_set_pending?(upload, post)
+    return true unless upload.uploader.upload_free? || upload.uploader.can_approve_posts?
+    return true if upload.upload_as_pending?
+    return true if post.avoid_posting_tags.any? && !upload.uploader.can_approve_posts?
+    false
   end
 end

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -350,6 +350,11 @@ RSpec.describe UploadService do
         upload.uploader.update(can_upload_free: true)
         expect(service.convert_to_post(upload).is_pending).to be true
       end
+
+      it "does not mark post as pending when uploader can approve but is below the karma threshold" do
+        allow(upload.uploader).to receive_messages(upload_free?: false, can_approve_posts?: true)
+        expect(service.convert_to_post(upload).is_pending).to be false
+      end
     end
 
     context "locked_rating" do


### PR DESCRIPTION
Reworked the condition to be less confusing.

Also, fixed a latent bug that caused approvers' posts to still be marked as pending if any DNP tags were present.
Didn't really make sense to do so - they can just approve the post immediately anyways.