### PR TITLE
[Autocomplete] Fix wiki lookup timeouts

### DIFF
--- a/app/javascript/src/js/components/autocomplete/Provider.ts
+++ b/app/javascript/src/js/components/autocomplete/Provider.ts
@@ -58,7 +58,10 @@ export default abstract class Provider<T extends AutocompleteItem = Autocomplete
    */
   protected static async clampSearchResults<T extends AutocompleteItem> (query: string, fetchFn: AutocompleteFinder<T>): Promise<T[]> {
     query = query?.trim();
-    if (!query || query.length < Provider.MIN_QUERY_LENGTH)
+    if (!query) return [];
+
+    // Do not count wildcard characters towards the minimum query length
+    if (query.replace(/\*/g, "").length < Provider.MIN_QUERY_LENGTH)
       return [];
 
     const results = await fetchFn(query);

--- a/app/javascript/src/js/components/autocomplete/providers/ArtistProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/ArtistProvider.ts
@@ -7,9 +7,9 @@ export default class ArtistProvider extends Provider<ArtistItem> {
   }
 
   public static async findArtists (term: string): Promise<ArtistItem[]> {
-    const searchTerm = term.trim().replace(/\s+/g, "_") + "*";
+    const searchTerm = term.trim().replace(/\s+/g, "_");
     const params = new URLSearchParams({
-      "search[name]": searchTerm,
+      "search[name]": searchTerm + (searchTerm.endsWith("*") ? "" : "*"),
       "search[order]": "post_count",
       "limit": "10",
       "expiry": "7",

--- a/app/javascript/src/js/components/autocomplete/providers/WikiProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/WikiProvider.ts
@@ -18,8 +18,11 @@ export default class WikiProvider extends Provider<WikiItem> {
   }
 
   public static async findWikis (term: string): Promise<WikiItem[]> {
+    term = term?.trim() || "";
+    if (!term) return [];
+
     const params = new URLSearchParams({
-      "search[title]": term + "*",
+      "search[title]": term + (term.endsWith("*") ? "" : "*"),
       "search[hide_deleted]": "Yes",
       "search[order]": "post_count",
       "limit": "10",

--- a/app/javascript/src/js/components/autocomplete/providers/WikiProvider.ts
+++ b/app/javascript/src/js/components/autocomplete/providers/WikiProvider.ts
@@ -18,9 +18,6 @@ export default class WikiProvider extends Provider<WikiItem> {
   }
 
   public static async findWikis (term: string): Promise<WikiItem[]> {
-    term = term?.trim() || "";
-    if (!term) return [];
-
     const params = new URLSearchParams({
       "search[title]": term + (term.endsWith("*") ? "" : "*"),
       "search[hide_deleted]": "Yes",


### PR DESCRIPTION
Previous approach counted wildcard characters for the purpose of `MIN_QUERY_LENGTH`.
As a result, some autocomplete searches were performed on 1-2 characters, which caused occasional timeouts.