### PR TITLE
[Users] Implement the karma ledger

### DIFF
--- a/app/blueprints/upload_karma_event_blueprint.rb
+++ b/app/blueprints/upload_karma_event_blueprint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UploadKarmaEventBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :user_id, :creator_id, :post_id, :reason, :delta, :balance, :extra_data, :created_at
+end

--- a/app/controllers/staff/users_controller.rb
+++ b/app/controllers/staff/users_controller.rb
@@ -50,7 +50,7 @@ module Staff
         old_karma = @user.upload_karma
         if new_karma != old_karma
           karma_delta = new_karma - old_karma
-          UserStatus.adjust_karma(@user.id, karma_delta)
+          UserStatus.adjust_karma(@user.id, karma_delta, :staff_override, data: { old_karma: old_karma, new_karma: new_karma })
           ModAction.log(:user_karma_change, { user_id: @user.id, old_karma: old_karma, new_karma: new_karma })
         end
       end

--- a/app/controllers/upload_karma_events_controller.rb
+++ b/app/controllers/upload_karma_events_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class UploadKarmaEventsController < ApplicationController
+  respond_to :html, :json
+
+  def index
+    @events = UploadKarmaEvent.search(search_params).paginate(params[:page], limit: params[:limit])
+    respond_with(@events) do |format|
+      format.html { @events = @events.includes(:user, :creator) }
+      format.json { render json: UploadKarmaEventBlueprint.render(@events) }
+    end
+  end
+end

--- a/app/logical/site_map.rb
+++ b/app/logical/site_map.rb
@@ -159,6 +159,7 @@ module SiteMap
   page :post_events, :post_approvals, "Approvals"
   page :post_events, :post_flags, "Flags"
   page :post_events, :post_replacements, "Replacements"
+  page :post_events, :upload_karma_events, "Upload Karma"
   page :post_events, :staff_post_disapprovals, "Disapprovals",
        gate: { inline: "approver flag, not a level boundary" }, visible: ->(u) { u.can_approve_posts? }
 

--- a/app/logical/upload_service.rb
+++ b/app/logical/upload_service.rb
@@ -42,7 +42,7 @@ class UploadService
 
     # Posts that bypass the review queue never pass through approve!, so karma is credited here instead.
     # Mirrors the credit awarded by approve! for queued posts.
-    UserStatus.adjust_karma(@post.uploader_id, UserStatus::KARMA_APPROVED_CREDIT) unless @post.is_pending?
+    UserStatus.adjust_karma(@post.uploader_id, UserStatus::KARMA_APPROVED_CREDIT, :queue_bypass, post_id: @post.id) unless @post.is_pending?
 
     upload.update(status: "completed", post_id: @post.id)
 

--- a/app/logical/upload_service/replacer.rb
+++ b/app/logical/upload_service/replacer.rb
@@ -83,14 +83,15 @@ class UploadService
         if penalize_current_uploader.to_s.truthy?
           UserStatus.for_user(previous_uploader).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count + 1")
           # Karma penalty for the previous uploader, in step with the penalize counter.
-          UserStatus.adjust_karma(previous_uploader, -UserStatus::KARMA_REPLACEMENT_PENALTY)
+          UserStatus.adjust_karma(previous_uploader, -UserStatus::KARMA_REPLACEMENT_PENALTY, :replacement_penalty, post_id: post.id, data: { replacement_id: replacement.id })
         end
 
         # The live post's approved credit follows ownership: previous owner loses it, new one gets it.
         # Skipped when the post is still pending.
         if replacement.creator_id != previous_uploader && !previous_pending
-          UserStatus.adjust_karma(previous_uploader, -UserStatus::KARMA_APPROVED_CREDIT)
-          UserStatus.adjust_karma(replacement.creator_id, UserStatus::KARMA_APPROVED_CREDIT)
+          transfer_data = { replacement_id: replacement.id, from: previous_uploader, to: replacement.creator_id }
+          UserStatus.adjust_karma(previous_uploader, -UserStatus::KARMA_APPROVED_CREDIT, :replacement_transfer, post_id: post.id, data: transfer_data)
+          UserStatus.adjust_karma(replacement.creator_id, UserStatus::KARMA_APPROVED_CREDIT, :replacement_transfer, post_id: post.id, data: transfer_data)
         end
 
         # Reset-to must revert any penalty that the previous version carried.

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -433,7 +433,7 @@ class Post < ApplicationRecord
       update(approver: nil, is_pending: true)
 
       # Roll back previous karma changes for the uploader
-      UserStatus.adjust_karma(uploader_id, -UserStatus::KARMA_APPROVED_CREDIT)
+      UserStatus.adjust_karma(uploader_id, -UserStatus::KARMA_APPROVED_CREDIT, :unapproved, post_id: id)
     end
 
     def is_unapprovable?(user)
@@ -461,7 +461,7 @@ class Post < ApplicationRecord
       end
 
       # Reward the uploader for a post that cleared the review queue.
-      UserStatus.adjust_karma(uploader_id, UserStatus::KARMA_APPROVED_CREDIT)
+      UserStatus.adjust_karma(uploader_id, UserStatus::KARMA_APPROVED_CREDIT, :approved, post_id: id)
     end
   end
 
@@ -1324,8 +1324,9 @@ class Post < ApplicationRecord
             0
           end
         if delta != 0 && !from_takedown
-          UserStatus.adjust_karma(old_owner_id, -delta)
-          UserStatus.adjust_karma(new_owner_id, delta)
+          transfer_data = { old_owner: old_owner_id, new_owner: new_owner_id }
+          UserStatus.adjust_karma(old_owner_id, -delta, :owner_change, post_id: id, data: transfer_data)
+          UserStatus.adjust_karma(new_owner_id, delta, :owner_change, post_id: id, data: transfer_data)
         end
       end
 
@@ -1720,7 +1721,7 @@ class Post < ApplicationRecord
       # Takedowns pass skip_karma: removal reflects the artist's wishes, not the uploader's conduct.
       unless options[:skip_karma]
         penalty = UserStatus::KARMA_DELETION_PENALTY + (was_credited ? UserStatus::KARMA_APPROVED_CREDIT : 0)
-        UserStatus.adjust_karma(uploader_id, -penalty)
+        UserStatus.adjust_karma(uploader_id, -penalty, :deleted, post_id: id, data: { credit_reversed: was_credited })
       end
       give_favorites_to_parent if options[:move_favorites]
       give_post_sets_to_parent if options[:move_favorites]
@@ -1766,7 +1767,7 @@ class Post < ApplicationRecord
       # credit lands the post back at the credit in every case. skip_karma restores from a
       # takedown, which never applied the penalty to begin with.
       unless options[:skip_karma]
-        UserStatus.adjust_karma(uploader_id, UserStatus::KARMA_DELETION_PENALTY + UserStatus::KARMA_APPROVED_CREDIT)
+        UserStatus.adjust_karma(uploader_id, UserStatus::KARMA_DELETION_PENALTY + UserStatus::KARMA_APPROVED_CREDIT, :undeleted, post_id: id)
       end
     end
 

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -252,11 +252,11 @@ class PostReplacement < ApplicationRecord
       if penalize_uploader_on_approve
         UserStatus.for_user(uploader_on_approve).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count - 1")
         # Reverse the karma penalty when the penalty is toggled off.
-        UserStatus.adjust_karma(uploader_on_approve, UserStatus::KARMA_REPLACEMENT_PENALTY)
+        UserStatus.adjust_karma(uploader_id_on_approve, UserStatus::KARMA_REPLACEMENT_PENALTY, :replacement_penalty_reversed, post_id: post_id, data: { replacement_id: id })
       else
         UserStatus.for_user(uploader_on_approve).update_all("own_post_replaced_penalize_count = own_post_replaced_penalize_count + 1")
         # Apply the karma penalty when the penalty is toggled on.
-        UserStatus.adjust_karma(uploader_on_approve, -UserStatus::KARMA_REPLACEMENT_PENALTY)
+        UserStatus.adjust_karma(uploader_id_on_approve, -UserStatus::KARMA_REPLACEMENT_PENALTY, :replacement_penalty, post_id: post_id, data: { replacement_id: id })
       end
       update_attribute(:penalize_uploader_on_approve, !penalize_uploader_on_approve)
     end

--- a/app/models/upload_karma_event.rb
+++ b/app/models/upload_karma_event.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class UploadKarmaEvent < ApplicationRecord
+  belongs_to :user
+  belongs_to :creator, class_name: "User"
+
+  enum :reason, {
+    approved: 0,
+    unapproved: 1,
+    deleted: 2,
+    undeleted: 3,
+    replacement_penalty: 4,
+    replacement_penalty_reversed: 5,
+    replacement_transfer: 6,
+    owner_change: 7,
+    staff_override: 8,
+    queue_bypass: 9,
+  }
+
+  # Ledger rows are immutable: created once, never updated or destroyed.
+  def readonly?
+    persisted?
+  end
+
+  def self.search(params)
+    q = super
+    q = q.where_user(:user_id, :user, params)
+    q = q.where_user(:creator_id, :creator, params)
+    q = q.where(post_id: params[:post_id]) if params[:post_id].present?
+    q = q.where(reason: reasons[params[:reason]]) if params[:reason].present?
+    q.apply_basic_order(params)
+  end
+
+  def description
+    base = case reason
+           when "approved" then "Post approved"
+           when "unapproved" then "Post unapproved"
+           when "deleted" then extra_data["credit_reversed"] ? "Post deleted (approval credit reversed)" : "Post deleted"
+           when "undeleted" then "Post restored"
+           when "replacement_penalty" then "Post replaced with penalty"
+           when "replacement_penalty_reversed" then "Replacement penalty lifted"
+           when "replacement_transfer" then delta > 0 ? "Approval credit received with replacement" : "Approval credit lost to replacement"
+           when "owner_change" then user_id == extra_data["new_owner"] ? "Received post ownership" : "Lost post ownership"
+           when "staff_override" then "Karma manually set to #{extra_data['new_karma']}"
+           when "queue_bypass" then "Post published without review"
+           end
+    extra_data["backfill"] ? "#{base} (recalculated)" : base
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -850,10 +850,11 @@ class User < ApplicationRecord
 
     def upload_karma=(value)
       value = value.to_i
-      delta = value - upload_karma
+      old = upload_karma
+      delta = value - old
       return if delta == 0
 
-      UserStatus.adjust_karma(id, delta)
+      UserStatus.adjust_karma(id, delta, :staff_override, data: { old_karma: old, new_karma: value })
       user_status&.reload
     end
 

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -15,7 +15,26 @@ class UserStatus < ApplicationRecord
     where("user_statuses.user_id = ?", user_id)
   end
 
-  def self.adjust_karma(user_id, delta)
-    for_user(user_id).update_all(["upload_karma = upload_karma + ?", delta])
+  # Applies the karma delta and records it in the upload_karma_events ledger,
+  # atomically. RETURNING captures the post-change balance race-free.
+  def self.adjust_karma(user_id, delta, reason, post_id: nil, data: {})
+    return if delta == 0
+    transaction do
+      result = connection.exec_query(
+        sanitize_sql(["UPDATE user_statuses SET upload_karma = upload_karma + ? WHERE user_id = ? RETURNING upload_karma", delta, user_id]),
+      )
+      # No user_statuses row — the same silent no-op update_all used to be.
+      next if result.rows.empty?
+
+      UploadKarmaEvent.create!(
+        user_id: user_id,
+        creator_id: CurrentUser.id,
+        post_id: post_id,
+        reason: reason,
+        delta: delta,
+        balance: result.rows[0][0],
+        extra_data: data,
+      )
+    end
   end
 end

--- a/app/views/staff/users/edit.html.erb
+++ b/app/views/staff/users/edit.html.erb
@@ -26,7 +26,8 @@
       <div class="input">
         <label for="user_upload_karma">Upload Karma</label>
         <%= number_field_tag "user[upload_karma]", @user.upload_karma %>
-        <span class="hint">Stored karma; may be negative. Adjustments are logged.</span>
+        <span class="hint">Stored karma; may be negative. Adjustments are logged.
+          <%= link_to "History", upload_karma_events_path(search: { user_id: @user.id }) %></span>
       </div>
 
       <% if CurrentUser.is_bd_staff? || !@user.is_bd_staff? %>

--- a/app/views/upload_karma_events/_search.html.erb
+++ b/app/views/upload_karma_events/_search.html.erb
@@ -1,0 +1,6 @@
+<%= form_search path: upload_karma_events_path do |f| %>
+  <%= f.user :user %>
+  <%= f.user :creator %>
+  <%= f.input :post_id, label: "Post #" %>
+  <%= f.input :reason, label: "Reason", collection: UploadKarmaEvent.reasons.keys.map { |k| [k.capitalize.tr("_", " "), k] }, include_blank: "Any" %>
+<% end %>

--- a/app/views/upload_karma_events/_secondary_links.html.erb
+++ b/app/views/upload_karma_events/_secondary_links.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:secondary_links) do %>
+  <%= subnav_link_to "Post Events", post_events_path(search: { post_id: params.dig(:search, :post_id) }) %>
+  <%= subnav_link_to "Approvals", post_approvals_path(search: { post_id: params.dig(:search, :post_id) }) %>
+  <%= subnav_link_to "Flags", post_flags_path(search: { post_id: params.dig(:search, :post_id) }) %>
+  <%= subnav_link_to "Replacements", post_replacements_path(search: { post_id: params.dig(:search, :post_id) }) %>
+<% end %>

--- a/app/views/upload_karma_events/index.html.erb
+++ b/app/views/upload_karma_events/index.html.erb
@@ -1,0 +1,53 @@
+<div id="c-upload-karma-events">
+  <div id="a-index">
+    <h1>Upload Karma</h1>
+
+    <%= render "search" %>
+
+    <table class="striped autofit">
+      <thead>
+        <tr>
+          <th>User</th>
+          <th>Change</th>
+          <th>Post</th>
+          <th>Reason</th>
+          <th>By</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @events.each do |event| %>
+          <tr>
+            <td>
+              <%= link_to_user event.user %>
+              <%= link_to "»", upload_karma_events_path(search: params[:search].merge(user_id: event.user_id)) %>
+            </td>
+            <td><%= format("%+d", event.delta) %> → <%= event.balance %></td>
+            <td>
+              <% if event.post_id.present? %>
+                <%= link_to "post ##{event.post_id}", post_path(event.post_id) %>
+                <%= link_to "»", upload_karma_events_path(search: params[:search].merge(post_id: event.post_id)) %>
+              <% end %>
+            </td>
+            <td class="col-expand">
+              <%= event.description %>
+              <%= link_to "»", upload_karma_events_path(search: params[:search].merge(reason: event.reason)) %>
+            </td>
+            <td>
+              <%= link_to_user event.creator %>
+              <%= link_to "»", upload_karma_events_path(search: params[:search].merge(creator_name: event.creator.name)) %>
+              <br><%= time_ago_in_words_tagged event.created_at %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= render PaginatorComponent.new(records: @events) %>
+  </div>
+</div>
+
+<%= render "secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Upload Karma
+<% end %>

--- a/app/views/users/partials/show/_user_info.html.erb
+++ b/app/views/users/partials/show/_user_info.html.erb
@@ -52,6 +52,16 @@
   <% end %>
 
   <div class="profile-line">
+    <h4><%= svg_icon(:upload) %> Upload Karma</h4>
+    <span class="profile-line-number">
+      <%= link_to user.upload_karma, upload_karma_events_path(search: { user_id: user.id }) %>
+    </span>
+    <span class="profile-line-extra">
+      Earned from approved uploads. Click for the full history.
+    </span>
+  </div>
+
+  <div class="profile-line">
     <h4><%= svg_icon(:replace) %> Changes</h4>
     <span class="profile-line-extra profile-line-show">
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,6 +410,7 @@ Rails.application.routes.draw do
     end
   end
   resource :tag_implication_request, only: %i[new create]
+  resources :upload_karma_events, only: :index
   resources :uploads
   resources :users do
     resource :password, only: %i[edit], controller: "maintenance/user/passwords"

--- a/db/fixes/142_recalculate_upload_karma_ledger.rb
+++ b/db/fixes/142_recalculate_upload_karma_ledger.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+# One-shot backfill for the upload karma ledger (design doc 32).
+#
+# Derives every uploader's karma from current post state, inserts it as
+# historically-dated upload_karma_events rows in chronological order (so ids
+# ascend with created_at), then overwrites every balance with its ledger sum.
+# Previous staff overrides are deliberately discarded.
+#
+# Must run under the site write freeze, before any live ledger row exists —
+# it refuses to run otherwise.
+module Fixes
+  class RecalculateUploadKarmaLedger
+    def self.run
+      raise "upload_karma_events is not empty; this backfill must run exactly once, before any live rows" if UploadKarmaEvent.exists?
+
+      conn = ApplicationRecord.connection
+      ApplicationRecord.without_timeout do
+        inserted = conn.execute(insert_sql).cmd_tuples
+        puts "Inserted #{inserted} ledger rows" unless Rails.env.test?
+
+        conn.execute(<<~SQL.squish)
+          UPDATE user_statuses us
+          SET upload_karma = sums.total
+          FROM (SELECT user_id, SUM(delta) AS total FROM upload_karma_events GROUP BY user_id) sums
+          WHERE sums.user_id = us.user_id AND us.upload_karma IS DISTINCT FROM sums.total
+        SQL
+        conn.execute(<<~SQL.squish)
+          UPDATE user_statuses us
+          SET upload_karma = 0
+          WHERE us.upload_karma <> 0
+            AND NOT EXISTS (SELECT 1 FROM upload_karma_events e WHERE e.user_id = us.user_id)
+        SQL
+
+        drift = conn.select_value(<<~SQL.squish).to_i
+          SELECT COUNT(*) FROM user_statuses us
+          LEFT JOIN (SELECT user_id, SUM(delta) AS total FROM upload_karma_events GROUP BY user_id) e
+            ON e.user_id = us.user_id
+          WHERE us.upload_karma IS DISTINCT FROM COALESCE(e.total, 0)
+        SQL
+        raise "karma/ledger drift for #{drift} users after recalculation" if drift > 0
+
+        users = conn.select_value("SELECT COUNT(DISTINCT user_id) FROM upload_karma_events")
+        puts "Done. Ledger covers #{users} users; all balances match their sums" unless Rails.env.test?
+      end
+    end
+
+    # One row per post (live => credit, deleted non-takedown => penalty) plus one
+    # per outstanding replacement penalty. The window ORDER BY matches the outer
+    # ORDER BY so per-user running balances agree with the global insert order.
+    def self.insert_sql
+      reasons = UploadKarmaEvent.reasons
+      actions = PostEvent.actions
+
+      <<~SQL.squish
+        WITH latest_approval AS (
+          SELECT DISTINCT ON (post_id) post_id, user_id, created_at
+          FROM post_approvals
+          ORDER BY post_id, id DESC
+        ), latest_approval_event AS (
+          SELECT DISTINCT ON (post_id) post_id, creator_id, created_at
+          FROM post_events
+          WHERE action = #{actions[:approved]}
+          ORDER BY post_id, id DESC
+        ), latest_deletion_event AS (
+          SELECT DISTINCT ON (post_id) post_id, creator_id, created_at
+          FROM post_events
+          WHERE action = #{actions[:deleted]}
+          ORDER BY post_id, id DESC
+        ), deletion_flag AS (
+          SELECT DISTINCT ON (post_id) post_id, creator_id, created_at,
+                 (reason LIKE 'takedown #%') AS is_takedown
+          FROM post_flags
+          WHERE is_deletion AND NOT is_resolved
+          ORDER BY post_id, id DESC
+        ), events AS (
+          SELECT p.uploader_id AS user_id,
+                 COALESCE(p.approver_id, la.user_id, lae.creator_id, p.uploader_id) AS creator_id,
+                 p.id AS post_id,
+                 CASE WHEN p.approver_id IS NOT NULL OR la.post_id IS NOT NULL
+                      THEN #{reasons[:approved]} ELSE #{reasons[:queue_bypass]} END AS reason,
+                 #{UserStatus::KARMA_APPROVED_CREDIT} AS delta,
+                 COALESCE(la.created_at, lae.created_at, p.created_at) AS event_time
+          FROM posts p
+          LEFT JOIN latest_approval la ON la.post_id = p.id
+          LEFT JOIN latest_approval_event lae ON lae.post_id = p.id
+          WHERE NOT p.is_deleted AND NOT p.is_pending
+
+          UNION ALL
+
+          SELECT p.uploader_id,
+                 COALESCE(lde.creator_id, df.creator_id, p.uploader_id),
+                 p.id,
+                 #{reasons[:deleted]},
+                 #{-UserStatus::KARMA_DELETION_PENALTY},
+                 COALESCE(lde.created_at, df.created_at, p.updated_at)
+          FROM posts p
+          LEFT JOIN latest_deletion_event lde ON lde.post_id = p.id
+          LEFT JOIN deletion_flag df ON df.post_id = p.id
+          WHERE p.is_deleted AND NOT COALESCE(df.is_takedown, FALSE)
+
+          UNION ALL
+
+          SELECT r.uploader_id_on_approve,
+                 COALESCE(r.approver_id, r.creator_id),
+                 r.post_id,
+                 #{reasons[:replacement_penalty]},
+                 #{-UserStatus::KARMA_REPLACEMENT_PENALTY},
+                 r.updated_at
+          FROM post_replacements2 r
+          WHERE r.penalize_uploader_on_approve
+            AND r.uploader_id_on_approve IS NOT NULL
+            AND r.status IN ('approved', 'original')
+        )
+        INSERT INTO upload_karma_events (user_id, creator_id, post_id, reason, delta, balance, extra_data, created_at)
+        SELECT user_id, creator_id, post_id, reason, delta,
+               SUM(delta) OVER (PARTITION BY user_id ORDER BY event_time, post_id, reason ROWS UNBOUNDED PRECEDING),
+               '{"backfill": true}'::jsonb,
+               event_time
+        FROM events
+        ORDER BY event_time, post_id, reason
+      SQL
+    end
+  end
+end
+
+Fixes::RecalculateUploadKarmaLedger.run unless Rails.env.test?

--- a/db/migrate/20260824220908_create_upload_karma_events.rb
+++ b/db/migrate/20260824220908_create_upload_karma_events.rb
@@ -14,6 +14,7 @@ class CreateUploadKarmaEvents < ActiveRecord::Migration[8.1]
 
       t.index %i[user_id id]
       t.index :post_id, where: "post_id IS NOT NULL"
+      t.index :creator_id
     end
   end
 end

--- a/db/migrate/20260824220908_create_upload_karma_events.rb
+++ b/db/migrate/20260824220908_create_upload_karma_events.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateUploadKarmaEvents < ActiveRecord::Migration[8.1]
+  def change
+    create_table :upload_karma_events do |t|
+      t.bigint :user_id, null: false
+      t.bigint :creator_id, null: false
+      t.bigint :post_id
+      t.integer :reason, null: false
+      t.integer :delta, null: false
+      t.integer :balance, null: false
+      t.jsonb :extra_data, null: false, default: {}
+      t.datetime :created_at, null: false
+
+      t.index %i[user_id id]
+      t.index :post_id, where: "post_id IS NOT NULL"
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,6 +20,10 @@ admin = User.find_or_create_by!(name: "admin") do |user|
   user.is_bd_auditor = true
 end
 
+# The karma setter below writes an upload_karma_events row attributed to CurrentUser.
+CurrentUser.user = admin
+CurrentUser.ip_addr = "127.0.0.1"
+
 required_karma = User.required_karma_for_level(Danbooru.config.upload_karma_free_threshold)
 if !required_karma.nil? && admin.upload_karma < required_karma
   admin.upload_karma = required_karma
@@ -142,8 +146,6 @@ end
 
 unless Rails.env.test?
   begin
-    CurrentUser.user = admin
-    CurrentUser.ip_addr = "127.0.0.1"
     import_mascots
     setup_upload_whitelist
     setup_report_reasons

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5806,6 +5806,13 @@ CREATE INDEX index_tags_on_name_trgm ON public.tags USING gin (name public.gin_t
 
 
 --
+-- Name: index_upload_karma_events_on_creator_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_upload_karma_events_on_creator_id ON public.upload_karma_events USING btree (creator_id);
+
+
+--
 -- Name: index_upload_karma_events_on_post_id; Type: INDEX; Schema: public; Owner: -
 --
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2702,6 +2702,42 @@ ALTER SEQUENCE public.tickets_id_seq OWNED BY public.tickets.id;
 
 
 --
+-- Name: upload_karma_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.upload_karma_events (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    creator_id bigint NOT NULL,
+    post_id bigint,
+    reason integer NOT NULL,
+    delta integer NOT NULL,
+    balance integer NOT NULL,
+    extra_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: upload_karma_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.upload_karma_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: upload_karma_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.upload_karma_events_id_seq OWNED BY public.upload_karma_events.id;
+
+
+--
 -- Name: upload_whitelists; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3646,6 +3682,13 @@ ALTER TABLE ONLY public.tickets ALTER COLUMN id SET DEFAULT nextval('public.tick
 
 
 --
+-- Name: upload_karma_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.upload_karma_events ALTER COLUMN id SET DEFAULT nextval('public.upload_karma_events_id_seq'::regclass);
+
+
+--
 -- Name: upload_whitelists id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4298,6 +4341,14 @@ ALTER TABLE ONLY public.takedowns
 
 ALTER TABLE ONLY public.tickets
     ADD CONSTRAINT tickets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: upload_karma_events upload_karma_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.upload_karma_events
+    ADD CONSTRAINT upload_karma_events_pkey PRIMARY KEY (id);
 
 
 --
@@ -5755,6 +5806,20 @@ CREATE INDEX index_tags_on_name_trgm ON public.tags USING gin (name public.gin_t
 
 
 --
+-- Name: index_upload_karma_events_on_post_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_upload_karma_events_on_post_id ON public.upload_karma_events USING btree (post_id) WHERE (post_id IS NOT NULL);
+
+
+--
+-- Name: index_upload_karma_events_on_user_id_and_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_upload_karma_events_on_user_id_and_id ON public.upload_karma_events USING btree (user_id, id);
+
+
+--
 -- Name: index_uploads_on_source; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6344,6 +6409,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260824220908'),
 ('20260819154314'),
 ('20260818231537'),
 ('20260812223301'),

--- a/spec/db_fixes/recalculate_upload_karma_ledger_spec.rb
+++ b/spec/db_fixes/recalculate_upload_karma_ledger_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Fixes::RecalculateUploadKarmaLedger do
   let(:uploader) { create(:user) }
   let(:approver) { create(:moderator_user) }
 
+  # db/seeds.rb writes staff_override rows for the admin/system users, which would
+  # trip the script's must-run-first guard. Cleared per example (transactional).
+  before { UploadKarmaEvent.delete_all }
+
   def run!
     described_class.run
   end

--- a/spec/db_fixes/recalculate_upload_karma_ledger_spec.rb
+++ b/spec/db_fixes/recalculate_upload_karma_ledger_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("db/fixes/142_recalculate_upload_karma_ledger")
+
+RSpec.describe Fixes::RecalculateUploadKarmaLedger do
+  include_context "as admin"
+
+  let(:uploader) { create(:user) }
+  let(:approver) { create(:moderator_user) }
+
+  def run!
+    described_class.run
+  end
+
+  it "refuses to run when the ledger already has rows" do
+    create(:upload_karma_event)
+    expect { run! }.to raise_error(/not empty/)
+  end
+
+  describe "live posts" do
+    it "credits an approved post to the uploader with the approver as creator" do
+      post = create(:post, uploader: uploader)
+      post.update_columns(approver_id: approver.id)
+
+      run!
+
+      event = UploadKarmaEvent.find_by(post_id: post.id)
+      expect(event).to have_attributes(
+        user_id: uploader.id,
+        creator_id: approver.id,
+        reason: "approved",
+        delta: UserStatus::KARMA_APPROVED_CREDIT,
+        extra_data: { "backfill" => true },
+      )
+      expect(uploader.user_status.reload.upload_karma).to eq(UserStatus::KARMA_APPROVED_CREDIT)
+    end
+
+    it "records a post without any approval trace as queue_bypass, dated at post creation" do
+      post = create(:post, uploader: uploader)
+
+      run!
+
+      event = UploadKarmaEvent.find_by(post_id: post.id)
+      expect(event).to have_attributes(user_id: uploader.id, creator_id: uploader.id, reason: "queue_bypass")
+      expect(event.created_at).to be_within(1.second).of(post.created_at)
+    end
+
+    it "dates an approved post from its approval event" do
+      post = create(:post, uploader: uploader)
+      post.update_columns(approver_id: approver.id)
+      create(:post_event, post_id: post.id, creator: approver, action: :approved, created_at: 3.days.ago)
+
+      run!
+
+      event = UploadKarmaEvent.find_by(post_id: post.id)
+      expect(event.reason).to eq("approved")
+      expect(event.created_at).to be_within(1.second).of(3.days.ago)
+    end
+
+    it "ignores pending posts" do
+      create(:pending_post, uploader: uploader)
+      run!
+      expect(UploadKarmaEvent.count).to eq(0)
+    end
+  end
+
+  describe "deleted posts" do
+    it "records only the net deletion penalty, even for a previously approved post" do
+      post = create(:deleted_post, uploader: uploader)
+      post.update_columns(approver_id: approver.id)
+
+      run!
+
+      events = UploadKarmaEvent.where(post_id: post.id)
+      expect(events.count).to eq(1)
+      expect(events.first).to have_attributes(reason: "deleted", delta: -UserStatus::KARMA_DELETION_PENALTY)
+      expect(uploader.user_status.reload.upload_karma).to eq(-UserStatus::KARMA_DELETION_PENALTY)
+    end
+
+    it "dates the penalty from the deletion event and attributes it to the deleter" do
+      post = create(:deleted_post, uploader: uploader)
+      create(:post_event, post_id: post.id, creator: approver, action: :deleted, created_at: 2.days.ago)
+
+      run!
+
+      event = UploadKarmaEvent.find_by(post_id: post.id)
+      expect(event.creator_id).to eq(approver.id)
+      expect(event.created_at).to be_within(1.second).of(2.days.ago)
+    end
+
+    it "skips takedown-deleted posts" do
+      post = create(:post, uploader: uploader)
+      create(:deletion_post_flag, post: post, reason: "takedown #123: artist request")
+      post.update_columns(is_deleted: true, is_pending: false)
+
+      run!
+
+      expect(UploadKarmaEvent.count).to eq(0)
+      expect(uploader.user_status.reload.upload_karma).to eq(0)
+    end
+  end
+
+  describe "replacement penalties" do
+    it "records outstanding penalties for approved and original replacements" do
+      approved = create(:approved_post_replacement, uploader_id_on_approve: uploader.id, penalize_uploader_on_approve: true)
+      original = create(:original_post_replacement, uploader_id_on_approve: uploader.id, penalize_uploader_on_approve: true)
+      create(:approved_post_replacement, uploader_id_on_approve: uploader.id, penalize_uploader_on_approve: false)
+
+      run!
+
+      events = UploadKarmaEvent.where(reason: :replacement_penalty)
+      expect(events.pluck(:post_id)).to contain_exactly(approved.post_id, original.post_id)
+      expect(events.pluck(:delta).uniq).to eq([-UserStatus::KARMA_REPLACEMENT_PENALTY])
+    end
+  end
+
+  describe "ordering and balances" do
+    it "inserts rows so ids ascend with created_at" do
+      newer = create(:post, uploader: uploader)
+      older = create(:post, uploader: create(:user))
+      newer.update_columns(created_at: 1.day.ago)
+      older.update_columns(created_at: 5.days.ago)
+
+      run!
+
+      timestamps = UploadKarmaEvent.order(:id).pluck(:created_at)
+      expect(timestamps).to eq(timestamps.sort)
+    end
+
+    it "computes per-user running balances and sets the final balance from the sum" do
+      live = create(:post, uploader: uploader)
+      live.update_columns(created_at: 5.days.ago)
+      deleted = create(:deleted_post, uploader: uploader)
+      create(:post_event, post_id: deleted.id, creator: approver, action: :deleted, created_at: 1.day.ago)
+
+      run!
+
+      expect(UploadKarmaEvent.where(user_id: uploader.id).order(:id).pluck(:balance)).to eq([1, -2])
+      expect(uploader.user_status.reload.upload_karma).to eq(-2)
+    end
+
+    it "resets stale nonzero balances for users with no ledger rows" do
+      uploader.user_status.update_columns(upload_karma: 50)
+
+      run!
+
+      expect(uploader.user_status.reload.upload_karma).to eq(0)
+    end
+  end
+end

--- a/spec/factories/upload_karma_event_factory.rb
+++ b/spec/factories/upload_karma_event_factory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :upload_karma_event do
+    association :user
+    association :creator, factory: :user
+    reason { :approved }
+    delta { 1 }
+    balance { 1 }
+    extra_data { {} }
+  end
+end

--- a/spec/logical/upload_service/replacer_spec.rb
+++ b/spec/logical/upload_service/replacer_spec.rb
@@ -74,6 +74,28 @@ RSpec.describe UploadService::Replacer do
       expect(replacement.reload.penalize_uploader_on_approve).to be true
       expect(replacement.uploader_id_on_approve).to eq(uploader.id)
     end
+
+    it "records a replacement_transfer ledger row for each side of the credit move" do
+      process!(replacement, penalize: false)
+      events = UploadKarmaEvent.where(reason: :replacement_transfer, post_id: post.id)
+      expect(events.pluck(:user_id, :delta)).to contain_exactly(
+        [uploader.id, -UserStatus::KARMA_APPROVED_CREDIT],
+        [replacer_user.id, UserStatus::KARMA_APPROVED_CREDIT],
+      )
+      expect(events.pluck(:extra_data).uniq).to eq(
+        [{ "replacement_id" => replacement.id, "from" => uploader.id, "to" => replacer_user.id }],
+      )
+    end
+
+    it "records a replacement_penalty ledger row when penalized" do
+      process!(replacement, penalize: true)
+      expect(UploadKarmaEvent.find_by(reason: :replacement_penalty)).to have_attributes(
+        user_id: uploader.id,
+        post_id: post.id,
+        delta: -UserStatus::KARMA_REPLACEMENT_PENALTY,
+        extra_data: { "replacement_id" => replacement.id },
+      )
+    end
   end
 
   context "reset-to (handing ownership back to a previous version)" do

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -212,6 +212,17 @@ RSpec.describe UploadService do
           .not_to(change { uploader.user_status.reload.upload_karma })
       end
 
+      it "records a queue_bypass ledger row for the credit" do
+        allow(uploader).to receive(:upload_free?).and_return(true)
+        post = service.create_post_from_upload(upload)
+        expect(UploadKarmaEvent.last).to have_attributes(
+          user_id: uploader.id,
+          post_id: post.id,
+          reason: "queue_bypass",
+          delta: UserStatus::KARMA_APPROVED_CREDIT,
+        )
+      end
+
       it "does not grant karma when upload_as_pending forces the post into the queue" do
         allow(uploader).to receive(:upload_free?).and_return(true)
         allow(upload).to receive(:upload_as_pending?).and_return(true)

--- a/spec/models/post/approval_methods_spec.rb
+++ b/spec/models/post/approval_methods_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe Post do
         expect { post.approve!(approver) }
           .to change { post.uploader.user_status.reload.upload_karma }.by(UserStatus::KARMA_APPROVED_CREDIT)
       end
+
+      it "records an approved ledger row" do
+        approver = create(:admin_user)
+        post = create(:pending_post)
+        post.approve!(approver)
+        expect(UploadKarmaEvent.last).to have_attributes(user_id: post.uploader_id, post_id: post.id, reason: "approved", delta: UserStatus::KARMA_APPROVED_CREDIT)
+      end
     end
 
     describe "#unapprove!" do
@@ -92,6 +99,14 @@ RSpec.describe Post do
         post = create(:pending_post)
         post.approve!(approver)
         expect { post.unapprove! }.to change { post.uploader.user_status.reload.upload_karma }.by(-UserStatus::KARMA_APPROVED_CREDIT)
+      end
+
+      it "records an unapproved ledger row" do
+        approver = create(:admin_user)
+        post = create(:pending_post)
+        post.approve!(approver)
+        post.unapprove!
+        expect(UploadKarmaEvent.last).to have_attributes(user_id: post.uploader_id, post_id: post.id, reason: "unapproved", delta: -UserStatus::KARMA_APPROVED_CREDIT)
       end
     end
 

--- a/spec/models/post/deletion_methods_spec.rb
+++ b/spec/models/post/deletion_methods_spec.rb
@@ -65,6 +65,31 @@ RSpec.describe Post do
           .not_to(change { post.uploader.user_status.reload.upload_karma })
       end
 
+      it "records a deleted ledger row noting whether the credit was reversed" do
+        credited = create(:post)
+        pending = create(:pending_post)
+        credited.delete!("Test reason")
+        pending.delete!("Test reason")
+
+        expect(UploadKarmaEvent.find_by(post_id: credited.id)).to have_attributes(
+          user_id: credited.uploader_id,
+          reason: "deleted",
+          delta: -(UserStatus::KARMA_DELETION_PENALTY + UserStatus::KARMA_APPROVED_CREDIT),
+          extra_data: { "credit_reversed" => true },
+        )
+        expect(UploadKarmaEvent.find_by(post_id: pending.id)).to have_attributes(
+          reason: "deleted",
+          delta: -UserStatus::KARMA_DELETION_PENALTY,
+          extra_data: { "credit_reversed" => false },
+        )
+      end
+
+      it "records no ledger row when skip_karma is set" do
+        post = create(:post)
+        expect { post.delete!("takedown #1: reason", force: true, skip_karma: true) }
+          .not_to change(UploadKarmaEvent, :count)
+      end
+
       # FIXME: Rework after adding a PostReplacement factory
       # it "rejects pending replacements on deletion" do
       #   post = create(:post)
@@ -113,6 +138,17 @@ RSpec.describe Post do
         post = create(:deleted_post, approver: create(:admin_user))
         expect { post.undelete!(force: true, skip_karma: true) }
           .not_to(change { post.uploader.user_status.reload.upload_karma })
+      end
+
+      it "records an undeleted ledger row" do
+        post = create(:deleted_post, approver: create(:admin_user))
+        post.undelete!
+        expect(UploadKarmaEvent.last).to have_attributes(
+          user_id: post.uploader_id,
+          post_id: post.id,
+          reason: "undeleted",
+          delta: UserStatus::KARMA_DELETION_PENALTY + UserStatus::KARMA_APPROVED_CREDIT,
+        )
       end
 
       it "nets zero upload karma across a delete then undelete of a credited post, even when karma goes negative" do

--- a/spec/models/post/uploader_methods_spec.rb
+++ b/spec/models/post/uploader_methods_spec.rb
@@ -182,6 +182,16 @@ RSpec.describe Post do
             .and change { new_owner.user_status.reload.upload_karma }.by(UserStatus::KARMA_APPROVED_CREDIT)
         end
 
+        it "records an owner_change ledger row for each side of the transfer" do
+          post.reowner!(new_owner)
+          events = UploadKarmaEvent.where(reason: :owner_change, post_id: post.id)
+          expect(events.pluck(:user_id, :delta)).to contain_exactly(
+            [old_owner.id, -UserStatus::KARMA_APPROVED_CREDIT],
+            [new_owner.id, UserStatus::KARMA_APPROVED_CREDIT],
+          )
+          expect(events.pluck(:extra_data).uniq).to eq([{ "old_owner" => old_owner.id, "new_owner" => new_owner.id }])
+        end
+
         it "moves the deletion penalty for a deleted post that had been approved" do
           post.delete!("Test deletion reason")
           expect { post.reowner!(new_owner) }
@@ -214,6 +224,11 @@ RSpec.describe Post do
           expect { post.reowner!(new_owner) }
             .not_to(change { [old_owner.user_status.reload.upload_karma, new_owner.user_status.reload.upload_karma] })
           expect(post.reload.uploader_id).to eq(new_owner.id)
+        end
+
+        it "records no ledger rows when nothing is transferred" do
+          pending = create(:pending_post)
+          expect { pending.reowner!(new_owner) }.not_to change(UploadKarmaEvent, :count)
         end
 
         it "does not transfer karma when the old and new owners are the same" do

--- a/spec/models/post_replacement/processing_methods_spec.rb
+++ b/spec/models/post_replacement/processing_methods_spec.rb
@@ -160,6 +160,29 @@ RSpec.describe PostReplacement do
       expect { replacement.toggle_penalize! }
         .to change { prev_uploader.user_status.reload.upload_karma }.by(UserStatus::KARMA_REPLACEMENT_PENALTY)
     end
+
+    it "records replacement_penalty and replacement_penalty_reversed ledger rows across a toggle cycle" do
+      prev_uploader = create(:user)
+      replacement = create(:approved_post_replacement)
+                    .tap { |r| r.update_columns(penalize_uploader_on_approve: false, uploader_id_on_approve: prev_uploader.id) }
+      allow(PostEvent).to receive(:add)
+
+      replacement.toggle_penalize!
+      expect(UploadKarmaEvent.last).to have_attributes(
+        user_id: prev_uploader.id,
+        post_id: replacement.post_id,
+        reason: "replacement_penalty",
+        delta: -UserStatus::KARMA_REPLACEMENT_PENALTY,
+        extra_data: { "replacement_id" => replacement.id },
+      )
+
+      replacement.toggle_penalize!
+      expect(UploadKarmaEvent.last).to have_attributes(
+        user_id: prev_uploader.id,
+        reason: "replacement_penalty_reversed",
+        delta: UserStatus::KARMA_REPLACEMENT_PENALTY,
+      )
+    end
   end
 
   # --------------------------------------------------------------------------

--- a/spec/models/upload_karma_event_spec.rb
+++ b/spec/models/upload_karma_event_spec.rb
@@ -65,7 +65,11 @@ RSpec.describe UploadKarmaEvent do
     end
 
     it "orders by id desc by default" do
-      expect(described_class.search({})).to eq([event_b, event_a])
+      # The seeded test DB already carries ledger rows, so assert the ordering
+      # property rather than the exact result set.
+      ids = described_class.search({}).ids
+      expect(ids).to include(event_a.id, event_b.id)
+      expect(ids).to eq(ids.sort.reverse)
     end
   end
 end

--- a/spec/models/upload_karma_event_spec.rb
+++ b/spec/models/upload_karma_event_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UploadKarmaEvent do
+  include_context "as admin"
+
+  describe "reason enum" do
+    it "pins the stored integers" do
+      expect(described_class.reasons).to eq(
+        "approved" => 0,
+        "unapproved" => 1,
+        "deleted" => 2,
+        "undeleted" => 3,
+        "replacement_penalty" => 4,
+        "replacement_penalty_reversed" => 5,
+        "replacement_transfer" => 6,
+        "owner_change" => 7,
+        "staff_override" => 8,
+        "queue_bypass" => 9,
+      )
+    end
+  end
+
+  describe "immutability" do
+    let(:event) { create(:upload_karma_event) }
+
+    it "allows creation" do
+      expect { create(:upload_karma_event) }.to change(described_class, :count).by(1)
+    end
+
+    it "refuses updates" do
+      expect { event.update!(delta: 5) }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+
+    it "refuses destroys" do
+      expect { event.destroy! }.to raise_error(ActiveRecord::ReadOnlyRecord)
+    end
+  end
+
+  describe ".search" do
+    let(:user_a) { create(:user) }
+    let(:user_b) { create(:user) }
+    let!(:event_a) { create(:upload_karma_event, user: user_a, post_id: 1, reason: :approved) }
+    let!(:event_b) { create(:upload_karma_event, user: user_b, post_id: 2, reason: :deleted) }
+
+    it "filters by user_id" do
+      expect(described_class.search(user_id: user_a.id.to_s)).to contain_exactly(event_a)
+    end
+
+    it "filters by user_name" do
+      expect(described_class.search(user_name: user_a.name)).to contain_exactly(event_a)
+    end
+
+    it "filters by creator_id" do
+      expect(described_class.search(creator_id: event_b.creator_id.to_s)).to contain_exactly(event_b)
+    end
+
+    it "filters by post_id" do
+      expect(described_class.search(post_id: "2")).to contain_exactly(event_b)
+    end
+
+    it "filters by reason" do
+      expect(described_class.search(reason: "deleted")).to contain_exactly(event_b)
+    end
+
+    it "orders by id desc by default" do
+      expect(described_class.search({})).to eq([event_b, event_a])
+    end
+  end
+end

--- a/spec/models/user/karma_methods_spec.rb
+++ b/spec/models/user/karma_methods_spec.rb
@@ -7,6 +7,9 @@ require "rails_helper"
 # --------------------------------------------------------------------------- #
 
 RSpec.describe User do
+  # The upload_karma= setter writes a ledger row attributed to CurrentUser.
+  include_context "as admin"
+
   let(:user) { create(:user) }
 
   before do
@@ -68,6 +71,20 @@ RSpec.describe User do
       allow(UserStatus).to receive(:adjust_karma)
       user.upload_karma = 42
       expect(UserStatus).not_to have_received(:adjust_karma)
+    end
+
+    it "records a staff_override ledger row" do
+      set_karma(user, 5)
+      user.upload_karma = 42
+      expect(UploadKarmaEvent.last).to have_attributes(
+        user_id: user.id,
+        creator_id: CurrentUser.id,
+        post_id: nil,
+        reason: "staff_override",
+        delta: 37,
+        balance: 42,
+        extra_data: { "old_karma" => 5, "new_karma" => 42 },
+      )
     end
   end
 

--- a/spec/models/user_status_spec.rb
+++ b/spec/models/user_status_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe UserStatus do
       described_class.adjust_karma(user.id, 5, :approved)
       described_class.adjust_karma(user.id, -3, :deleted)
 
-      expect(UploadKarmaEvent.order(:id).pluck(:balance)).to eq([5, 2])
+      expect(UploadKarmaEvent.where(user_id: user.id).order(:id).pluck(:balance)).to eq([5, 2])
       expect(user.user_status.reload.upload_karma).to eq(2)
     end
 

--- a/spec/models/user_status_spec.rb
+++ b/spec/models/user_status_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserStatus do
+  include_context "as admin"
+
+  let(:user) { create(:user) }
+
+  describe ".adjust_karma" do
+    it "applies the delta and records a matching ledger row" do
+      described_class.adjust_karma(user.id, 5, :approved, post_id: 123)
+
+      expect(user.user_status.reload.upload_karma).to eq(5)
+      event = UploadKarmaEvent.last
+      expect(event).to have_attributes(
+        user_id: user.id,
+        creator_id: CurrentUser.id,
+        post_id: 123,
+        reason: "approved",
+        delta: 5,
+        balance: 5,
+      )
+    end
+
+    it "records extra data" do
+      described_class.adjust_karma(user.id, -4, :deleted, post_id: 1, data: { credit_reversed: true })
+      expect(UploadKarmaEvent.last.extra_data).to eq({ "credit_reversed" => true })
+    end
+
+    it "chains balances across consecutive adjustments" do
+      described_class.adjust_karma(user.id, 5, :approved)
+      described_class.adjust_karma(user.id, -3, :deleted)
+
+      expect(UploadKarmaEvent.order(:id).pluck(:balance)).to eq([5, 2])
+      expect(user.user_status.reload.upload_karma).to eq(2)
+    end
+
+    it "does nothing for a zero delta" do
+      expect { described_class.adjust_karma(user.id, 0, :approved) }.not_to change(UploadKarmaEvent, :count)
+      expect(user.user_status.reload.upload_karma).to eq(0)
+    end
+
+    it "silently no-ops for a user without a user_statuses row" do
+      user.user_status.delete
+      expect { described_class.adjust_karma(user.id, 5, :approved) }.not_to change(UploadKarmaEvent, :count)
+    end
+
+    it "rolls back the balance change when the ledger insert fails" do
+      allow(UploadKarmaEvent).to receive(:create!).and_raise("ledger insert failed")
+
+      expect { described_class.adjust_karma(user.id, 5, :approved) }.to raise_error("ledger insert failed")
+      expect(user.user_status.reload.upload_karma).to eq(0)
+    end
+  end
+end

--- a/spec/requests/staff/users_controller_spec.rb
+++ b/spec/requests/staff/users_controller_spec.rb
@@ -154,6 +154,26 @@ RSpec.describe Staff::UsersController do
         end.not_to(change { ModAction.where(action: "user_karma_change").count })
       end
 
+      it "records a staff_override ledger row for the karma change" do
+        user.user_status.update_columns(upload_karma: 5)
+        patch staff_user_path(user), params: { user: { upload_karma: -20 } }
+        expect(UploadKarmaEvent.last).to have_attributes(
+          user_id: user.id,
+          post_id: nil,
+          reason: "staff_override",
+          delta: -25,
+          balance: -20,
+          extra_data: { "old_karma" => 5, "new_karma" => -20 },
+        )
+      end
+
+      it "records no ledger row when karma is unchanged" do
+        user.user_status.update_columns(upload_karma: 5)
+        expect do
+          patch staff_user_path(user), params: { user: { upload_karma: 5 } }
+        end.not_to change(UploadKarmaEvent, :count)
+      end
+
       it "grants can_upload_free and logs a user_flags_change ModAction" do
         patch staff_user_path(user), params: { user: { level: user.level, can_upload_free: "true" } }
         expect(user.reload.can_upload_free?).to be true

--- a/spec/requests/upload_karma_events_controller_spec.rb
+++ b/spec/requests/upload_karma_events_controller_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UploadKarmaEventsController do
+  include_context "as admin"
+
+  let(:member) { create(:user) }
+
+  describe "GET /upload_karma_events" do
+    it "returns 200 for anonymous" do
+      get upload_karma_events_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns 200 for a member" do
+      sign_in_as member
+      get upload_karma_events_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "renders rows of every reason" do
+      UploadKarmaEvent.reasons.each_key do |reason|
+        create(:upload_karma_event, reason: reason, post_id: 1, extra_data: { "new_owner" => 1, "new_karma" => 5 })
+      end
+      get upload_karma_events_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns a bare JSON array with the expected fields" do
+      event = create(:upload_karma_event, post_id: 123, delta: -4, balance: 6, extra_data: { "credit_reversed" => true })
+      get upload_karma_events_path(format: :json)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to be_an(Array)
+      entry = response.parsed_body.find { |e| e["id"] == event.id }
+      expect(entry).to include(
+        "user_id" => event.user_id,
+        "creator_id" => event.creator_id,
+        "post_id" => 123,
+        "reason" => "approved",
+        "delta" => -4,
+        "balance" => 6,
+        "extra_data" => { "credit_reversed" => true },
+      )
+    end
+
+    context "with search params" do
+      let!(:event_a) { create(:upload_karma_event, post_id: 1, reason: :approved) }
+      let!(:event_b) { create(:upload_karma_event, post_id: 2, reason: :deleted) }
+
+      def returned_ids
+        response.parsed_body.pluck("id")
+      end
+
+      it "filters by user_id" do
+        get upload_karma_events_path(format: :json, params: { search: { user_id: event_a.user_id } })
+        expect(returned_ids).to eq([event_a.id])
+      end
+
+      it "filters by user_name" do
+        get upload_karma_events_path(format: :json, params: { search: { user_name: event_a.user.name } })
+        expect(returned_ids).to eq([event_a.id])
+      end
+
+      it "filters by creator_id" do
+        get upload_karma_events_path(format: :json, params: { search: { creator_id: event_b.creator_id } })
+        expect(returned_ids).to eq([event_b.id])
+      end
+
+      it "filters by post_id" do
+        get upload_karma_events_path(format: :json, params: { search: { post_id: 2 } })
+        expect(returned_ids).to eq([event_b.id])
+      end
+
+      it "filters by reason" do
+        get upload_karma_events_path(format: :json, params: { search: { reason: "deleted" } })
+        expect(returned_ids).to eq([event_b.id])
+      end
+    end
+  end
+end


### PR DESCRIPTION
The current karma system is a little obscure – users can't tell what caused karma to be incremented / decremented without digging through their uploads, deletions, and replacements.

This PR adds a karma ledger – an immutable record of karma changes for all users.
Additionally, this includes a backfill fixer script - recalculating karma and creating ledger events based on existing activity.