### PR TITLE
[Misc] Hide links that use `post_tags_match` from anonymous users

### DIFF
--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -57,7 +57,9 @@
             <td>
               <%= compact_time post_flag.post.created_at %>
               <br> by <%= link_to_user post_flag.post.uploader %>
-              <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} user:#{post_flag.post.uploader.name}".strip)) %>
+              <% if CurrentUser.is_member? %>
+                <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} user:#{post_flag.post.uploader.name}".strip)) %>
+              <% end %>
             </td>
             <td>
               <%= compact_time post_flag.created_at %>
@@ -72,10 +74,14 @@
             <td>
               <% if post_flag.post.approver %>
                 <%= link_to_user post_flag.post.approver %>
-                <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} approver:#{post_flag.post.approver.name}".strip)) %>
+                <% if CurrentUser.is_member? %>
+                  <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} approver:#{post_flag.post.approver.name}".strip)) %>
+                <% end %>
               <% else %>
                 <em>none</em>
-                <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} approver:none".strip)) %>
+                <% if CurrentUser.is_member? %>
+                  <%= link_to "»", post_flags_path(search: @search_params.merge(post_tags_match: "#{@search_params[:post_tags_match]} approver:none".strip)) %>
+                <% end %>
               <% end %>
             </td>
           </tr>

--- a/app/views/users/partials/show/_post_summary.html.erb
+++ b/app/views/users/partials/show/_post_summary.html.erb
@@ -11,8 +11,10 @@
 
       <div class="profile-sample-links">
         <%= link_to(sanitize("<b>#{artist.tag&.post_count || 0}</b> total"), posts_path(tags: artist.name)) %>
-        <span class="spacer"></span>
-        <%= link_to("Comments", comments_path(group_by: "comment", search: { post_tags_match: artist.name }), class: "profile-comments-link") %>
+        <% if CurrentUser.is_member? %>
+          <span class="spacer"></span>
+          <%= link_to("Comments", comments_path(group_by: "comment", search: { post_tags_match: artist.name }), class: "profile-comments-link") %>
+        <% end %>
       </div>
 
       <div class="profile-sample-posts">


### PR DESCRIPTION
- `Comments` on the `Artwork` section of a user profile (when linked)
- Search links on the flags page

Those fail with `found unpermitted parameter: :post_tags_match` and redirect to the login page, which is confusing to users, and they're far from essential, so just hide them. Reported by a user: https://discord.com/channels/1352777803036364892/1421568898951807068/1540644444376666194