### PR TITLE
[Posts] Fix `avoid_posting_tags` not using normalized tags on upload

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1162,6 +1162,7 @@ class Post < ApplicationRecord
           candidate_names = tag_array
           if new_record? || tag_string_changed?
             # Apply canonicalization if the raw tag string had not gone through normalize_tags yet.
+            candidate_names = candidate_names.map { |name| name.downcase.sub(/\A(#{Tag.categories.regexp}):/, "") }
             candidate_names = TagAlias.to_aliased(candidate_names.map(&:downcase))
           end
           tags = Tag

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1163,7 +1163,7 @@ class Post < ApplicationRecord
           if new_record? || tag_string_changed?
             # Apply canonicalization if the raw tag string had not gone through normalize_tags yet.
             candidate_names = candidate_names.map { |name| name.downcase.sub(/\A(#{Tag.categories.regexp}):/, "") }
-            candidate_names = TagAlias.to_aliased(candidate_names.map(&:downcase))
+            candidate_names = TagAlias.to_aliased(candidate_names)
           end
           tags = Tag
                  .where(name: candidate_names, category: [Tag.categories.artist, Tag.categories.copyright, Tag.categories.character])

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1159,8 +1159,13 @@ class Post < ApplicationRecord
       @avoid_posting_tags ||= begin
         # We only care about artist, copyright, and character tags.
         if @categorized_tags.nil?
+          candidate_names = tag_array
+          if new_record? || tag_string_changed?
+            # Apply canonicalization if the raw tag string had not gone through normalize_tags yet.
+            candidate_names = TagAlias.to_aliased(candidate_names.map(&:downcase))
+          end
           tags = Tag
-                 .where(name: tag_array, category: [Tag.categories.artist, Tag.categories.copyright, Tag.categories.character])
+                 .where(name: candidate_names, category: [Tag.categories.artist, Tag.categories.copyright, Tag.categories.character])
                  .pluck(:name)
                  .filter { |tag| NON_ARTIST_TAGS.exclude?(tag) }
         else

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -324,6 +324,23 @@ RSpec.describe UploadService do
         expect(service.convert_to_post(upload).is_pending).to be true
       end
 
+      it "marks post as pending when a DNP artist is tagged with different casing" do
+        artist = create(:artist)
+        create(:avoid_posting, artist: artist)
+        upload.tag_string = artist.name.upcase
+        allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: false)
+        expect(service.convert_to_post(upload).is_pending).to be true
+      end
+
+      it "marks post as pending when a DNP artist is tagged through an alias" do
+        artist = create(:artist)
+        create(:avoid_posting, artist: artist)
+        create(:active_tag_alias, antecedent_name: "#{artist.name}_(artist)", consequent_name: artist.name)
+        upload.tag_string = "#{artist.name}_(artist)"
+        allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: false)
+        expect(service.convert_to_post(upload).is_pending).to be true
+      end
+
       it "marks post as pending when upload_as_pending? is true" do
         allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: true)
         allow(upload).to receive(:upload_as_pending?).and_return(true)

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -341,6 +341,14 @@ RSpec.describe UploadService do
         expect(service.convert_to_post(upload).is_pending).to be true
       end
 
+      it "marks post as pending when a DNP artist tag has a category prefix" do
+        artist = create(:artist)
+        create(:avoid_posting, artist: artist)
+        upload.tag_string = "artist:#{artist.name}"
+        allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: false)
+        expect(service.convert_to_post(upload).is_pending).to be true
+      end
+
       it "marks post as pending when upload_as_pending? is true" do
         allow(upload.uploader).to receive_messages(upload_free?: true, can_approve_posts?: true)
         allow(upload).to receive(:upload_as_pending?).and_return(true)

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -763,6 +763,13 @@ RSpec.describe Post do
         expect(post.avoid_posting_tags).to include(avoid)
       end
 
+      it "matches tags with a category prefix on an unsaved post" do
+        artist = create(:artist)
+        avoid = create(:avoid_posting, artist: artist)
+        post = build(:post, tag_string: "artist:#{artist.name}")
+        expect(post.avoid_posting_tags).to include(avoid)
+      end
+
       # Persisted tag strings are always normalized, so the alias lookup would be
       # a wasted query on every render of the avoid-posting notice.
       it "does not resolve aliases for a persisted post with a clean tag string" do

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -745,6 +745,34 @@ RSpec.describe Post do
         post = create(:post, tag_string: (1..10).map { |i| "gen_only_#{i}" }.join(" "))
         expect(post.avoid_posting_tags).to eq([])
       end
+
+      # The raw tag string of an unsaved post has not gone through normalize_tags yet,
+      # so the check must canonicalize the input itself to match the eventual result.
+      it "matches differently-cased tags on an unsaved post" do
+        artist = create(:artist)
+        avoid = create(:avoid_posting, artist: artist)
+        post = build(:post, tag_string: artist.name.upcase)
+        expect(post.avoid_posting_tags).to include(avoid)
+      end
+
+      it "matches aliases of DNP tags on an unsaved post" do
+        artist = create(:artist)
+        avoid = create(:avoid_posting, artist: artist)
+        create(:active_tag_alias, antecedent_name: "#{artist.name}_(artist)", consequent_name: artist.name)
+        post = build(:post, tag_string: "#{artist.name}_(artist)")
+        expect(post.avoid_posting_tags).to include(avoid)
+      end
+
+      # Persisted tag strings are always normalized, so the alias lookup would be
+      # a wasted query on every render of the avoid-posting notice.
+      it "does not resolve aliases for a persisted post with a clean tag string" do
+        artist = create(:artist)
+        avoid = create(:avoid_posting, artist: artist)
+        post = Post.find(create(:post, tag_string: "artist:#{artist.name} " + (1..10).map { |i| "gen_#{i}" }.join(" ")).id)
+        allow(TagAlias).to receive(:to_aliased).and_call_original
+        expect(post.avoid_posting_tags).to include(avoid)
+        expect(TagAlias).not_to have_received(:to_aliased)
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, `avoid_posting_tags` did not take aliases and casing into account on upload.
That caused posts to fail to be marked as pending.