### PR TITLE
[Artists] Fix performance issues when searching for linked users

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -482,7 +482,10 @@ class Artist < ApplicationRecord
       q = q.where_user(:linked_user_id, :linked_user, params)
 
       if params[:has_tag].to_s.truthy?
-        q = q.joins(:tag).where("tags.post_count > 0")
+        # This horrifying query is necessary to force the database to use the btree index.
+        # Without it, the query planner will use the GIN index, which is somehow 1000x slower.
+        q = q.joins("INNER JOIN tags ON tags.name >= artists.name AND tags.name <= artists.name")
+             .where("tags.post_count > 0")
       elsif params[:has_tag].to_s.falsy?
         q = q.includes(:tag).where("tags.name IS NULL OR tags.post_count <= 0").references(:tags)
       end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -482,8 +482,11 @@ class Artist < ApplicationRecord
       q = q.where_user(:linked_user_id, :linked_user, params)
 
       if params[:has_tag].to_s.truthy?
-        # This horrifying query is necessary to force the database to use the btree index.
-        # Without it, the query planner will use the GIN index, which is somehow 1000x slower.
+        # Deliberate hack: an equality join here makes the planner use the trigram GIN index
+        # (index_tags_on_name_trgm), whose equality support degenerates into a recheck-heavy bitmap
+        # scan (~27s on prod). gin_trgm_ops has no range operators, so >= AND <= forces the unique
+        # btree index instead (~0.3s).
+        # Note this ruins the planner's row estimates for anything built on top of this join.
         q = q.joins("INNER JOIN tags ON tags.name >= artists.name AND tags.name <= artists.name")
              .where("tags.post_count > 0")
       elsif params[:has_tag].to_s.falsy?


### PR DESCRIPTION
Before:
```
e621=> EXPLAIN (ANALYZE, BUFFERS)
SELECT "artists".*
FROM "artists"
INNER JOIN "tags" ON "tags"."name" = "artists"."name"
WHERE (tags.post_count > 0)
  AND "artists"."linked_user_id" IS NOT NULL
ORDER BY artists.name
LIMIT 75 OFFSET 7425;
                                                                               QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=15963.42..15963.54 rows=1 width=74) (actual time=26724.040..26811.977 rows=75 loops=1)
   Buffers: shared hit=3419763 read=391 written=6
   ->  Gather Merge  (cost=15596.11..15963.42 rows=3194 width=74) (actual time=26721.613..26811.715 rows=7500 loops=1)
         Workers Planned: 1
         Workers Launched: 1
         Buffers: shared hit=3419763 read=391 written=6
         ->  Sort  (cost=14596.10..14604.09 rows=3194 width=74) (actual time=26694.786..26695.086 rows=4006 loops=2)
               Sort Key: artists.name
               Sort Method: quicksort  Memory: 926kB
               Buffers: shared hit=3419763 read=391 written=6
               Worker 0:  Sort Method: quicksort  Memory: 932kB
               ->  Nested Loop  (cost=92.77..14410.19 rows=3194 width=74) (actual time=9.857..26682.709 rows=4754 loops=2)
                     Buffers: shared hit=3419755 read=391 written=6
                     ->  Parallel Bitmap Heap Scan on artists  (cost=91.79..1943.22 rows=5943 width=74) (actual time=1.170..10.965 rows=5172 loops=2)
                           Recheck Cond: (linked_user_id IS NOT NULL)
                           Heap Blocks: exact=852
                           Buffers: shared hit=1718 read=6
                           ->  Bitmap Index Scan on index_artists_on_linked_user_id  (cost=0.00..89.27 rows=10103 width=0) (actual time=1.925..1.926 rows=10345 loops=1)
                                 Index Cond: (linked_user_id IS NOT NULL)
                                 Buffers: shared hit=36
                     ->  Bitmap Heap Scan on tags  (cost=0.98..2.10 rows=1 width=14) (actual time=5.154..5.154 rows=1 loops=10343)
                           Recheck Cond: (name = (artists.name)::text)
                           Rows Removed by Index Recheck: 4
                           Filter: (post_count > 0)
                           Rows Removed by Filter: 0
                           Heap Blocks: exact=22625
                           Buffers: shared hit=3418037 read=385 written=6
                           ->  Bitmap Index Scan on index_tags_on_name_trgm  (cost=0.00..0.98 rows=1 width=0) (actual time=5.131..5.131 rows=6 loops=10343)
                                 Index Cond: (name = (artists.name)::text)
                                 Buffers: shared hit=3372027 read=385 written=6
 Planning:
   Buffers: shared hit=19
 Planning Time: 0.865 ms
 Execution Time: 26812.146 ms
(34 rows)
```

After:
```
e621=> EXPLAIN (ANALYZE, BUFFERS)
SELECT "artists".* FROM "artists"
INNER JOIN "tags" ON "tags"."name" >= "artists"."name" AND "tags"."name" <= "artists"."name"
WHERE (tags.post_count > 0) AND "artists"."linked_user_id" IS NOT NULL
ORDER BY artists.name LIMIT 75 OFFSET 7425;
                                                                      QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=386.44..390.34 rows=75 width=74) (actual time=170.664..172.020 rows=75 loops=1)
   Buffers: shared hit=130461 read=344
   ->  Nested Loop  (cost=0.84..47993968.37 rows=924168557 width=74) (actual time=0.590..171.623 rows=7500 loops=1)
         Buffers: shared hit=130461 read=344
         ->  Index Scan using index_artists_on_name on artists  (cost=0.42..4451.27 rows=10103 width=74) (actual time=0.547..97.820 rows=8147 loops=1)
               Filter: (linked_user_id IS NOT NULL)
               Rows Removed by Filter: 90364
               Buffers: shared hit=97952 read=269
         ->  Index Scan using index_tags_on_name on tags  (cost=0.43..3835.28 rows=91475 width=14) (actual time=0.008..0.008 rows=1 loops=8147)
               Index Cond: ((name >= (artists.name)::text) AND (name <= (artists.name)::text))
               Filter: (post_count > 0)
               Rows Removed by Filter: 0
               Buffers: shared hit=32509 read=75
 Planning Time: 0.343 ms
 Execution Time: 172.081 ms
(15 rows)
```