### PR TITLE
[Users] Display raw karma values to staff and current user

### DIFF
--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -14,6 +14,6 @@
     </div>
   </div>
   <div class="karma-badge-progress">
-    <%= user.upload_karma %>
+    <%= should_show_raw_karma? ? user.raw_upload_karma : user.upload_karma %>
   </div>
 </a>

--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -14,6 +14,6 @@
     </div>
   </div>
   <div class="karma-badge-progress">
-    <%= should_show_raw_karma? ? user.raw_upload_karma : user.upload_karma %>
+    <%= karma_value %>
   </div>
 </a>

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -8,8 +8,7 @@ class KarmaBadge < ViewComponent::Base
 
   def render?
     return false if user.blank?
-    return false if user.upload_karma <= 0
-
+    return false if user.upload_karma <= 0 && !should_show_raw_karma?
     true
   end
 
@@ -38,5 +37,9 @@ class KarmaBadge < ViewComponent::Base
 
   def progress_degree_style
     "background: conic-gradient(var(--color-button-active) #{progress_degree}deg, var(--color-section) 0deg);"
+  end
+
+  def should_show_raw_karma?
+    CurrentUser.user.is_staff? || CurrentUser.user.id == user.id
   end
 end

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -21,13 +21,17 @@ class KarmaBadge < ViewComponent::Base
     user.upload_karma_level
   end
 
+  def karma_value
+    should_show_raw_karma? ? user.raw_upload_karma : user.upload_karma
+  end
+
   def badge_title
     if user.upload_karma_level >= User.max_karma_level
       return "Upload Karma: #{user.upload_karma} (Level S)"
     end
 
     next_level = user.upload_karma_level + 1
-    "Upload Karma: #{user.upload_karma} / #{User.required_karma_for_level(next_level)} (Level #{karma_level})"
+    "Upload Karma: #{karma_value} / #{User.required_karma_for_level(next_level)} (Level #{karma_level})"
   end
 
   def progress_degree

--- a/spec/components/karma_badge/badge_methods_spec.rb
+++ b/spec/components/karma_badge/badge_methods_spec.rb
@@ -35,6 +35,36 @@ RSpec.describe KarmaBadge do
     end
   end
 
+  describe "#karma_value" do
+    describe "with positive karma" do
+      it "returns the upload karma" do
+        set_karma(user, Danbooru.config.upload_karma_l1_threshold)
+        expect(component.send(:karma_value)).to eq(user.upload_karma)
+      end
+    end
+
+    describe "with negative karma" do
+      before do
+        set_karma(user, -100)
+      end
+
+      it "returns the upload karma for staff" do
+        allow(CurrentUser).to receive(:user).and_return(create(:admin_user))
+        expect(component.send(:karma_value)).to eq(user.raw_upload_karma)
+      end
+
+      it "returns the upload karma for the user themselves" do
+        allow(CurrentUser).to receive(:user).and_return(user)
+        expect(component.send(:karma_value)).to eq(user.raw_upload_karma)
+      end
+
+      it "returns 0 for other users" do
+        allow(CurrentUser).to receive(:user).and_return(create(:user))
+        expect(component.send(:karma_value)).to eq(0)
+      end
+    end
+  end
+
   describe "#badge_title" do
     it "shows progress toward the next level below the maximum" do
       set_karma(user, Danbooru.config.upload_karma_l1_threshold)
@@ -72,6 +102,23 @@ RSpec.describe KarmaBadge do
       expect(component.send(:progress_degree_style)).to eq(
         "background: conic-gradient(var(--color-button-active) 180deg, var(--color-section) 0deg);",
       )
+    end
+  end
+
+  describe "#should_show_raw_karma?" do
+    it "returns true for staff users" do
+      allow(CurrentUser).to receive(:user).and_return(create(:admin_user))
+      expect(component.send(:should_show_raw_karma?)).to be_truthy
+    end
+
+    it "returns true for the user themselves" do
+      allow(CurrentUser).to receive(:user).and_return(user)
+      expect(component.send(:should_show_raw_karma?)).to be_truthy
+    end
+
+    it "returns false for other users" do
+      allow(CurrentUser).to receive(:user).and_return(create(:user))
+      expect(component.send(:should_show_raw_karma?)).to be_falsey
     end
   end
 end


### PR DESCRIPTION
Users expressed confusion at not being able to see where their karma value sits when it goes into the negatives.