### PR TITLE
[Users] Remove the display-only upload karma clamp

### DIFF
--- a/app/components/karma_badge.html.erb
+++ b/app/components/karma_badge.html.erb
@@ -14,6 +14,6 @@
     </div>
   </div>
   <div class="karma-badge-progress">
-    <%= karma_value %>
+    <%= user.upload_karma %>
   </div>
 </a>

--- a/app/components/karma_badge.rb
+++ b/app/components/karma_badge.rb
@@ -8,7 +8,7 @@ class KarmaBadge < ViewComponent::Base
 
   def render?
     return false if user.blank?
-    return false if user.upload_karma <= 0 && !should_show_raw_karma?
+    return false if user.upload_karma <= 0 && !force_visible?
     true
   end
 
@@ -21,17 +21,13 @@ class KarmaBadge < ViewComponent::Base
     user.upload_karma_level
   end
 
-  def karma_value
-    should_show_raw_karma? ? user.raw_upload_karma : user.upload_karma
-  end
-
   def badge_title
     if user.upload_karma_level >= User.max_karma_level
       return "Upload Karma: #{user.upload_karma} (Level S)"
     end
 
     next_level = user.upload_karma_level + 1
-    "Upload Karma: #{karma_value} / #{User.required_karma_for_level(next_level)} (Level #{karma_level})"
+    "Upload Karma: #{user.upload_karma} / #{User.required_karma_for_level(next_level)} (Level #{karma_level})"
   end
 
   def progress_degree
@@ -43,7 +39,8 @@ class KarmaBadge < ViewComponent::Base
     "background: conic-gradient(var(--color-button-active) #{progress_degree}deg, var(--color-section) 0deg);"
   end
 
-  def should_show_raw_karma?
+  # Staff and the user themselves see the badge even at zero or negative karma.
+  def force_visible?
     CurrentUser.user.is_staff? || CurrentUser.user.id == user.id
   end
 end

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -47,7 +47,7 @@ module Staff
 
       if params[:user][:upload_karma].present?
         new_karma = params[:user][:upload_karma].to_i
-        old_karma = @user.raw_upload_karma
+        old_karma = @user.upload_karma
         if new_karma != old_karma
           @user.user_status.update!(upload_karma: new_karma)
           ModAction.log(:user_karma_change, { user_id: @user.id, old_karma: old_karma, new_karma: new_karma })

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -843,15 +843,9 @@ class User < ApplicationRecord
   end
 
   module KarmaMethods
-    # Raw stored karma, may be negative.
-    def raw_upload_karma
-      user_status&.upload_karma || 0
-    end
-
-    # Display/API value: karma is never shown below 0 ([raw, 0].max). The clamp is
-    # presentation-only; no write ever floors the stored value.
+    # Stored karma, may be negative.
     def upload_karma
-      [raw_upload_karma, 0].max
+      user_status&.upload_karma || 0
     end
 
     def upload_karma=(value)
@@ -872,7 +866,7 @@ class User < ApplicationRecord
       # Ensure we don't divide by zero
       return 100 if next_level_karma == current_level_karma
 
-      ((upload_karma - current_level_karma) / (next_level_karma - current_level_karma).to_f * 100).round
+      ((upload_karma - current_level_karma) / (next_level_karma - current_level_karma).to_f * 100).round.clamp(0, 100)
     end
 
     # Once the upload karma level reaches the free threshold, uploads bypass the review queue.

--- a/app/views/staff/users/edit.html.erb
+++ b/app/views/staff/users/edit.html.erb
@@ -25,8 +25,8 @@
 
       <div class="input">
         <label for="user_upload_karma">Upload Karma</label>
-        <%= number_field_tag "user[upload_karma]", @user.raw_upload_karma %>
-        <span class="hint">Raw stored karma; may be negative. Adjustments are logged.</span>
+        <%= number_field_tag "user[upload_karma]", @user.upload_karma %>
+        <span class="hint">Stored karma; may be negative. Adjustments are logged.</span>
       </div>
 
       <% if CurrentUser.is_bd_staff? || !@user.is_bd_staff? %>

--- a/spec/components/karma_badge/badge_methods_spec.rb
+++ b/spec/components/karma_badge/badge_methods_spec.rb
@@ -35,36 +35,6 @@ RSpec.describe KarmaBadge do
     end
   end
 
-  describe "#karma_value" do
-    describe "with positive karma" do
-      it "returns the upload karma" do
-        set_karma(user, Danbooru.config.upload_karma_l1_threshold)
-        expect(component.send(:karma_value)).to eq(user.upload_karma)
-      end
-    end
-
-    describe "with negative karma" do
-      before do
-        set_karma(user, -100)
-      end
-
-      it "returns the upload karma for staff" do
-        allow(CurrentUser).to receive(:user).and_return(create(:admin_user))
-        expect(component.send(:karma_value)).to eq(user.raw_upload_karma)
-      end
-
-      it "returns the upload karma for the user themselves" do
-        allow(CurrentUser).to receive(:user).and_return(user)
-        expect(component.send(:karma_value)).to eq(user.raw_upload_karma)
-      end
-
-      it "returns 0 for other users" do
-        allow(CurrentUser).to receive(:user).and_return(create(:user))
-        expect(component.send(:karma_value)).to eq(0)
-      end
-    end
-  end
-
   describe "#badge_title" do
     it "shows progress toward the next level below the maximum" do
       set_karma(user, Danbooru.config.upload_karma_l1_threshold)
@@ -75,6 +45,12 @@ RSpec.describe KarmaBadge do
     it "shows the S level at the maximum" do
       set_karma(user, Danbooru.config.upload_karma_l10_threshold)
       expect(component.send(:badge_title)).to eq("Upload Karma: #{user.upload_karma} (Level S)")
+    end
+
+    it "shows negative karma" do
+      set_karma(user, -7)
+      required_for_next = User.required_karma_for_level(1)
+      expect(component.send(:badge_title)).to eq("Upload Karma: -7 / #{required_for_next} (Level 0)")
     end
   end
 
@@ -94,6 +70,11 @@ RSpec.describe KarmaBadge do
       set_karma(user, Danbooru.config.upload_karma_l10_threshold)
       expect(component.send(:progress_degree)).to eq(0)
     end
+
+    it "returns 0 for negative karma" do
+      set_karma(user, -7)
+      expect(component.send(:progress_degree)).to eq(0)
+    end
   end
 
   describe "#progress_degree_style" do
@@ -105,20 +86,20 @@ RSpec.describe KarmaBadge do
     end
   end
 
-  describe "#should_show_raw_karma?" do
+  describe "#force_visible?" do
     it "returns true for staff users" do
       allow(CurrentUser).to receive(:user).and_return(create(:admin_user))
-      expect(component.send(:should_show_raw_karma?)).to be_truthy
+      expect(component.send(:force_visible?)).to be_truthy
     end
 
     it "returns true for the user themselves" do
       allow(CurrentUser).to receive(:user).and_return(user)
-      expect(component.send(:should_show_raw_karma?)).to be_truthy
+      expect(component.send(:force_visible?)).to be_truthy
     end
 
     it "returns false for other users" do
       allow(CurrentUser).to receive(:user).and_return(create(:user))
-      expect(component.send(:should_show_raw_karma?)).to be_falsey
+      expect(component.send(:force_visible?)).to be_falsey
     end
   end
 end

--- a/spec/components/karma_badge/render_spec.rb
+++ b/spec/components/karma_badge/render_spec.rb
@@ -34,5 +34,17 @@ RSpec.describe KarmaBadge do
       set_karma(user, 1)
       expect(component.render?).to be true
     end
+
+    it "returns true for the user themselves with negative karma" do
+      allow(CurrentUser).to receive(:user).and_return(user)
+      set_karma(user, -7)
+      expect(component.render?).to be true
+    end
+
+    it "returns true for staff with negative karma" do
+      allow(CurrentUser).to receive(:user).and_return(create(:admin_user))
+      set_karma(user, -7)
+      expect(component.render?).to be true
+    end
   end
 end

--- a/spec/models/user/karma_methods_spec.rb
+++ b/spec/models/user/karma_methods_spec.rb
@@ -31,31 +31,21 @@ RSpec.describe User do
   end
 
   # -------------------------------------------------------------------------
-  # #raw_upload_karma
-  # -------------------------------------------------------------------------
-  describe "#raw_upload_karma" do
-    it "defaults to 0 for a new user" do
-      expect(user.raw_upload_karma).to eq(0)
-    end
-
-    it "returns the raw stored value, including negatives" do
-      set_karma(user, -7)
-      expect(user.raw_upload_karma).to eq(-7)
-    end
-  end
-
-  # -------------------------------------------------------------------------
   # #upload_karma
   # -------------------------------------------------------------------------
   describe "#upload_karma" do
-    it "returns the raw value when positive" do
+    it "defaults to 0 for a new user" do
+      expect(user.upload_karma).to eq(0)
+    end
+
+    it "returns the stored value" do
       set_karma(user, 42)
       expect(user.upload_karma).to eq(42)
     end
 
-    it "clamps negative karma to 0 for display" do
+    it "returns the stored value, including negatives" do
       set_karma(user, -7)
-      expect(user.upload_karma).to eq(0)
+      expect(user.upload_karma).to eq(-7)
     end
   end
 


### PR DESCRIPTION
Initially, the upload karma was meant to always be positive – but then edge cases got in the way.
As such, it ended up only being _displayed_ as a positive number.

In hindsight, this is silly. There is no real reason to hide this information.