### PR TITLE
[WikiPages] Decouple tag category editing from wiki pages

### DIFF
--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -46,6 +46,8 @@ class WikiPagesController < ApplicationController
 
   def new
     @wiki_page = WikiPage.new(wiki_page_params(:create))
+    # normalize eagerly so the has_one :tag lookup matches for prefilled titles
+    @wiki_page.title = WikiPage.normalize_title(@wiki_page.title) if @wiki_page.title.present?
     respond_with(@wiki_page)
   end
 

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -124,12 +124,14 @@ class WikiPagesController < ApplicationController
   end
 
   def wiki_page_params(context)
+    # category_id and category_is_locked are deprecated: still permitted so API
+    # clients don't get rejected, but ignored. Category changes go through tags#update.
     permitted_params = %i[body category_id edit_reason featured_posts_string]
     permitted_params += %i[parent] if CurrentUser.is_privileged?
     permitted_params += %i[is_locked is_deleted skip_secondary_validations] if CurrentUser.is_staff?
     permitted_params += %i[category_is_locked] if CurrentUser.is_admin?
     permitted_params += %i[title] if context == :create || CurrentUser.is_staff?
 
-    params.fetch(:wiki_page, {}).permit(permitted_params)
+    params.fetch(:wiki_page, {}).permit(permitted_params).except(:category_id, :category_is_locked)
   end
 end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -7,8 +7,6 @@ class WikiPage < ApplicationRecord
   before_validation :normalize_other_names
   before_validation :normalize_parent
   before_save :log_changes
-  before_save :update_tag
-  before_create :create_tag
   before_destroy :validate_not_used_as_help_page
   before_destroy :log_destroy
   after_destroy :clear_recent_changes_cache
@@ -23,6 +21,7 @@ class WikiPage < ApplicationRecord
   validates :title, tag_name: true, if: :title_changed?
   validates :title, length: { minimum: 1, maximum: 100 }
   validates :body, length: { maximum: Danbooru.config.wiki_page_max_size }
+  validates :body, presence: true, on: :create, unless: -> { parent.present? }
   validate :user_not_limited
   validate :validate_rename
   validate :validate_redirect
@@ -150,89 +149,8 @@ class WikiPage < ApplicationRecord
   end
 
   module TagMethods
-    def tag
-      @tag ||= super
-    end
-
-    def tag=(value)
-      @tag = value
-    end
-
     def category_id
-      @category_id ||= tag&.category
-    end
-
-    def category_id=(value)
-      @category_id = value.to_i if value.present?
-    end
-
-    def category_is_locked
-      @category_is_locked ||= tag&.is_locked || false
-    end
-
-    def category_is_locked=(value)
-      @category_is_locked = value
-    end
-
-    def tag_update_map
-      updates = {}
-      updates[:category] = @category_id if defined?(@category_id)
-      updates[:is_locked] = @category_is_locked if defined?(@category_is_locked)
-      updates
-    end
-
-    def category_editable_by?(user = CurrentUser.user)
-      tag.nil? || tag.category_editable_by?(user)
-    end
-
-    def create_tag
-      return if tag
-
-      updates = tag_update_map
-      return if updates.empty?
-
-      unless category_editable_by?
-        tag_error("Cannot be picked")
-      end
-
-      self.tag = Tag.create({ name: title }.merge(updates))
-      unless tag.persisted?
-        tag_error(tag.errors.full_messages.join(", "))
-      end
-
-      reload_tag_attributes
-    end
-
-    def update_tag
-      return unless tag
-
-      updates = tag_update_map
-      return if updates.empty?
-
-      unless category_editable_by?
-        tag_error("Cannot be changed")
-      end
-
-      unless tag.update(updates)
-        tag_error(tag.errors.full_messages.join(", "))
-      end
-
-      reload_tag_attributes
-    end
-
-    private
-
-    def tag_error(message)
-      errors.add(:category_id, message)
-      reload_tag_attributes
-      throw(:abort)
-    end
-
-    def reload_tag_attributes
-      remove_instance_variable(:@category_id) if defined?(@category_id)
-      remove_instance_variable(:@category_is_locked) if defined?(@category_is_locked)
-      remove_instance_variable(:@tag) if defined?(@tag)
-      association(:tag).reset
+      tag&.category
     end
   end
 
@@ -325,7 +243,6 @@ class WikiPage < ApplicationRecord
 
     title = self.title.downcase.tr(" ", "_")
     if title =~ /\A(#{Tag.categories.regexp}):(.+)\Z/
-      self.category_id = Tag.categories.value_for($1)
       title = $2
     end
     self.title = title

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -241,11 +241,15 @@ class WikiPage < ApplicationRecord
   def normalize_title
     return if title.nil?
 
-    title = self.title.downcase.tr(" ", "_")
+    self.title = WikiPage.normalize_title(title)
+  end
+
+  def self.normalize_title(title)
+    title = normalize_name(title)
     if title =~ /\A(#{Tag.categories.regexp}):(.+)\Z/
       title = $2
     end
-    self.title = title
+    title
   end
 
   def normalize_other_names

--- a/app/views/tags/_edit_form.html.erb
+++ b/app/views/tags/_edit_form.html.erb
@@ -1,0 +1,14 @@
+<%= custom_form_for(tag) do |f| %>
+  <%= f.hidden_field(:from_wiki, value: from_wiki) %>
+  <% if tag.is_locked? %>
+    <p>This tag is category locked</p>
+  <% else %>
+    <%= f.input :category, collection: CurrentUser.is_privileged? ? TagCategory::CANONICAL_MAPPING.to_a : TagCategory::MEMBER_EDITABLE_MAPPING.to_a, include_blank: false %>
+  <% end %>
+
+  <% if CurrentUser.is_admin? %>
+    <%= f.input :is_locked, collection: [%w[No false], %w[Yes true]], include_blank: false %>
+  <% end %>
+
+  <%= f.button :submit, "Submit" %>
+<% end %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -2,20 +2,7 @@
   <div id="a-edit">
     <h1>Tag: <%= link_to @tag.name, posts_path(:tags => @tag.name), :class => "tag-type-#{@tag.category}" %></h1>
 
-    <%= custom_form_for(@tag) do |f| %>
-      <%= f.hidden_field(:from_wiki, value: @from_wiki) %>
-      <% if @tag.is_locked? %>
-        <p>This tag is category locked</p>
-      <% else %>
-        <%= f.input :category, collection: CurrentUser.is_privileged? ? TagCategory::CANONICAL_MAPPING.to_a : TagCategory::MEMBER_EDITABLE_MAPPING.to_a, include_blank: false %>
-      <% end %>
-
-      <% if CurrentUser.is_admin? %>
-        <%= f.input :is_locked, :collection => [["No", "false"], ["Yes", "true"]], :include_blank => false %>
-      <% end %>
-
-      <%= f.button :submit, "Submit" %>
-    <% end %>
+    <%= render "edit_form", tag: @tag, from_wiki: @from_wiki %>
   </div>
 </div>
 

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -19,18 +19,6 @@
       <div class="featured-posts-preview-list"></div>
     </div>
 
-    <% if @wiki_page.new_record? || @wiki_page.tag.present? %>
-      <%= f.input :category_id, 
-        label: "Tag Category", 
-        collection: CurrentUser.is_privileged? ? TagCategory::CANONICAL_MAPPING.to_a : TagCategory::MEMBER_EDITABLE_MAPPING.to_a, 
-        include_blank: @wiki_page.tag.blank?,
-        disabled: !@wiki_page.category_editable_by? %>
-
-      <% if CurrentUser.is_admin? %>
-        <%= f.input :category_is_locked, label: "Lock Category", as: :boolean %>
-      <% end %>
-    <% end %>
-
     <%= f.input :parent, label: "Redirects to", autocomplete: "wiki-page", input_html: { disabled: !CurrentUser.is_privileged? } %>
 
     <% if CurrentUser.is_staff? %>

--- a/app/views/wiki_pages/_tag_category.html.erb
+++ b/app/views/wiki_pages/_tag_category.html.erb
@@ -1,0 +1,10 @@
+<% if tag.present? && (tag.category_editable_by?(CurrentUser.user) || tag.is_locked?) %>
+  <div id="wiki-page-tag-category">
+    <h2>Tag Category</h2>
+    <% if tag.category_editable_by?(CurrentUser.user) %>
+      <%= render "tags/edit_form", tag: tag, from_wiki: "1" %>
+    <% else %>
+      <p>This tag is category locked</p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/wiki_pages/edit.html.erb
+++ b/app/views/wiki_pages/edit.html.erb
@@ -7,6 +7,8 @@
 
       <%= render "form" %>
 
+      <%= render "tag_category", tag: @wiki_page.tag %>
+
       <%= wiki_page_alias_and_implication_list(@wiki_page)%>
       <%= render "recent_posts" %>
       <div class="clearfix"></div>

--- a/app/views/wiki_pages/new.html.erb
+++ b/app/views/wiki_pages/new.html.erb
@@ -7,6 +7,8 @@
 
       <%= render "form" %>
 
+      <%= render "tag_category", tag: @wiki_page.tag %>
+
       <%= wiki_page_alias_and_implication_list(@wiki_page)%>
       <%= render "recent_posts" %>
       <div class="clearfix"></div>

--- a/spec/models/wiki_page/instance_methods_spec.rb
+++ b/spec/models/wiki_page/instance_methods_spec.rb
@@ -29,26 +29,28 @@ RSpec.describe WikiPage do
   # #pretty_title_with_category
   # -------------------------------------------------------------------------
   describe "#pretty_title_with_category" do
-    it "returns pretty_title without a prefix when category_id is nil" do
+    include_context "with tag categories"
+
+    it "returns pretty_title without a prefix when no tag exists" do
       page = build(:wiki_page, title: "some_page")
       expect(page.pretty_title_with_category).to eq("some page")
     end
 
-    it "returns pretty_title without a prefix when category_id is 0 (general)" do
-      page = build(:wiki_page, title: "some_page")
-      page.category_id = 0 # general
+    it "returns pretty_title without a prefix when the tag is general" do
+      create(:tag, name: "some_page", category: general_tag_category)
+      page = create(:wiki_page, title: "some_page").reload
       expect(page.pretty_title_with_category).to eq("some page")
     end
 
-    it "prepends the capitalized category name for category 1" do
-      page = build(:wiki_page, title: "my_tag")
-      page.category_id = 1
-      expect(page.pretty_title_with_category).to eq("#{TagCategory::REVERSE_MAPPING[1].capitalize}: my tag")
+    it "prepends the capitalized category name for an artist tag" do
+      create(:tag, name: "my_tag", category: artist_tag_category)
+      page = create(:wiki_page, title: "my_tag").reload
+      expect(page.pretty_title_with_category).to eq("#{TagCategory::REVERSE_MAPPING[artist_tag_category].capitalize}: my tag")
     end
 
-    it "prepends the correct category name for species" do
-      page = build(:wiki_page, title: "my_species")
-      page.category_id = 5 # species
+    it "prepends the correct category name for a species tag" do
+      create(:tag, name: "my_species", category: species_tag_category)
+      page = create(:wiki_page, title: "my_species").reload
       expect(page.pretty_title_with_category).to eq("Species: my species")
     end
   end

--- a/spec/models/wiki_page/normalizations_spec.rb
+++ b/spec/models/wiki_page/normalizations_spec.rb
@@ -23,26 +23,29 @@ RSpec.describe WikiPage do
       expect(page.title).to eq("a_page_title")
     end
 
-    it "strips the category-1 prefix and sets category_id to 1" do
+    it "strips the category-1 prefix from the title" do
       cat1 = TagCategory::REVERSE_MAPPING[1]
       page = build(:wiki_page, title: "#{cat1}:some_tag")
       page.valid?
       expect(page.title).to eq("some_tag")
-      expect(page.category_id).to eq(1)
     end
 
-    it "strips the species: prefix and sets category_id to species" do
+    it "strips the species: prefix from the title" do
       page = build(:wiki_page, title: "species:some_species")
       page.valid?
       expect(page.title).to eq("some_species")
-      expect(page.category_id).to eq(5) # species
     end
 
-    it "strips the character: prefix and sets category_id to character" do
+    it "strips the character: prefix from the title" do
       page = build(:wiki_page, title: "character:some_character")
       page.valid?
       expect(page.title).to eq("some_character")
-      expect(page.category_id).to eq(4) # character
+    end
+
+    it "does not create a tag for a category-prefixed title" do
+      expect do
+        create(:wiki_page, title: "species:prefix_no_tag")
+      end.not_to change(Tag, :count)
     end
 
     it "leaves titles without a category prefix unchanged" do
@@ -55,7 +58,6 @@ RSpec.describe WikiPage do
       page = build(:wiki_page, title: "#{cat1.upcase}:foo_artist")
       page.valid?
       expect(page.title).to eq("foo_artist")
-      expect(page.category_id).to eq(1) # artist
     end
   end
 

--- a/spec/models/wiki_page/normalizations_spec.rb
+++ b/spec/models/wiki_page/normalizations_spec.rb
@@ -62,6 +62,19 @@ RSpec.describe WikiPage do
   end
 
   # -------------------------------------------------------------------------
+  # .normalize_title (class method)
+  # -------------------------------------------------------------------------
+  describe ".normalize_title" do
+    it "downcases, underscores, and strips a category prefix" do
+      expect(WikiPage.normalize_title("Species:Some Tag")).to eq("some_tag")
+    end
+
+    it "leaves unprefixed titles unchanged apart from casing and spaces" do
+      expect(WikiPage.normalize_title("Plain Title")).to eq("plain_title")
+    end
+  end
+
+  # -------------------------------------------------------------------------
   # normalize_other_names (before_validation)
   # -------------------------------------------------------------------------
   describe "normalize_other_names" do

--- a/spec/models/wiki_page/tag_methods_spec.rb
+++ b/spec/models/wiki_page/tag_methods_spec.rb
@@ -26,162 +26,34 @@ RSpec.describe WikiPage do
       page.reload
       expect(page.category_id).to eq(artist_tag_category)
     end
-  end
 
-  # -------------------------------------------------------------------------
-  # #category_id=
-  # -------------------------------------------------------------------------
-  describe "#category_id=" do
-    it "sets the category_id instance variable to the integer value of the input" do
-      page = build(:wiki_page)
-      page.category_id = artist_tag_category.to_s
-      expect(page.category_id).to eq(artist_tag_category)
-    end
-
-    it "does not set category_id when the value is blank" do
-      page = build(:wiki_page)
-      page.category_id = ""
-      expect(page.category_id).to be_nil
-    end
-  end
-
-  # -------------------------------------------------------------------------
-  # #category_is_locked getter
-  # -------------------------------------------------------------------------
-  describe "#category_is_locked" do
-    it "returns false when no associated tag exists" do
-      page = create(:wiki_page)
-      expect(page.category_is_locked).to be false
-    end
-
-    it "returns the tag's is_locked value when a tag is associated" do
-      create(:tag, name: "locked_category_page", is_locked: true)
-      page = create(:wiki_page, title: "locked_category_page")
+    it "reflects external tag category changes after a reload" do
+      tag = create(:tag, name: "recategorized_page", category: artist_tag_category)
+      page = create(:wiki_page, title: "recategorized_page")
       page.reload
-      expect(page.category_is_locked).to be true
+      expect(page.category_id).to eq(artist_tag_category)
+
+      tag.update!(category: species_tag_category)
+      page.reload
+      expect(page.category_id).to eq(species_tag_category)
     end
   end
 
   # -------------------------------------------------------------------------
-  # create_tag (before_create)
+  # Tag creation decoupling
   # -------------------------------------------------------------------------
-  describe "create_tag" do
-    it "creates a Tag record when category_id is set during creation" do
-      expect do
-        page = build(:wiki_page, title: "new_artist_wiki")
-        page.category_id = artist_tag_category
-        page.save!
-      end.to change(Tag, :count).by(1)
-      expect(Tag.find_by(name: "new_artist_wiki")).to be_present
-    end
-
-    it "does not create a Tag when category_id is not set" do
+  describe "tag creation" do
+    it "never creates a Tag when a wiki page is created" do
       expect do
         create(:wiki_page, title: "plain_wiki_no_tag")
       end.not_to change(Tag, :count)
     end
 
-    it "does not create a duplicate Tag when a tag with the same name already exists" do
-      create(:tag, name: "existing_tag_wiki")
-      expect do
-        page = build(:wiki_page, title: "existing_tag_wiki")
-        page.category_id = artist_tag_category
-        page.save!
-      end.not_to change(Tag, :count)
-    end
-
-    it "stores the correct category on the newly created tag" do
-      page = build(:wiki_page, title: "species_wiki")
-      page.category_id = species_tag_category
-      page.save!
-      expect(Tag.find_by(name: "species_wiki").category).to eq(species_tag_category)
-    end
-
-    it "adds a category_id error and aborts when the user cannot create the tag category" do
-      # Members cannot create admin-only categories (meta=7, invalid=6, lore=8).
-      # The Tag model's user_can_change_category? validation fires on create
-      # when category changes from the default, causing Tag#save to fail,
-      # which triggers tag_error on the wiki page.
-      CurrentUser.user = create(:user)
-      page = build(:wiki_page, title: "member_meta_wiki")
-      page.category_id = meta_tag_category
-      result = page.save
-      expect(result).to be false
-      expect(page.errors[:category_id]).to be_present
-    end
-  end
-
-  # -------------------------------------------------------------------------
-  # update_tag (before_save)
-  # -------------------------------------------------------------------------
-  describe "update_tag" do
-    let!(:wiki_with_tag) do
-      p = build(:wiki_page, title: "updateable_tag_wiki")
-      p.category_id = artist_tag_category
-      p.save!
-      p
-    end
-
-    it "updates the tag's category when category_id changes" do
-      wiki_with_tag.category_id = species_tag_category
-      wiki_with_tag.save!
-      expect(Tag.find_by(name: "updateable_tag_wiki").category).to eq(species_tag_category)
-    end
-
-    it "updates the tag's is_locked when category_is_locked changes" do
-      wiki_with_tag.category_is_locked = true
-      wiki_with_tag.save!
-      expect(Tag.find_by(name: "updateable_tag_wiki").is_locked).to be true
-    end
-
-    it "is a no-op when neither category_id nor category_is_locked has been assigned" do
-      original_category = Tag.find_by(name: "updateable_tag_wiki").category
-      wiki_with_tag.body = "just a body update"
-      wiki_with_tag.save!
-      expect(Tag.find_by(name: "updateable_tag_wiki").category).to eq(original_category)
-    end
-
-    it "adds a category_id error and aborts when the user cannot change the category" do
-      # Create a wiki page with meta category (7) as admin so the tag is admin-only.
-      # A member's attempt to change the category should be blocked because
-      # tag.category_editable_by? returns false for an admin-only category.
-      meta_page = build(:wiki_page, title: "meta_tag_wiki")
-      meta_page.category_id = meta_tag_category
-      meta_page.save!
-
-      CurrentUser.user = create(:user)
-      meta_page.category_id = artist_tag_category
-      result = meta_page.save
-      expect(result).to be false
-      expect(meta_page.errors[:category_id]).to be_present
-    end
-  end
-
-  # -------------------------------------------------------------------------
-  # #category_editable_by?
-  # -------------------------------------------------------------------------
-  describe "#category_editable_by?" do
-    it "returns true when no tag is associated (tag is nil)" do
-      page = create(:wiki_page)
-      member = create(:user)
-      expect(page.category_editable_by?(member)).to be true
-    end
-
-    it "delegates to tag.category_editable_by? when a tag is associated" do
-      page = build(:wiki_page, title: "delegate_cat_wiki")
-      page.category_id = artist_tag_category
-      page.save!
-      page.reload
-      expect(page.category_editable_by?(CurrentUser.user)).to eq(page.tag.category_editable_by?(CurrentUser.user))
-    end
-
-    it "returns false for a member when the existing tag is in an admin-only category" do
-      meta_page = build(:wiki_page, title: "meta_editable_wiki")
-      meta_page.category_id = meta_tag_category
-      meta_page.save!
-      meta_page.reload
-      member = create(:user)
-      expect(meta_page.category_editable_by?(member)).to be false
+    it "does not update an existing tag when the wiki page is saved" do
+      tag = create(:tag, name: "existing_tag_wiki", category: artist_tag_category)
+      page = create(:wiki_page, title: "existing_tag_wiki")
+      page.update!(body: "updated body")
+      expect(tag.reload.category).to eq(artist_tag_category)
     end
   end
 end

--- a/spec/models/wiki_page/validations_spec.rb
+++ b/spec/models/wiki_page/validations_spec.rb
@@ -118,6 +118,31 @@ RSpec.describe WikiPage do
     end
 
     # -------------------------------------------------------------------------
+    # body — presence (on create, unless redirect)
+    # -------------------------------------------------------------------------
+    describe "body — presence" do
+      it "is invalid on create when body is blank and no parent is set" do
+        page = build(:wiki_page, body: "")
+        expect(page).not_to be_valid
+        expect(page.errors[:body]).to be_present
+      end
+
+      it "is valid on create when body is blank but parent points to an existing page" do
+        create(:wiki_page, title: "presence_redirect_target")
+        page = build(:wiki_page, body: "", parent: "presence_redirect_target")
+        expect(page).to be_valid, page.errors.full_messages.join(", ")
+      end
+
+      it "allows updating a legacy record with a blank body" do
+        page = create(:wiki_page)
+        page.update_columns(body: "")
+        page.reload
+        page.other_names = ["legacy_alias"]
+        expect(page).to be_valid
+      end
+    end
+
+    # -------------------------------------------------------------------------
     # user_not_limited
     # -------------------------------------------------------------------------
     describe "user_not_limited" do

--- a/spec/requests/wiki_pages_controller_spec.rb
+++ b/spec/requests/wiki_pages_controller_spec.rb
@@ -179,6 +179,14 @@ RSpec.describe WikiPagesController do
       expect(response.body).to include(tag_path(tag))
       expect(response.body).to include("tag[from_wiki]")
     end
+
+    it "normalizes the prefilled title before looking up the tag" do
+      tag = create(:tag, name: "wikiless_tag")
+      sign_in_as user
+      get new_wiki_page_path, params: { wiki_page: { title: "Species:Wikiless Tag" } }
+      expect(response.body).to include(tag_path(tag))
+      expect(response.body).to include("tag[from_wiki]")
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/requests/wiki_pages_controller_spec.rb
+++ b/spec/requests/wiki_pages_controller_spec.rb
@@ -171,6 +171,14 @@ RSpec.describe WikiPagesController do
       get new_wiki_page_path
       expect(response).to have_http_status(:ok)
     end
+
+    it "renders the tag category form when the prefilled title matches an existing tag" do
+      tag = create(:tag, name: "wikiless_tag")
+      sign_in_as user
+      get new_wiki_page_path, params: { wiki_page: { title: "wikiless_tag" } }
+      expect(response.body).to include(tag_path(tag))
+      expect(response.body).to include("tag[from_wiki]")
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -205,6 +213,20 @@ RSpec.describe WikiPagesController do
       sign_in_as janitor
       get edit_wiki_page_path(locked_wiki_page)
       expect(response).to have_http_status(:ok)
+    end
+
+    it "renders the tag category form when the wiki's tag exists and is editable" do
+      tag = create(:tag, name: wiki_page.title)
+      sign_in_as user
+      get edit_wiki_page_path(wiki_page)
+      expect(response.body).to include(tag_path(tag))
+      expect(response.body).to include("tag[from_wiki]")
+    end
+
+    it "does not render the tag category form when the wiki has no tag" do
+      sign_in_as user
+      get edit_wiki_page_path(wiki_page)
+      expect(response.body).not_to include("tag[from_wiki]")
     end
   end
 
@@ -246,6 +268,18 @@ RSpec.describe WikiPagesController do
         end.not_to change(WikiPage, :count)
       end
 
+      it "does not create a page with a blank body" do
+        expect do
+          post wiki_pages_path, params: { wiki_page: { title: "blank_body_page", body: "" } }
+        end.not_to change(WikiPage, :count)
+      end
+
+      it "does not create a tag as a side effect" do
+        expect do
+          post wiki_pages_path, params: { wiki_page: { title: "no_tag_side_effect", body: "body", category_id: 1 } }
+        end.not_to change(Tag, :count)
+      end
+
       it "allows setting featured posts" do
         posts = create_list(:post, 2)
         post wiki_pages_path, params: { wiki_page: { title: "featured_member_page", body: "body", featured_posts_string: posts.map(&:id).join(" ") } }
@@ -269,6 +303,13 @@ RSpec.describe WikiPagesController do
         post wiki_pages_path, params: { wiki_page: { title: "child_page_privileged", body: "body", parent: parent_page.title } }
         expect(WikiPage.titled("child_page_privileged").parent).to eq(parent_page.title)
       end
+
+      it "allows creating a redirect page with a blank body" do
+        parent_page = create(:wiki_page)
+        expect do
+          post wiki_pages_path, params: { wiki_page: { title: "blank_redirect_page", body: "", parent: parent_page.title } }
+        end.to change(WikiPage, :count).by(1)
+      end
     end
 
     context "as a janitor" do
@@ -283,10 +324,13 @@ RSpec.describe WikiPagesController do
     context "as an admin" do
       before { sign_in_as admin }
 
-      it "accepts the category_is_locked param without error" do
+      it "accepts and ignores the deprecated category params" do
+        tag = create(:tag, name: "catlock_wiki_page")
         expect do
-          post wiki_pages_path, params: { wiki_page: { title: "catlock_wiki_page", body: "body", category_is_locked: true } }
+          post wiki_pages_path, params: { wiki_page: { title: "catlock_wiki_page", body: "body", category_id: 1, category_is_locked: true } }
         end.to change(WikiPage, :count).by(1)
+        expect(tag.reload.category).to eq(0)
+        expect(tag.is_locked).to be false
       end
     end
   end


### PR DESCRIPTION
Spiritual successor of sorts to #1706.

Tag category editing being mixed in with wiki editing has created one big mess.
Rather than expand the mess like the other PR suggests, I chose to separate those two concerns.

Changing the category can now be done through a separate form on the wiki edit page.
- Editing a tag category via the wiki edit page will no longer create a blank wiki page.
- Creating a wiki page will no longer automatically create a tag.
- Users can no longer create blank wiki pages, except for redirects.
- Category prefixes like `species:` in titles are automatically stripped without categorizing anything.
- API users will need to switch to the more standard `PATCH /tags/:id`.