### PR TITLE
[Sidekiq] Add capsule support for per-queue concurrency caps

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,6 +22,15 @@
 # export QUERY_TRACE=
 
 #
+# Sidekiq
+#
+
+# Sidekiq capsules configuration.
+# Format: <name> <concurrency> <queue1>:<weight1>,<queue2>:<weight2>; ...
+# Example:
+# SIDEKIQ_CAPSULES=media 2 video:1,thumb:3; iqdb 1 iqdb:1
+
+#
 # Danbooru
 #
 # DANBOORU_DRAIN_FILE=tmp/out_of_rotation

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 server: bin/rails server -p 9000 -b 0.0.0.0 --pid=/tmp/rails-server.pid
 # server: PITCHFORK_LISTEN_ADDRESS=0.0.0.0:9000 PITCHFORK_WORKER_COUNT=2 bundle exec pitchfork -c config/pitchfork.rb
-jobs: SIDEKIQ_QUEUES="low_prio:1;video:1;thumb:1;iqdb:1;tags:2;default:3;high_prio:5" bundle exec sidekiq
+jobs: SIDEKIQ_QUEUES="low_prio:1;tags:2;default:3;high_prio:5" SIDEKIQ_CAPSULES="media 2 video:1,thumb:1;iqdb 1 iqdb" bundle exec sidekiq

--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,8 @@ development:
   <<: *default
   database: e621_development
   host: postgres
-  pool: 5
+  # Covers the Procfile sidekiq process: default capsule (5) + media (2) + iqdb (1)
+  pool: 10
 
 test:
   <<: *default

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,7 @@
 
 require "sidekiq-unique-jobs"
 require "sidekiq-cron"
+require_relative "../../lib/sidekiq_capsules"
 
 Sidekiq.logger.level = Logger::WARN if Rails.env.test?
 
@@ -17,6 +18,23 @@ Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
   end
 
   SidekiqUniqueJobs::Server.configure(config)
+
+  # Extra capsules with their own thread pools, capping per-queue concurrency
+  # (e.g. concurrent video transcodes) without a dedicated host per queue.
+  SidekiqCapsules.parse(ENV.fetch("SIDEKIQ_CAPSULES", nil)).each do |spec|
+    config.capsule(spec[:name]) do |cap|
+      cap.concurrency = spec[:concurrency]
+      cap.queues = spec[:queues]
+    end
+  end
+
+  config.on(:startup) do
+    pool = ActiveRecord::Base.connection_pool.size
+    total = config.total_concurrency
+    if pool < total
+      Sidekiq.logger.warn("Database pool (#{pool}) is smaller than total Sidekiq concurrency (#{total}); raise DB_WORKER_POOL_SIZE or busy threads will wait on connections")
+    end
+  end
 
   # Schedule recurring jobs
   schedule = {

--- a/lib/sidekiq_capsules.rb
+++ b/lib/sidekiq_capsules.rb
@@ -8,7 +8,10 @@
 #   SIDEKIQ_CAPSULES="media 2 video:1,thumb:1;iqdb 1 iqdb"
 module SidekiqCapsules
   def self.parse(raw)
-    capsules = raw.to_s.split(";").map(&:strip).reject(&:empty?).map { |spec| parse_capsule(spec) }
+    capsules = raw.to_s.split(";")
+                  .map(&:strip)
+                  .reject(&:empty?)
+                  .map { |spec| parse_capsule(spec) }
 
     duplicates = capsules.pluck(:name).tally.select { |_, count| count > 1 }.keys
     raise ArgumentError, "SIDEKIQ_CAPSULES: duplicate capsule name(s): #{duplicates.join(', ')}" if duplicates.any?
@@ -39,6 +42,7 @@ module SidekiqCapsules
     value.split(",").map(&:strip).reject(&:empty?).map do |entry|
       queue, weight = entry.split(":", 2)
       weight ||= "1"
+      raise ArgumentError, "SIDEKIQ_CAPSULES: capsule #{name}: queue name cannot be empty" if queue.nil? || queue.strip.empty?
       raise ArgumentError, "SIDEKIQ_CAPSULES: capsule #{name}: invalid queue entry #{entry.inspect}" unless weight.match?(/\A[1-9]\d*\z/)
 
       [queue, Integer(weight)]

--- a/lib/sidekiq_capsules.rb
+++ b/lib/sidekiq_capsules.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Parses the SIDEKIQ_CAPSULES env var into Sidekiq capsule definitions.
+# Capsules get their own thread pool, giving per-queue concurrency caps
+# within a single process (e.g. "at most 2 concurrent video transcodes").
+#
+# Format: semicolon-separated "<name> <concurrency> <queue>[:<weight>],..."
+#   SIDEKIQ_CAPSULES="media 2 video:1,thumb:1;iqdb 1 iqdb"
+module SidekiqCapsules
+  def self.parse(raw)
+    capsules = raw.to_s.split(";").map(&:strip).reject(&:empty?).map { |spec| parse_capsule(spec) }
+
+    duplicates = capsules.pluck(:name).tally.select { |_, count| count > 1 }.keys
+    raise ArgumentError, "SIDEKIQ_CAPSULES: duplicate capsule name(s): #{duplicates.join(', ')}" if duplicates.any?
+
+    capsules
+  end
+
+  def self.parse_capsule(spec)
+    name, concurrency, queues = spec.split(/\s+/, 3)
+    raise ArgumentError, "SIDEKIQ_CAPSULES: expected \"<name> <concurrency> <queues>\", got #{spec.inspect}" if queues.nil? || queues.strip.empty?
+    raise ArgumentError, "SIDEKIQ_CAPSULES: \"default\" is reserved; configure it through SIDEKIQ_QUEUES" if name == "default"
+
+    {
+      name: name,
+      concurrency: parse_concurrency(name, concurrency),
+      queues: parse_queues(name, queues),
+    }
+  end
+
+  def self.parse_concurrency(name, value)
+    concurrency = Integer(value, exception: false)
+    raise ArgumentError, "SIDEKIQ_CAPSULES: capsule #{name}: concurrency must be a positive integer, got #{value.inspect}" if concurrency.nil? || concurrency < 1
+
+    concurrency
+  end
+
+  def self.parse_queues(name, value)
+    value.split(",").map(&:strip).reject(&:empty?).map do |entry|
+      queue, weight = entry.split(":", 2)
+      weight ||= "1"
+      raise ArgumentError, "SIDEKIQ_CAPSULES: capsule #{name}: invalid queue entry #{entry.inspect}" unless weight.match?(/\A[1-9]\d*\z/)
+
+      [queue, Integer(weight)]
+    end
+  end
+end

--- a/spec/lib/sidekiq_capsules_spec.rb
+++ b/spec/lib/sidekiq_capsules_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SidekiqCapsules do
+  describe ".parse" do
+    it "returns an empty array for nil or blank input" do
+      expect(described_class.parse(nil)).to eq([])
+      expect(described_class.parse("")).to eq([])
+      expect(described_class.parse("  ;  ")).to eq([])
+    end
+
+    it "parses a single capsule with a default queue weight" do
+      expect(described_class.parse("iqdb 1 iqdb")).to eq([
+        { name: "iqdb", concurrency: 1, queues: [["iqdb", 1]] },
+      ])
+    end
+
+    it "parses multiple capsules with explicit weights" do
+      expect(described_class.parse("media 2 video:1,thumb:3; iqdb 1 iqdb:1")).to eq([
+        { name: "media", concurrency: 2, queues: [["video", 1], ["thumb", 3]] },
+        { name: "iqdb", concurrency: 1, queues: [["iqdb", 1]] },
+      ])
+    end
+
+    it "tolerates extra whitespace" do
+      expect(described_class.parse("  media   2   video:1 , thumb:1  ")).to eq([
+        { name: "media", concurrency: 2, queues: [["video", 1], ["thumb", 1]] },
+      ])
+    end
+
+    it "rejects the reserved default capsule name" do
+      expect { described_class.parse("default 5 low_prio") }.to raise_error(ArgumentError, /reserved/)
+    end
+
+    it "rejects duplicate capsule names" do
+      expect { described_class.parse("media 2 video;media 1 thumb") }.to raise_error(ArgumentError, /duplicate/)
+    end
+
+    it "rejects capsules without queues" do
+      expect { described_class.parse("media 2") }.to raise_error(ArgumentError, /expected/)
+    end
+
+    it "rejects non-integer concurrency" do
+      expect { described_class.parse("media two video") }.to raise_error(ArgumentError, /concurrency/)
+    end
+
+    it "rejects zero concurrency" do
+      expect { described_class.parse("media 0 video") }.to raise_error(ArgumentError, /concurrency/)
+    end
+
+    it "rejects invalid queue weights" do
+      expect { described_class.parse("media 2 video:x") }.to raise_error(ArgumentError, /queue entry/)
+      expect { described_class.parse("media 2 video:0") }.to raise_error(ArgumentError, /queue entry/)
+    end
+  end
+end

--- a/spec/lib/sidekiq_capsules_spec.rb
+++ b/spec/lib/sidekiq_capsules_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe SidekiqCapsules do
       ])
     end
 
+    it "rejects capsules with empty names" do
+      expect { described_class.parse("  2 video") }.to raise_error(ArgumentError, /expected "<name> <concurrency> <queues>", got "2 video"/)
+    end
+
     it "rejects the reserved default capsule name" do
       expect { described_class.parse("default 5 low_prio") }.to raise_error(ArgumentError, /reserved/)
     end
@@ -52,6 +56,10 @@ RSpec.describe SidekiqCapsules do
     it "rejects invalid queue weights" do
       expect { described_class.parse("media 2 video:x") }.to raise_error(ArgumentError, /queue entry/)
       expect { described_class.parse("media 2 video:0") }.to raise_error(ArgumentError, /queue entry/)
+    end
+
+    it "rejects empty queue names" do
+      expect { described_class.parse("media 2 :1") }.to raise_error(ArgumentError, /queue name cannot be empty/)
     end
   end
 end


### PR DESCRIPTION
On all app hosts:
```
SIDEKIQ_CAPSULES="media 2 video:1,thumb:1;iqdb 1 iqdb"
```