### PR TITLE
[Favorites] Add (user_id, id) index for sequential pagination

### DIFF
--- a/db/migrate/20260827214903_add_user_id_and_id_index_to_favorites.rb
+++ b/db/migrate/20260827214903_add_user_id_and_id_index_to_favorites.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddUserIdAndIdIndexToFavorites < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  INDEX_NAME = "index_favorites_on_user_id_and_id"
+
+  def up
+    # Serves sequential (a/b cursor) pagination of a user's favorites, which
+    # orders by id. Without it, the planner walks favorites_pkey and filters by
+    # user, which times out for users whose favorites are mostly old.
+    Favorite.without_timeout do
+      add_index :favorites,
+                %i[user_id id],
+                name: INDEX_NAME,
+                algorithm: :concurrently
+    end
+  end
+
+  def down
+    remove_index :favorites, name: INDEX_NAME, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4916,6 +4916,13 @@ CREATE INDEX index_favorites_on_user_id_and_created_at ON public.favorites USING
 
 
 --
+-- Name: index_favorites_on_user_id_and_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_favorites_on_user_id_and_id ON public.favorites USING btree (user_id, id);
+
+
+--
 -- Name: index_favorites_on_user_id_and_post_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6416,6 +6423,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260827214903'),
 ('20260824220908'),
 ('20260819154314'),
 ('20260818231537'),


### PR DESCRIPTION
This should help with timeouts on `/favorites` when in sequential pagination mode.