### PR TITLE
[DbExports] Record list of columns

### DIFF
--- a/app/blueprints/db_export_blueprint.rb
+++ b/app/blueprints/db_export_blueprint.rb
@@ -5,6 +5,7 @@ class DbExportBlueprint < Blueprinter::Base
   field :file_name
   field :file_size
   field :checksum
+  field :columns
   field :updated_at
   field :url
 end

--- a/app/javascript/entrypoints/v_db-exports.ts
+++ b/app/javascript/entrypoints/v_db-exports.ts
@@ -1,0 +1,8 @@
+// db_exports
+
+import E621Type from "@/interfaces/E621";
+declare const E621: E621Type;
+
+import "@/pages/db_exports/db_exports";
+
+E621.Registry.register("v_db-exports");

--- a/app/javascript/src/js/pages/db_exports/db_exports.ts
+++ b/app/javascript/src/js/pages/db_exports/db_exports.ts
@@ -1,0 +1,18 @@
+class DbExports {
+  static init () {
+    document.querySelectorAll<HTMLDivElement>(".exports-list .row").forEach((row) => {
+      const toggle = row.querySelector<HTMLDetailsElement>(".row-toggle");
+      if (!toggle) return;
+
+      row.addEventListener("click", (event) => {
+        const target = event.target as HTMLElement;
+        if (target.closest("a, input, summary, .time-switchable")) return;
+        toggle.open = !toggle.open;
+      });
+    });
+  }
+}
+
+$(() => DbExports.init());
+
+export default DbExports;

--- a/app/javascript/src/styles/specific/db_exports.scss
+++ b/app/javascript/src/styles/specific/db_exports.scss
@@ -18,12 +18,13 @@ body.c-db-exports.a-index {
     grid-template-columns: 1fr 0.75fr 1fr 1.5fr auto;
     margin-bottom: 1rem;
 
-    .export-checksum {
-      font-family: monospace;
-      font-size: 0.85em;
-      word-break: break-all;
+    .export-checksum-input {
+      width: 100%;
+      max-width: 25rem;
       min-width: 0;
-      cursor: text;
+      font-family: monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     .export-checksum-missing {

--- a/app/javascript/src/styles/specific/db_exports.scss
+++ b/app/javascript/src/styles/specific/db_exports.scss
@@ -23,6 +23,7 @@ body.c-db-exports.a-index {
       font-size: 0.85em;
       word-break: break-all;
       min-width: 0;
+      cursor: text;
     }
 
     .export-checksum-missing {
@@ -48,7 +49,8 @@ body.c-db-exports.a-index {
     .row {
       display: contents;
 
-      &:last-child .cell {
+      &:last-child .cell,
+      &:last-child .row-columns {
         border-bottom: none;
       }
 
@@ -56,6 +58,79 @@ body.c-db-exports.a-index {
         &:hover .cell {
           background-color: var(--color-section-lighten-10);
         }
+      }
+
+      &:has(.row-toggle[open]) {
+        .cell,
+        .row-columns {
+          background-color: var(--color-section-darken-5);
+        }
+
+        .row-columns {
+          display: block;
+        }
+      }
+
+      &:has(.row-toggle) {
+        .cell,
+        .row-columns {
+          cursor: pointer;
+        }
+      }
+    }
+
+    .row-toggle {
+      summary {
+        display: flex;
+        align-items: center;
+        gap: 0.375rem;
+        cursor: pointer;
+        list-style: none;
+
+        &::-webkit-details-marker {
+          display: none;
+        }
+      }
+
+      .row-toggle-icon {
+        flex-shrink: 0;
+        color: var(--color-text-muted);
+        transition: transform 0.15s ease;
+      }
+
+      &[open] .row-toggle-icon {
+        transform: rotate(90deg);
+      }
+    }
+
+    .row-columns {
+      display: none;
+      grid-column: 1 / -1;
+      background-color: var(--color-section);
+      border-bottom: 1px solid var(--color-table-border);
+      padding: 0 $padding-025 $padding-050;
+    }
+
+    .export-columns-table {
+      width: 100%;
+      max-width: 30rem;
+      border-collapse: collapse;
+      margin-bottom: $padding-050;
+      font-size: 0.9em;
+
+      th,
+      td {
+        text-align: left;
+        padding: 0.25rem 0.5rem;
+        border-bottom: 1px solid var(--color-table-border);
+      }
+
+      th {
+        color: var(--color-text-table-header);
+      }
+
+      code {
+        font-size: 0.95em;
       }
     }
 

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -56,13 +56,16 @@ class DbExportJob < ApplicationJob
   def generate_export(name, config)
     Rails.logger.info("DbExportJob: Generating #{name} export")
 
+    query = config[:query].call
+    columns = export_columns(query)
+
     file = Tempfile.new(["#{name}-export", ".csv.gz"], binmode: true)
-    write_csv_gz(config[:query].call, file)
+    write_csv_gz(query, file)
     file.rewind
 
     checksum = Digest::SHA256.file(file.path).hexdigest
     Danbooru.config.storage_manager.store_db_export(file, "#{name}.csv.gz")
-    record_export(name, file.size, checksum)
+    record_export(name, file.size, checksum, columns)
 
     Rails.logger.info("DbExportJob: Finished #{name} export (#{ActiveSupport::NumberHelper.number_to_human_size(file.size)})")
   rescue StandardError => e
@@ -70,6 +73,25 @@ class DbExportJob < ApplicationJob
     ActiveRecord::Base.connection.reconnect!
   ensure
     file&.close!
+  end
+
+  def export_columns(query)
+    conn = ActiveRecord::Base.connection.raw_connection
+    result = conn.exec("SELECT * FROM (#{query}) db_export_columns LIMIT 0")
+    oids = result.nfields.times.map { |i| result.ftype(i) }
+    type_names = resolve_type_names(conn, oids)
+    result.fields.each_with_index.to_h { |field, i| [field, type_names[oids[i]]] }
+  ensure
+    result&.clear
+  end
+
+  def resolve_type_names(conn, oids)
+    return {} if oids.empty?
+
+    types = conn.exec_params("SELECT oid, format_type(oid, NULL) AS type_name FROM pg_type WHERE oid = ANY($1::oid[])", ["{#{oids.uniq.join(',')}}"])
+    types.each_with_object({}) { |row, hash| hash[row["oid"].to_i] = row["type_name"] }
+  ensure
+    types&.clear
   end
 
   def write_csv_gz(query, file)
@@ -86,8 +108,8 @@ class DbExportJob < ApplicationJob
     gz&.finish
   end
 
-  def record_export(name, file_size, checksum)
+  def record_export(name, file_size, checksum, columns)
     export = DbExport.find_or_initialize_by(name: name)
-    export.update!(file_size: file_size, checksum: checksum, updated_at: Time.current)
+    export.update!(file_size: file_size, checksum: checksum, columns: columns, updated_at: Time.current)
   end
 end

--- a/app/views/db_exports/index.html.erb
+++ b/app/views/db_exports/index.html.erb
@@ -18,7 +18,15 @@
 
         <% @exports.each do |export| %>
           <div class="row">
-            <div class="cell" data-label="Name"><strong><%= export.name %></strong></div>
+            <div class="cell" data-label="Name">
+              <% if export.columns.present? %>
+                <details class="row-toggle">
+                  <summary><%= svg_icon(:chevron_right, width: 12, height: 12, class: "row-toggle-icon") %> <strong><%= export.name %></strong></summary>
+                </details>
+              <% else %>
+                <strong><%= export.name %></strong>
+              <% end %>
+            </div>
             <div class="cell" data-label="Size"><%= number_to_human_size(export.file_size) %></div>
             <div class="cell" data-label="Updated"><%= time_ago_in_words_tagged(export.updated_at) %></div>
             <div class="cell" data-label="Checksum">
@@ -33,6 +41,27 @@
                 <%= svg_icon(:download, width: 16, height: 16) %> Download
               <% end %>
             </div>
+
+            <% if export.columns.present? %>
+              <div class="row-columns">
+                <table class="export-columns-table">
+                  <thead>
+                    <tr>
+                      <th>Column</th>
+                      <th>Postgres type</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% export.columns.each do |column_name, column_type| %>
+                      <tr>
+                        <td><code><%= column_name %></code></td>
+                        <td><code><%= column_type %></code></td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            <% end %>
           </div>
         <% end %>
       </div>

--- a/db/migrate/20260818231600_add_columns_to_db_exports.rb
+++ b/db/migrate/20260818231600_add_columns_to_db_exports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddColumnsToDbExports < ActiveRecord::Migration[8.1]
+  def change
+    add_column(:db_exports, :columns, :jsonb, default: {}, null: false)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -590,7 +590,8 @@ CREATE TABLE public.db_exports (
     file_size bigint DEFAULT 0 NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
-    checksum character varying
+    checksum character varying,
+    columns jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 
 
@@ -6337,6 +6338,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260818231600'),
 ('20260818231537'),
 ('20260812223301'),
 ('20260812223255'),

--- a/spec/jobs/db_export_job_spec.rb
+++ b/spec/jobs/db_export_job_spec.rb
@@ -66,6 +66,26 @@ RSpec.describe DbExportJob do
       expect(export.checksum).to eq(Digest::SHA256.hexdigest(raw["tags.csv.gz"]))
     end
 
+    it "records each column mapped to its Postgres type" do
+      perform
+      export = DbExport.find_by(name: "tags")
+      expect(export.columns).to eq(
+        "id" => "integer",
+        "name" => "character varying",
+        "category" => "smallint",
+        "post_count" => "integer",
+        "created_at" => "timestamp without time zone",
+        "updated_at" => "timestamp without time zone",
+        "is_locked" => "boolean",
+      )
+    end
+
+    it "records the actual output type of computed and array columns" do
+      perform
+      expect(DbExport.find_by(name: "pools").columns["post_ids"]).to eq("integer[]")
+      expect(DbExport.find_by(name: "artists").columns["active_urls"]).to eq("text")
+    end
+
     it "reuses the existing row on a subsequent run" do
       perform
       expect { perform }.not_to change(DbExport, :count)

--- a/spec/requests/db_exports_controller_spec.rb
+++ b/spec/requests/db_exports_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe DbExportsController do
   before do
     allow(Danbooru.config.custom_configuration).to receive(:db_export_enabled?).and_return(true)
-    DbExport.create!(name: "posts", file_size: 2048, checksum: "a" * 64)
+    DbExport.create!(name: "posts", file_size: 2048, checksum: "a" * 64, columns: { "id" => "integer", "md5" => "character varying" })
     DbExport.create!(name: "tags", file_size: 512)
   end
 
@@ -21,6 +21,11 @@ RSpec.describe DbExportsController do
       expect(response.body).to include("tags")
     end
 
+    it "lists the columns and Postgres types for an export with recorded column metadata" do
+      get db_exports_path
+      expect(response.body).to include("id", "integer", "md5", "character varying")
+    end
+
     it "returns 404 when exports are disabled" do
       allow(Danbooru.config.custom_configuration).to receive(:db_export_enabled?).and_return(false)
       get db_exports_path
@@ -34,6 +39,7 @@ RSpec.describe DbExportsController do
       expect(body).to be_an(Array)
       entry = body.find { |export| export["name"] == "posts" }
       expect(entry).to include("file_name" => "posts.csv.gz", "file_size" => 2048, "checksum" => "a" * 64)
+      expect(entry["columns"]).to eq("id" => "integer", "md5" => "character varying")
       expect(entry["url"]).to be_present
     end
   end


### PR DESCRIPTION
This records the list of columns used in queries along with their postgres type. It's surfaced in both the json and html, with the html having the row as toggle a table showing a list of the columns and their types.
I also expanded the checksum input so the full value is visible when possible, since there is plenty of leftover space.