### PR TITLE
[RIS] Adjust throttles on the reverse image search

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -57,17 +57,35 @@ class IqdbQueriesController < ApplicationController
   def throttle(search_params)
     return if Danbooru.config.disable_throttles?
 
-    if %i[file url post_id hash].any? { |key| search_params[key].present? }
-      if CurrentUser.user.is_anonymous?
-        raise APIThrottled if IqdbProxy.anon_lockdown?
-        raise APIThrottled if RateLimiter.throttle!("img:anon:#{CurrentUser.ip_addr}", limit: 1, period: 60.seconds)
-      else
-        ip_limiter = RateLimiter.new("img:#{CurrentUser.ip_addr}", limit: 1, period: 2.seconds)
-        user_limiter = RateLimiter.new("img:user:#{CurrentUser.user.id}", limit: 1, period: 2.seconds)
-        raise APIThrottled if ip_limiter.throttled? || user_limiter.throttled?
-        ip_limiter.hit!
-        user_limiter.hit!
-      end
+    # Heavy throttles for file and URL queries
+    create_throttle(
+      type: "heavy",
+      anon_limit: 1,
+      anon_period: 60.seconds,
+      user_limit: 6,
+      user_period: 10.seconds
+    ) if %i[file url].any? { |key| search_params[key].present? }
+
+    # Lighter throttles for post_id and hash queries
+    create_throttle(
+      type: "light",
+      anon_limit: 60,
+      anon_period: 60.seconds,
+      user_limit: 60,
+      user_period: 60.seconds
+    ) if %i[post_id hash].any? { |key| search_params[key].present? }
+  end
+
+  def create_throttle(type:, anon_limit:, anon_period:, user_limit:, user_period:)
+    if CurrentUser.user.is_anonymous?
+      raise APIThrottled if IqdbProxy.anon_lockdown?
+      raise APIThrottled if RateLimiter.throttle!("eris:#{type}:anon:#{CurrentUser.ip_addr}", limit: anon_limit, period: anon_period)
+    else
+      ip_limiter = RateLimiter.new("eris:#{type}:#{CurrentUser.ip_addr}", limit: user_limit, period: user_period)
+      user_limiter = RateLimiter.new("eris:#{type}:user:#{CurrentUser.user.id}", limit: user_limit, period: user_period)
+      raise APIThrottled if ip_limiter.throttled? || user_limiter.throttled?
+      ip_limiter.hit!
+      user_limiter.hit!
     end
   end
 

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -70,10 +70,10 @@ class IqdbQueriesController < ApplicationController
       # Lighter throttles for post_id and hash queries
       enforce_throttle!(
         type: "light",
-        anon_limit: 60,
-        anon_period: 60.seconds,
-        user_limit: 60,
-        user_period: 60.seconds,
+        anon_limit: 10,
+        anon_period: 10.seconds,
+        user_limit: 10,
+        user_period: 10.seconds,
       )
     end
   end

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -58,22 +58,26 @@ class IqdbQueriesController < ApplicationController
     return if Danbooru.config.disable_throttles?
 
     # Heavy throttles for file and URL queries
-    create_throttle(
-      type: "heavy",
-      anon_limit: 1,
-      anon_period: 60.seconds,
-      user_limit: 6,
-      user_period: 10.seconds
-    ) if %i[file url].any? { |key| search_params[key].present? }
+    if %i[file url].any? { |key| search_params[key].present? }
+      create_throttle(
+        type: "heavy",
+        anon_limit: 1,
+        anon_period: 60.seconds,
+        user_limit: 6,
+        user_period: 10.seconds,
+      )
+    end
 
     # Lighter throttles for post_id and hash queries
-    create_throttle(
-      type: "light",
-      anon_limit: 60,
-      anon_period: 60.seconds,
-      user_limit: 60,
-      user_period: 60.seconds
-    ) if %i[post_id hash].any? { |key| search_params[key].present? }
+    if %i[post_id hash].any? { |key| search_params[key].present? }
+      create_throttle(
+        type: "light",
+        anon_limit: 60,
+        anon_period: 60.seconds,
+        user_limit: 60,
+        user_period: 60.seconds,
+      )
+    end
   end
 
   def create_throttle(type:, anon_limit:, anon_period:, user_limit:, user_period:)

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -57,20 +57,18 @@ class IqdbQueriesController < ApplicationController
   def throttle(search_params)
     return if Danbooru.config.disable_throttles?
 
-    # Heavy throttles for file and URL queries
     if %i[file url].any? { |key| search_params[key].present? }
-      create_throttle(
+      # Heavy throttles for file and URL queries
+      enforce_throttle!(
         type: "heavy",
         anon_limit: 1,
         anon_period: 60.seconds,
         user_limit: 6,
         user_period: 10.seconds,
       )
-    end
-
-    # Lighter throttles for post_id and hash queries
-    if %i[post_id hash].any? { |key| search_params[key].present? }
-      create_throttle(
+    elsif %i[post_id hash].any? { |key| search_params[key].present? }
+      # Lighter throttles for post_id and hash queries
+      enforce_throttle!(
         type: "light",
         anon_limit: 60,
         anon_period: 60.seconds,
@@ -80,7 +78,7 @@ class IqdbQueriesController < ApplicationController
     end
   end
 
-  def create_throttle(type:, anon_limit:, anon_period:, user_limit:, user_period:)
+  def enforce_throttle!(type:, anon_limit:, anon_period:, user_limit:, user_period:)
     if CurrentUser.user.is_anonymous?
       raise APIThrottled if IqdbProxy.anon_lockdown?
       raise APIThrottled if RateLimiter.throttle!("eris:#{type}:anon:#{CurrentUser.ip_addr}", limit: anon_limit, period: anon_period)

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -243,21 +243,35 @@ RSpec.describe IqdbQueriesController do
     end
 
     it "returns 429 when the per-IP rate limit is exceeded" do
-      allow(RateLimiter).to receive(:new).with("img:127.0.0.1", any_args).and_return(instance_double(RateLimiter, throttled?: true))
+      allow(RateLimiter).to receive(:new).with("eris:light:127.0.0.1", any_args).and_return(instance_double(RateLimiter, throttled?: true))
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end
 
     it "returns 429 when the per-user rate limit is exceeded" do
-      allow(RateLimiter).to receive(:new).with("img:user:#{user.id}", any_args).and_return(instance_double(RateLimiter, throttled?: true))
+      allow(RateLimiter).to receive(:new).with("eris:light:user:#{user.id}", any_args).and_return(instance_double(RateLimiter, throttled?: true))
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end
 
-    it "checks the rate limit keyed by IP address and user ID" do
+    it "applies the light limits to hash queries, keyed by IP address and user ID" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
-      expect(RateLimiter).to have_received(:new).with("img:127.0.0.1", limit: 1, period: 2.seconds)
-      expect(RateLimiter).to have_received(:new).with("img:user:#{user.id}", limit: 1, period: 2.seconds)
+      expect(RateLimiter).to have_received(:new).with("eris:light:127.0.0.1", limit: 60, period: 60.seconds)
+      expect(RateLimiter).to have_received(:new).with("eris:light:user:#{user.id}", limit: 60, period: 60.seconds)
+    end
+
+    it "does not consume the heavy budget for hash queries" do
+      get iqdb_queries_path, params: { hash: "deadbeef" }
+      expect(RateLimiter).not_to have_received(:new).with(/heavy/, any_args)
+    end
+
+    it "applies the heavy limits to url queries" do
+      allow(UploadWhitelist).to receive(:is_whitelisted?).and_return([true, "ok"])
+      allow(IqdbProxy).to receive(:query_url).and_return([])
+      get iqdb_queries_path, params: { url: "https://example.com/image.jpg" }
+      expect(RateLimiter).to have_received(:new).with("eris:heavy:127.0.0.1", limit: 6, period: 10.seconds)
+      expect(RateLimiter).to have_received(:new).with("eris:heavy:user:#{user.id}", limit: 6, period: 10.seconds)
+      expect(RateLimiter).not_to have_received(:new).with(/light/, any_args)
     end
 
     it "is not blocked by the anonymous lockdown" do
@@ -277,18 +291,25 @@ RSpec.describe IqdbQueriesController do
       allow(RateLimiter).to receive(:throttle!).and_return(false)
     end
 
-    it "allows requests within the 1/min limit" do
+    it "allows requests within the limit" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:ok)
     end
 
-    it "checks the rate limit with the anon-specific key" do
+    it "applies the light limits to hash queries with the anon-specific key" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
-      expect(RateLimiter).to have_received(:throttle!).with("img:anon:127.0.0.1", limit: 1, period: 60.seconds)
+      expect(RateLimiter).to have_received(:throttle!).with("eris:light:anon:127.0.0.1", limit: 60, period: 60.seconds)
+    end
+
+    it "applies the heavy limits to url queries with the anon-specific key" do
+      allow(UploadWhitelist).to receive(:is_whitelisted?).and_return([true, "ok"])
+      allow(IqdbProxy).to receive(:query_url).and_return([])
+      get iqdb_queries_path, params: { url: "https://example.com/image.jpg" }
+      expect(RateLimiter).to have_received(:throttle!).with("eris:heavy:anon:127.0.0.1", limit: 1, period: 60.seconds)
     end
 
     it "returns 429 when the per-IP rate limit is exceeded" do
-      allow(RateLimiter).to receive(:throttle!).with("img:anon:127.0.0.1", any_args).and_return(true)
+      allow(RateLimiter).to receive(:throttle!).with("eris:light:anon:127.0.0.1", any_args).and_return(true)
       get iqdb_queries_path, params: { hash: "deadbeef" }
       expect(response).to have_http_status(:too_many_requests)
     end

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -274,6 +274,15 @@ RSpec.describe IqdbQueriesController do
       expect(RateLimiter).not_to have_received(:new).with(/light/, any_args)
     end
 
+    it "does not apply the light limits when both hash and url params are present" do
+      allow(UploadWhitelist).to receive(:is_whitelisted?).and_return([true, "ok"])
+      allow(IqdbProxy).to receive(:query_url).and_return([])
+      get iqdb_queries_path, params: { hash: "deadbeef", url: "https://example.com/image.jpg" }
+      expect(RateLimiter).to have_received(:new).with("eris:heavy:127.0.0.1", limit: 6, period: 10.seconds)
+      expect(RateLimiter).to have_received(:new).with("eris:heavy:user:#{user.id}", limit: 6, period: 10.seconds)
+      expect(RateLimiter).not_to have_received(:new).with(/light/, any_args)
+    end
+
     it "is not blocked by the anonymous lockdown" do
       allow(IqdbProxy).to receive(:anon_lockdown?).and_return(true)
       get iqdb_queries_path, params: { hash: "deadbeef" }
@@ -306,6 +315,14 @@ RSpec.describe IqdbQueriesController do
       allow(IqdbProxy).to receive(:query_url).and_return([])
       get iqdb_queries_path, params: { url: "https://example.com/image.jpg" }
       expect(RateLimiter).to have_received(:throttle!).with("eris:heavy:anon:127.0.0.1", limit: 1, period: 60.seconds)
+    end
+
+    it "does not apply the light limits when both hash and url params are present" do
+      allow(UploadWhitelist).to receive(:is_whitelisted?).and_return([true, "ok"])
+      allow(IqdbProxy).to receive(:query_url).and_return([])
+      get iqdb_queries_path, params: { hash: "deadbeef", url: "https://example.com/image.jpg" }
+      expect(RateLimiter).to have_received(:throttle!).with("eris:heavy:anon:127.0.0.1", limit: 1, period: 60.seconds)
+      expect(RateLimiter).not_to have_received(:throttle!).with("eris:light:anon:127.0.0.1", any_args)
     end
 
     it "returns 429 when the per-IP rate limit is exceeded" do

--- a/spec/requests/iqdb_queries_controller_spec.rb
+++ b/spec/requests/iqdb_queries_controller_spec.rb
@@ -256,8 +256,8 @@ RSpec.describe IqdbQueriesController do
 
     it "applies the light limits to hash queries, keyed by IP address and user ID" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
-      expect(RateLimiter).to have_received(:new).with("eris:light:127.0.0.1", limit: 60, period: 60.seconds)
-      expect(RateLimiter).to have_received(:new).with("eris:light:user:#{user.id}", limit: 60, period: 60.seconds)
+      expect(RateLimiter).to have_received(:new).with("eris:light:127.0.0.1", limit: 10, period: 10.seconds)
+      expect(RateLimiter).to have_received(:new).with("eris:light:user:#{user.id}", limit: 10, period: 10.seconds)
     end
 
     it "does not consume the heavy budget for hash queries" do
@@ -307,7 +307,7 @@ RSpec.describe IqdbQueriesController do
 
     it "applies the light limits to hash queries with the anon-specific key" do
       get iqdb_queries_path, params: { hash: "deadbeef" }
-      expect(RateLimiter).to have_received(:throttle!).with("eris:light:anon:127.0.0.1", limit: 60, period: 60.seconds)
+      expect(RateLimiter).to have_received(:throttle!).with("eris:light:anon:127.0.0.1", limit: 10, period: 10.seconds)
     end
 
     it "applies the heavy limits to url queries with the anon-specific key" do


### PR DESCRIPTION
With the shiny new ERIS system, we no longer have to worry about IQDB choking and dying on requests.
Well, not as much, at least.

Set up two different throttles:
`file` and `url` require a file to be download and processed, and thus remain fairly heavily throttled.
`post_id` and `hash` cost us very little, and can have the throttles loosened to 1 request per second.