### PR TITLE
[Posts] Stop reading and writing pool_string

### DIFF
--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -103,7 +103,7 @@ class PostSetsController < ApplicationController
         actually_removed = remove_ids.empty? ? [] : @post_set.process_posts_remove!(remove_ids)
         actually_added   = add_ids.empty?    ? [] : @post_set.process_posts_add!(add_ids)
 
-        @post_set.sync_posts_for_delta(added_ids: actually_added, removed_ids: actually_removed)
+        @post_set.reindex_posts(actually_removed + actually_added)
       end
 
       @post_set.reload

--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -103,13 +103,7 @@ class PostSetsController < ApplicationController
         actually_removed = remove_ids.empty? ? [] : @post_set.process_posts_remove!(remove_ids)
         actually_added   = add_ids.empty?    ? [] : @post_set.process_posts_add!(add_ids)
 
-        # Sync posts inline for tiny changes, otherwise enqueue background sync
-        total_changes = actually_added.size + actually_removed.size
-        if total_changes <= 1
-          @post_set.sync_posts_for_delta(added_ids: actually_added, removed_ids: actually_removed)
-        else
-          PostSetPostsSyncJob.perform_later(@post_set.id)
-        end
+        @post_set.sync_posts_for_delta(added_ids: actually_added, removed_ids: actually_removed)
       end
 
       @post_set.reload

--- a/app/jobs/post_set_cleanup_job.rb
+++ b/app/jobs/post_set_cleanup_job.rb
@@ -1,38 +1,51 @@
 # frozen_string_literal: true
 
+# Cleans up denormalized post state after a pool is destroyed.
 class PostSetCleanupJob < ApplicationJob
   queue_as :default
   sidekiq_options lock: :until_executing
 
-  # General cleanup for post membership tokens in pool_string.
   def perform(type, obj_id)
-    type = type.to_sym
-
-    case type
-    when :set
-      token_prefix = "set:"
-      removal_method = :remove_set!
+    case type.to_sym
     when :pool
-      token_prefix = "pool:"
-      removal_method = :remove_pool!
+      cleanup_pool(obj_id)
+    when :set
+      # Legacy: sets no longer keep post-side DB state; PostSet#enqueue_destroy_cleanup
+      # now reindexes members directly. This branch only serves jobs that were already
+      # enqueued when that change was deployed.
+      # TODO: delete this branch (and rename the job) when pool_string is dropped.
+      reindex_legacy_set_members(obj_id)
     else
       raise ArgumentError, "Invalid type: #{type.inspect}"
     end
+  end
 
-    tag = "#{token_prefix}#{obj_id}"
-    scope = Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", tag)
+  private
+
+  # Scoped on posts.pool_ids rather than the destroyed pool's post_ids snapshot,
+  # so any post that still claims membership is cleaned even if the two drifted.
+  def cleanup_pool(pool_id)
+    stub = Struct.new(:id).new(pool_id)
+    scope = Post.where("pool_ids @> ARRAY[?]::int[]", pool_id)
 
     # Pools check for whether the user account is older than 7 days.
     CurrentUser.as_system do
       scope.find_in_batches(batch_size: 1000) do |batch|
         Post.transaction do
           batch.each do |post|
-            stub = Struct.new(:id).new(obj_id)
-            post.public_send(removal_method, stub)
+            post.remove_pool!(stub)
             post.save!
           end
         end
       end
     end
+  end
+
+  # The pool_string column still exists in the DB during the transition (it is
+  # merely ignored by ActiveRecord), so its token index can still locate the
+  # destroyed set's members for reindexing.
+  def reindex_legacy_set_members(set_id)
+    ids = Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", "set:#{set_id}").pluck(:id)
+    ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
   end
 end

--- a/app/jobs/post_set_posts_sync_job.rb
+++ b/app/jobs/post_set_posts_sync_job.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Legacy: pool_string set tokens are no longer maintained. Kept for one release
+# so jobs enqueued before that deploy still resolve; it reindexes both the set's
+# current members (covers pending adds) and any posts whose still-extant
+# pool_string tokens reference the set (covers pending removals).
+# TODO: delete together with the pool_string column drop.
 class PostSetPostsSyncJob < ApplicationJob
   queue_as :default
   sidekiq_options lock: :until_executing, lock_args_method: :lock_args
@@ -9,42 +14,10 @@ class PostSetPostsSyncJob < ApplicationJob
   end
 
   def perform(set_id)
-    set   = PostSet.find(set_id)
-    token = "set:#{set_id}"
-
-    current_ids = set.post_ids.to_set
-    token_ids   = Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", token)
-                      .pluck(:id).to_set
-
-    to_add    = (current_ids - token_ids).to_a
-    to_remove = (token_ids - current_ids).to_a
-    return if to_add.empty? && to_remove.empty?
-
-    pg = Post.connection.raw_connection
-
-    if to_add.any?
-      pg.exec_params(
-        "UPDATE posts
-         SET pool_string = trim(pool_string || $1)
-         WHERE id = ANY($2::int[])
-           AND NOT ($3 = ANY(string_to_array(pool_string, ' ')))",
-        [" #{token}", "{#{to_add.join(',')}}", token],
-      )
-    end
-
-    if to_remove.any?
-      pg.exec_params(
-        "UPDATE posts
-         SET pool_string = array_to_string(
-               array_remove(string_to_array(pool_string, ' '), $1), ' ')
-         WHERE id = ANY($2::int[])
-           AND $1 = ANY(string_to_array(pool_string, ' '))",
-        [token, "{#{to_remove.join(',')}}"],
-      )
-    end
-
-    BulkIndexUpdateJob.perform_later("Post", to_add + to_remove)
+    ids = PostSet.find(set_id).post_ids
+    ids |= Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", "set:#{set_id}").pluck(:id)
+    ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
   rescue ActiveRecord::RecordNotFound
-    # Set was deleted; nothing to do.
+    # Set was deleted; the destroy path reindexed its members.
   end
 end

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -128,9 +128,9 @@ class PostQueryBuilder
     end
 
     if q[:pool] == "none" || q[:inpool_must_not] || (q[:inpool] == false)
-      relation = relation.where("posts.pool_string = ''")
+      relation = relation.where("COALESCE(cardinality(posts.pool_ids), 0) = 0")
     elsif q[:pool] == "any" || q[:inpool] || (q[:inpool_must_not] == false)
-      relation = relation.where("posts.pool_string != ''")
+      relation = relation.where("COALESCE(cardinality(posts.pool_ids), 0) > 0")
     end
 
     q[:uploader_ids]&.each do |uploader_id|

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,6 +14,10 @@ class Post < ApplicationRecord
   # Smaller favours fresher posts; larger lets posts stay hot longer.
   HOTNESS_TIME_DIVISOR = 432_000.0
 
+  # Replaced by pool_ids for pools; sets keep no post-side state (queried via
+  # post_sets.post_ids). Dropped in a follow-up migration after the rollback window.
+  self.ignored_columns += %w[pool_string]
+
   before_validation :initialize_uploader, :on => :create
   before_validation :merge_old_changes
   before_validation :apply_source_diff
@@ -1317,23 +1321,6 @@ class Post < ApplicationRecord
       @post_sets ||= new_record? ? PostSet.none : PostSet.where("post_ids @> ARRAY[?]::int[]", id)
     end
 
-    def belongs_to_post_set(set)
-      pool_string =~ /(?:\A| )set:#{set.id}(?:\z| )/
-    end
-
-    def add_set!(set, force = false)
-      return if belongs_to_post_set(set) && !force
-      with_lock do
-        self.pool_string = "#{pool_string} set:#{set.id}".strip
-      end
-    end
-
-    def remove_set!(set)
-      with_lock do
-        self.pool_string = (pool_string.split(' ') - ["set:#{set.id}"]).join(' ').strip
-      end
-    end
-
     def give_post_sets_to_parent
       transaction do
         post_sets.find_each do |set|
@@ -1356,19 +1343,15 @@ class Post < ApplicationRecord
   end
 
   module PoolMethods
-    # Falls back to pool_string for rows that haven't been backfilled yet (see db/fixes/141).
+    # Denormalizes pools.post_ids, which remains the source of truth
+    # (db/fixes/141 reconciles). NULL-safe until the column gains NOT NULL.
     def pool_ids
-      self[:pool_ids] || pool_ids_from_string
+      self[:pool_ids] || []
     end
-
-    def pool_ids_from_string
-      pool_string.scan(/pool:(\d+)/).map { |pool| ParseValue.safe_id(pool[0]) }
-    end
-    private :pool_ids_from_string
 
     def pools
       @pools ||= begin
-        return Pool.none if pool_string.blank?
+        return Pool.none if pool_ids.empty?
         Pool.where(id: pool_ids).series_first
       end
     end
@@ -1378,15 +1361,18 @@ class Post < ApplicationRecord
     end
 
     def belongs_to_pool?(pool)
-      pool_string =~ /(?:\A| )pool:#{pool.id}(?:\Z| )/
+      pool_ids.include?(pool.id)
     end
 
+    # Mutates pool_ids under a row lock; the caller must save inside the same
+    # transaction that holds the lock (Pool#add!/remove! via pool.with_lock,
+    # Pool#synchronize inside after_save, PostSetCleanupJob's batch transaction).
     def add_pool!(pool)
       return if belongs_to_pool?(pool)
 
       with_lock do
-        self.pool_string = "#{pool_string} pool:#{pool.id}".strip
-        self[:pool_ids] = pool_ids_from_string
+        # Sorted to match the canonical order produced by db/fixes/141.
+        self[:pool_ids] = (pool_ids | [pool.id]).sort
       end
     end
 
@@ -1395,8 +1381,7 @@ class Post < ApplicationRecord
       return unless CurrentUser.user.can_remove_from_pools?
 
       with_lock do
-        self.pool_string = pool_string.gsub(/(?:\A| )pool:#{pool.id}(?:\Z| )/, " ").strip
-        self[:pool_ids] = pool_ids_from_string
+        self[:pool_ids] = pool_ids - [pool.id]
       end
     end
 
@@ -1864,7 +1849,7 @@ class Post < ApplicationRecord
 
   module ApiMethods
     def hidden_attributes
-      list = super + [:pool_string, :pool_ids]
+      list = super + [:pool_ids]
       if !visible?
         list += [:md5, :file_ext]
       end

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -221,11 +221,7 @@ class PostSet < ApplicationRecord
     def add(ids)
       ids = Array(ids)
       added = process_posts_add!(ids)
-      if added.size <= 1
-        sync_posts_for_delta(added_ids: added) if added.any?
-      else
-        PostSetPostsSyncJob.perform_later(id)
-      end
+      sync_posts_for_delta(added_ids: added)
       added
     end
 
@@ -242,8 +238,7 @@ class PostSet < ApplicationRecord
         return
       end
 
-      post.add_set!(self, true)
-      post.save
+      post.update_index
     end
 
     # Add specified post IDs to the set using SQL functions.
@@ -344,11 +339,7 @@ class PostSet < ApplicationRecord
     def remove(ids)
       ids = Array(ids)
       removed = process_posts_remove!(ids)
-      if removed.size <= 1
-        sync_posts_for_delta(removed_ids: removed) if removed.any?
-      else
-        PostSetPostsSyncJob.perform_later(id)
-      end
+      sync_posts_for_delta(removed_ids: removed)
       removed
     end
 
@@ -358,8 +349,7 @@ class PostSet < ApplicationRecord
       removed = process_posts_remove!([post.id])
       return if removed.empty?
 
-      post.remove_set!(self)
-      post.save
+      post.update_index
     end
 
     # Remove specified post IDs from the set using SQL functions.
@@ -435,17 +425,9 @@ class PostSet < ApplicationRecord
     # ========= Post Synchronization ========= #
     # ======================================== #
 
-    # Synchronize Post side for a known delta to avoid computing large diffs.
+    # Refresh the search index of posts affected by a known membership delta.
     def sync_posts_for_delta(added_ids: [], removed_ids: [])
-      Post.where(id: added_ids).find_each do |post|
-        post.add_set!(self, true)
-        post.save
-      end
-
-      Post.where(id: removed_ids).find_each do |post|
-        post.remove_set!(self)
-        post.save
-      end
+      reindex_posts(added_ids + removed_ids)
     end
 
     def synchronize
@@ -453,17 +435,7 @@ class PostSet < ApplicationRecord
       added = post_ids - post_ids_before
       removed = post_ids_before - post_ids
 
-      added_posts = Post.where(id: added)
-      added_posts.find_each do |post|
-        post.add_set!(self, true)
-        post.save
-      end
-
-      removed_posts = Post.where(id: removed)
-      removed_posts.find_each do |post|
-        post.remove_set!(self)
-        post.save
-      end
+      reindex_posts(added + removed)
     end
 
     def synchronize!
@@ -484,7 +456,16 @@ class PostSet < ApplicationRecord
     end
 
     def enqueue_destroy_cleanup
-      PostSetCleanupJob.perform_later(:set, id)
+      reindex_posts(post_ids)
+    end
+
+    # Posts store no set membership in the DB; only their OpenSearch docs
+    # (the sets field is sourced from post_sets.post_ids at import time)
+    # need refreshing when membership changes.
+    def reindex_posts(ids)
+      ids = Array(ids)
+      return if ids.empty?
+      ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
     end
   end
 

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -221,7 +221,7 @@ class PostSet < ApplicationRecord
     def add(ids)
       ids = Array(ids)
       added = process_posts_add!(ids)
-      sync_posts_for_delta(added_ids: added)
+      reindex_posts(added)
       added
     end
 
@@ -339,7 +339,7 @@ class PostSet < ApplicationRecord
     def remove(ids)
       ids = Array(ids)
       removed = process_posts_remove!(ids)
-      sync_posts_for_delta(removed_ids: removed)
+      reindex_posts(removed)
       removed
     end
 
@@ -425,9 +425,13 @@ class PostSet < ApplicationRecord
     # ========= Post Synchronization ========= #
     # ======================================== #
 
-    # Refresh the search index of posts affected by a known membership delta.
-    def sync_posts_for_delta(added_ids: [], removed_ids: [])
-      reindex_posts(added_ids + removed_ids)
+    # Posts store no set membership in the DB; only their OpenSearch docs
+    # (the sets field is sourced from post_sets.post_ids at import time)
+    # need refreshing when membership changes.
+    def reindex_posts(ids)
+      ids = Array(ids)
+      return if ids.empty?
+      ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
     end
 
     def synchronize
@@ -457,15 +461,6 @@ class PostSet < ApplicationRecord
 
     def enqueue_destroy_cleanup
       reindex_posts(post_ids)
-    end
-
-    # Posts store no set membership in the DB; only their OpenSearch docs
-    # (the sets field is sourced from post_sets.post_ids at import time)
-    # need refreshing when membership changes.
-    def reindex_posts(ids)
-      ids = Array(ids)
-      return if ids.empty?
-      ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
     end
   end
 

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -431,7 +431,11 @@ class PostSet < ApplicationRecord
     def reindex_posts(ids)
       ids = Array(ids)
       return if ids.empty?
-      ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
+      # Deferred to commit so the job cannot import pre-commit membership state
+      # when called inside a transaction; runs immediately when none is open.
+      ActiveRecord.after_all_transactions_commit do
+        ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
+      end
     end
 
     def synchronize

--- a/spec/jobs/post_set_cleanup_job_spec.rb
+++ b/spec/jobs/post_set_cleanup_job_spec.rb
@@ -10,36 +10,9 @@ RSpec.describe PostSetCleanupJob do
   end
 
   describe "#perform" do
-    context "with type :set" do
-      let(:set_id) { 42 }
-      let!(:post_in_set) { create(:post).tap { |p| p.update_columns(pool_string: "set:#{set_id}") } }
-      let!(:post_not_in_set) { create(:post) }
-
-      it "removes the set token from posts belonging to the set" do
-        perform(:set, set_id)
-        expect(post_in_set.reload.pool_string).not_to include("set:#{set_id}")
-      end
-
-      it "does not modify posts that do not belong to the set" do
-        original = post_not_in_set.pool_string.dup
-        perform(:set, set_id)
-        expect(post_not_in_set.reload.pool_string).to eq(original)
-      end
-
-      context "when the post also belongs to other sets" do
-        let(:other_set_id) { 99 }
-        let!(:post_in_both) { create(:post).tap { |p| p.update_columns(pool_string: "set:#{set_id} set:#{other_set_id}") } }
-
-        it "preserves other set tokens" do
-          perform(:set, set_id)
-          expect(post_in_both.reload.pool_string).to include("set:#{other_set_id}")
-        end
-      end
-    end
-
     context "with type :pool" do
       let(:pool_id) { 42 }
-      let!(:post_in_pool) { create(:post).tap { |p| p.update_columns(pool_string: "pool:#{pool_id}", pool_ids: [pool_id]) } }
+      let!(:post_in_pool) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id]) } }
       let!(:post_not_in_pool) { create(:post) }
 
       before do
@@ -49,30 +22,64 @@ RSpec.describe PostSetCleanupJob do
         User.system.update_columns(created_at: 8.days.ago)
       end
 
-      it "removes the pool token from posts belonging to the pool" do
-        perform(:pool, pool_id)
-        expect(post_in_pool.reload.pool_string).not_to include("pool:#{pool_id}")
-      end
-
       it "removes the pool id from the raw pool_ids column" do
         perform(:pool, pool_id)
         expect(post_in_pool.reload[:pool_ids]).not_to include(pool_id)
       end
 
       it "does not modify posts that do not belong to the pool" do
-        original = post_not_in_pool.pool_string.dup
         perform(:pool, pool_id)
-        expect(post_not_in_pool.reload.pool_string).to eq(original)
+        expect(post_not_in_pool.reload[:pool_ids]).to eq([])
+      end
+
+      context "when the post also belongs to other pools" do
+        let(:other_pool_id) { 99 }
+        let!(:post_in_both) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id, other_pool_id]) } }
+
+        it "preserves the other pool ids" do
+          perform(:pool, pool_id)
+          expect(post_in_both.reload[:pool_ids]).to eq([other_pool_id])
+        end
+      end
+
+      context "when posts.pool_ids drifted from the pool's post_ids" do
+        # Regression test: a pool that never listed the post in its own post_ids
+        # must still get cleaned out of the post's pool_ids on deletion. The old
+        # pool_string-scoped implementation silently skipped such posts.
+        let!(:drifted_post) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id]) } }
+
+        it "clears the stale membership anyway" do
+          perform(:pool, pool_id)
+          expect(drifted_post.reload[:pool_ids]).to eq([])
+        end
+      end
+    end
+
+    context "with type :set (legacy jobs enqueued before the pool_string removal)" do
+      let(:set_id) { 42 }
+      let!(:post_in_set) { create(:post).tap { |p| Post.where(id: p.id).update_all(pool_string: "set:#{set_id}") } }
+
+      before { create(:post) } # a post without the token, to prove scoping
+
+      it "enqueues a reindex for posts that carried the set token" do
+        expect { perform(:set, set_id) }
+          .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post_in_set.id])
+      end
+
+      it "does not enqueue anything when no posts carry the token" do
+        expect { perform(:set, 999_999) }.not_to have_enqueued_job(BulkIndexUpdateJob)
       end
     end
 
     context "when type is passed as a string" do
-      let(:set_id) { 42 }
-      let!(:post_in_set) { create(:post).tap { |p| p.update_columns(pool_string: "set:#{set_id}") } }
+      let(:pool_id) { 42 }
+      let!(:post_in_pool) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id]) } }
+
+      before { User.system.update_columns(created_at: 8.days.ago) }
 
       it "converts the string to a symbol and processes correctly" do
-        perform("set", set_id)
-        expect(post_in_set.reload.pool_string).not_to include("set:#{set_id}")
+        perform("pool", pool_id)
+        expect(post_in_pool.reload[:pool_ids]).not_to include(pool_id)
       end
     end
 
@@ -82,9 +89,9 @@ RSpec.describe PostSetCleanupJob do
       end
     end
 
-    context "when no posts contain the token" do
+    context "when no posts contain the pool" do
       it "does not raise an error" do
-        expect { perform(:set, 999_999) }.not_to raise_error
+        expect { perform(:pool, 999_999) }.not_to raise_error
       end
     end
   end

--- a/spec/jobs/post_set_posts_sync_job_spec.rb
+++ b/spec/jobs/post_set_posts_sync_job_spec.rb
@@ -2,6 +2,8 @@
 
 require "rails_helper"
 
+# Legacy stub kept for jobs enqueued before the pool_string removal; it only
+# reindexes affected posts. Delete together with the job when the column drops.
 RSpec.describe PostSetPostsSyncJob do
   subject(:job) { described_class }
 
@@ -22,71 +24,29 @@ RSpec.describe PostSetPostsSyncJob do
       end
     end
 
-    context "when a post is in post_ids but missing the token" do
+    context "when the set has members" do
       let(:post) { create(:post) }
 
-      before { Post.where(id: post.id).update_all(pool_string: "") }
-
-      it "adds the token to pool_string" do
-        post_set.update_column(:post_ids, [post.id])
-        job.perform_now(post_set.id)
-        expect(post.reload.pool_string).to include("set:#{post_set.id}")
-      end
-
-      it "enqueues a BulkIndexUpdateJob for the post" do
+      it "enqueues a BulkIndexUpdateJob for them" do
         post_set.update_column(:post_ids, [post.id])
         expect { job.perform_now(post_set.id) }
           .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
       end
     end
 
-    context "when a post has the token but is not in post_ids" do
+    context "when a post still carries a legacy set token without being a member" do
       let(:post) { create(:post) }
 
       before { Post.where(id: post.id).update_all(pool_string: "set:#{post_set.id}") }
 
-      it "removes the token from pool_string" do
-        post_set.update_column(:post_ids, [])
-        job.perform_now(post_set.id)
-        expect(post.reload.pool_string).not_to include("set:#{post_set.id}")
-      end
-
-      it "enqueues a BulkIndexUpdateJob for the post" do
+      it "enqueues a BulkIndexUpdateJob for it" do
         post_set.update_column(:post_ids, [])
         expect { job.perform_now(post_set.id) }
           .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
       end
     end
 
-    context "when a post is correctly in both post_ids and pool_string" do
-      let(:post) { create(:post) }
-
-      before { Post.where(id: post.id).update_all(pool_string: "set:#{post_set.id}") }
-
-      it "does not change pool_string" do
-        post_set.update_column(:post_ids, [post.id])
-        expect { job.perform_now(post_set.id) }
-          .not_to(change { post.reload.pool_string })
-      end
-
-      it "does not enqueue a BulkIndexUpdateJob" do
-        post_set.update_column(:post_ids, [post.id])
-        expect { job.perform_now(post_set.id) }
-          .not_to have_enqueued_job(BulkIndexUpdateJob)
-      end
-    end
-
-    context "when a post is correctly absent from both post_ids and pool_string" do
-      let(:post) { create(:post) }
-
-      before { Post.where(id: post.id).update_all(pool_string: "") }
-
-      it "does not change pool_string" do
-        post_set.update_column(:post_ids, [])
-        expect { job.perform_now(post_set.id) }
-          .not_to(change { post.reload.pool_string })
-      end
-
+    context "when the set is empty and no posts carry its token" do
       it "does not enqueue a BulkIndexUpdateJob" do
         post_set.update_column(:post_ids, [])
         expect { job.perform_now(post_set.id) }

--- a/spec/logical/post_query_builder/pool_spec.rb
+++ b/spec/logical/post_query_builder/pool_spec.rb
@@ -11,15 +11,28 @@ RSpec.describe PostQueryBuilder do
 
   describe "pool: metatag" do
     describe "pool:none" do
-      it "includes posts with an empty pool_string" do
+      it "includes posts with an empty pool_ids" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
+        expect(run("pool:none")).to include(post)
+      end
+
+      it "includes posts whose pool_ids is NULL" do
+        post = create(:post)
+        post.update_columns(pool_ids: nil)
+        expect(run("pool:none")).to include(post)
+      end
+
+      it "includes posts that only belong to a set" do
+        set = create(:post_set)
+        post = create(:post)
+        set.update_column(:post_ids, [post.id])
         expect(run("pool:none")).to include(post)
       end
 
       it "excludes posts that belong to a pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("pool:none")).not_to include(post)
       end
     end
@@ -27,13 +40,13 @@ RSpec.describe PostQueryBuilder do
     describe "pool:any" do
       it "includes posts that belong to at least one pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("pool:any")).to include(post)
       end
 
-      it "excludes posts with an empty pool_string" do
+      it "excludes posts with an empty pool_ids" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
         expect(run("pool:any")).not_to include(post)
       end
     end
@@ -41,27 +54,27 @@ RSpec.describe PostQueryBuilder do
     describe "inpool:true" do
       it "includes posts that belong to at least one pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("inpool:true")).to include(post)
       end
 
-      it "excludes posts with an empty pool_string" do
+      it "excludes posts with an empty pool_ids" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
         expect(run("inpool:true")).not_to include(post)
       end
     end
 
     describe "inpool:false" do
-      it "includes posts with an empty pool_string" do
+      it "includes posts with an empty pool_ids" do
         post = create(:post)
-        post.update_columns(pool_string: "")
+        post.update_columns(pool_ids: [])
         expect(run("inpool:false")).to include(post)
       end
 
       it "excludes posts that belong to a pool" do
         post = create(:post)
-        post.update_columns(pool_string: "pool:1")
+        post.update_columns(pool_ids: [1])
         expect(run("inpool:false")).not_to include(post)
       end
     end

--- a/spec/models/pool/creation_methods_spec.rb
+++ b/spec/models/pool/creation_methods_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PoolsController, ".create" do
     expect(pool.post_ids).to eq(posts.map(&:id))
 
     posts.each(&:reload)
-    expect(posts.map(&:pool_string)).to eq(["pool:#{pool.id}"] * posts.size)
+    expect(posts.pluck(:pool_ids)).to eq([[pool.id]] * posts.size)
   end
 
   it "error when post ids are invalid" do

--- a/spec/models/pool/destroy_spec.rb
+++ b/spec/models/pool/destroy_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Pool, "#destroy" do
+  include_context "as admin"
+
+  it "enqueues the cleanup job" do
+    pool = create(:pool)
+
+    expect { pool.destroy }
+      .to have_enqueued_job(PostSetCleanupJob).with(:pool, pool.id)
+  end
+
+  it "clears the members' pool_ids once the cleanup job runs" do
+    User.system.update_columns(created_at: 8.days.ago)
+    post = create(:post)
+    pool = create(:pool, post_ids: [post.id])
+    expect(post.reload[:pool_ids]).to eq([pool.id])
+
+    pool.destroy
+    PostSetCleanupJob.perform_now(:pool, pool.id)
+
+    expect(post.reload[:pool_ids]).to eq([])
+  end
+end

--- a/spec/models/post/api_methods_spec.rb
+++ b/spec/models/post/api_methods_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe Post do
     end
 
     describe "#hidden_attributes" do
-      it "always hides the raw membership string and pool id column" do
+      it "always hides the raw pool id column" do
         post = create(:post)
-        expect(post.hidden_attributes).to include(:pool_string, :pool_ids)
+        expect(post.hidden_attributes).to include(:pool_ids)
       end
 
       it "additionally hides md5 and file_ext when the post is not visible" do

--- a/spec/models/post/pool_methods_spec.rb
+++ b/spec/models/post/pool_methods_spec.rb
@@ -9,25 +9,18 @@ RSpec.describe Post do
     describe "#belongs_to_pool?" do
       it "returns truthy when the post is in the pool" do
         pool = create(:pool)
-        post = build(:post, pool_string: "pool:#{pool.id}")
+        post = build(:post, pool_ids: [pool.id])
         expect(post).to be_belongs_to_pool(pool)
       end
 
       it "returns falsy when the post is not in the pool" do
         pool = create(:pool)
-        post = build(:post, pool_string: "")
+        post = build(:post, pool_ids: [])
         expect(post).not_to be_belongs_to_pool(pool)
       end
     end
 
     describe "#add_pool!" do
-      it "appends pool:<id> to pool_string" do
-        pool = create(:pool)
-        post = create(:post)
-        post.add_pool!(pool)
-        expect(post.pool_string).to include("pool:#{pool.id}")
-      end
-
       it "adds the pool id to the raw pool_ids column" do
         pool = create(:pool)
         post = create(:post)
@@ -35,14 +28,14 @@ RSpec.describe Post do
         expect(post[:pool_ids]).to include(pool.id)
       end
 
-      it "rebuilds the raw pool_ids column from pool_string" do
-        existing_pool = create(:pool)
-        added_pool = create(:pool)
-        post = create(:post, pool_string: "pool:#{existing_pool.id}", pool_ids: nil)
+      it "keeps pool_ids sorted" do
+        later_pool = create(:pool)
+        earlier_pool = create(:pool)
+        post = create(:post, pool_ids: [later_pool.id])
 
-        post.add_pool!(added_pool)
+        post.add_pool!(earlier_pool)
 
-        expect(post[:pool_ids]).to contain_exactly(existing_pool.id, added_pool.id)
+        expect(post[:pool_ids]).to eq([later_pool.id, earlier_pool.id].sort)
       end
 
       it "does not add the pool a second time if already present" do
@@ -50,64 +43,72 @@ RSpec.describe Post do
         post = create(:post)
         post.add_pool!(pool)
         post.add_pool!(pool)
-        expect(post.pool_string.scan("pool:#{pool.id}").size).to eq(1)
+        expect(post[:pool_ids].count(pool.id)).to eq(1)
       end
     end
 
     describe "#remove_pool!" do
-      it "removes pool:<id> from pool_string" do
-        pool = create(:pool)
-        post = create(:post, pool_string: "pool:#{pool.id}", pool_ids: [pool.id])
-        post.remove_pool!(pool)
-        expect(post.pool_string).not_to include("pool:#{pool.id}")
-      end
-
       it "removes the pool id from the raw pool_ids column" do
         pool = create(:pool)
-        post = create(:post, pool_string: "pool:#{pool.id}", pool_ids: [pool.id])
+        post = create(:post, pool_ids: [pool.id])
         post.remove_pool!(pool)
         expect(post[:pool_ids]).not_to include(pool.id)
       end
 
-      it "does nothing when the pool is not in pool_string" do
+      it "keeps other pool ids intact" do
         pool = create(:pool)
-        post = create(:post, pool_string: "")
-        original = post.pool_string
+        other_pool = create(:pool)
+        post = create(:post, pool_ids: [pool.id, other_pool.id].sort)
+
         post.remove_pool!(pool)
-        expect(post.pool_string).to eq(original)
+
+        expect(post[:pool_ids]).to eq([other_pool.id])
+      end
+
+      it "does nothing when the pool is not in pool_ids" do
+        pool = create(:pool)
+        post = create(:post, pool_ids: [])
+        post.remove_pool!(pool)
+        expect(post[:pool_ids]).to eq([])
+      end
+
+      it "does nothing when the user cannot remove from pools" do
+        pool = create(:pool)
+        post = create(:post, pool_ids: [pool.id])
+        allow(CurrentUser.user).to receive(:can_remove_from_pools?).and_return(false)
+
+        post.remove_pool!(pool)
+
+        expect(post[:pool_ids]).to eq([pool.id])
       end
     end
 
     describe "#has_active_pools?" do
-      it "returns false when pool_string is blank" do
-        post = build(:post, pool_string: "")
+      it "returns false when pool_ids is empty" do
+        post = build(:post, pool_ids: [])
         expect(post.has_active_pools?).to be false
       end
 
-      it "returns true when pool_string contains an active pool" do
+      it "returns true when pool_ids contains an active pool" do
         pool = create(:pool, is_active: true)
-        post = create(:post, pool_string: "pool:#{pool.id}", pool_ids: nil)
+        post = create(:post, pool_ids: [pool.id])
         expect(post.has_active_pools?).to be true
       end
     end
 
     describe "#pool_ids" do
       it "returns the raw column value when present" do
-        pool = create(:pool)
-        post = build(:post, pool_string: "pool:#{pool.id}", pool_ids: [42])
+        post = build(:post, pool_ids: [42])
         expect(post.pool_ids).to eq([42])
       end
 
-      it "falls back to parsing pool_string when the column has not been backfilled" do
-        pool1 = create(:pool)
-        pool2 = create(:pool)
-        post = build(:post, pool_string: "pool:#{pool1.id} pool:#{pool2.id}", pool_ids: nil)
-        expect(post.pool_ids).to include(pool1.id, pool2.id)
-      end
-
-      it "ignores set tokens when falling back to pool_string" do
-        post = build(:post, pool_string: "set:123", pool_ids: nil)
+      it "returns an empty array when the column is NULL" do
+        post = create(:post)
+        post.update_columns(pool_ids: nil)
+        post.reload
         expect(post.pool_ids).to eq([])
+        expect(post.pools).to be_empty
+        expect(post.has_active_pools?).to be false
       end
     end
 

--- a/spec/models/post/set_methods_spec.rb
+++ b/spec/models/post/set_methods_spec.rb
@@ -6,46 +6,6 @@ RSpec.describe Post do
   include_context "as admin"
 
   describe "SetMethods" do
-    describe "#belongs_to_post_set" do
-      it "returns truthy when the set id is present in pool_string" do
-        set  = create(:post_set)
-        post = build(:post, pool_string: "set:#{set.id}")
-        expect(post.belongs_to_post_set(set)).to be_truthy
-      end
-
-      it "returns falsy when the set id is absent" do
-        set  = create(:post_set)
-        post = build(:post, pool_string: "")
-        expect(post.belongs_to_post_set(set)).to be_falsy
-      end
-    end
-
-    describe "#add_set!" do
-      it "adds set:<id> to pool_string" do
-        set  = create(:post_set)
-        post = create(:post)
-        post.add_set!(set)
-        expect(post.pool_string).to include("set:#{set.id}")
-      end
-
-      it "does not add the same set twice" do
-        set  = create(:post_set)
-        post = create(:post)
-        post.add_set!(set)
-        post.add_set!(set)
-        expect(post.pool_string.scan("set:#{set.id}").size).to eq(1)
-      end
-    end
-
-    describe "#remove_set!" do
-      it "removes set:<id> from pool_string" do
-        set  = create(:post_set)
-        post = create(:post, pool_string: "set:#{set.id}")
-        post.remove_set!(set)
-        expect(post.pool_string).not_to include("set:#{set.id}")
-      end
-    end
-
     describe "#post_sets" do
       it "finds sets whose post_ids contain the post" do
         set1 = create(:post_set)

--- a/spec/models/post_set/write_methods_spec.rb
+++ b/spec/models/post_set/write_methods_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# --------------------------------------------------------------------------- #
+#                         PostSet Write Methods                               #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe PostSet do
+  include_context "as member"
+
+  let(:set) { create(:post_set) }
+
+  describe "#add!" do
+    it "adds the post and refreshes its search index" do
+      post = create(:post)
+      allow(post).to receive(:update_index)
+
+      set.add!(post)
+
+      expect(set.reload.post_ids).to eq([post.id])
+      expect(post).to have_received(:update_index)
+    end
+  end
+
+  describe "#remove!" do
+    it "removes the post and refreshes its search index" do
+      post = create(:post)
+      set.update_columns(post_ids: [post.id], post_count: 1)
+      allow(post).to receive(:update_index)
+
+      set.remove!(post)
+
+      expect(set.reload.post_ids).to eq([])
+      expect(post).to have_received(:update_index)
+    end
+  end
+
+  describe "#add" do
+    it "enqueues a reindex for the added posts" do
+      posts = create_list(:post, 2)
+
+      expect { set.add(posts.map(&:id)) }
+        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+    end
+  end
+
+  describe "#remove" do
+    it "enqueues a reindex for the removed posts" do
+      posts = create_list(:post, 2)
+      set.update_columns(post_ids: posts.map(&:id), post_count: posts.size)
+
+      expect { set.remove(posts.map(&:id)) }
+        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+    end
+  end
+
+  describe "#destroy" do
+    it "enqueues a reindex for the set's members" do
+      posts = create_list(:post, 2)
+      set.update_columns(post_ids: posts.map(&:id), post_count: posts.size)
+      set.reload
+
+      expect { set.destroy }
+        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+    end
+
+    it "enqueues nothing for an empty set" do
+      set # create before the expectation block
+      expect { set.destroy }.not_to have_enqueued_job(BulkIndexUpdateJob)
+    end
+  end
+end

--- a/spec/models/post_set/write_methods_spec.rb
+++ b/spec/models/post_set/write_methods_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PostSet do
       posts = create_list(:post, 2)
 
       expect { set.add(posts.map(&:id)) }
-        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe PostSet do
       set.update_columns(post_ids: posts.map(&:id), post_count: posts.size)
 
       expect { set.remove(posts.map(&:id)) }
-        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
     end
   end
 

--- a/spec/requests/post_sets_controller_spec.rb
+++ b/spec/requests/post_sets_controller_spec.rb
@@ -397,21 +397,13 @@ RSpec.describe PostSetsController do
         expect(response).to redirect_to(post_list_post_set_path(private_set))
       end
 
-      it "performs inline sync and does not enqueue a job when only one post changes" do
-        new_post = create(:post)
-        expect do
-          post update_posts_post_set_path(private_set),
-               params: { post_set: { post_ids_string: new_post.id.to_s } }
-        end.not_to have_enqueued_job(PostSetPostsSyncJob)
-        expect(private_set.reload.post_ids).to include(new_post.id)
-      end
-
-      it "enqueues PostSetPostsSyncJob when more than one post changes" do
+      it "applies the change and enqueues a reindex for the delta" do
         posts = create_list(:post, 2)
         expect do
           post update_posts_post_set_path(private_set),
                params: { post_set: { post_ids_string: posts.map(&:id).join(" ") } }
-        end.to have_enqueued_job(PostSetPostsSyncJob)
+        end.to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+        expect(private_set.reload.post_ids).to match_array(posts.map(&:id))
       end
     end
   end

--- a/spec/requests/post_sets_controller_spec.rb
+++ b/spec/requests/post_sets_controller_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe PostSetsController do
         expect do
           post update_posts_post_set_path(private_set),
                params: { post_set: { post_ids_string: posts.map(&:id).join(" ") } }
-        end.to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+        end.to have_enqueued_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
         expect(private_set.reload.post_ids).to match_array(posts.map(&:id))
       end
     end


### PR DESCRIPTION
Pool membership now lives solely in posts.pool_ids (denormalized frompools.post_ids).
Set membership has no post-side storage and is queried through post_sets.post_ids.

PostSetCleanupJob's pool branch is scoped on `posts.pool_ids` so pool deletion can no longer skip drifted rows.
The column is ignored but not yet dropped.
