### PR TITLE
[Config] Canonize the login requirement for posts

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -720,7 +720,8 @@ You can see a list of your deleted posts \"here\":[/deleted_posts?user_id=%UPLOA
       !(is_user_restricted?(user) && is_post_restricted?(post))
     end
 
-    def user_needs_login_for_post?(_post)
+    def user_needs_login_for_post?(post)
+      return true if post.tag_array.include?("young") && post.rating != "s"
       false
     end
 


### PR DESCRIPTION
Updated the default config to match production.
This line is present on all apps, e6ai included.

Technically, prod also checks for `loli` and `shota`, but those tags implicate `young` on e621, and are aliased to `young` on e6ai.
It's extremely unlikely that this kind of coupling will be removed.