### PR TITLE
[Users] Show colored usernames to everyone

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -336,7 +336,7 @@ class UsersController < ApplicationController
 
       receive_email_notifications enable_keyboard_navigation
       enable_privacy_mode disable_user_dmails blacklist_users show_post_statistics
-      style_usernames show_hidden_comments
+      show_hidden_comments
       enable_auto_complete
       enable_safe_mode disable_responsive_mode
       forum_notification_dot

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -133,7 +133,6 @@ module ApplicationHelper
     user_class = user.level_css_class
     user_class += " user-post-approver" if user.can_approve_posts?
     user_class += " user-banned" if user.is_restricted?
-    user_class += " with-style" if CurrentUser.user.style_usernames?
     html = link_to(user.pretty_name.presence || "<blank>", user_path(user), class: user_class, rel: "nofollow")
     html << " (Unactivated)" if include_activation && !user.is_verified?
     html

--- a/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/TagQueryProvider.ts
@@ -3,7 +3,6 @@ import Provider from "@/components/autocomplete/Provider";
 import TagFrequencyCache from "@/components/autocomplete/TagFrequencyCache";
 import * as Types from "@/components/autocomplete/Types";
 import LStorage from "@/utility/storage/Local";
-import Utility from "@/utility/utility";
 
 import PoolProvider from "./PoolProvider";
 import TagProvider from "./TagProvider";
@@ -60,8 +59,6 @@ export default class TagQueryProvider extends Provider<Types.AutocompleteItem> {
     if ("level" in item && item.level) {
       const levelClass = `user-${item.level.replace(/ /g, "-").toLowerCase()}`;
       link.classList.add(levelClass);
-      if (Utility.meta("style-usernames") === "true")
-        link.classList.add("with-style");
     }
 
     // Add alias information

--- a/app/javascript/src/js/components/autocomplete/providers/UserProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/UserProvider.ts
@@ -1,6 +1,5 @@
 import Provider from "@/components/autocomplete/Provider";
 import { UserItem } from "@/components/autocomplete/Types";
-import Utility from "@/utility/utility";
 
 export default class UserProvider extends Provider<UserItem> {
   public async search (query: string) {
@@ -14,8 +13,6 @@ export default class UserProvider extends Provider<UserItem> {
       const link = li.querySelector("a");
       const levelClass = `user-${item.level.replace(/ /g, "-").toLowerCase()}`;
       link.classList.add(levelClass);
-      if (Utility.meta("style-usernames") === "true")
-        link.classList.add("with-style");
     }
 
     return li;

--- a/app/javascript/src/js/pages/forum_posts/ForumPostVote.ts
+++ b/app/javascript/src/js/pages/forum_posts/ForumPostVote.ts
@@ -127,7 +127,7 @@ export default class ForumPostVote {
         "href": `/users/${vote.creator_id}`,
         "rel": "nofollow",
       })
-      .addClass("with-style user-" + E621.CurrentUser.levelString.replace(/ /g, "-").toLowerCase())
+      .addClass("user-" + E621.CurrentUser.levelString.replace(/ /g, "-").toLowerCase())
       .text(vote.creator_name.replace(/_+/g, " "));
     const $li = $("<li>").addClass("forum-post-vote own-forum-vote").append($link);
     $votesList.append($li);

--- a/app/javascript/src/styles/common/user_styles.scss
+++ b/app/javascript/src/styles/common/user_styles.scss
@@ -10,7 +10,7 @@ $levels: (
 );
 
 @each $level in $levels {
-  a.user-#{$level}.with-style {
+  a.user-#{$level} {
     color: themed("color-user-#{$level}");
 
     &:hover {
@@ -19,7 +19,7 @@ $levels: (
   }
 }
 
-a.user-blocked.with-style {
+a.user-blocked {
   text-decoration: line-through;
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
     receive_email_notifications
     enable_keyboard_navigation
     enable_privacy_mode
-    style_usernames
+    _style_usernames
     enable_auto_complete
     _has_saved_searches
     can_approve_posts
@@ -935,7 +935,7 @@ class User < ApplicationRecord
           hide_comments show_hidden_comments show_post_statistics
           is_banned receive_email_notifications
           enable_keyboard_navigation enable_privacy_mode
-          style_usernames enable_auto_complete
+          enable_auto_complete
           can_approve_posts can_upload_free
           enable_safe_mode
           disable_responsive_mode no_flagging disable_user_dmails

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -15,7 +15,6 @@
   <meta name="blacklisted-tags" content="[]">
   <meta name="blacklist-users" content="false">
 <% end %>
-<meta name="style-usernames" content="<%= CurrentUser.user.style_usernames? %>">
 
 <%# Data for autocomplete %>
 <meta name="metatags" content="<%= TagQuery::METATAGS.to_json %>">

--- a/app/views/staff/wikis/partials/_involved.html.erb
+++ b/app/views/staff/wikis/partials/_involved.html.erb
@@ -5,7 +5,7 @@
 
   <% claimant_id = @staff_wiki.claimant_id %>
   <% users.each do |user| %>
-    <% klass = "#{user.level_css_class} with-style" %>
+    <% klass = "#{user.level_css_class}" %>
     <% klass += " claimant" if user.id == claimant_id %>
     <span><%= link_to user.pretty_name.presence || "<blank>", user, class: klass, rel: "nofollow" %></span>
   <% end %>

--- a/app/views/staff/wikis/partials/_involved.html.erb
+++ b/app/views/staff/wikis/partials/_involved.html.erb
@@ -5,7 +5,7 @@
 
   <% claimant_id = @staff_wiki.claimant_id %>
   <% users.each do |user| %>
-    <% klass = "#{user.level_css_class}" %>
+    <% klass = user.level_css_class %>
     <% klass += " claimant" if user.id == claimant_id %>
     <span><%= link_to user.pretty_name.presence || "<blank>", user, class: klass, rel: "nofollow" %></span>
   <% end %>

--- a/app/views/users/partials/edit/_advanced.html.erb
+++ b/app/views/users/partials/edit/_advanced.html.erb
@@ -25,17 +25,6 @@
   </tab-hint>
 </tab-entry>
 
-<tab-entry tab="<%= tab_name %>" group="accessibility" class="inline" search="users colored usernames level rank">
-  <tab-head>Colored Usernames</tab-head>
-  <tab-body>
-    <%= form.input_field :style_usernames, as: :boolean, class: "st-toggle" %>
-    <%= form.label :style_usernames, "!", class: "st-toggle", role: "switch" %>
-  </tab-body>
-  <tab-hint>
-    Color names depending on the user's level.
-  </tab-hint>
-</tab-entry>
-
 
 <!-- Privacy & Messaging -->
 <tab-group name="privacy">Privacy & Messaging</tab-group>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -88,7 +88,6 @@ module Danbooru
       user.enable_keyboard_navigation = true
       user.per_page = records_per_page
       user.show_post_statistics = true
-      user.style_usernames = true
     end
 
     def default_blacklist


### PR DESCRIPTION
Colored usernames have been the default for a while.
However, older users still typically have it turned off, unless they explicitly turned it on.

With the recent attempts at mass phishing, it's best if we don't offer this option at all.
It's harder to pretend to be staff if your username isn't colored in, after all.