### PR TITLE
[RIS] Use the new ERIS API for searches by post ID

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -31,7 +31,7 @@ class IqdbQueriesController < ApplicationController
       @matches = IqdbProxy.query_url(parsed_url.to_s, search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:post_id].present?
       raise ProcessingError, "Invalid post_id parameter" unless search_params[:post_id].to_s =~ /\A\d+\z/
-      @matches = IqdbProxy.query_post(Post.find_by(id: search_params[:post_id]), search_params[:score_cutoff], v2_format: v2_format)
+      @matches = IqdbProxy.query_post(search_params[:post_id], search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:hash].present?
       raise ProcessingError, "Invalid hash parameter" unless search_params[:hash].is_a?(String) && search_params[:hash] =~ /\A[0-9a-fA-F]+\z/
       @matches = IqdbProxy.query_hash(search_params[:hash], search_params[:score_cutoff], v2_format: v2_format)

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -57,7 +57,7 @@ module IqdbProxy
 
     check_circuit!
     with_query_semaphore do
-      response = record_circuit_outcome { make_request("/query/", :post, { post_id: post_id }) }
+      response = record_circuit_outcome { make_request("/query", :post, { post_id: post_id }) }
       return [] if response.status != 200
 
       process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -51,19 +51,22 @@ module IqdbProxy
     raise Error, "iqdb request failed" if response.status != 200
   end
 
+  def query_post(post_id, score_cutoff, v2_format: false)
+    post_id = post_id.to_i
+    return [] if post_id <= 0
+
+    check_circuit!
+    with_query_semaphore do
+      response = record_circuit_outcome { make_request("/query/", :post, { post_id: post_id }) }
+      return [] if response.status != 200
+
+      process_iqdb_result(JSON.parse(response.body), score_cutoff, v2_format: v2_format)
+    end
+  end
+
   def query_url(image_url, score_cutoff, v2_format: false)
     file, _strategy = Downloads::File.new(image_url).download!
     query_file(file, score_cutoff, v2_format: v2_format)
-  end
-
-  def query_post(post, score_cutoff, v2_format: false)
-    return [] unless post&.has_preview?
-
-    File.open(post.preview_file_path) do |f|
-      query_file(f, score_cutoff, v2_format: v2_format)
-    end
-  rescue Errno::ENOENT # Preview file not found
-    []
   end
 
   def query_file(file, score_cutoff, v2_format: false)

--- a/app/logical/iqdb_proxy.rb
+++ b/app/logical/iqdb_proxy.rb
@@ -145,7 +145,7 @@ module IqdbProxy
 
   def record_circuit_outcome
     response = yield
-    record_circuit_failure unless response.status == 200
+    record_circuit_failure if response.status >= 500
     response
   rescue IqdbProxy::Error
     record_circuit_failure


### PR DESCRIPTION
[ERIS](https://github.com/e621ng/eris), the new IQDB replacement, allows for searches by post ID.
That lets us skip thumbnail generation and gathering channel data in e621ng.