### PR TITLE
[OpenSearch] Self-heal version conflicts on single-document writes

### DIFF
--- a/app/logical/document_store/instance_method_proxy.rb
+++ b/app/logical/document_store/instance_method_proxy.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 module DocumentStore
+  class VersionConflictError < StandardError; end
+
   class InstanceMethodProxy
+    # A write that still conflicts after refreshing the version means something is
+    # actively racing ahead of us; give up loudly instead of looping.
+    MAX_CONFLICT_RETRIES = 2
+
     delegate :client, :index_name, to: :class_document_store
     delegate_missing_to :@target
 
@@ -10,25 +16,28 @@ module DocumentStore
     end
 
     def update_index(refresh: "false")
-      params = { index: index_name, id: id, body: as_indexed_json, refresh: refresh }
+      version = index_version
+      body = as_indexed_json
+      return client.index(index: index_name, id: id, body: body, refresh: refresh) if version.nil?
 
       # Optimistic concurrency control.
       # Any indexer that reads a record and writes the document some time later can otherwise
       # clobber a fresher document with the stale snapshot it read. Tagging the write with
       # the record's own version makes OpenSearch reject it (409) instead.
-      if (version = index_version)
-        params[:version] = version
-        params[:version_type] = "external_gte"
-        params[:ignore] = 409
+      (MAX_CONFLICT_RETRIES + 1).times do
+        response = client.index(index: index_name, id: id, body: body, refresh: refresh,
+                                version: version, version_type: "external_gte", ignore: 409)
+        return response unless conflict?(response)
+
+        # The document is ahead of the record, typically after an unstamped write bumped
+        # its version. The content being written here is fresher than whatever is indexed,
+        # so retry at the document's own version (external_gte accepts equal) rather than
+        # dropping the update.
+        version = [version, current_document_version].compact.max
+        Rails.logger.warn("[DocumentStore] version conflict indexing #{index_name}/#{id}: retrying at version #{version}")
       end
 
-      response = client.index(**params)
-      # `ignore` suppresses the transport's own logging, leaving rejections silent.
-      if response.is_a?(Hash) && response["status"] == 409
-        Rails.logger.warn("[DocumentStore] version conflict indexing #{index_name}/#{id}: indexed document is at or above version #{params[:version]}")
-      end
-
-      response
+      raise VersionConflictError, "#{index_name}/#{id} still conflicts after #{MAX_CONFLICT_RETRIES} retries at version #{version}"
     end
 
     def delete_document(refresh: "false")
@@ -36,6 +45,15 @@ module DocumentStore
     end
 
     private
+
+    def conflict?(response)
+      response.is_a?(Hash) && response["status"] == 409
+    end
+
+    def current_document_version
+      response = client.get(index: index_name, id: id, _source: false, ignore: 404)
+      response["_version"] if response.is_a?(Hash)
+    end
 
     def class_document_store
       @target.class.document_store

--- a/app/logical/document_store/instance_method_proxy.rb
+++ b/app/logical/document_store/instance_method_proxy.rb
@@ -34,6 +34,9 @@ module DocumentStore
         # so retry at the document's own version (external_gte accepts equal) rather than
         # dropping the update.
         version = [version, current_document_version].compact.max
+        @target.reload
+        body = as_indexed_json
+        version = [version, index_version].compact.max
         Rails.logger.warn("[DocumentStore] version conflict indexing #{index_name}/#{id}: retrying at version #{version}")
       end
 

--- a/spec/logical/document_store/instance_method_proxy_spec.rb
+++ b/spec/logical/document_store/instance_method_proxy_spec.rb
@@ -29,16 +29,53 @@ RSpec.describe DocumentStore::InstanceMethodProxy do
       end
 
       context "when the write is rejected" do
-        let(:client) { instance_double(OpenSearch::Client, index: { "status" => 409, "error" => { "type" => "version_conflict_engine_exception" } }) }
+        let(:conflict) { { "status" => 409, "error" => { "type" => "version_conflict_engine_exception" } } }
+        let(:success) { { "result" => "updated" } }
+        let(:client) { instance_double(OpenSearch::Client, get: { "_version" => 23_456 }) }
 
-        it "does not raise" do
-          expect { update_index }.not_to raise_error
+        before { allow(Rails.logger).to receive(:warn) }
+
+        context "when the document has moved ahead" do
+          before { allow(client).to receive(:index).and_return(conflict, success) }
+
+          it "rewrites the same content at the document's version" do
+            update_index
+            expect(client).to have_received(:index).with(hash_including(version: 23_456, version_type: "external_gte")).once
+          end
+
+          it "logs the retry, which the transport itself swallows" do
+            update_index
+            expect(Rails.logger).to have_received(:warn).with(/version conflict indexing .*#{post.id}/)
+          end
         end
 
-        it "logs the rejection, which the transport itself swallows" do
-          allow(Rails.logger).to receive(:warn)
-          update_index
-          expect(Rails.logger).to have_received(:warn).with(/version conflict indexing .*#{post.id}/)
+        context "when the document was deleted in the meantime" do
+          before do
+            allow(client).to receive(:get).and_return({ "found" => false })
+            allow(client).to receive(:index).and_return(conflict, success)
+          end
+
+          it "retries at the record's own version" do
+            update_index
+            expect(client).to have_received(:index).with(hash_including(version: 12_345)).twice
+          end
+        end
+
+        context "when the conflict persists" do
+          before { allow(client).to receive(:index).and_return(conflict) }
+
+          it "raises after bounded retries instead of dropping the update" do
+            expect { update_index }.to raise_error(DocumentStore::VersionConflictError, /#{post.id}/)
+          end
+
+          it "stops writing after the retry budget" do
+            begin
+              update_index
+            rescue DocumentStore::VersionConflictError
+              nil
+            end
+            expect(client).to have_received(:index).exactly(3).times
+          end
         end
       end
     end


### PR DESCRIPTION
A stamped write that lost to a document with a higher version was silently dropped with a warn-level log, permanently desyncing the document from the database for fields that do not bump change_seq (faves, votes, counts). Seen in production after a partial deploy restart left a pre-versioning worker writing unstamped documents, which bumped their internal versions past the rows' change_seq and blackholed every subsequent update to the affected posts.

On a 409, re-read the document's current version and rewrite the fresh content at that version (external_gte accepts equal), so the content converges instead of losing the update. If the conflict persists after bounded retries, raise so the job retries loudly instead of reporting success.