### PR TITLE
[Posts] Wire in the `old_description` accessor

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -67,7 +67,7 @@ class Post < ApplicationRecord
   has_many :favorites
   has_many :replacements, class_name: "PostReplacement", :dependent => :destroy
 
-  attr_accessor :old_tag_string, :old_parent_id, :old_source, :old_rating,
+  attr_accessor :old_tag_string, :old_parent_id, :old_source, :old_rating, :old_description,
                 :do_not_version_changes, :tag_string_diff, :source_diff, :edit_reason
 
   has_many :versions, -> {order("post_versions.id ASC")}, :class_name => "PostVersion", :dependent => :destroy
@@ -656,6 +656,10 @@ class Post < ApplicationRecord
 
       if old_rating == rating
         self.rating = rating_before_last_save || rating_was
+      end
+
+      if old_description == description.to_s
+        self.description = description_before_last_save || description_was
       end
     end
 

--- a/app/views/posts/partials/show/content/_edit.html.erb
+++ b/app/views/posts/partials/show/content/_edit.html.erb
@@ -19,6 +19,7 @@
   <%= f.hidden_field :old_parent_id, value: post.parent_id %>
   <%= f.hidden_field :old_source, value: post.source %>
   <%= f.hidden_field :old_rating, value: post.rating %>
+  <%= f.hidden_field :old_description, value: post.description %>
 
   <div class="input" id="tags-container">
     <div class="header">

--- a/spec/models/post/tag_methods_spec.rb
+++ b/spec/models/post/tag_methods_spec.rb
@@ -346,6 +346,20 @@ RSpec.describe Post do
           expect(child.parent_id).to eq(parent_b.id)
         end
       end
+
+      describe "when old_description matches submitted description (user did not intend to change it)" do
+        it "reverts description to the previous value in memory after validation" do
+          post = create(:post, description: "Old description")
+          post.update_columns(description: "New description")
+          post.reload
+
+          post.old_description = "Old description"
+          post.description = "Old description"
+          post.valid?
+
+          expect(post.description).to eq("New description")
+        end
+      end
     end
 
     describe "normalize_tags — locked_tags blank string → nil" do


### PR DESCRIPTION
`old_description` had been a permitted parameter since 2019, but apparently nobody wired it in.
Without this PR, using it would return an `ActiveModel::UnknownAttributeError` error.