### PR TITLE
[RateLimiter] Rewrite as an atomic fixed-window limiter

### DIFF
--- a/app/controllers/emails_controller.rb
+++ b/app/controllers/emails_controller.rb
@@ -12,11 +12,9 @@ class EmailsController < ApplicationController
     raise User::PrivilegeError.new("Must be logged in to resend verification email.") if CurrentUser.user.is_logged_out?
     raise User::PrivilegeError.new("Account already active.") if CurrentUser.user.is_verified?
     raise User::PrivilegeError.new('Cannot send confirmation because the email is not allowed.') if EmailBlacklist.is_banned?(CurrentUser.user.email)
-    if RateLimiter.check_limit("emailconfirm:#{CurrentUser.user.id}", 1, 12.hours)
+    if RateLimiter.throttle!("emailconfirm:#{CurrentUser.user.id}", limit: 1, period: 12.hours)
       raise User::PrivilegeError.new("Confirmation email sent too recently. Please wait at least 12 hours between sends.")
     end
-    RateLimiter.hit("emailconfirm:#{CurrentUser.user.id}", 12.hours)
-
 
     Maintenance::User::EmailConfirmationMailer.confirmation(CurrentUser.user).deliver_now
     redirect_to home_users_path, notice: "Activation email resent"

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -31,7 +31,7 @@ class IqdbQueriesController < ApplicationController
       @matches = IqdbProxy.query_url(parsed_url.to_s, search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:post_id].present?
       raise ProcessingError, "Invalid post_id parameter" unless search_params[:post_id].to_s =~ /\A\d+\z/
-      @matches = IqdbProxy.query_post(search_params[:post_id], search_params[:score_cutoff], v2_format: v2_format)
+      @matches = IqdbProxy.query_post(Post.find_by(id: search_params[:post_id]), search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:hash].present?
       raise ProcessingError, "Invalid hash parameter" unless search_params[:hash].is_a?(String) && search_params[:hash] =~ /\A[0-9a-fA-F]+\z/
       @matches = IqdbProxy.query_hash(search_params[:hash], search_params[:score_cutoff], v2_format: v2_format)
@@ -60,13 +60,13 @@ class IqdbQueriesController < ApplicationController
     if %i[file url post_id hash].any? { |key| search_params[key].present? }
       if CurrentUser.user.is_anonymous?
         raise APIThrottled if IqdbProxy.anon_lockdown?
-        raise APIThrottled if RateLimiter.check_limit("img:anon:#{CurrentUser.ip_addr}", 1, 60.seconds)
-        RateLimiter.hit("img:anon:#{CurrentUser.ip_addr}", 60.seconds)
+        raise APIThrottled if RateLimiter.throttle!("img:anon:#{CurrentUser.ip_addr}", limit: 1, period: 60.seconds)
       else
-        raise APIThrottled if RateLimiter.check_limit("img:#{CurrentUser.ip_addr}", 1, 2.seconds)
-        raise APIThrottled if RateLimiter.check_limit("img:user:#{CurrentUser.user.id}", 1, 2.seconds)
-        RateLimiter.hit("img:#{CurrentUser.ip_addr}", 2.seconds)
-        RateLimiter.hit("img:user:#{CurrentUser.user.id}", 2.seconds)
+        ip_limiter = RateLimiter.new("img:#{CurrentUser.ip_addr}", limit: 1, period: 2.seconds)
+        user_limiter = RateLimiter.new("img:user:#{CurrentUser.user.id}", limit: 1, period: 2.seconds)
+        raise APIThrottled if ip_limiter.throttled? || user_limiter.throttled?
+        ip_limiter.hit!
+        user_limiter.hit!
       end
     end
   end

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -31,7 +31,7 @@ class IqdbQueriesController < ApplicationController
       @matches = IqdbProxy.query_url(parsed_url.to_s, search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:post_id].present?
       raise ProcessingError, "Invalid post_id parameter" unless search_params[:post_id].to_s =~ /\A\d+\z/
-      @matches = IqdbProxy.query_post(Post.find_by(id: search_params[:post_id]), search_params[:score_cutoff], v2_format: v2_format)
+      @matches = IqdbProxy.query_post(search_params[:post_id], search_params[:score_cutoff], v2_format: v2_format)
     elsif search_params[:hash].present?
       raise ProcessingError, "Invalid hash parameter" unless search_params[:hash].is_a?(String) && search_params[:hash] =~ /\A[0-9a-fA-F]+\z/
       @matches = IqdbProxy.query_hash(search_params[:hash], search_params[:score_cutoff], v2_format: v2_format)

--- a/app/controllers/post_set_maintainers_controller.rb
+++ b/app/controllers/post_set_maintainers_controller.rb
@@ -27,15 +27,18 @@ class PostSetMaintainersController < ApplicationController
       return
     end
 
-    if RateLimiter.check_limit("set.invite.#{CurrentUser.id}", 5, 1.hours)
+    invite_limiter = RateLimiter.new("set.invite.#{CurrentUser.id}", limit: 5, period: 1.hour)
+    if invite_limiter.throttled?
       flash[:notice] = "You must wait an hour before inviting more set maintainers"
+      redirect_to maintainers_post_set_path(@set)
+      return
     end
 
     PostSetMaintainer.where(user_id: @user.id, post_set_id: @set.id).destroy_all
     @invite.save
 
     if @invite.valid?
-      RateLimiter.hit("set.invite.#{CurrentUser.id}", 1.hours)
+      invite_limiter.hit!
       flash[:notice] = "#{@user.pretty_name} invited to be a maintainer"
     else
       flash[:notice] = @invite.errors.full_messages.join('; ')

--- a/app/controllers/post_sets_controller.rb
+++ b/app/controllers/post_sets_controller.rb
@@ -218,11 +218,8 @@ class PostSetsController < ApplicationController
   end
 
   def check_set_modify_rate_limit
-    key = "post_set.modify.#{CurrentUser.id}"
-    if RateLimiter.check_limit(key, 30, 1.minute)
+    if RateLimiter.throttle!("post_set.modify.#{CurrentUser.id}", limit: 30, period: 1.minute)
       render_expected_error(429, "You are modifying sets too quickly. Wait a bit and try again.")
-    else
-      RateLimiter.hit(key, 1.minute)
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
 
   def create
     sparams = params.fetch(:session, {}).slice(:url, :name, :password, :remember)
-    if RateLimiter.check_limit("login:#{request.remote_ip}", 15, 12.hours)
+    if login_limiter.throttled?
       DanbooruLogger.add_attributes("user.login" => "rate_limited")
       respond_to do |fmt|
         fmt.html { redirect_to(new_session_path, notice: "Too many login attempts. Try again later.") }
@@ -32,7 +32,7 @@ class SessionsController < ApplicationController
         fmt.json { render(json: { error: "Two-factor authentication required. Log in through the website, or use an API key for scripts.", code: "totp_required", url: totp_session_path }, status: 401) }
       end
     else
-      RateLimiter.hit("login:#{request.remote_ip}", 6.hours)
+      login_limiter.hit!
       DanbooruLogger.add_attributes("user.login" => "fail")
       respond_to do |fmt|
         fmt.html { redirect_back(fallback_location: new_session_path, allow_other_host: false, notice: "Username / Password was incorrect.") }
@@ -69,7 +69,8 @@ class SessionsController < ApplicationController
       return
     end
 
-    if RateLimiter.check_limit("totp:#{user.id}", 10, 1.hour)
+    totp_limiter = UserTotp.rate_limiter(user)
+    if totp_limiter.throttled?
       DanbooruLogger.add_attributes("user.login" => "totp_rate_limited")
       respond_to do |fmt|
         fmt.html { redirect_to(totp_session_path, notice: "Too many attempts. Try again later.") }
@@ -90,7 +91,7 @@ class SessionsController < ApplicationController
         fmt.json { render(json: { url: url || posts_path }) }
       end
     else
-      RateLimiter.hit("totp:#{user.id}", 1.hour)
+      totp_limiter.hit!
       DanbooruLogger.add_attributes("user.login" => "totp_fail")
       respond_to do |fmt|
         fmt.html do
@@ -115,6 +116,12 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  # Failures are measured over a 6-hour window, but tripping the limit locks
+  # the IP out for a full 12 hours. Only failed logins count; see #create.
+  def login_limiter
+    RateLimiter.new("login:#{request.remote_ip}", limit: 15, period: 6.hours, lockout: 12.hours)
+  end
 
   def session_creator
     SessionCreator.new(request, session, cookies, nil, nil)

--- a/app/controllers/totps_controller.rb
+++ b/app/controllers/totps_controller.rb
@@ -92,12 +92,13 @@ class TotpsController < ApplicationController
   # Disable and backup-code regeneration are code-guessing surfaces just like the login
   # challenge, so they share its per-user rate limit.
   def verify_code_with_rate_limit(user_totp)
-    return :rate_limited if RateLimiter.check_limit("totp:#{CurrentUser.user.id}", 10, 1.hour)
+    limiter = UserTotp.rate_limiter(CurrentUser.user)
+    return :rate_limited if limiter.throttled?
 
     result = user_totp.verify_code!(params.dig(:totp, :code))
     return :ok if result
 
-    RateLimiter.hit("totp:#{CurrentUser.user.id}", 1.hour)
+    limiter.hit!
     :incorrect
   end
 end

--- a/app/logical/cache.rb
+++ b/app/logical/cache.rb
@@ -10,8 +10,11 @@ class Cache
     sanitized_key_to_value_hash.transform_keys(&sanitized_key_to_key_hash)
   end
 
-  def self.fetch(key, expires_in: nil, &)
-    Rails.cache.fetch(key, expires_in: expires_in, &)
+  # raw: true is required to read counters created by Cache.increment — on
+  # memcached they are stored as raw strings that a regular read cannot
+  # deserialize (it returns nil instead).
+  def self.fetch(key, expires_in: nil, raw: false, &)
+    Rails.cache.fetch(key, expires_in: expires_in, raw: raw, &)
   end
 
   def self.write(key, value, expires_in: nil)

--- a/app/logical/cache.rb
+++ b/app/logical/cache.rb
@@ -18,6 +18,10 @@ class Cache
     Rails.cache.write(key, value, expires_in: expires_in)
   end
 
+  def self.increment(key, amount = 1, expires_in: nil)
+    Rails.cache.increment(key, amount, expires_in: expires_in)
+  end
+
   def self.delete(key)
     Rails.cache.delete(key)
   end

--- a/app/logical/rate_limiter.rb
+++ b/app/logical/rate_limiter.rb
@@ -1,25 +1,65 @@
 # frozen_string_literal: true
 
+# Fixed-window rate limiter backed by atomic cache increments.
+#
+# The window starts at the first hit and expires +period+ later; hits inside
+# the window do NOT extend it. "limit: 30, period: 1.minute" therefore means
+# what it reads as: at most 30 hits per minute.
+#
+# Checking and counting are separate so call sites can decide what counts:
+# every attempt (use RateLimiter.throttle!), only failures (login, TOTP), or
+# only successes (email changes, invites).
+#
+#   limiter = RateLimiter.new("totp:#{user.id}", limit: 10, period: 1.hour, lockout: 1.hour)
+#   return :rate_limited if limiter.throttled?
+#   ...
+#   limiter.hit! unless code_valid
+#
+# With lockout: nil, exceeding the limit blocks until the window expires.
+# With a lockout duration, the hit that reaches the limit starts a lockout
+# lasting that long, independent of the window.
 class RateLimiter
-  def self.check_limit(key, max_attempts, lockout_time = 1.minute)
-    return true if Cache.fetch("#{key}:lockout")
+  attr_reader :limit, :period, :lockout
 
-    attempts = Cache.fetch(key) || 0
-    if attempts >= max_attempts
-      Cache.write("#{key}:lockout", true, expires_in: lockout_time)
-      reset_limit(key)
-      return true
-    end
+  # Check-then-count in one call, for sites where every attempt counts.
+  # Returns true if the caller should reject the request; otherwise records
+  # the hit and returns false.
+  def self.throttle!(key, limit:, period:, lockout: nil)
+    limiter = new(key, limit: limit, period: period, lockout: lockout)
+    return true if limiter.throttled?
+    limiter.hit!
     false
   end
 
-  def self.hit(key, time_period = 1.minute)
-    value = Cache.fetch(key) || 0
-    Cache.write(key, value.to_i + 1, expires_in: time_period)
-    value.to_i + 1
+  def initialize(key, limit:, period:, lockout: nil)
+    @key = "throttle:#{key}"
+    @limit = limit
+    @period = period
+    @lockout = lockout
   end
 
-  def self.reset_limit(key)
-    Cache.delete(key)
+  # Read-only: never increments, never trips or extends a lockout.
+  def throttled?
+    return true if lockout && Cache.fetch(lockout_key)
+    Cache.fetch(@key).to_i >= limit
+  end
+
+  # Returns the count within the current window. Exactly one concurrent hit
+  # observes count == limit, so the lockout is written once per window.
+  def hit!
+    count = Cache.increment(@key, expires_in: period).to_i
+    Cache.write(lockout_key, true, expires_in: lockout) if lockout && count == limit
+    count
+  end
+
+  def reset!
+    Cache.delete(@key)
+    Cache.delete(lockout_key)
+  end
+
+  private
+
+  def lockout_key
+    "#{@key}:lockout"
   end
 end

--- a/app/logical/rate_limiter.rb
+++ b/app/logical/rate_limiter.rb
@@ -41,7 +41,7 @@ class RateLimiter
   # Read-only: never increments, never trips or extends a lockout.
   def throttled?
     return true if lockout && Cache.fetch(lockout_key)
-    Cache.fetch(@key).to_i >= limit
+    Cache.fetch(@key, raw: true).to_i >= limit
   end
 
   # Returns the count within the current window. Exactly one concurrent hit

--- a/app/logical/user_email_change.rb
+++ b/app/logical/user_email_change.rb
@@ -14,7 +14,8 @@ class UserEmailChange
       raise ::User::PrivilegeError.new("Cannot change email while banned")
     end
 
-    if RateLimiter.check_limit("email:#{user.id}", 2, 24.hours)
+    limiter = RateLimiter.new("email:#{user.id}", limit: 2, period: 24.hours)
+    if limiter.throttled?
       user.errors.add(:base, "Email changed too recently")
       return
     end
@@ -28,7 +29,7 @@ class UserEmailChange
       user.save
 
       if user.errors.empty?
-        RateLimiter.hit("email:#{user.id}", 24.hours)
+        limiter.hit!
         if Danbooru.config.enable_email_verification?
           Maintenance::User::EmailConfirmationMailer.confirmation(user).deliver_now
         end

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -87,11 +87,11 @@ class PostSet < ApplicationRecord
     end
 
     def send_maintainer_public_dmails
-      if RateLimiter.check_limit("set.public.#{id}", 1, 24.hours)
-        return
-      end
+      dmail_limiter = RateLimiter.new("set.public.#{id}", limit: 1, period: 24.hours)
+      return if dmail_limiter.throttled?
+
       if is_public_changed? && !is_public # If set was made private
-        RateLimiter.hit("set.public.#{id}", 24.hours)
+        dmail_limiter.hit!
         PostSetMaintainer.active.where(post_set_id: id).find_each do |maintainer|
           Dmail.create_automated(to_id: maintainer.user_id, title: "A set you maintain was made private",
                                  body: "The set \"#{name}\":#{post_set_path(self)} by \"#{creator.name}\":#{user_path(creator)} that you maintain was set to private. You will not be able to view, add posts, or remove posts from the set until the owner makes it public again.")
@@ -99,7 +99,7 @@ class PostSet < ApplicationRecord
 
         PostSetMaintainer.pending.where(post_set_id: id).delete
       elsif is_public_changed? && is_public # If set was made public
-        RateLimiter.hit("set.public.#{id}", 24.hours)
+        dmail_limiter.hit!
         PostSetMaintainer.active.where(post_set_id: id).find_each do |maintainer|
           Dmail.create_automated(to_id: maintainer.user_id, title: "A private set you had maintained was made public again",
                                  body: "The set \"#{name}\":#{post_set_path(self)} by \"#{creator.name}\":#{user_path(creator)} that you previously maintained was made public again. You are now able to view the set and add/remove posts.")

--- a/app/models/search_trend_hourly.rb
+++ b/app/models/search_trend_hourly.rb
@@ -73,10 +73,8 @@ class SearchTrendHourly < ApplicationRecord
     return unless Setting.trends_enabled
 
     # Rate limiting check for IP (once per bulk operation)
-    if ip.present?
-      ip_key = "trends:ip:#{ip}"
-      return if RateLimiter.check_limit(ip_key, Setting.trends_ip_limit, Setting.trends_ip_window.seconds)
-    end
+    ip_limiter = ip_rate_limiter(ip) if ip.present?
+    return if ip_limiter&.throttled?
 
     # Group by tag-hour pairs and sum counts
     grouped = data.group_by { |item| [item[:tag].to_s.downcase.strip, item[:hour].utc.beginning_of_hour] }
@@ -91,8 +89,7 @@ class SearchTrendHourly < ApplicationRecord
       next if SearchTrendBlacklist.blacklisted?(tag)
 
       # Rate limiting check for tag
-      tag_key = "trends:tag:#{tag}"
-      next if RateLimiter.check_limit(tag_key, Setting.trends_tag_limit, Setting.trends_tag_window.seconds)
+      next if tag_rate_limiter(tag).throttled?
 
       count = items.length
       values << "(#{connection.quote(tag)}, #{connection.quote(hour_time)}, #{count}, false, #{connection.quote(now)}, #{connection.quote(now)})"
@@ -111,15 +108,19 @@ class SearchTrendHourly < ApplicationRecord
     connection.execute(sql)
 
     # Increment rate limit counters after successful database operation
-    if ip.present?
-      ip_key = "trends:ip:#{ip}"
-      RateLimiter.hit(ip_key, Setting.trends_ip_window.seconds)
-    end
+    ip_limiter&.hit!
 
     processed_tags.each do |tag|
-      tag_key = "trends:tag:#{tag}"
-      RateLimiter.hit(tag_key, Setting.trends_tag_window.seconds)
+      tag_rate_limiter(tag).hit!
     end
+  end
+
+  def self.ip_rate_limiter(ip)
+    RateLimiter.new("trends:ip:#{ip}", limit: Setting.trends_ip_limit, period: Setting.trends_ip_window.seconds)
+  end
+
+  def self.tag_rate_limiter(tag)
+    RateLimiter.new("trends:tag:#{tag}", limit: Setting.trends_tag_limit, period: Setting.trends_tag_window.seconds)
   end
 
   # Find tags that are trending upward compared to the previous equivalent time window

--- a/app/models/user_totp.rb
+++ b/app/models/user_totp.rb
@@ -14,6 +14,13 @@ class UserTotp < ApplicationRecord
     ROTP::Base32.random
   end
 
+  # Shared by the login challenge and the settings-page code-guessing surfaces
+  # (disable, backup-code regeneration) so they draw from one failure budget.
+  # Only incorrect codes count against it.
+  def self.rate_limiter(user)
+    RateLimiter.new("totp:#{user.id}", limit: 10, period: 1.hour, lockout: 1.hour)
+  end
+
   # Atomic bit flip so a concurrent write to another bit_prefs flag can't be clobbered.
   def self.set_user_flag(user_id, enabled)
     mask = User.flag_value_for("totp_enabled")

--- a/spec/logical/rate_limiter_spec.rb
+++ b/spec/logical/rate_limiter_spec.rb
@@ -98,4 +98,35 @@ RSpec.describe RateLimiter do
       expect(lock).not_to be_throttled
     end
   end
+
+  # MemoryStore doesn't distinguish raw from serialized values, so it can't
+  # catch reads that fail against production's MemCacheStore, where incr
+  # stores raw strings that a non-raw read silently returns nil for. Cover the
+  # counter round-trip against the real store. No expiry tests here: memcached
+  # TTLs are wall-clock and ignore travel.
+  context "with the production cache store (memcached)" do
+    around do |example|
+      original = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemCacheStore.new(
+        Danbooru.config.memcached_servers,
+        namespace: "rl_spec_#{SecureRandom.hex(8)}",
+      )
+      example.run
+    ensure
+      Rails.cache = original
+    end
+
+    it "reads back counters created by hit!" do
+      2.times { limiter.hit! }
+      expect(limiter).not_to be_throttled
+      limiter.hit!
+      expect(limiter).to be_throttled
+    end
+
+    it "reads back a tripped lockout" do
+      lock = described_class.new("spec", limit: 1, period: 1.minute, lockout: 1.hour)
+      lock.hit!
+      expect(lock).to be_throttled
+    end
+  end
 end

--- a/spec/logical/rate_limiter_spec.rb
+++ b/spec/logical/rate_limiter_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RateLimiter do
+  # The test environment uses a null cache store, which would make the limiter
+  # inert; swap in a real store so counting and expiry behave like production.
+  around do |example|
+    original = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+  ensure
+    Rails.cache = original
+  end
+
+  let(:limiter) { described_class.new("spec", limit: 3, period: 1.minute) }
+
+  describe "#hit!" do
+    it "returns the count within the current window" do
+      expect(limiter.hit!).to eq(1)
+      expect(limiter.hit!).to eq(2)
+    end
+
+    it "does not extend the window (fixed window, not rolling)" do
+      limiter.hit!
+      travel 50.seconds
+      limiter.hit!
+      travel 11.seconds # 61s after the first hit: the window has expired
+      expect(limiter.hit!).to eq(1)
+    end
+  end
+
+  describe "#throttled?" do
+    it "is false before the limit is reached" do
+      2.times { limiter.hit! }
+      expect(limiter).not_to be_throttled
+    end
+
+    it "is true once the limit is reached" do
+      3.times { limiter.hit! }
+      expect(limiter).to be_throttled
+    end
+
+    it "unthrottles once the window expires" do
+      3.times { limiter.hit! }
+      travel 61.seconds
+      expect(limiter).not_to be_throttled
+    end
+
+    it "does not modify any state" do
+      3.times { limiter.hit! }
+      10.times { limiter.throttled? }
+      travel 61.seconds
+      expect(limiter).not_to be_throttled
+    end
+  end
+
+  describe "lockout" do
+    let(:limiter) { described_class.new("spec", limit: 2, period: 1.minute, lockout: 10.minutes) }
+
+    it "keeps throttling after the window expires until the lockout ends" do
+      2.times { limiter.hit! }
+      travel 61.seconds
+      expect(limiter).to be_throttled
+      travel 10.minutes
+      expect(limiter).not_to be_throttled
+    end
+
+    it "is not extended by hits made during the lockout" do
+      2.times { limiter.hit! }
+      travel 5.minutes
+      limiter.hit!
+      travel 5.minutes + 1.second
+      expect(limiter).not_to be_throttled
+    end
+  end
+
+  describe ".throttle!" do
+    it "counts the attempt and allows it while under the limit" do
+      expect(described_class.throttle!("spec", limit: 2, period: 1.minute)).to be(false)
+      expect(described_class.throttle!("spec", limit: 2, period: 1.minute)).to be(false)
+      expect(described_class.throttle!("spec", limit: 2, period: 1.minute)).to be(true)
+    end
+
+    it "does not count rejected attempts" do
+      3.times { described_class.throttle!("spec", limit: 2, period: 1.minute) }
+      travel 61.seconds
+      expect(described_class.throttle!("spec", limit: 2, period: 1.minute)).to be(false)
+    end
+  end
+
+  describe "#reset!" do
+    it "clears the counter and any lockout" do
+      lock = described_class.new("spec", limit: 1, period: 1.minute, lockout: 1.hour)
+      lock.hit!
+      expect(lock).to be_throttled
+      lock.reset!
+      expect(lock).not_to be_throttled
+    end
+  end
+end

--- a/spec/models/search_trend_hourly/class_methods_spec.rb
+++ b/spec/models/search_trend_hourly/class_methods_spec.rb
@@ -101,8 +101,7 @@ RSpec.describe SearchTrendHourly do
         trends_tag_window: 60,
       )
       allow(SearchTrendBlacklist).to receive(:blacklisted?).and_return(false)
-      allow(RateLimiter).to receive(:check_limit).and_return(false)
-      allow(RateLimiter).to receive(:hit)
+      allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
     end
 
     it "does not write to the DB when data is blank" do
@@ -156,14 +155,14 @@ RSpec.describe SearchTrendHourly do
     end
 
     it "returns early without any DB writes when the IP rate limit is exceeded" do
-      allow(RateLimiter).to receive(:check_limit).with("trends:ip:1.2.3.4", anything, anything).and_return(true)
+      allow(RateLimiter).to receive(:new).with("trends:ip:1.2.3.4", any_args).and_return(instance_double(RateLimiter, throttled?: true))
       expect { SearchTrendHourly.bulk_increment!([{ tag: "fox", hour: fixed_hour }], ip: "1.2.3.4") }
         .not_to change(SearchTrendHourly, :count)
     end
 
     it "skips rate-limited tags but still writes other tags in the same batch" do
-      allow(RateLimiter).to receive(:check_limit).with("trends:tag:slow_tag", anything, anything).and_return(true)
-      allow(RateLimiter).to receive(:check_limit).with("trends:tag:fast_tag", anything, anything).and_return(false)
+      allow(RateLimiter).to receive(:new).with("trends:tag:slow_tag", any_args).and_return(instance_double(RateLimiter, throttled?: true))
+      allow(RateLimiter).to receive(:new).with("trends:tag:fast_tag", any_args).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
 
       data = [
         { tag: "slow_tag", hour: fixed_hour },

--- a/spec/requests/auths_controller_spec.rb
+++ b/spec/requests/auths_controller_spec.rb
@@ -43,8 +43,7 @@ RSpec.describe AuthsController do
 
     before do
       create(:user_totp, user: totp_user)
-      allow(RateLimiter).to receive(:check_limit).and_return(false)
-      allow(RateLimiter).to receive(:hit)
+      allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
     end
 
     it "returns 404 without a live challenge" do

--- a/spec/requests/emails_controller_spec.rb
+++ b/spec/requests/emails_controller_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe EmailsController do
       end
 
       context "when rate-limited" do
-        before { allow(RateLimiter).to receive(:check_limit).and_return(true) }
+        before { allow(RateLimiter).to receive(:throttle!).and_return(true) }
 
         it "returns 403" do
           get resend_confirmation_email_path
@@ -74,8 +74,7 @@ RSpec.describe EmailsController do
         let(:mail_message) { instance_double(ActionMailer::MessageDelivery, deliver_now: true) }
 
         before do
-          allow(RateLimiter).to receive(:check_limit).and_return(false)
-          allow(RateLimiter).to receive(:hit)
+          allow(RateLimiter).to receive(:throttle!).and_return(false)
           allow(Maintenance::User::EmailConfirmationMailer).to receive(:confirmation).and_return(mail_message)
         end
 

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe IqdbQueriesController do
 
   before do
     allow(IqdbProxy).to receive(:enabled?).and_return(true)
-    allow(RateLimiter).to receive(:throttle!).and_return(false)
-    allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
+    allow(RateLimiter).to receive_messages(throttle!: false, new: instance_double(RateLimiter, throttled?: false, hit!: 1))
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe IqdbQueriesController do
 
   before do
     allow(IqdbProxy).to receive(:enabled?).and_return(true)
-    allow(RateLimiter).to receive(:check_limit).and_return(false)
-    allow(RateLimiter).to receive(:hit)
+    allow(RateLimiter).to receive(:throttle!).and_return(false)
+    allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
   end
 
   # ---------------------------------------------------------------------------
@@ -42,7 +42,8 @@ RSpec.describe IqdbQueriesController do
 
     it "does not call RateLimiter when no search params are present" do
       get iqdb_queries_path
-      expect(RateLimiter).not_to have_received(:check_limit)
+      expect(RateLimiter).not_to have_received(:new)
+      expect(RateLimiter).not_to have_received(:throttle!)
     end
   end
 
@@ -225,8 +226,8 @@ RSpec.describe IqdbQueriesController do
     it "allows requests without hitting the RateLimiter" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:ok)
-      expect(RateLimiter).not_to have_received(:check_limit)
-      expect(RateLimiter).not_to have_received(:hit)
+      expect(RateLimiter).not_to have_received(:new)
+      expect(RateLimiter).not_to have_received(:throttle!)
     end
   end
 
@@ -243,21 +244,21 @@ RSpec.describe IqdbQueriesController do
     end
 
     it "returns 429 when the per-IP rate limit is exceeded" do
-      allow(RateLimiter).to receive(:check_limit).with("img:127.0.0.1", 1, 2.seconds).and_return(true)
+      allow(RateLimiter).to receive(:new).with("img:127.0.0.1", any_args).and_return(instance_double(RateLimiter, throttled?: true))
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end
 
     it "returns 429 when the per-user rate limit is exceeded" do
-      allow(RateLimiter).to receive(:check_limit).with("img:user:#{user.id}", 1, 2.seconds).and_return(true)
+      allow(RateLimiter).to receive(:new).with("img:user:#{user.id}", any_args).and_return(instance_double(RateLimiter, throttled?: true))
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end
 
     it "checks the rate limit keyed by IP address and user ID" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
-      expect(RateLimiter).to have_received(:check_limit).with("img:127.0.0.1", 1, 2.seconds)
-      expect(RateLimiter).to have_received(:check_limit).with("img:user:#{user.id}", 1, 2.seconds)
+      expect(RateLimiter).to have_received(:new).with("img:127.0.0.1", limit: 1, period: 2.seconds)
+      expect(RateLimiter).to have_received(:new).with("img:user:#{user.id}", limit: 1, period: 2.seconds)
     end
 
     it "is not blocked by the anonymous lockdown" do
@@ -274,8 +275,7 @@ RSpec.describe IqdbQueriesController do
   describe "throttling — anonymous user" do
     before do
       allow(IqdbProxy).to receive_messages(enabled?: true, query_hash: [], anon_lockdown?: false)
-      allow(RateLimiter).to receive(:check_limit).and_return(false)
-      allow(RateLimiter).to receive(:hit)
+      allow(RateLimiter).to receive(:throttle!).and_return(false)
     end
 
     it "allows requests within the 1/min limit" do
@@ -285,11 +285,11 @@ RSpec.describe IqdbQueriesController do
 
     it "checks the rate limit with the anon-specific key" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
-      expect(RateLimiter).to have_received(:check_limit).with("img:anon:127.0.0.1", 1, 60.seconds)
+      expect(RateLimiter).to have_received(:throttle!).with("img:anon:127.0.0.1", limit: 1, period: 60.seconds)
     end
 
     it "returns 429 when the per-IP rate limit is exceeded" do
-      allow(RateLimiter).to receive(:check_limit).with("img:anon:127.0.0.1", 1, 60.seconds).and_return(true)
+      allow(RateLimiter).to receive(:throttle!).with("img:anon:127.0.0.1", any_args).and_return(true)
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end
@@ -303,7 +303,7 @@ RSpec.describe IqdbQueriesController do
     it "does not call RateLimiter when the lockdown is active" do
       allow(IqdbProxy).to receive(:anon_lockdown?).and_return(true)
       get iqdb_queries_path, params: { hash: "deadbeef" }
-      expect(RateLimiter).not_to have_received(:check_limit)
+      expect(RateLimiter).not_to have_received(:throttle!)
     end
   end
 end

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe IqdbQueriesController do
       expect(response).to have_http_status(:ok)
     end
 
-    it "delegates to IqdbProxy.query_post" do
+    it "delegates to IqdbProxy.query_post with the raw post_id param" do
       get iqdb_queries_path, params: { post_id: post.id }
-      expect(IqdbProxy).to have_received(:query_post)
+      expect(IqdbProxy).to have_received(:query_post).with(post.id.to_s, any_args)
     end
 
     it "returns 400 for a non-numeric post_id" do

--- a/spec/requests/maintenance/user/email_changes_controller_spec.rb
+++ b/spec/requests/maintenance/user/email_changes_controller_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe Maintenance::User::EmailChangesController do
     context "as a member" do
       before do
         sign_in_as user
-        allow(RateLimiter).to receive(:check_limit).and_return(false)
-        allow(RateLimiter).to receive(:hit)
+        allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
       end
 
       context "with a correct password and valid email" do
@@ -82,7 +81,7 @@ RSpec.describe Maintenance::User::EmailChangesController do
       end
 
       context "when rate-limited" do
-        before { allow(RateLimiter).to receive(:check_limit).and_return(true) }
+        before { allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: true)) }
 
         it "redirects to the new page with an error notice" do
           post maintenance_user_email_change_path, params: { email_change: { email: "new@example.com", password: "hexerade" } }

--- a/spec/requests/post_sets_controller_spec.rb
+++ b/spec/requests/post_sets_controller_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe PostSetsController do
   let(:public_set)   { create(:public_post_set, creator: owner) }
 
   before do
-    allow(RateLimiter).to receive(:throttle!).and_return(false)
-    allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
+    allow(RateLimiter).to receive_messages(throttle!: false, new: instance_double(RateLimiter, throttled?: false, hit!: 1))
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/requests/post_sets_controller_spec.rb
+++ b/spec/requests/post_sets_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe PostSetsController do
   let(:public_set)   { create(:public_post_set, creator: owner) }
 
   before do
-    allow(RateLimiter).to receive(:check_limit).and_return(false)
+    allow(RateLimiter).to receive(:throttle!).and_return(false)
+    allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
   end
 
   # ---------------------------------------------------------------------------
@@ -577,7 +578,7 @@ RSpec.describe PostSetsController do
 
     before do
       sign_in_as owner
-      allow(RateLimiter).to receive(:check_limit).and_return(true)
+      allow(RateLimiter).to receive(:throttle!).and_return(true)
     end
 
     it "returns 429 when the rate limit is exceeded while adding posts" do

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -24,12 +24,11 @@ RSpec.describe SessionsController do
 
   describe "POST /session" do
     before do
-      allow(RateLimiter).to receive(:check_limit).and_return(false)
-      allow(RateLimiter).to receive(:hit)
+      allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
     end
 
     context "when rate limited" do
-      before { allow(RateLimiter).to receive(:check_limit).and_return(true) }
+      before { allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: true)) }
 
       it "redirects to new_session_path with a notice (HTML)" do
         post session_path, params: { session: { name: member.name, password: "hexerade" } }
@@ -98,8 +97,7 @@ RSpec.describe SessionsController do
 
   describe "DELETE /session" do
     before do
-      allow(RateLimiter).to receive(:check_limit).and_return(false)
-      allow(RateLimiter).to receive(:hit)
+      allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
       make_session(member)
     end
 

--- a/spec/requests/sessions_totp_spec.rb
+++ b/spec/requests/sessions_totp_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "TOTP login challenge" do
   let!(:user_totp) { create(:user_totp, user: user, secret: secret) }
 
   before do
-    allow(RateLimiter).to receive(:check_limit).and_return(false)
-    allow(RateLimiter).to receive(:hit)
+    allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
   end
 
   # Step-aligned instant so code validity doesn't depend on where inside the
@@ -174,7 +173,7 @@ RSpec.describe "TOTP login challenge" do
       end
 
       it "returns 429 while rate limited" do
-        allow(RateLimiter).to receive(:check_limit).with("totp:#{user.id}", 10, 1.hour).and_return(true)
+        allow(RateLimiter).to receive(:new).with("totp:#{user.id}", any_args).and_return(instance_double(RateLimiter, throttled?: true))
         login!
         post verify_totp_session_path(format: :json), params: { totp: { code: current_code } }
         expect(response).to have_http_status(:too_many_requests)
@@ -182,7 +181,7 @@ RSpec.describe "TOTP login challenge" do
     end
 
     it "rejects even a correct code while rate limited" do
-      allow(RateLimiter).to receive(:check_limit).with("totp:#{user.id}", 10, 1.hour).and_return(true)
+      allow(RateLimiter).to receive(:new).with("totp:#{user.id}", any_args).and_return(instance_double(RateLimiter, throttled?: true))
       login!
       post verify_totp_session_path, params: { totp: { code: current_code } }
       expect(response).to redirect_to(totp_session_path)

--- a/spec/requests/totps_controller_spec.rb
+++ b/spec/requests/totps_controller_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe TotpsController do
   let(:user) { create(:user) }
 
   before do
-    allow(RateLimiter).to receive(:check_limit).and_return(false)
-    allow(RateLimiter).to receive(:hit)
+    allow(RateLimiter).to receive(:new).and_return(instance_double(RateLimiter, throttled?: false, hit!: 1))
   end
 
   around { |example| travel_to(Time.zone.at(1_775_000_010), &example) }


### PR DESCRIPTION
Previous implementation was functional, but did not behave the way you would expect a rate limiter to behave.
For example, a limiter with the `max_attempts` of 30 and timeout of 1 minute meant "You get 30 attempts total, at any pace, as long as you never go quiet for a full minute. A full minute of silence resets your count."

This PR reworks the rate limiting in a way that "limit: 30, period: 1.minute" means what it reads as: at most 30 hits per minute.