### PR TITLE
Improve TOTP and backup code input

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,6 +27,9 @@ class SessionsController < ApplicationController
       end
     when :totp_required
       DanbooruLogger.add_attributes("user.login" => "totp_challenge")
+      # A stale error from an interrupted/abandoned earlier PRG cycle must not
+      # leak into a brand-new challenge for this (or a different) login.
+      session.delete(:totp_error)
       respond_to do |fmt|
         fmt.html { redirect_to(totp_session_path) }
         fmt.json { render(json: { error: "Two-factor authentication required. Log in through the website, or use an API key for scripts.", code: "totp_required", url: totp_session_path }, status: 401) }
@@ -43,7 +46,19 @@ class SessionsController < ApplicationController
 
   def totp
     @user = session_creator.challenge_user
-    redirect_to(new_session_path, notice: "Your login attempt has expired. Please log in again.") if @user.nil?
+    if @user.nil?
+      # No live challenge to attach a "wrong code" error to — drop any leftover
+      # from an earlier PRG cycle too, so it can't resurface on a later challenge.
+      session.delete(:totp_error)
+      redirect_to(new_session_path, notice: "Your login attempt has expired. Please log in again.")
+      return
+    end
+    # session, not flash: _toasts.html.erb renders every flash key generically
+    # (flash.each), so a flash-based transport here would also duplicate this
+    # as a top-of-page toast alongside the intended inline #auth-error message.
+    # session.delete reads and clears it in one step, so it can't replay on a
+    # later plain refresh either.
+    @totp_error = session.delete(:totp_error)
   end
 
   def verify_totp
@@ -95,9 +110,8 @@ class SessionsController < ApplicationController
       DanbooruLogger.add_attributes("user.login" => "totp_fail")
       respond_to do |fmt|
         fmt.html do
-          @user = user
-          flash.now[:notice] = "Verification code was incorrect."
-          render(:totp)
+          session[:totp_error] = "Verification code was incorrect."
+          redirect_to(totp_session_path)
         end
         fmt.json { render(json: { error: "Verification code was incorrect." }, status: 401) }
       end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,8 +27,7 @@ class SessionsController < ApplicationController
       end
     when :totp_required
       DanbooruLogger.add_attributes("user.login" => "totp_challenge")
-      # A stale error from an interrupted/abandoned earlier PRG cycle must not
-      # leak into a brand-new challenge for this (or a different) login.
+      # Don't carry an error from an abandoned challenge into a new one.
       session.delete(:totp_error)
       respond_to do |fmt|
         fmt.html { redirect_to(totp_session_path) }
@@ -47,17 +46,11 @@ class SessionsController < ApplicationController
   def totp
     @user = session_creator.challenge_user
     if @user.nil?
-      # No live challenge to attach a "wrong code" error to — drop any leftover
-      # from an earlier PRG cycle too, so it can't resurface on a later challenge.
       session.delete(:totp_error)
       redirect_to(new_session_path, notice: "Your login attempt has expired. Please log in again.")
       return
     end
-    # session, not flash: _toasts.html.erb renders every flash key generically
-    # (flash.each), so a flash-based transport here would also duplicate this
-    # as a top-of-page toast alongside the intended inline #auth-error message.
-    # session.delete reads and clears it in one step, so it can't replay on a
-    # later plain refresh either.
+    # Flash would also render this as a toast; keep the error inline only.
     @totp_error = session.delete(:totp_error)
   end
 

--- a/app/javascript/entrypoints/v_sessions_totp.ts
+++ b/app/javascript/entrypoints/v_sessions_totp.ts
@@ -1,0 +1,8 @@
+// sessions # totp
+
+import E621Type from "@/interfaces/E621";
+declare const E621: E621Type;
+
+import "@/pages/sessions/totp";
+
+E621.Registry.register("v_sessions_totp");

--- a/app/javascript/entrypoints/v_sessions_totp.ts
+++ b/app/javascript/entrypoints/v_sessions_totp.ts
@@ -1,0 +1,7 @@
+// sessions # totp
+
+import ModuleRegistry from "@/utility/ModuleRegistry";
+
+import "@/pages/sessions/totp";
+
+ModuleRegistry.register("v_sessions_totp");

--- a/app/javascript/src/js/components/OtpCodeInput.ts
+++ b/app/javascript/src/js/components/OtpCodeInput.ts
@@ -1,46 +1,17 @@
 type Mode = "totp" | "backup";
 
 const TOTP_LENGTH = 6;
-const TOTP_SHAPED = /^\d+$/;
-
-interface TotpInputSnapshot {
-  value: string;
-  disabled: boolean;
-  hidden: HTMLElement["hidden"];
-  autocomplete: string | null;
-  inputmode: string | null;
-  pattern: string | null;
-  labelFor: string;
-  labelText: string | null;
-}
-
-function restoreAttribute (el: HTMLElement, name: string, value: string | null) {
-  if (value === null) el.removeAttribute(name);
-  else el.setAttribute(name, value);
-}
+const TOTP_SHAPED = /^\d{1,6}$/;
 
 /**
- * Enhances a single dual-purpose TOTP/backup-code text field with a six-cell
- * authenticator-code presentation and a mode switch to a dedicated backup-code field.
- *
- * The six cells are aria-hidden and purely presentational. Once enhanced, the
- * original server-rendered input becomes the dedicated TOTP control and a second,
- * JS-created input becomes the dedicated backup-code control — password managers
- * (Bitwarden in particular) key off `data-bwignore`/`autocomplete` per element and
- * don't reliably notice those being changed on a single reused element, so the two
- * modes get genuinely separate elements instead. Only one is ever enabled at a
- * time, so only one submits as `totp[code]` regardless of which mode is active.
- *
- * `inputmode`/`pattern` are applied here, at runtime, rather than being
- * server-rendered, so a JS failure leaves the field exactly as capable as it is
- * today (plain text, no restrictions, works for either code type). Length is
- * enforced only by the sanitizer, not `maxlength`, so a raw browser paste is never
- * truncated ahead of it.
+ * Enhances the dual-purpose OTP field with six visual TOTP cells and a separate
+ * backup-code input. Separate elements are intentional because password managers
+ * don't reliably re-evaluate autocomplete/data-bwignore when one input changes mode.
+ * Only the enabled input submits as totp[code].
  */
 export default class OtpCodeInput {
 
-  // Delay between each cell's reveal during a bulk-fill (autofill/paste)
-  // animation — see handleValueChange()/startBulkReveal().
+  // Delay between cells during a bulk-fill reveal.
   private static readonly REVEAL_STEP_MS = 90;
 
   private wrapper: HTMLElement;
@@ -52,22 +23,14 @@ export default class OtpCodeInput {
 
   private mode: Mode = "totp";
   private errorElement: HTMLElement | null = null;
-  private errorDismissTimer?: number;
   private errorShakeTimer?: number;
 
-  // Bulk-fill reveal state. previousValue tracks the last value handleValueChange()
-  // saw, to detect a jump straight to a complete code in one event (autofill/paste)
-  // versus normal one-digit-at-a-time typing. revealGeneration is a monotonic token:
-  // every cancelReveal() bumps it, so a delayed callback from a superseded reveal can
-  // recognize itself as stale and no-op instead of overwriting newer cell contents.
   private previousValue = "";
+
+  // Invalidates callbacks belonging to a superseded reveal.
   private revealGeneration = 0;
-  private revealTimers: number[] = [];
-  // The value a bulk reveal is currently authoritative for, or null when no
-  // reveal owns the display. Lets handleValueChange() and render() recognize
-  // a duplicate event for the exact value already being revealed (Bitwarden
-  // fires both `input` and `change` for the same fill) and leave it alone,
-  // instead of treating it as a fresh state change that cancels the reveal.
+
+  // Bitwarden can emit both input and change for the same autofill.
   private revealValue: string | null = null;
 
   constructor (wrapper: JQuery<HTMLElement>) {
@@ -80,10 +43,21 @@ export default class OtpCodeInput {
     const totpInput = root.querySelector<HTMLInputElement>(".otp-code-input-real");
     const cells = Array.from(root.querySelectorAll<HTMLElement>(".otp-code-input-cell"));
     const toggle = root.querySelector<HTMLButtonElement>(".otp-code-input-toggle");
+    const { labelTotp, labelBackup, toggleToBackup, toggleToTotp } = root.dataset;
 
-    // Incomplete markup: bail out without touching anything, so the plain
-    // server-rendered input remains usable exactly as if JS never ran.
-    if (!box || !labelElement || !field || !totpInput || !toggle || cells.length !== TOTP_LENGTH) return;
+    // Bail out before mutating the DOM if the component markup is incomplete.
+    if (
+      !box
+      || !labelElement
+      || !field
+      || !totpInput
+      || !toggle
+      || cells.length !== TOTP_LENGTH
+      || !labelTotp
+      || !labelBackup
+      || !toggleToBackup
+      || !toggleToTotp
+    ) return;
 
     this.wrapper = root;
     this.labelElement = labelElement;
@@ -91,98 +65,81 @@ export default class OtpCodeInput {
     this.cells = cells;
     this.toggle = toggle;
 
-    // Build the backup input fully detached — no live-DOM mutation yet.
     this.backupInput = this.createBackupInput();
 
-    // Snapshot the exact pre-enhancement state, captured before ANY mutation —
-    // not reconstructed defaults. Enhancement is about to (a) move a restored
-    // backup-shaped value into backupInput and clear totpInput, or (b) sanitize/
-    // clamp totpInput's own value in place, and (c) hide/disable it. If anything
-    // below throws, rollback must undo exactly what happened, or it could
-    // silently destroy a value the user (or a restored session) had entered.
-    const snapshot: TotpInputSnapshot = {
-      value: totpInput.value,
-      disabled: totpInput.disabled,
-      hidden: totpInput.hidden,
-      autocomplete: totpInput.getAttribute("autocomplete"),
-      inputmode: totpInput.getAttribute("inputmode"),
-      pattern: totpInput.getAttribute("pattern"),
-      labelFor: labelElement.getAttribute("for")!,
-      labelText: labelElement.textContent,
-    };
+    const raw = totpInput.value;
+    const normalized = raw.replace(/[\s-]/g, "");
+    const startMode: Mode = raw === "" || TOTP_SHAPED.test(normalized) ? "totp" : "backup";
+    const wasAutofocused = totpInput.hasAttribute("autofocus");
 
-    try {
-      const raw = totpInput.value;
-      const startMode: Mode = raw === "" || TOTP_SHAPED.test(raw) ? "totp" : "backup";
-      const wasAutofocused = totpInput.hasAttribute("autofocus");
+    field.appendChild(this.backupInput);
 
-      field.appendChild(this.backupInput);
-
-      if (startMode === "backup") {
-        this.backupInput.value = raw;
-        totpInput.value = "";
-      } else {
-        this.sanitize();
-      }
-      this.applyMode(startMode);
-
-      this.render();
-      this.previousValue = this.totpInput.value;
-      this.wrapper.classList.add("is-enhanced");
-
-      if (startMode === "backup" && wasAutofocused) {
-        this.backupInput.focus();
-        const end = this.backupInput.value.length;
-        this.backupInput.setSelectionRange(end, end);
-      }
-
-      // Only now, after everything else has succeeded: listeners.
-      this.totpInput.addEventListener("beforeinput", (event) => this.handleBeforeInput(event as InputEvent));
-      this.totpInput.addEventListener("input", () => this.handleValueChange());
-      this.totpInput.addEventListener("change", () => this.handleValueChange());
-      this.totpInput.addEventListener("focus", () => this.render());
-      this.totpInput.addEventListener("blur", () => this.render());
-      this.totpInput.addEventListener("keyup", () => this.render());
-      this.totpInput.addEventListener("select", () => this.render());
-      this.totpInput.addEventListener("click", (event) => this.handleClick(event));
-      this.toggle.addEventListener("click", () => this.switchMode(this.mode === "totp" ? "backup" : "totp"));
-
-      root.dataset.otpInitialized = "true";
-    } catch (error) {
-      // Roll back to the CAPTURED snapshot, not assumed/reconstructed defaults —
-      // this is what keeps a restored backup code (or an as-typed, not-yet-
-      // sanitized TOTP value) from being silently lost if something throws.
-      this.backupInput.remove();
-      totpInput.value = snapshot.value;
-      totpInput.disabled = snapshot.disabled;
-      totpInput.hidden = snapshot.hidden;
-      restoreAttribute(totpInput, "autocomplete", snapshot.autocomplete);
-      restoreAttribute(totpInput, "inputmode", snapshot.inputmode);
-      restoreAttribute(totpInput, "pattern", snapshot.pattern);
-      labelElement.setAttribute("for", snapshot.labelFor);
-      labelElement.textContent = snapshot.labelText;
-      root.classList.remove("is-enhanced");
-      delete root.dataset.mode;
-      delete root.dataset.otpInitialized;
-      throw error;
+    if (startMode === "backup") {
+      this.backupInput.value = raw;
+      totpInput.value = "";
+    } else {
+      this.sanitize();
     }
 
-    // Best-effort additive extras — neither participates in the transactional
-    // rollback above; the core six-cell/backup-field enhancement already fully
-    // succeeded by this point regardless of what happens here.
+    this.applyMode(startMode);
+    this.render();
+    this.previousValue = this.totpInput.value;
+    this.wrapper.classList.add("is-enhanced");
+
+    if (startMode === "backup" && wasAutofocused) {
+      this.backupInput.focus();
+      const end = this.backupInput.value.length;
+      this.backupInput.setSelectionRange(end, end);
+    }
+
+    this.totpInput.addEventListener("paste", (event) => this.handlePaste(event));
+    this.totpInput.addEventListener("beforeinput", (event) => this.handleBeforeInput(event as InputEvent));
+    this.totpInput.addEventListener("input", () => this.handleValueChange());
+    this.totpInput.addEventListener("change", () => this.handleValueChange());
+    this.totpInput.addEventListener("focus", () => this.render());
+    this.totpInput.addEventListener("blur", () => this.render());
+    this.totpInput.addEventListener("keyup", () => this.render());
+    this.totpInput.addEventListener("select", () => this.render());
+    this.totpInput.addEventListener("click", (event) => this.handleClick(event));
+    this.toggle.addEventListener("click", () => this.switchMode(this.mode === "totp" ? "backup" : "totp"));
+
+    this.cells.forEach((cell) => {
+      cell.addEventListener("animationend", (event) => {
+        if (event.animationName === "otp-cell-pop") {
+          cell.classList.remove("digit-pop");
+        }
+      });
+    });
+
+    root.dataset.otpInitialized = "true";
+
     const form = root.closest("form");
     if (form) form.addEventListener("submit", (event) => this.handleSubmit(event));
-    // Scoped to this component's own form, not document-wide: a bare
-    // getElementById("auth-error") would be ambiguous if a full-page auth form
-    // and overlay/auth UI ever coexist or duplicate IDs appear. If there's no
-    // owning form or no #auth-error in it, error-feedback is simply skipped —
-    // core OTP behavior above doesn't depend on it.
+
     this.errorElement = form?.querySelector<HTMLElement>("#auth-error") ?? null;
     this.observeAuthError();
   }
 
+  private handleSubmit (event: Event) {
+    if (this.mode !== "backup") return;
+
+    const normalized = this.backupInput.value.replace(/[\s-]/g, "");
+    if (!/^\d{6}$/.test(normalized)) return;
+
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.showError("Verification code was incorrect.");
+    this.backupInput.focus();
+  }
+
+  private showError (message: string) {
+    if (this.errorElement) this.errorElement.textContent = message;
+  }
+
   private createBackupInput (): HTMLInputElement {
     const input = document.createElement("input");
+    const describedBy = this.totpInput.getAttribute("aria-describedby");
+    if (describedBy) input.setAttribute("aria-describedby", describedBy);
     input.type = "text";
     input.id = "totp_backup_code";
     input.name = "totp[code]";
@@ -193,13 +150,6 @@ export default class OtpCodeInput {
     input.setAttribute("autocapitalize", "none");
     input.spellcheck = false;
     input.setAttribute("autocorrect", "off");
-    // Generated backup codes are 16 hex chars, either the canonical hyphenated
-    // grouping or the compact equivalent — accept both, but not a 6-digit TOTP.
-    // The backend already normalizes case/separators, so this is a frontend-only
-    // sanity check, not a change to what the server accepts.
-    input.setAttribute("pattern", "(?:[0-9A-Fa-f]{16}|[0-9A-Fa-f]{4}(?:-[0-9A-Fa-f]{4}){3})");
-    input.maxLength = 19; // canonical "a1b2-c3d4-e5f6-a7b8" form is exactly 19 chars
-    input.title = "Invalid backup code.";
     input.disabled = true;
     return input;
   }
@@ -210,41 +160,43 @@ export default class OtpCodeInput {
     const value = this.totpInput.value;
 
     if (this.mode === "totp" && this.revealValue !== null && this.revealValue === value) {
-      // Duplicate input/change event carrying the exact value a reveal is
-      // already displaying (Bitwarden fires both for one fill) — leave the
-      // in-flight reveal alone; only keep previousValue in sync.
+      // Ignore Bitwarden's duplicate change event for an autofill already being revealed.
       this.previousValue = value;
       return;
     }
 
-    const grew = value.length - this.previousValue.length;
+    const previousValue = this.previousValue;
     this.previousValue = value;
-
-    // A bulk fill (autofill, or a full-code paste) lands a complete value in a
-    // single event; normal one-digit-at-a-time typing never grows by more than
-    // one character per event, so this can't misfire on ordinary keystrokes.
-    const isBulkFill = this.mode === "totp" && value.length === TOTP_LENGTH && grew > 1;
-
-    if (isBulkFill && !this.prefersReducedMotion()) {
-      this.startBulkReveal(value);
-    } else {
-      this.cancelRevealAndRender();
-    }
+    this.renderValueChange(previousValue, value);
   }
 
   private prefersReducedMotion (): boolean {
     return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   }
 
-  /**
-   * Reveals an already-complete totpInput value cell-by-cell instead of all at
-   * once. The real input's value is already fully set by the caller — only the
-   * presentation cells lag behind, purely visually. The six cell boxes stay
-   * visible and stationary throughout; only their text and a brief per-cell
-   * pop (see restartCellPop()) change. Guarded by revealGeneration so a stale
-   * timer from a superseded reveal can never clobber newer content — see
-   * cancelReveal(), called by every genuine state change (cancelRevealAndRender()).
-   */
+  private renderValueChange (previousValue: string, value: string) {
+    const changedCells = this.cells.filter((_, index) => previousValue[index] !== value[index]);
+    const isDeletion = value.length < previousValue.length;
+    const reducedMotion = this.prefersReducedMotion();
+
+    if (
+      !isDeletion
+      && changedCells.length > 1
+      && value.length === TOTP_LENGTH
+      && !reducedMotion
+    ) {
+      this.startBulkReveal(value);
+      return;
+    }
+
+    this.cancelRevealAndRender();
+
+    if (isDeletion || reducedMotion) return;
+
+    changedCells.forEach((cell) => this.restartCellPop(cell));
+  }
+
+  // The real input is complete immediately; only the visual cells are staggered.
   private startBulkReveal (value: string) {
     this.cancelReveal();
     this.revealValue = value;
@@ -256,85 +208,80 @@ export default class OtpCodeInput {
     });
 
     value.split("").forEach((char, index) => {
-      const timer = window.setTimeout(() => {
-        if (generation !== this.revealGeneration) return; // superseded — a newer edit/render already took over
+      window.setTimeout(() => {
+        if (generation !== this.revealGeneration) return;
+
         const cell = this.cells[index];
         cell.textContent = char;
         this.restartCellPop(cell);
-        // Last cell revealed: the reveal is done being authoritative for this
-        // value — hand off to a normal render for the final caret state (from
-        // the real, current selectionStart), rather than pretending the caret
-        // animated along with the reveal.
+
         if (index === value.length - 1) {
           this.revealValue = null;
           this.render();
         }
       }, index * OtpCodeInput.REVEAL_STEP_MS);
-      this.revealTimers.push(timer);
     });
   }
 
-  /** One-shot "digit landed" pop for a single cell — used only during a bulk-fill reveal. */
   private restartCellPop (cell: HTMLElement) {
-    cell.classList.remove("bulk-pop");
-    void cell.offsetWidth; // restart the animation reliably even if triggered twice in a row
-    cell.classList.add("bulk-pop");
-    cell.addEventListener("animationend", () => cell.classList.remove("bulk-pop"), { once: true });
+    cell.classList.remove("digit-pop");
+    void cell.offsetWidth;
+    cell.classList.add("digit-pop");
   }
 
-  /** Cancels any in-flight bulk reveal and clears any leftover per-cell pop state. */
   private cancelReveal () {
     this.revealGeneration++;
-    this.revealTimers.forEach((timer) => window.clearTimeout(timer));
-    this.revealTimers = [];
     this.revealValue = null;
-    this.cells.forEach((cell) => cell.classList.remove("bulk-pop"));
+    this.cells.forEach((cell) => cell.classList.remove("digit-pop"));
   }
 
-  /** For genuine state changes (edits, mode switches) that must override an in-flight reveal, unlike a plain render(). */
   private cancelRevealAndRender () {
     this.cancelReveal();
     this.render();
   }
 
-  /**
-   * Six-slot overwrite semantics: typing a single digit while the caret targets
-   * an already-populated slot replaces that slot instead of inserting and
-   * shifting later digits right (which would silently discard the last digit in
-   * a fixed-length code). Handled at `beforeinput` so it works with normal
-   * browser/mobile text-input semantics rather than reimplementing key handling.
-   */
+  private handlePaste (event: ClipboardEvent) {
+    if (this.mode !== "totp") return;
+
+    const pasted = event.clipboardData?.getData("text") ?? "";
+    const code = pasted.replace(/\D/g, "");
+
+    if (code.length !== TOTP_LENGTH) return;
+
+    event.preventDefault();
+
+    const previousValue = this.totpInput.value;
+    this.totpInput.value = code;
+    this.totpInput.setSelectionRange(TOTP_LENGTH, TOTP_LENGTH);
+    this.previousValue = code;
+    this.renderValueChange(previousValue, code);
+  }
+
+  // Overwrite an occupied TOTP slot instead of inserting and shifting later digits.
   private handleBeforeInput (event: InputEvent) {
     if (this.mode !== "totp") return;
-    if (event.inputType !== "insertText") return; // excludes paste/autofill/composition/replacement
+    if (event.inputType !== "insertText") return;
     const data = event.data;
-    if (!data || data.length !== 1 || !/^[0-9]$/.test(data)) return; // only a single digit
-    if (this.totpInput.selectionStart !== this.totpInput.selectionEnd) return; // collapsed caret only — a selection keeps native replace behavior
-
+    if (!data || data.length !== 1 || !/^[0-9]$/.test(data)) return;
+    if (this.totpInput.selectionStart !== this.totpInput.selectionEnd) return;
     const start = this.totpInput.selectionStart ?? 0;
     const value = this.totpInput.value;
 
-    // Boundary 6 on an already-full value is where the active-cell highlight
-    // parks (render() collapses it onto the last cell), so typing there targets
-    // that same last slot rather than falling through to append-then-clamp,
-    // which would silently no-op instead of overwriting anything.
+    // A caret at boundary 6 on a full code targets the last visible slot.
     const target = value.length === TOTP_LENGTH && start === TOTP_LENGTH ? TOTP_LENGTH - 1 : start;
 
     if (target >= value.length) return; // genuinely at/after the end with room to grow — normal append; sanitizer clamps to 6 as before
 
-    // Occupied slot: overwrite in place instead of insert-and-shift.
     event.preventDefault();
-    this.totpInput.value = value.slice(0, target) + data + value.slice(target + 1);
+
+    const nextValue = value.slice(0, target) + data + value.slice(target + 1);
+    this.totpInput.value = nextValue;
     this.totpInput.setSelectionRange(target + 1, target + 1);
-    this.previousValue = this.totpInput.value;
-    this.cancelRevealAndRender();
+    this.previousValue = nextValue;
+    this.renderValueChange(value, nextValue);
   }
 
-  /**
-   * Strips non-digits and clamps to 6 characters, preserving the caret/selection
-   * boundaries (mapped through how many characters were removed ahead of them)
-   * instead of letting a blind `value =` reassignment shove the caret to the end.
-   */
+  // Strip non-digits and clamp to six while preserving the selection.
   private sanitize () {
     const raw = this.totpInput.value;
     const rawStart = this.totpInput.selectionStart ?? raw.length;
@@ -350,25 +297,12 @@ export default class OtpCodeInput {
     this.totpInput.setSelectionRange(start, end);
   }
 
-  /**
-   * Paints the cells for the current state. Deliberately does NOT cancel an
-   * in-flight bulk reveal on its own — render() is wired to harmless events
-   * (focus/blur/keyup/select/click) that can fire mid-reveal without
-   * representing a real state change (a duplicate Bitwarden `change` event in
-   * particular), and unconditionally repainting there would finish the reveal
-   * instantly regardless of whether any timer was actually cancelled. Callers
-   * that represent a genuine new state (an edit, a mode switch) must cancel
-   * explicitly via cancelRevealAndRender() instead.
-   */
   private render () {
     if (this.mode !== "totp") return;
 
     const value = this.totpInput.value;
 
-    // A reveal already owns the display for this exact value — its own timers
-    // are progressively painting the cells; don't race them with a full,
-    // instant repaint. render() is called again with revealValue cleared once
-    // the reveal finishes (see startBulkReveal's last cell).
+    // Don't overwrite cells while a reveal for this value owns the presentation.
     if (this.revealValue !== null && this.revealValue === value) return;
 
     const focused = document.activeElement === this.totpInput;
@@ -387,15 +321,7 @@ export default class OtpCodeInput {
     });
   }
 
-  /**
-   * Maps a click's horizontal position to the containing (or nearest) cell
-   * *slot*, 0..5, rather than relying on the real input's text metrics to line
-   * up with the cells. The caret is authoritative for what's visibly active
-   * (a centered blinking bar inside that slot — see the CSS), so a click always
-   * targets a whole slot, clamped to the current value's length: clicking a
-   * cell past the entered digits parks the caret right after the last digit,
-   * not out in empty space with nothing to overwrite.
-   */
+  // Map clicks to the nearest visual slot rather than the hidden input's text metrics.
   private handleClick (event: MouseEvent) {
     if (this.mode !== "totp" || this.cells.length === 0) return;
 
@@ -418,7 +344,6 @@ export default class OtpCodeInput {
     this.render();
   }
 
-  /** Attribute-only: enables/shows the active input, disables/hides the other. No value clearing — used by both init and switchMode. */
   private applyMode (mode: Mode) {
     this.mode = mode;
     this.wrapper.dataset.mode = mode;
@@ -456,68 +381,28 @@ export default class OtpCodeInput {
     active.setSelectionRange(0, 0);
   }
 
-  /**
-   * Client-side gate for the dedicated backup-code field's `pattern`/`required`
-   * constraints. This project disables native browser constraint validation on
-   * all forms (SimpleForm's `browser_validations = false`, i.e. every form is
-   * rendered with `novalidate`), so those attributes are otherwise decorative —
-   * `checkValidity()` still works regardless, since `novalidate` only skips the
-   * browser's automatic pre-submit validation walk, not the API itself.
-   *
-   * Attached to the form during construction, before AuthOverlay attaches its
-   * own submit handler (see `bootstrapFormSubmission`), so this runs first and
-   * `stopImmediatePropagation()` here also blocks the AJAX submit path.
-   */
-  private handleSubmit (event: Event) {
-    if (this.mode !== "backup" || this.backupInput.checkValidity()) return;
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    this.showError(this.backupInput.title || "Enter a valid backup code.");
-    this.backupInput.focus();
-  }
-
-  /** Puts a message in this component's own #auth-error, where observeAuthError()'s MutationObserver picks it up. */
-  private showError (message: string) {
-    if (this.errorElement) this.errorElement.textContent = message;
-  }
-
-  /**
-   * #auth-error gets populated two different ways — server-rendered on a
-   * full-page reload after a failed attempt, or injected later by
-   * AuthOverlay.showError() after a failed AJAX submission — so a
-   * MutationObserver is what lets one piece of code drive the shake/dismiss
-   * feedback for both without OtpCodeInput and AuthOverlay needing any direct
-   * reference to each other. Scoped to this.errorElement (this component's own
-   * form), not a document-wide lookup — see where it's resolved in the constructor.
-   */
+  // Handles both server-rendered errors and errors injected later by AuthOverlay.
   private observeAuthError () {
     const errorEl = this.errorElement;
     if (!errorEl) return;
 
     const trigger = () => {
-      if (errorEl.textContent?.trim()) this.triggerErrorFeedback(errorEl);
+      if (errorEl.textContent?.trim()) this.triggerErrorFeedback();
     };
 
     new MutationObserver(trigger).observe(errorEl, { childList: true, characterData: true, subtree: true });
-    trigger(); // catches a server-rendered error already present at construction time
+    trigger(); // Handle an error already rendered with the page.
   }
 
-  /** Red border + horizontal shake for 2s, then the message itself clears after 5s. */
-  private triggerErrorFeedback (errorEl: HTMLElement) {
-    window.clearTimeout(this.errorDismissTimer);
+  private triggerErrorFeedback () {
     window.clearTimeout(this.errorShakeTimer);
 
-    // Remove-then-reflow-then-reapply so the shake restarts cleanly even if a
-    // previous one is still mid-flight (e.g. two failed attempts in a row).
+    // Restart the shake if an earlier one is still running.
     this.wrapper.classList.remove("otp-code-input-error");
     void this.wrapper.offsetWidth;
     this.wrapper.classList.add("otp-code-input-error");
     this.errorShakeTimer = window.setTimeout(() => {
       this.wrapper.classList.remove("otp-code-input-error");
     }, 2000);
-
-    this.errorDismissTimer = window.setTimeout(() => {
-      errorEl.textContent = "";
-    }, 5000);
   }
 }

--- a/app/javascript/src/js/components/OtpCodeInput.ts
+++ b/app/javascript/src/js/components/OtpCodeInput.ts
@@ -1,0 +1,523 @@
+type Mode = "totp" | "backup";
+
+const TOTP_LENGTH = 6;
+const TOTP_SHAPED = /^\d+$/;
+
+interface TotpInputSnapshot {
+  value: string;
+  disabled: boolean;
+  hidden: HTMLElement["hidden"];
+  autocomplete: string | null;
+  inputmode: string | null;
+  pattern: string | null;
+  labelFor: string;
+  labelText: string | null;
+}
+
+function restoreAttribute (el: HTMLElement, name: string, value: string | null) {
+  if (value === null) el.removeAttribute(name);
+  else el.setAttribute(name, value);
+}
+
+/**
+ * Enhances a single dual-purpose TOTP/backup-code text field with a six-cell
+ * authenticator-code presentation and a mode switch to a dedicated backup-code field.
+ *
+ * The six cells are aria-hidden and purely presentational. Once enhanced, the
+ * original server-rendered input becomes the dedicated TOTP control and a second,
+ * JS-created input becomes the dedicated backup-code control — password managers
+ * (Bitwarden in particular) key off `data-bwignore`/`autocomplete` per element and
+ * don't reliably notice those being changed on a single reused element, so the two
+ * modes get genuinely separate elements instead. Only one is ever enabled at a
+ * time, so only one submits as `totp[code]` regardless of which mode is active.
+ *
+ * `inputmode`/`pattern` are applied here, at runtime, rather than being
+ * server-rendered, so a JS failure leaves the field exactly as capable as it is
+ * today (plain text, no restrictions, works for either code type). Length is
+ * enforced only by the sanitizer, not `maxlength`, so a raw browser paste is never
+ * truncated ahead of it.
+ */
+export default class OtpCodeInput {
+
+  // Delay between each cell's reveal during a bulk-fill (autofill/paste)
+  // animation — see handleValueChange()/startBulkReveal().
+  private static readonly REVEAL_STEP_MS = 90;
+
+  private wrapper: HTMLElement;
+  private totpInput: HTMLInputElement;
+  private backupInput: HTMLInputElement;
+  private cells: HTMLElement[];
+  private labelElement: HTMLLabelElement;
+  private toggle: HTMLButtonElement;
+
+  private mode: Mode = "totp";
+  private errorElement: HTMLElement | null = null;
+  private errorDismissTimer?: number;
+  private errorShakeTimer?: number;
+
+  // Bulk-fill reveal state. previousValue tracks the last value handleValueChange()
+  // saw, to detect a jump straight to a complete code in one event (autofill/paste)
+  // versus normal one-digit-at-a-time typing. revealGeneration is a monotonic token:
+  // every cancelReveal() bumps it, so a delayed callback from a superseded reveal can
+  // recognize itself as stale and no-op instead of overwriting newer cell contents.
+  private previousValue = "";
+  private revealGeneration = 0;
+  private revealTimers: number[] = [];
+  // The value a bulk reveal is currently authoritative for, or null when no
+  // reveal owns the display. Lets handleValueChange() and render() recognize
+  // a duplicate event for the exact value already being revealed (Bitwarden
+  // fires both `input` and `change` for the same fill) and leave it alone,
+  // instead of treating it as a fresh state change that cancels the reveal.
+  private revealValue: string | null = null;
+
+  constructor (wrapper: JQuery<HTMLElement>) {
+    const root = wrapper[0];
+    if (!root || root.dataset.otpInitialized === "true") return;
+
+    const box = root.querySelector<HTMLElement>(".otp-code-input-box");
+    const labelElement = root.querySelector<HTMLLabelElement>(".otp-code-input-label");
+    const field = root.querySelector<HTMLElement>(".otp-code-input-field");
+    const totpInput = root.querySelector<HTMLInputElement>(".otp-code-input-real");
+    const cells = Array.from(root.querySelectorAll<HTMLElement>(".otp-code-input-cell"));
+    const toggle = root.querySelector<HTMLButtonElement>(".otp-code-input-toggle");
+
+    // Incomplete markup: bail out without touching anything, so the plain
+    // server-rendered input remains usable exactly as if JS never ran.
+    if (!box || !labelElement || !field || !totpInput || !toggle || cells.length !== TOTP_LENGTH) return;
+
+    this.wrapper = root;
+    this.labelElement = labelElement;
+    this.totpInput = totpInput;
+    this.cells = cells;
+    this.toggle = toggle;
+
+    // Build the backup input fully detached — no live-DOM mutation yet.
+    this.backupInput = this.createBackupInput();
+
+    // Snapshot the exact pre-enhancement state, captured before ANY mutation —
+    // not reconstructed defaults. Enhancement is about to (a) move a restored
+    // backup-shaped value into backupInput and clear totpInput, or (b) sanitize/
+    // clamp totpInput's own value in place, and (c) hide/disable it. If anything
+    // below throws, rollback must undo exactly what happened, or it could
+    // silently destroy a value the user (or a restored session) had entered.
+    const snapshot: TotpInputSnapshot = {
+      value: totpInput.value,
+      disabled: totpInput.disabled,
+      hidden: totpInput.hidden,
+      autocomplete: totpInput.getAttribute("autocomplete"),
+      inputmode: totpInput.getAttribute("inputmode"),
+      pattern: totpInput.getAttribute("pattern"),
+      labelFor: labelElement.getAttribute("for")!,
+      labelText: labelElement.textContent,
+    };
+
+    try {
+      const raw = totpInput.value;
+      const startMode: Mode = raw === "" || TOTP_SHAPED.test(raw) ? "totp" : "backup";
+      const wasAutofocused = totpInput.hasAttribute("autofocus");
+
+      field.appendChild(this.backupInput);
+
+      if (startMode === "backup") {
+        this.backupInput.value = raw;
+        totpInput.value = "";
+      } else {
+        this.sanitize();
+      }
+      this.applyMode(startMode);
+
+      this.render();
+      this.previousValue = this.totpInput.value;
+      this.wrapper.classList.add("is-enhanced");
+
+      if (startMode === "backup" && wasAutofocused) {
+        this.backupInput.focus();
+        const end = this.backupInput.value.length;
+        this.backupInput.setSelectionRange(end, end);
+      }
+
+      // Only now, after everything else has succeeded: listeners.
+      this.totpInput.addEventListener("beforeinput", (event) => this.handleBeforeInput(event as InputEvent));
+      this.totpInput.addEventListener("input", () => this.handleValueChange());
+      this.totpInput.addEventListener("change", () => this.handleValueChange());
+      this.totpInput.addEventListener("focus", () => this.render());
+      this.totpInput.addEventListener("blur", () => this.render());
+      this.totpInput.addEventListener("keyup", () => this.render());
+      this.totpInput.addEventListener("select", () => this.render());
+      this.totpInput.addEventListener("click", (event) => this.handleClick(event));
+      this.toggle.addEventListener("click", () => this.switchMode(this.mode === "totp" ? "backup" : "totp"));
+
+      root.dataset.otpInitialized = "true";
+    } catch (error) {
+      // Roll back to the CAPTURED snapshot, not assumed/reconstructed defaults —
+      // this is what keeps a restored backup code (or an as-typed, not-yet-
+      // sanitized TOTP value) from being silently lost if something throws.
+      this.backupInput.remove();
+      totpInput.value = snapshot.value;
+      totpInput.disabled = snapshot.disabled;
+      totpInput.hidden = snapshot.hidden;
+      restoreAttribute(totpInput, "autocomplete", snapshot.autocomplete);
+      restoreAttribute(totpInput, "inputmode", snapshot.inputmode);
+      restoreAttribute(totpInput, "pattern", snapshot.pattern);
+      labelElement.setAttribute("for", snapshot.labelFor);
+      labelElement.textContent = snapshot.labelText;
+      root.classList.remove("is-enhanced");
+      delete root.dataset.mode;
+      delete root.dataset.otpInitialized;
+      throw error;
+    }
+
+    // Best-effort additive extras — neither participates in the transactional
+    // rollback above; the core six-cell/backup-field enhancement already fully
+    // succeeded by this point regardless of what happens here.
+    const form = root.closest("form");
+    if (form) form.addEventListener("submit", (event) => this.handleSubmit(event));
+    // Scoped to this component's own form, not document-wide: a bare
+    // getElementById("auth-error") would be ambiguous if a full-page auth form
+    // and overlay/auth UI ever coexist or duplicate IDs appear. If there's no
+    // owning form or no #auth-error in it, error-feedback is simply skipped —
+    // core OTP behavior above doesn't depend on it.
+    this.errorElement = form?.querySelector<HTMLElement>("#auth-error") ?? null;
+    this.observeAuthError();
+  }
+
+  private createBackupInput (): HTMLInputElement {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.id = "totp_backup_code";
+    input.name = "totp[code]";
+    input.className = "otp-code-input-backup";
+    input.autocomplete = "off";
+    input.setAttribute("data-bwignore", "1");
+    input.required = true;
+    input.setAttribute("autocapitalize", "none");
+    input.spellcheck = false;
+    input.setAttribute("autocorrect", "off");
+    // Generated backup codes are 16 hex chars, either the canonical hyphenated
+    // grouping or the compact equivalent — accept both, but not a 6-digit TOTP.
+    // The backend already normalizes case/separators, so this is a frontend-only
+    // sanity check, not a change to what the server accepts.
+    input.setAttribute("pattern", "(?:[0-9A-Fa-f]{16}|[0-9A-Fa-f]{4}(?:-[0-9A-Fa-f]{4}){3})");
+    input.maxLength = 19; // canonical "a1b2-c3d4-e5f6-a7b8" form is exactly 19 chars
+    input.title = "Invalid backup code.";
+    input.disabled = true;
+    return input;
+  }
+
+  private handleValueChange () {
+    if (this.mode === "totp") this.sanitize();
+
+    const value = this.totpInput.value;
+
+    if (this.mode === "totp" && this.revealValue !== null && this.revealValue === value) {
+      // Duplicate input/change event carrying the exact value a reveal is
+      // already displaying (Bitwarden fires both for one fill) — leave the
+      // in-flight reveal alone; only keep previousValue in sync.
+      this.previousValue = value;
+      return;
+    }
+
+    const grew = value.length - this.previousValue.length;
+    this.previousValue = value;
+
+    // A bulk fill (autofill, or a full-code paste) lands a complete value in a
+    // single event; normal one-digit-at-a-time typing never grows by more than
+    // one character per event, so this can't misfire on ordinary keystrokes.
+    const isBulkFill = this.mode === "totp" && value.length === TOTP_LENGTH && grew > 1;
+
+    if (isBulkFill && !this.prefersReducedMotion()) {
+      this.startBulkReveal(value);
+    } else {
+      this.cancelRevealAndRender();
+    }
+  }
+
+  private prefersReducedMotion (): boolean {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  /**
+   * Reveals an already-complete totpInput value cell-by-cell instead of all at
+   * once. The real input's value is already fully set by the caller — only the
+   * presentation cells lag behind, purely visually. The six cell boxes stay
+   * visible and stationary throughout; only their text and a brief per-cell
+   * pop (see restartCellPop()) change. Guarded by revealGeneration so a stale
+   * timer from a superseded reveal can never clobber newer content — see
+   * cancelReveal(), called by every genuine state change (cancelRevealAndRender()).
+   */
+  private startBulkReveal (value: string) {
+    this.cancelReveal();
+    this.revealValue = value;
+    const generation = this.revealGeneration;
+
+    this.cells.forEach((cell) => {
+      cell.textContent = "";
+      cell.classList.remove("active", "empty", "occupied");
+    });
+
+    value.split("").forEach((char, index) => {
+      const timer = window.setTimeout(() => {
+        if (generation !== this.revealGeneration) return; // superseded — a newer edit/render already took over
+        const cell = this.cells[index];
+        cell.textContent = char;
+        this.restartCellPop(cell);
+        // Last cell revealed: the reveal is done being authoritative for this
+        // value — hand off to a normal render for the final caret state (from
+        // the real, current selectionStart), rather than pretending the caret
+        // animated along with the reveal.
+        if (index === value.length - 1) {
+          this.revealValue = null;
+          this.render();
+        }
+      }, index * OtpCodeInput.REVEAL_STEP_MS);
+      this.revealTimers.push(timer);
+    });
+  }
+
+  /** One-shot "digit landed" pop for a single cell — used only during a bulk-fill reveal. */
+  private restartCellPop (cell: HTMLElement) {
+    cell.classList.remove("bulk-pop");
+    void cell.offsetWidth; // restart the animation reliably even if triggered twice in a row
+    cell.classList.add("bulk-pop");
+    cell.addEventListener("animationend", () => cell.classList.remove("bulk-pop"), { once: true });
+  }
+
+  /** Cancels any in-flight bulk reveal and clears any leftover per-cell pop state. */
+  private cancelReveal () {
+    this.revealGeneration++;
+    this.revealTimers.forEach((timer) => window.clearTimeout(timer));
+    this.revealTimers = [];
+    this.revealValue = null;
+    this.cells.forEach((cell) => cell.classList.remove("bulk-pop"));
+  }
+
+  /** For genuine state changes (edits, mode switches) that must override an in-flight reveal, unlike a plain render(). */
+  private cancelRevealAndRender () {
+    this.cancelReveal();
+    this.render();
+  }
+
+  /**
+   * Six-slot overwrite semantics: typing a single digit while the caret targets
+   * an already-populated slot replaces that slot instead of inserting and
+   * shifting later digits right (which would silently discard the last digit in
+   * a fixed-length code). Handled at `beforeinput` so it works with normal
+   * browser/mobile text-input semantics rather than reimplementing key handling.
+   */
+  private handleBeforeInput (event: InputEvent) {
+    if (this.mode !== "totp") return;
+    if (event.inputType !== "insertText") return; // excludes paste/autofill/composition/replacement
+    const data = event.data;
+    if (!data || data.length !== 1 || !/^[0-9]$/.test(data)) return; // only a single digit
+    if (this.totpInput.selectionStart !== this.totpInput.selectionEnd) return; // collapsed caret only — a selection keeps native replace behavior
+
+    const start = this.totpInput.selectionStart ?? 0;
+    const value = this.totpInput.value;
+
+    // Boundary 6 on an already-full value is where the active-cell highlight
+    // parks (render() collapses it onto the last cell), so typing there targets
+    // that same last slot rather than falling through to append-then-clamp,
+    // which would silently no-op instead of overwriting anything.
+    const target = value.length === TOTP_LENGTH && start === TOTP_LENGTH ? TOTP_LENGTH - 1 : start;
+
+    if (target >= value.length) return; // genuinely at/after the end with room to grow — normal append; sanitizer clamps to 6 as before
+
+    // Occupied slot: overwrite in place instead of insert-and-shift.
+    event.preventDefault();
+    this.totpInput.value = value.slice(0, target) + data + value.slice(target + 1);
+    this.totpInput.setSelectionRange(target + 1, target + 1);
+    this.previousValue = this.totpInput.value;
+    this.cancelRevealAndRender();
+  }
+
+  /**
+   * Strips non-digits and clamps to 6 characters, preserving the caret/selection
+   * boundaries (mapped through how many characters were removed ahead of them)
+   * instead of letting a blind `value =` reassignment shove the caret to the end.
+   */
+  private sanitize () {
+    const raw = this.totpInput.value;
+    const rawStart = this.totpInput.selectionStart ?? raw.length;
+    const rawEnd = this.totpInput.selectionEnd ?? raw.length;
+
+    const adjust = (boundary: number) => Math.min(raw.slice(0, boundary).replace(/\D/g, "").length, TOTP_LENGTH);
+
+    const sanitized = raw.replace(/\D/g, "").slice(0, TOTP_LENGTH);
+    const start = adjust(rawStart);
+    const end = adjust(rawEnd);
+
+    if (sanitized !== raw) this.totpInput.value = sanitized;
+    this.totpInput.setSelectionRange(start, end);
+  }
+
+  /**
+   * Paints the cells for the current state. Deliberately does NOT cancel an
+   * in-flight bulk reveal on its own — render() is wired to harmless events
+   * (focus/blur/keyup/select/click) that can fire mid-reveal without
+   * representing a real state change (a duplicate Bitwarden `change` event in
+   * particular), and unconditionally repainting there would finish the reveal
+   * instantly regardless of whether any timer was actually cancelled. Callers
+   * that represent a genuine new state (an edit, a mode switch) must cancel
+   * explicitly via cancelRevealAndRender() instead.
+   */
+  private render () {
+    if (this.mode !== "totp") return;
+
+    const value = this.totpInput.value;
+
+    // A reveal already owns the display for this exact value — its own timers
+    // are progressively painting the cells; don't race them with a full,
+    // instant repaint. render() is called again with revealValue cleared once
+    // the reveal finishes (see startBulkReveal's last cell).
+    if (this.revealValue !== null && this.revealValue === value) return;
+
+    const focused = document.activeElement === this.totpInput;
+    const activeBoundary = this.totpInput.selectionStart ?? 0;
+    const activeCell = Math.min(activeBoundary, this.cells.length - 1);
+
+    this.cells.forEach((cell, index) => {
+      const char = value[index] ?? "";
+      cell.textContent = char;
+      const isActive = focused && index === activeCell;
+      cell.classList.toggle("active", isActive);
+      // CSS picks the caret shape from these: a centered pipe in an empty
+      // slot, an underscore beneath the glyph in an occupied one.
+      cell.classList.toggle("empty", isActive && char === "");
+      cell.classList.toggle("occupied", isActive && char !== "");
+    });
+  }
+
+  /**
+   * Maps a click's horizontal position to the containing (or nearest) cell
+   * *slot*, 0..5, rather than relying on the real input's text metrics to line
+   * up with the cells. The caret is authoritative for what's visibly active
+   * (a centered blinking bar inside that slot — see the CSS), so a click always
+   * targets a whole slot, clamped to the current value's length: clicking a
+   * cell past the entered digits parks the caret right after the last digit,
+   * not out in empty space with nothing to overwrite.
+   */
+  private handleClick (event: MouseEvent) {
+    if (this.mode !== "totp" || this.cells.length === 0) return;
+
+    const rects = this.cells.map((cell) => cell.getBoundingClientRect());
+    let index = rects.findIndex((rect) => event.clientX >= rect.left && event.clientX < rect.right);
+    if (index === -1) {
+      // Clicked a gap/padding pixel between cells: fall back to nearest center.
+      let nearestDistance = Infinity;
+      rects.forEach((rect, i) => {
+        const distance = Math.abs(event.clientX - (rect.left + (rect.width / 2)));
+        if (distance < nearestDistance) {
+          nearestDistance = distance;
+          index = i;
+        }
+      });
+    }
+
+    const caret = Math.min(index, this.totpInput.value.length);
+    this.totpInput.setSelectionRange(caret, caret);
+    this.render();
+  }
+
+  /** Attribute-only: enables/shows the active input, disables/hides the other. No value clearing — used by both init and switchMode. */
+  private applyMode (mode: Mode) {
+    this.mode = mode;
+    this.wrapper.dataset.mode = mode;
+
+    const active = mode === "totp" ? this.totpInput : this.backupInput;
+    const inactive = mode === "totp" ? this.backupInput : this.totpInput;
+    active.disabled = false;
+    inactive.disabled = true;
+
+    this.labelElement.htmlFor = active.id;
+
+    if (mode === "totp") {
+      // No maxlength: the browser would apply it to a raw paste before the
+      // sanitizer ever sees it (e.g. "123 456" -> truncated to "123 45" -> only
+      // "12345" survives sanitization). The sanitizer alone clamps to 6 digits.
+      this.totpInput.setAttribute("inputmode", "numeric");
+      this.totpInput.setAttribute("pattern", "[0-9]{6}");
+      this.labelElement.textContent = this.wrapper.dataset.labelTotp!;
+      this.toggle.textContent = this.wrapper.dataset.toggleToBackup!;
+    } else {
+      this.labelElement.textContent = this.wrapper.dataset.labelBackup!;
+      this.toggle.textContent = this.wrapper.dataset.toggleToTotp!;
+    }
+  }
+
+  private switchMode (mode: Mode) {
+    this.cancelReveal();
+    this.totpInput.value = "";
+    this.backupInput.value = "";
+    this.previousValue = "";
+    this.applyMode(mode);
+    this.render();
+    const active = mode === "totp" ? this.totpInput : this.backupInput;
+    active.focus();
+    active.setSelectionRange(0, 0);
+  }
+
+  /**
+   * Client-side gate for the dedicated backup-code field's `pattern`/`required`
+   * constraints. This project disables native browser constraint validation on
+   * all forms (SimpleForm's `browser_validations = false`, i.e. every form is
+   * rendered with `novalidate`), so those attributes are otherwise decorative —
+   * `checkValidity()` still works regardless, since `novalidate` only skips the
+   * browser's automatic pre-submit validation walk, not the API itself.
+   *
+   * Attached to the form during construction, before AuthOverlay attaches its
+   * own submit handler (see `bootstrapFormSubmission`), so this runs first and
+   * `stopImmediatePropagation()` here also blocks the AJAX submit path.
+   */
+  private handleSubmit (event: Event) {
+    if (this.mode !== "backup" || this.backupInput.checkValidity()) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.showError(this.backupInput.title || "Enter a valid backup code.");
+    this.backupInput.focus();
+  }
+
+  /** Puts a message in this component's own #auth-error, where observeAuthError()'s MutationObserver picks it up. */
+  private showError (message: string) {
+    if (this.errorElement) this.errorElement.textContent = message;
+  }
+
+  /**
+   * #auth-error gets populated two different ways — server-rendered on a
+   * full-page reload after a failed attempt, or injected later by
+   * AuthOverlay.showError() after a failed AJAX submission — so a
+   * MutationObserver is what lets one piece of code drive the shake/dismiss
+   * feedback for both without OtpCodeInput and AuthOverlay needing any direct
+   * reference to each other. Scoped to this.errorElement (this component's own
+   * form), not a document-wide lookup — see where it's resolved in the constructor.
+   */
+  private observeAuthError () {
+    const errorEl = this.errorElement;
+    if (!errorEl) return;
+
+    const trigger = () => {
+      if (errorEl.textContent?.trim()) this.triggerErrorFeedback(errorEl);
+    };
+
+    new MutationObserver(trigger).observe(errorEl, { childList: true, characterData: true, subtree: true });
+    trigger(); // catches a server-rendered error already present at construction time
+  }
+
+  /** Red border + horizontal shake for 2s, then the message itself clears after 5s. */
+  private triggerErrorFeedback (errorEl: HTMLElement) {
+    window.clearTimeout(this.errorDismissTimer);
+    window.clearTimeout(this.errorShakeTimer);
+
+    // Remove-then-reflow-then-reapply so the shake restarts cleanly even if a
+    // previous one is still mid-flight (e.g. two failed attempts in a row).
+    this.wrapper.classList.remove("otp-code-input-error");
+    void this.wrapper.offsetWidth;
+    this.wrapper.classList.add("otp-code-input-error");
+    this.errorShakeTimer = window.setTimeout(() => {
+      this.wrapper.classList.remove("otp-code-input-error");
+    }, 2000);
+
+    this.errorDismissTimer = window.setTimeout(() => {
+      errorEl.textContent = "";
+    }, 5000);
+  }
+}

--- a/app/javascript/src/js/components/OtpCodeInput.ts
+++ b/app/javascript/src/js/components/OtpCodeInput.ts
@@ -41,6 +41,7 @@ export default class OtpCodeInput {
     const labelElement = root.querySelector<HTMLLabelElement>(".otp-code-input-label");
     const field = root.querySelector<HTMLElement>(".otp-code-input-field");
     const totpInput = root.querySelector<HTMLInputElement>(".otp-code-input-real");
+    const cellsContainer = root.querySelector<HTMLElement>(".otp-code-input-cells");
     const cells = Array.from(root.querySelectorAll<HTMLElement>(".otp-code-input-cell"));
     const toggle = root.querySelector<HTMLButtonElement>(".otp-code-input-toggle");
     const { labelTotp, labelBackup, toggleToBackup, toggleToTotp } = root.dataset;
@@ -51,6 +52,7 @@ export default class OtpCodeInput {
       || !labelElement
       || !field
       || !totpInput
+      || !cellsContainer
       || !toggle
       || cells.length !== TOTP_LENGTH
       || !labelTotp
@@ -100,8 +102,12 @@ export default class OtpCodeInput {
     this.totpInput.addEventListener("blur", () => this.render());
     this.totpInput.addEventListener("keyup", () => this.render());
     this.totpInput.addEventListener("select", () => this.render());
-    this.totpInput.addEventListener("click", (event) => this.handleClick(event));
     this.toggle.addEventListener("click", () => this.switchMode(this.mode === "totp" ? "backup" : "totp"));
+
+    cellsContainer.addEventListener("click", (event) => {
+      this.totpInput.focus();
+      this.handleClick(event);
+    });
 
     this.cells.forEach((cell) => {
       cell.addEventListener("animationend", (event) => {

--- a/app/javascript/src/js/core/AuthOverlay.ts
+++ b/app/javascript/src/js/core/AuthOverlay.ts
@@ -1,4 +1,5 @@
 import ImmersiveInput from "@/components/ImmersiveInput";
+import OtpCodeInput from "@/components/OtpCodeInput";
 import E621Type from "@/interfaces/E621";
 import Page from "@/utility/Page";
 
@@ -68,6 +69,7 @@ export default class AuthOverlay {
         this.$overlay.html(""); // Clear loading state
         this.$overlay.append($form);
         this.bootstrapImmersiveInputs();
+        this.bootstrapOtpCodeInputs();
         this.bootstrapFormSubmission();
         return true;
       },
@@ -137,7 +139,10 @@ export default class AuthOverlay {
 
   private focusFirstInput () {
     setTimeout(() => {
-      this.$overlay.find("input[type=text], input[type=password], input[type=email]").first().focus();
+      // :enabled — a disabled-but-first-in-DOM-order field (e.g. the TOTP input
+      // when OtpCodeInput starts in backup mode) must not steal focus from the
+      // control that's actually usable.
+      this.$overlay.find("input[type=text]:enabled, input[type=password]:enabled, input[type=email]:enabled").first().focus();
     }, 100);
   }
 
@@ -178,8 +183,15 @@ export default class AuthOverlay {
   }
 
   private bootstrapImmersiveInputs () {
+    // The TOTP/backup-code field doesn't use .st-immersive-input at all (it manages
+    // its own focus styling via OtpCodeInput), so it's naturally excluded here.
     for (const input of this.$overlay.find(".st-immersive-input > input"))
       new ImmersiveInput($(input as HTMLInputElement));
+  }
+
+  private bootstrapOtpCodeInputs () {
+    for (const el of this.$overlay.find("[data-otp-code-input]"))
+      new OtpCodeInput($(el as HTMLElement));
   }
 
 
@@ -201,8 +213,10 @@ export default class AuthOverlay {
       const errorMessage = this.$overlay.find("#auth-error");
       if (errorMessage.text().length > 0) errorMessage.html("&nbsp;");
 
-      // Check for empty fields before submitting
-      const emptyFields = $form.find("input[required]").filter((_, input) => !$(input).val());
+      // Check for empty fields before submitting. :enabled — a disabled required
+      // field (e.g. the inactive TOTP/backup-code input) never participates in
+      // native constraint validation or submission, so it shouldn't here either.
+      const emptyFields = $form.find("input[required]:enabled").filter((_, input) => !$(input).val());
       if (emptyFields.length > 0) {
         this.showError("Please fill in all required fields.");
         submitButton.prop("disabled", false);

--- a/app/javascript/src/js/core/AuthOverlay.ts
+++ b/app/javascript/src/js/core/AuthOverlay.ts
@@ -1,4 +1,5 @@
 import ImmersiveInput from "@/components/ImmersiveInput";
+import OtpCodeInput from "@/components/OtpCodeInput";
 import CurrentUser from "@/models/CurrentUser";
 import Page from "@/utility/Page";
 
@@ -66,6 +67,7 @@ export default class AuthOverlay {
         this.$overlay.html(""); // Clear loading state
         this.$overlay.append($form);
         this.bootstrapImmersiveInputs();
+        this.bootstrapOtpCodeInputs();
         this.bootstrapFormSubmission();
         return true;
       },
@@ -135,7 +137,10 @@ export default class AuthOverlay {
 
   private focusFirstInput () {
     setTimeout(() => {
-      this.$overlay.find("input[type=text], input[type=password], input[type=email]").first().focus();
+      // :enabled — a disabled-but-first-in-DOM-order field (e.g. the TOTP input
+      // when OtpCodeInput starts in backup mode) must not steal focus from the
+      // control that's actually usable.
+      this.$overlay.find("input[type=text]:enabled, input[type=password]:enabled, input[type=email]:enabled").first().focus();
     }, 100);
   }
 
@@ -176,8 +181,15 @@ export default class AuthOverlay {
   }
 
   private bootstrapImmersiveInputs () {
+    // The TOTP/backup-code field doesn't use .st-immersive-input at all (it manages
+    // its own focus styling via OtpCodeInput), so it's naturally excluded here.
     for (const input of this.$overlay.find(".st-immersive-input > input"))
       new ImmersiveInput($(input as HTMLInputElement));
+  }
+
+  private bootstrapOtpCodeInputs () {
+    for (const el of this.$overlay.find("[data-otp-code-input]"))
+      new OtpCodeInput($(el as HTMLElement));
   }
 
 
@@ -199,8 +211,10 @@ export default class AuthOverlay {
       const errorMessage = this.$overlay.find("#auth-error");
       if (errorMessage.text().length > 0) errorMessage.html("&nbsp;");
 
-      // Check for empty fields before submitting
-      const emptyFields = $form.find("input[required]").filter((_, input) => !$(input).val());
+      // Check for empty fields before submitting. :enabled — a disabled required
+      // field (e.g. the inactive TOTP/backup-code input) never participates in
+      // native constraint validation or submission, so it shouldn't here either.
+      const emptyFields = $form.find("input[required]:enabled").filter((_, input) => !$(input).val());
       if (emptyFields.length > 0) {
         this.showError("Please fill in all required fields.");
         submitButton.prop("disabled", false);

--- a/app/javascript/src/js/pages/sessions/totp.ts
+++ b/app/javascript/src/js/pages/sessions/totp.ts
@@ -1,0 +1,9 @@
+import OtpCodeInput from "@/components/OtpCodeInput";
+import Page from "@/utility/Page";
+
+$(() => {
+  if (!Page.matches("sessions", "totp")) return;
+
+  for (const el of $("[data-otp-code-input]"))
+    new OtpCodeInput($(el as HTMLElement));
+});

--- a/app/javascript/src/styles/views/auths/_auths.scss
+++ b/app/javascript/src/styles/views/auths/_auths.scss
@@ -152,8 +152,8 @@
 
 
 @keyframes otp-caret-blink {
-  0%, 50% { opacity: 1; }
-  50.01%, 100% { opacity: 0; }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
 }
 
 @keyframes otp-shake {
@@ -163,9 +163,7 @@
   40%, 60% { transform: translateX(4px); }
 }
 
-// One-shot "digit landed" pop for a single cell during a bulk-fill (autofill/
-// paste) reveal — see startBulkReveal()/restartCellPop() in OtpCodeInput.
-// transform-only, so it never affects layout or neighboring cells.
+// One-shot pop when a digit changes.
 @keyframes otp-cell-pop {
   0% { transform: scale(1); }
   45% { transform: scale(1.25); }
@@ -219,10 +217,7 @@
     width: 100% !important;
   }
 
-  // Fallback-only focus glow. Scoped away from .is-enhanced: once enhanced, TOTP
-  // mode has its own per-cell active highlight and backup mode has its own field
-  // focus style (below) — an outer glow here would otherwise still fire around the
-  // whole six-cell row whenever the transparent TOTP overlay input is focused.
+  // No-JS field keeps the standard focus glow; enhanced modes handle focus themselves.
   &:not(.is-enhanced) .otp-code-input-box:focus-within {
     box-shadow: 0 0 0.25rem themed("color-link-active") inset;
   }
@@ -300,10 +295,7 @@
       border: 1px solid rgba(0, 0, 0, 0.2);
     }
 
-    // One-shot pop when a digit lands during a bulk-fill reveal. The box
-    // itself is never hidden/faded — only toggled briefly per cell as its
-    // digit arrives, see restartCellPop() in OtpCodeInput.
-    .otp-code-input-cell.bulk-pop {
+    .otp-code-input-cell.digit-pop {
       animation: otp-cell-pop 160ms ease-out;
 
       @media (prefers-reduced-motion: reduce) {
@@ -311,14 +303,7 @@
       }
     }
 
-    // Synthetic blinking text caret, authoritative for "where you are" — the
-    // real input's own caret stays suppressed (caret-color: transparent,
-    // below). Only shown while actually focused. Shape depends on whether the
-    // active slot is empty or already has a digit (render() toggles .empty/
-    // .occupied alongside .active): a centered vertical bar reads naturally in
-    // an empty slot, but sitting directly on top of a digit glyph in an
-    // occupied slot reads as a collision — a low underscore stays legible
-    // alongside the character there instead.
+    // Draw the visible caret in the presentation cells while the real input stays hidden.
     .otp-code-input-field:focus-within .otp-code-input-cell.active::after {
       content: "";
       position: absolute;
@@ -346,17 +331,11 @@
       transform: translateX(-50%);
     }
 
-    // The real input covers the cell row (for native focus/click/paste/autofill)
-    // but paints no visible text of its own — the cells are authoritative for
-    // what's displayed, so this never depends on text metrics lining up with them.
-    // Its own focus indication is the per-cell .active highlight, not an outer glow.
+    // Transparent overlay preserves native focus, selection, paste, and autofill.
     .otp-code-input-real {
       position: absolute;
       inset: 0;
-      // Cells are position:relative too (for the ::after caret below) and come
-      // later in DOM order, so without an explicit z-index they'd win the
-      // default same-stacking-order tiebreak and start intercepting clicks
-      // instead of letting them reach this input.
+      // Keep the overlay above the presentational cells so it receives pointer input.
       z-index: 1;
       height: 100% !important;
       color: transparent !important;
@@ -380,23 +359,18 @@
       box-sizing: border-box;
       background: white !important;
       color: black;
-      border: 1px solid rgba(0, 0, 0, 0.2);
+      border: 1px solid rgba(0, 0, 0, 0.2) !important;
       border-radius: 0.25rem;
       padding: 0 0.5rem;
 
       &:focus {
         outline: none;
-        border-color: transparent;
         box-shadow: 0 0 0.25rem themed("color-link-active") inset;
       }
     }
   }
 
-  // Applied briefly (2s, self-clearing) whenever #auth-error gets a message —
-  // a rejected code from the server, or a malformed backup code caught
-  // client-side before submission. Shakes whichever control is visible (both
-  // live inside .otp-code-input-field) and red-borders it, matching
-  // #auth-error's own text color.
+  // Briefly marks the active OTP control after an inline auth error.
   &.otp-code-input-error {
     .otp-code-input-field {
       animation: otp-shake 0.4s ease-in-out;
@@ -406,8 +380,8 @@
       }
     }
 
-    .otp-code-input-cell, .otp-code-input-backup {
-      border-color: palette("text-red") !important;
+    .otp-code-input-cell, &[data-mode="backup"] .otp-code-input-backup {
+      border: 2px solid palette("text-red") !important;
     }
   }
 }

--- a/app/javascript/src/styles/views/auths/_auths.scss
+++ b/app/javascript/src/styles/views/auths/_auths.scss
@@ -149,3 +149,265 @@
   align-items: center;
   margin-top: 10rem;
 }
+
+
+@keyframes otp-caret-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+@keyframes otp-shake {
+  10%, 90% { transform: translateX(-1px); }
+  20%, 80% { transform: translateX(2px); }
+  30%, 50%, 70% { transform: translateX(-4px); }
+  40%, 60% { transform: translateX(4px); }
+}
+
+// One-shot "digit landed" pop for a single cell during a bulk-fill (autofill/
+// paste) reveal — see startBulkReveal()/restartCellPop() in OtpCodeInput.
+// transform-only, so it never affects layout or neighboring cells.
+@keyframes otp-cell-pop {
+  0% { transform: scale(1); }
+  45% { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+
+// Six-cell TOTP / backup-code field (OtpCodeInput).
+// Cells and the mode toggle stay hidden until JS marks the field enhanced, so a
+// JS failure just leaves the plain dual-purpose field, styled by .otp-code-input-box
+// below (independent of .st-immersive-input — the label/field are siblings here,
+// not a label wrapping the field, since the enhanced version has two real inputs
+// and a label must not wrap more than one labelable control).
+.otp-code-input {
+  --otp-code-control-height: 3rem;
+  $spacing: 0.25rem;
+
+  // Baseline (no-JS) box: recreates .st-immersive-input's look without relying on
+  // being a <label> — the visible label and the field are plain siblings instead.
+  .otp-code-input-box {
+    display: flex;
+    flex-flow: column;
+    background: white;
+    border-radius: 0.25rem;
+    padding: 0.25rem;
+    box-sizing: border-box;
+  }
+
+  .otp-code-input-label {
+    margin: 0;
+    font-size: 0.85rem;
+    line-height: 0.85rem;
+    color: black;
+    font-weight: normal;
+    font-family: "Roboto", Verdana, Geneva, sans-serif;
+  }
+
+  .otp-code-input-field {
+    position: relative;
+    display: block;
+  }
+
+  .otp-code-input-real, .otp-code-input-backup {
+    // Baseline input reset, previously inherited from `.st-immersive-input input`.
+    border-radius: unset;
+    padding: 0;
+    line-height: 1rem;
+    font-size: 1rem !important;
+    height: 1rem;
+    background: transparent !important;
+    border: none !important;
+    width: 100% !important;
+  }
+
+  // Fallback-only focus glow. Scoped away from .is-enhanced: once enhanced, TOTP
+  // mode has its own per-cell active highlight and backup mode has its own field
+  // focus style (below) — an outer glow here would otherwise still fire around the
+  // whole six-cell row whenever the transparent TOTP overlay input is focused.
+  &:not(.is-enhanced) .otp-code-input-box:focus-within {
+    box-shadow: 0 0 0.25rem themed("color-link-active") inset;
+  }
+
+  .otp-code-input-cells {
+    display: none;
+  }
+
+  .otp-code-input-backup {
+    display: none;
+  }
+
+  .otp-code-input-toggle {
+    display: none;
+
+    // Button reset so it reads as a plain link, matching the unstyled
+    // `.hint-link` anchors used elsewhere in this flow.
+    margin-top: $spacing;
+    align-self: flex-start;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    color: themed("color-link");
+    &:hover { color: themed("color-link-hover"); }
+  }
+
+  &.is-enhanced {
+    .otp-code-input-toggle {
+      display: inline-block;
+    }
+
+    // Kill the plate: the dialog background shows through the gaps between cells
+    // and around the row instead.
+    .otp-code-input-box {
+      background: transparent;
+      padding: 0;
+    }
+
+    .otp-code-input-label {
+      color: themed("color-text");
+      font-weight: bold;
+      margin-block: $spacing;
+    }
+
+    .otp-code-input-field {
+      height: var(--otp-code-control-height);
+    }
+  }
+
+  &.is-enhanced[data-mode="totp"] {
+    .otp-code-input-cells {
+      display: flex;
+      gap: 0.35rem;
+      height: 100%;
+    }
+
+    .otp-code-input-cell {
+      position: relative;
+      flex: 1 1 0;
+      height: 100%;
+      box-sizing: border-box;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      background: white;
+      color: black;
+      font-family: monospace;
+      font-size: 1.25rem;
+      border-radius: 0.25rem;
+      // Without this, adjacent white cells on the (now transparent) box
+      // background are visually indistinguishable from one another.
+      border: 1px solid rgba(0, 0, 0, 0.2);
+    }
+
+    // One-shot pop when a digit lands during a bulk-fill reveal. The box
+    // itself is never hidden/faded — only toggled briefly per cell as its
+    // digit arrives, see restartCellPop() in OtpCodeInput.
+    .otp-code-input-cell.bulk-pop {
+      animation: otp-cell-pop 160ms ease-out;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+
+    // Synthetic blinking text caret, authoritative for "where you are" — the
+    // real input's own caret stays suppressed (caret-color: transparent,
+    // below). Only shown while actually focused. Shape depends on whether the
+    // active slot is empty or already has a digit (render() toggles .empty/
+    // .occupied alongside .active): a centered vertical bar reads naturally in
+    // an empty slot, but sitting directly on top of a digit glyph in an
+    // occupied slot reads as a collision — a low underscore stays legible
+    // alongside the character there instead.
+    .otp-code-input-field:focus-within .otp-code-input-cell.active::after {
+      content: "";
+      position: absolute;
+      background: black;
+      animation: otp-caret-blink 1s step-end infinite;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+
+    .otp-code-input-field:focus-within .otp-code-input-cell.active.empty::after {
+      left: 50%;
+      top: 50%;
+      width: 1px;
+      height: 60%;
+      transform: translate(-50%, -50%);
+    }
+
+    .otp-code-input-field:focus-within .otp-code-input-cell.active.occupied::after {
+      left: 50%;
+      bottom: 15%;
+      width: 55%;
+      height: 1px;
+      transform: translateX(-50%);
+    }
+
+    // The real input covers the cell row (for native focus/click/paste/autofill)
+    // but paints no visible text of its own — the cells are authoritative for
+    // what's displayed, so this never depends on text metrics lining up with them.
+    // Its own focus indication is the per-cell .active highlight, not an outer glow.
+    .otp-code-input-real {
+      position: absolute;
+      inset: 0;
+      // Cells are position:relative too (for the ::after caret below) and come
+      // later in DOM order, so without an explicit z-index they'd win the
+      // default same-stacking-order tiebreak and start intercepting clicks
+      // instead of letting them reach this input.
+      z-index: 1;
+      height: 100% !important;
+      color: transparent !important;
+      caret-color: transparent;
+    }
+  }
+
+  &.is-enhanced[data-mode="backup"] {
+    .otp-code-input-cells {
+      display: none;
+    }
+
+    .otp-code-input-real {
+      display: none;
+    }
+
+    .otp-code-input-backup {
+      display: block;
+      height: 100%;
+      width: 100% !important;
+      box-sizing: border-box;
+      background: white !important;
+      color: black;
+      border: 1px solid rgba(0, 0, 0, 0.2);
+      border-radius: 0.25rem;
+      padding: 0 0.5rem;
+
+      &:focus {
+        outline: none;
+        border-color: transparent;
+        box-shadow: 0 0 0.25rem themed("color-link-active") inset;
+      }
+    }
+  }
+
+  // Applied briefly (2s, self-clearing) whenever #auth-error gets a message —
+  // a rejected code from the server, or a malformed backup code caught
+  // client-side before submission. Shakes whichever control is visible (both
+  // live inside .otp-code-input-field) and red-borders it, matching
+  // #auth-error's own text color.
+  &.otp-code-input-error {
+    .otp-code-input-field {
+      animation: otp-shake 0.4s ease-in-out;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+      }
+    }
+
+    .otp-code-input-cell, .otp-code-input-backup {
+      border-color: palette("text-red") !important;
+    }
+  }
+}

--- a/app/javascript/src/styles/views/auths/_auths.scss
+++ b/app/javascript/src/styles/views/auths/_auths.scss
@@ -179,6 +179,7 @@
 .otp-code-input {
   --otp-code-control-height: 3rem;
   $spacing: 0.25rem;
+  $cell-gap: 0.35rem;
 
   // Baseline (no-JS) box: recreates .st-immersive-input's look without relying on
   // being a <label> — the visible label and the field are plain siblings instead.
@@ -271,9 +272,14 @@
 
   &.is-enhanced[data-mode="totp"] {
     .otp-code-input-cells {
+      position: relative;
+      z-index: 1;
+
       display: flex;
-      gap: 0.35rem;
+      gap: $cell-gap;
       height: 100%;
+      cursor: text;
+      user-select: none;
     }
 
     .otp-code-input-cell {
@@ -331,13 +337,20 @@
       transform: translateX(-50%);
     }
 
-    // Transparent overlay preserves native focus, selection, paste, and autofill.
+    // Keep the password-manager anchor's right edge positioned like a seventh
+    // OTP cell, but give it a normal field-sized rectangle so extension popups
+    // can align against it cleanly.
     .otp-code-input-real {
+      --otp-code-cell-width: calc((100% - #{5 * $cell-gap}) / 6);
+
       position: absolute;
-      inset: 0;
-      // Keep the overlay above the presentational cells so it receives pointer input.
-      z-index: 1;
+      top: 0;
+      right: calc(0px - var(--otp-code-cell-width) - #{$cell-gap});
+      z-index: 0;
+
+      width: 100% !important;
       height: 100% !important;
+
       color: transparent !important;
       caret-color: transparent;
     }

--- a/app/views/auths/_totp.html.erb
+++ b/app/views/auths/_totp.html.erb
@@ -16,7 +16,7 @@
               plain dual-purpose field (TOTP or backup code) when JS is unavailable.
               OtpCodeInput applies those restrictions itself once it has enhanced
               the field. %>
-          <%= form.input_field :code, required: true, autocomplete: "one-time-code", autofocus: true, class: "otp-code-input-real" %>
+          <%= form.input_field :code, required: true, autocomplete: "one-time-code", autofocus: true, class: "otp-code-input-real", aria: { describedby: "auth-error" } %>
           <div class="otp-code-input-cells" aria-hidden="true">
             <% 6.times do %><span class="otp-code-input-cell"></span><% end %>
           </div>
@@ -27,6 +27,6 @@
 
     <%= form.submit("Continue", class: "st-button submit") %>
 
-    <div class="auth-spacer" id="auth-error"><%= @totp_error %></div>
+    <div class="auth-spacer" id="auth-error" role="alert" aria-atomic="true"><%= @totp_error %></div>
   <% end %>
 </div>

--- a/app/views/auths/_totp.html.erb
+++ b/app/views/auths/_totp.html.erb
@@ -3,16 +3,30 @@
     <h1>Two-factor authentication</h1>
     <p>Enter the code from your authenticator app, or one of your backup codes.</p>
 
-    <div class="auth-input">
-      <%= form.label :code, class: "st-immersive-input" do %>
-        <span class="label-text">Code</span>
-        <%# No inputmode: backup codes are alphanumeric, and a numeric keyboard would block them on mobile. %>
-        <%= form.input_field :code, required: true, autocomplete: "one-time-code", autofocus: true %>
-      <% end %>
+    <div class="auth-input otp-code-input"
+         data-otp-code-input
+         data-label-totp="Authentication code"
+         data-label-backup="Backup code"
+         data-toggle-to-backup="Use a backup code"
+         data-toggle-to-totp="Use an authentication code">
+      <div class="otp-code-input-box">
+        <%= form.label :code, "Code", class: "otp-code-input-label" %>
+        <div class="otp-code-input-field">
+          <%# No inputmode/pattern here, and never a maxlength: this must stay the
+              plain dual-purpose field (TOTP or backup code) when JS is unavailable.
+              OtpCodeInput applies those restrictions itself once it has enhanced
+              the field. %>
+          <%= form.input_field :code, required: true, autocomplete: "one-time-code", autofocus: true, class: "otp-code-input-real" %>
+          <div class="otp-code-input-cells" aria-hidden="true">
+            <% 6.times do %><span class="otp-code-input-cell"></span><% end %>
+          </div>
+        </div>
+      </div>
+      <button type="button" class="otp-code-input-toggle hint-link">Use a backup code</button>
     </div>
 
     <%= form.submit("Continue", class: "st-button submit") %>
 
-    <div class="auth-spacer" id="auth-error"></div>
+    <div class="auth-spacer" id="auth-error"><%= @totp_error %></div>
   <% end %>
 </div>

--- a/spec/requests/sessions_totp_spec.rb
+++ b/spec/requests/sessions_totp_spec.rb
@@ -63,6 +63,23 @@ RSpec.describe "TOTP login challenge" do
       get totp_session_path
       expect(response).to redirect_to(new_session_path)
     end
+
+    it "server-renders a single plain totp[code] field, with no JS-only restrictions baked in" do
+      login!
+      get totp_session_path
+
+      # Progressive-enhancement contract: OtpCodeInput applies inputmode/pattern itself
+      # once it enhances the field (maxlength is never applied at all, even by JS - see
+      # OtpCodeInput). If inputmode/pattern/maxlength ever end up server-rendered, a JS
+      # failure would block backup-code entry. autocomplete stays server-rendered since
+      # it's safe/correct in the no-JS baseline and is the password-manager/browser OTP
+      # autofill contract.
+      assert_select "input[name='totp[code]'][type='text']", 1
+      assert_select "input[name='totp[code]'][autocomplete='one-time-code']", 1
+      assert_select "input[name='totp[code]'][maxlength]", false
+      assert_select "input[name='totp[code]'][pattern]", false
+      assert_select "input[name='totp[code]'][inputmode]", false
+    end
   end
 
   describe "POST /session/verify_totp" do
@@ -85,9 +102,17 @@ RSpec.describe "TOTP login challenge" do
     it "rejects a wrong code and keeps the challenge alive" do
       login!
       post verify_totp_session_path, params: { totp: { code: "000000" } }
-      expect(response).to have_http_status(:ok)
+      expect(response).to redirect_to(totp_session_path)
       expect(session[:user_id]).to be_nil
       expect(session[:totp_user_id]).to eq(user.id)
+
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Verification code was incorrect.")
+
+      # The session-transported error must not replay on a later plain refresh.
+      get totp_session_path
+      expect(response.body).not_to include("Verification code was incorrect.")
     end
 
     it "rejects a replayed code" do

--- a/spec/requests/sessions_totp_spec.rb
+++ b/spec/requests/sessions_totp_spec.rb
@@ -108,10 +108,22 @@ RSpec.describe "TOTP login challenge" do
 
       follow_redirect!
       expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Verification code was incorrect.")
+      assert_select "#auth-error", text: "Verification code was incorrect.", count: 1
+      expect(response.body.scan("Verification code was incorrect.").length).to eq(1)
 
-      # The session-transported error must not replay on a later plain refresh.
       get totp_session_path
+      expect(response.body).not_to include("Verification code was incorrect.")
+    end
+
+    it "does not carry an old error into a new challenge" do
+      login!
+      post verify_totp_session_path, params: { totp: { code: "000000" } }
+
+      delete session_path
+      login!
+      get totp_session_path
+
+      expect(response).to have_http_status(:ok)
       expect(response.body).not_to include("Verification code was incorrect.")
     end
 


### PR DESCRIPTION
Improves the 2FA login field with a dedicated six-digit TOTP UI and separate backup-code mode.

- Better password-manager/autofill support
- Numeric TOTP input without restricting backup codes
- Improved paste, overwrite and error handling
- Keeps the existing plain dual-purpose field as the no-JS fallback

Tested in both the login overlay and full-page TOTP flow.

The TOTP request spec has 3 existing API-auth failures; the same failures reproduce on `master`.

**Recordings:**

<details>
<summary>Authentication code</summary>
<img width="500" height="500" alt="2026-08-22 19-58-16" src="https://github.com/user-attachments/assets/a5e998c5-6e70-460e-b93f-3df556702a10" />
</details>

<details>
<summary>Backup code</summary>
<img width="500" height="500" alt="2026-08-22 19-59-46" src="https://github.com/user-attachments/assets/f7de90c9-6667-4042-adb3-40f6f491686c" />
</details>