### PR TITLE
[Jobs] Migrate from ActiveJob to native Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :development, :test do
 
   # Testing suite
   gem "rspec-rails", "~> 8.0.0", require: false
+  gem "rspec-sidekiq", "~> 5.3", require: false
   gem "parallel_tests", ">= 4.0"
   gem "factory_bot_rails", require: false
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -362,6 +362,11 @@ GEM
       rspec-expectations (>= 3.13.0, < 5.0.0)
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
+    rspec-sidekiq (5.3.0)
+      rspec-core (~> 3.0)
+      rspec-expectations (~> 3.0)
+      rspec-mocks (~> 3.0)
+      sidekiq (>= 5, < 9)
     rspec-support (3.13.7)
     rubocop (1.63.4)
       json (~> 2.3)
@@ -510,6 +515,7 @@ DEPENDENCIES
   rotp (~> 6.3)
   rqrcode (~> 3.0)
   rspec-rails (~> 8.0.0)
+  rspec-sidekiq (~> 5.3)
   rubocop
   rubocop-erb
   rubocop-rails

--- a/app/concerns/transactional_enqueue.rb
+++ b/app/concerns/transactional_enqueue.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Enqueue only after the surrounding DB transaction commits (and drop on rollback),
+# so the worker never runs before the row it reads is committed. Off in test, where
+# transactional fixtures never commit and a deferred push would never fire.
+module TransactionalEnqueue
+  extend ActiveSupport::Concern
+
+  included do
+    unless Rails.env.test?
+      require "sidekiq/transaction_aware_client"
+      sidekiq_options client_class: Sidekiq::TransactionAwareClient
+    end
+  end
+end

--- a/app/controllers/maintenance/user/avatars_controller.rb
+++ b/app/controllers/maintenance/user/avatars_controller.rb
@@ -61,7 +61,7 @@ module Maintenance
           redirect_to edit_maintenance_user_avatar_path and return
         end
 
-        AvatarCropJob.perform_later(CurrentUser.id, post_id, x, y, w)
+        AvatarCropJob.perform_async(CurrentUser.id, post_id, x, y, w)
         flash[:notice] = "Crop is being processed. It may take a few minutes to complete"
         redirect_to user_path(CurrentUser.user)
       end

--- a/app/controllers/staff/user_cleanups_controller.rb
+++ b/app/controllers/staff/user_cleanups_controller.rb
@@ -43,19 +43,19 @@ module Staff
     end
 
     def hide_comments
-      HideUserCommentsJob.perform_later(@user.id, CurrentUser.id)
+      HideUserCommentsJob.perform_async(@user.id, CurrentUser.id)
       ModAction.log(:user_comments_hide, { user_id: @user.id })
       redirect_to staff_user_cleanup_path(@user), notice: "Comment hide job scheduled."
     end
 
     def hide_forum_posts
-      HideUserForumPostsJob.perform_later(@user.id, CurrentUser.id)
+      HideUserForumPostsJob.perform_async(@user.id, CurrentUser.id)
       ModAction.log(:user_forum_posts_hide, { user_id: @user.id })
       redirect_to staff_user_cleanup_path(@user), notice: "Forum post hide job scheduled."
     end
 
     def hide_blips
-      HideUserBlipsJob.perform_later(@user.id, CurrentUser.id)
+      HideUserBlipsJob.perform_async(@user.id, CurrentUser.id)
       ModAction.log(:user_blips_delete, { user_id: @user.id })
       redirect_to staff_user_cleanup_path(@user), notice: "Blip delete job scheduled."
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -193,7 +193,7 @@ class UsersController < ApplicationController
 
   def flush_favorites
     @user = User.find(User.name_or_id_to_id_forced(params[:id]))
-    FlushFavoritesJob.perform_later(@user.id)
+    FlushFavoritesJob.perform_async(@user.id)
     ModAction.log(:user_flush_favorites, { user_id: @user.id })
 
     redirect_to user_path(@user)

--- a/app/jobs/api_key_expiration_warning_job.rb
+++ b/app/jobs/api_key_expiration_warning_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApiKeyExpirationWarningJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   def perform
     ApiKey.expiring_soon.find_each do |api_key|

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-class ApplicationJob < ActiveJob::Base
-  class JobError < StandardError; end
-  # Automatically retry jobs that encountered a deadlock
-  retry_on ActiveRecord::Deadlocked
+class ApplicationJob
+  include Sidekiq::Job
 
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  class JobError < StandardError; end
 end

--- a/app/jobs/asn_ranges_update_job.rb
+++ b/app/jobs/asn_ranges_update_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AsnRangesUpdateJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   def perform
     AsnRangeImporter.import!

--- a/app/jobs/automod_check_job.rb
+++ b/app/jobs/automod_check_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AutomodCheckJob < ApplicationJob
-  queue_as :default
+  sidekiq_options queue: "default"
 
   def perform(comment_id)
     comment = Comment.find(comment_id)

--- a/app/jobs/automod_user_check_job.rb
+++ b/app/jobs/automod_user_check_job.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class AutomodUserCheckJob < ApplicationJob
-  queue_as :default
+  sidekiq_options queue: "default"
 
-  def perform(user_id, check_username:, check_profile:)
+  def perform(user_id, check_username, check_profile)
     user = User.find(user_id)
     return if Ticket.active.where(qtype: "user", disp_id: user.id).exists?
 

--- a/app/jobs/avatar_cleanup_job.rb
+++ b/app/jobs/avatar_cleanup_job.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class AvatarCleanupJob < ApplicationJob
-  queue_as :default
+  sidekiq_options queue: "default"
 
-  def perform(user_id, force: false)
+  # Sidekiq args are positional JSON; keywords are not an option here.
+  def perform(user_id, force = false) # rubocop:disable Style/OptionalBooleanParameter
     user = User.find(user_id)
 
     # Don't perform cleanup if the user has a cropped avatar set.

--- a/app/jobs/avatar_crop_job.rb
+++ b/app/jobs/avatar_crop_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AvatarCropJob < ApplicationJob
-  queue_as :default
+  sidekiq_options queue: "default"
 
   def perform(user_id, post_id, pos_x, pos_y, width)
     user = User.find(user_id)

--- a/app/jobs/bulk_index_update_job.rb
+++ b/app/jobs/bulk_index_update_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BulkIndexUpdateJob < ApplicationJob
-  queue_as :default
+  sidekiq_options queue: "default"
 
   def perform(klass_name, ids)
     klass = klass_name.constantize

--- a/app/jobs/daily_prune_job.rb
+++ b/app/jobs/daily_prune_job.rb
@@ -4,8 +4,7 @@
 # idempotent, so default retries are safe. Each task is isolated so that one
 # failure doesn't skip the rest.
 class DailyPruneJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options lock: :until_executed
+  sidekiq_options queue: "low_prio", lock: :until_executed, lock_ttl: 12.hours.to_i
 
   def perform
     ApplicationRecord.without_timeout do

--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -3,7 +3,7 @@
 # Each export is public: the SELECT projection lists only publicly visible
 # columns, and hidden/deleted rows are filtered out.
 class DbExportJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   def self.read_export_sql(name)
     contents = Rails.root.join("db", "exports", "#{name}.sql").read

--- a/app/jobs/discord_reports_job.rb
+++ b/app/jobs/discord_reports_job.rb
@@ -5,8 +5,7 @@
 # isolated so one failed webhook doesn't skip the others, and each no-ops
 # when its webhook URL is unconfigured.
 class DiscordReportsJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options retry: false, lock: :until_executed
+  sidekiq_options queue: "low_prio", retry: false, lock: :until_executed, lock_ttl: 12.hours.to_i
 
   REPORTS = [
     DiscordReport::JanitorStats,

--- a/app/jobs/flush_favorites_job.rb
+++ b/app/jobs/flush_favorites_job.rb
@@ -3,10 +3,10 @@
 # This job is used to remove all of the user's favorites.
 # It is intended to be run when a user is deleted or when they request to clear their favorites.
 class FlushFavoritesJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
-  def perform(*args)
-    user = User.find(args[0])
+  def perform(user_id)
+    user = User.find(user_id)
 
     Thread.current[:skip_post_index_update] = true
 
@@ -17,7 +17,7 @@ class FlushFavoritesJob < ApplicationJob
         Post.without_timeout do
           Post.where(id: ids).update_all("fav_count = fav_count - 1")
         end
-        BulkIndexUpdateJob.perform_later("Post", ids)
+        BulkIndexUpdateJob.perform_async("Post", ids)
       end
     end
 

--- a/app/jobs/forum_subscription_mail_job.rb
+++ b/app/jobs/forum_subscription_mail_job.rb
@@ -3,8 +3,7 @@
 # Sends forum topic digest emails to subscribed users. Not idempotent: a
 # retry would resend the same digests.
 class ForumSubscriptionMailJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options retry: false, lock: :until_executed
+  sidekiq_options queue: "low_prio", retry: false, lock: :until_executed, lock_ttl: 12.hours.to_i
 
   def perform
     ForumSubscription.process_all!

--- a/app/jobs/hide_user_blips_job.rb
+++ b/app/jobs/hide_user_blips_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class HideUserBlipsJob < ApplicationJob
-  queue_as :default
-  sidekiq_options lock: :until_executing
+  sidekiq_options queue: "default", lock: :until_executing, lock_ttl: 1.hour.to_i
 
   def perform(user_id, initiator_id)
     user = User.find(user_id)

--- a/app/jobs/hide_user_comments_job.rb
+++ b/app/jobs/hide_user_comments_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class HideUserCommentsJob < ApplicationJob
-  queue_as :default
-  sidekiq_options lock: :until_executing
+  sidekiq_options queue: "default", lock: :until_executing, lock_ttl: 1.hour.to_i
 
   def perform(user_id, initiator_id)
     user = User.find(user_id)

--- a/app/jobs/hide_user_forum_posts_job.rb
+++ b/app/jobs/hide_user_forum_posts_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class HideUserForumPostsJob < ApplicationJob
-  queue_as :default
-  sidekiq_options lock: :until_executing
+  sidekiq_options queue: "default", lock: :until_executing, lock_ttl: 1.hour.to_i
 
   def perform(user_id, initiator_id)
     user = User.find(user_id)

--- a/app/jobs/index_update_job.rb
+++ b/app/jobs/index_update_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class IndexUpdateJob < ApplicationJob
-  queue_as :high_prio
-  sidekiq_options lock: :until_executing
+  sidekiq_options queue: "high_prio", lock: :until_executing, lock_ttl: 1.hour.to_i
 
   def perform(klass, id)
     obj = klass.constantize.find(id)

--- a/app/jobs/iqdb_concurrency_reset_job.rb
+++ b/app/jobs/iqdb_concurrency_reset_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IqdbConcurrencyResetJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   def perform
     keys = Cache.redis.smembers("iqdb:concurrent:keys")

--- a/app/jobs/iqdb_remove_job.rb
+++ b/app/jobs/iqdb_remove_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IqdbRemoveJob < ApplicationJob
-  queue_as :iqdb
+  sidekiq_options queue: "iqdb"
 
   def perform(post_id)
     IqdbProxy.remove_post(post_id)

--- a/app/jobs/iqdb_update_job.rb
+++ b/app/jobs/iqdb_update_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IqdbUpdateJob < ApplicationJob
-  queue_as :iqdb
+  sidekiq_options queue: "iqdb"
 
   def perform(post_id)
     post = Post.find_by id: post_id

--- a/app/jobs/post_image_sampler_job.rb
+++ b/app/jobs/post_image_sampler_job.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class PostImageSamplerJob < ApplicationJob
-  queue_as :thumb
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args, retry: 1
+  # until_executing: a regeneration requested while one is running must not be
+  # dropped; the lock only dedupes queued duplicates.
+  sidekiq_options queue: "thumb", lock: :until_executing, lock_args_method: :lock_args, lock_ttl: 1.hour.to_i, retry: 1
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/post_prune_job.rb
+++ b/app/jobs/post_prune_job.rb
@@ -4,8 +4,7 @@
 # Not idempotent: each deleted post dmails its uploader, so a retry would
 # send duplicate notifications.
 class PostPruneJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options retry: false, lock: :until_executed
+  sidekiq_options queue: "low_prio", retry: false, lock: :until_executed, lock_ttl: 12.hours.to_i
 
   def perform
     PostPruner.new.prune!

--- a/app/jobs/post_set_cleanup_job.rb
+++ b/app/jobs/post_set_cleanup_job.rb
@@ -2,8 +2,7 @@
 
 # Cleans up denormalized post state after a pool is destroyed.
 class PostSetCleanupJob < ApplicationJob
-  queue_as :default
-  sidekiq_options lock: :until_executing
+  sidekiq_options queue: "default", lock: :until_executing, lock_ttl: 1.hour.to_i
 
   def perform(type, obj_id)
     case type.to_sym
@@ -46,6 +45,6 @@ class PostSetCleanupJob < ApplicationJob
   # destroyed set's members for reindexing.
   def reindex_legacy_set_members(set_id)
     ids = Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", "set:#{set_id}").pluck(:id)
-    ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
+    ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_async("Post", slice) }
   end
 end

--- a/app/jobs/post_set_posts_sync_job.rb
+++ b/app/jobs/post_set_posts_sync_job.rb
@@ -6,8 +6,7 @@
 # pool_string tokens reference the set (covers pending removals).
 # TODO: delete together with the pool_string column drop.
 class PostSetPostsSyncJob < ApplicationJob
-  queue_as :default
-  sidekiq_options lock: :until_executing, lock_args_method: :lock_args
+  sidekiq_options queue: "default", lock: :until_executing, lock_args_method: :lock_args, lock_ttl: 1.hour.to_i
 
   def self.lock_args(args)
     [args.first]
@@ -16,7 +15,7 @@ class PostSetPostsSyncJob < ApplicationJob
   def perform(set_id)
     ids = PostSet.find(set_id).post_ids
     ids |= Post.where("string_to_array(pool_string, ' ') @> ARRAY[?]::text[]", "set:#{set_id}").pluck(:id)
-    ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
+    ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_async("Post", slice) }
   rescue ActiveRecord::RecordNotFound
     # Set was deleted; the destroy path reindexed its members.
   end

--- a/app/jobs/post_video_conversion_job.rb
+++ b/app/jobs/post_video_conversion_job.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class PostVideoConversionJob < ApplicationJob
-  queue_as :video
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args, retry: 3
+  # until_executing: a replacement arriving while a conversion runs must not be
+  # dropped; the lock only dedupes queued duplicates.
+  sidekiq_options queue: "video", lock: :until_executing, lock_args_method: :lock_args, lock_ttl: 6.hours.to_i, retry: 3
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/post_video_conversion_job.rb
+++ b/app/jobs/post_video_conversion_job.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class PostVideoConversionJob < ApplicationJob
-  # until_executing: a replacement arriving while a conversion runs must not be
-  # dropped; the lock only dedupes queued duplicates.
-  sidekiq_options queue: "video", lock: :until_executing, lock_args_method: :lock_args, lock_ttl: 6.hours.to_i, retry: 3
+  # perform is destructive, so same-post runs must not overlap: until_and_while_executing
+  # serializes per post, and reschedule re-queues a concurrent arrival instead of dropping it.
+  sidekiq_options queue: "video", lock: :until_and_while_executing, lock_args_method: :lock_args,
+                  lock_ttl: 6.hours.to_i, on_conflict: { server: :reschedule }, schedule_in: 30, retry: 3
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/search_trend_aggregate_job.rb
+++ b/app/jobs/search_trend_aggregate_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SearchTrendAggregateJob < ApplicationJob
-  queue_as :default
+  sidekiq_options queue: "default"
 
   def perform
     aggregate_unprocessed_records!

--- a/app/jobs/search_trend_cache_warm_job.rb
+++ b/app/jobs/search_trend_cache_warm_job.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class SearchTrendCacheWarmJob < ApplicationJob
-  sidekiq_options queue: "low_prio", lock: :until_executing, lock_ttl: 12.hours.to_i
+  # Runs every 15 minutes; scope the lock_ttl to match that.
+  sidekiq_options queue: "low_prio", lock: :until_executing, lock_ttl: 15.minutes.to_i
 
   def perform
     SearchTrendHourly.without_timeout do

--- a/app/jobs/search_trend_cache_warm_job.rb
+++ b/app/jobs/search_trend_cache_warm_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class SearchTrendCacheWarmJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options lock: :until_executing
+  sidekiq_options queue: "low_prio", lock: :until_executing, lock_ttl: 12.hours.to_i
 
   def perform
     SearchTrendHourly.without_timeout do

--- a/app/jobs/search_trend_prune_job.rb
+++ b/app/jobs/search_trend_prune_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SearchTrendPruneJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   def perform
     SearchTrend.without_timeout do

--- a/app/jobs/sitemap_generator_job.rb
+++ b/app/jobs/sitemap_generator_job.rb
@@ -3,7 +3,7 @@
 require "sitemap_generator"
 
 class SitemapGeneratorJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   module SitemapMethods
     def include_static_page(path, wiki_page_title)

--- a/app/jobs/stats_update_job.rb
+++ b/app/jobs/stats_update_job.rb
@@ -3,8 +3,7 @@
 # Recalculates the site-wide statistics shown on /stats and caches them in
 # Redis. Idempotent, but the aggregate queries are heavy.
 class StatsUpdateJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options lock: :until_executed
+  sidekiq_options queue: "low_prio", lock: :until_executed, lock_ttl: 12.hours.to_i
 
   def perform
     ApplicationRecord.without_timeout do

--- a/app/jobs/tag_alias_finalize_job.rb
+++ b/app/jobs/tag_alias_finalize_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class TagAliasFinalizeJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/tag_alias_job.rb
+++ b/app/jobs/tag_alias_job.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 class TagAliasJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
-  self.enqueue_after_transaction_commit = true
+  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)
     [args[0]]
   end
 
-  def perform(*args)
-    ta = TagAlias.find(args[0])
-    ta.process!(update_topic: args[1])
+  def perform(alias_id, update_topic)
+    ta = TagAlias.find(alias_id)
+    ta.process!(update_topic: update_topic)
   end
 end

--- a/app/jobs/tag_alias_job.rb
+++ b/app/jobs/tag_alias_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TagAliasJob < ApplicationJob
+  include TransactionalEnqueue
   sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)

--- a/app/jobs/tag_alias_undo_job.rb
+++ b/app/jobs/tag_alias_undo_job.rb
@@ -1,29 +1,25 @@
 # frozen_string_literal: true
 
 class TagAliasUndoJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
-
-  # These conditions never self-heal, so retrying is pointless; tell the
-  # undoer what happened instead.
-  discard_on TagAlias::UndoError do |job, error|
-    alias_id, _update_topic, undoer_id = job.arguments
-    next if undoer_id.blank?
-
-    Dmail.create_automated(
-      to_id: undoer_id,
-      title: "Tag alias ##{alias_id} could not be undone",
-      body: "The undo of \"tag alias ##{alias_id}\":/tag_aliases/#{alias_id} was rejected: #{error.message}",
-    )
-  end
+  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)
     [args[0]]
   end
 
-  def perform(*args)
-    ta = TagAlias.find(args[0])
-    undoer = User.find_by(id: args[2])
-    ta.process_undo!(update_topic: args[1], undoer: undoer)
+  def perform(alias_id, update_topic, undoer_id = nil)
+    ta = TagAlias.find(alias_id)
+    undoer = User.find_by(id: undoer_id)
+    ta.process_undo!(update_topic: update_topic, undoer: undoer)
+  rescue TagAlias::UndoError => e
+    # These conditions never self-heal, so retrying is pointless; tell the
+    # undoer what happened instead.
+    return if undoer_id.blank?
+
+    Dmail.create_automated(
+      to_id: undoer_id,
+      title: "Tag alias ##{alias_id} could not be undone",
+      body: "The undo of \"tag alias ##{alias_id}\":/tag_aliases/#{alias_id} was rejected: #{e.message}",
+    )
   end
 end

--- a/app/jobs/tag_batch_finalize_job.rb
+++ b/app/jobs/tag_batch_finalize_job.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class TagBatchFinalizeJob < ApplicationJob
-  queue_as :tags
   # Keyed on full args: an enqueue carrying stragglers must never dedup away against a pending one.
-  # Currently inert either way — sidekiq-unique-jobs cannot see through the ActiveJob wrapper.
-  sidekiq_options lock: :until_executed
+  sidekiq_options queue: "tags", lock: :until_executed, lock_ttl: 24.hours.to_i
 
   def perform(consequent, straggler_ids = [])
     Post.without_timeout do

--- a/app/jobs/tag_batch_job.rb
+++ b/app/jobs/tag_batch_job.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
 class TagBatchJob < ApplicationJob
-  queue_as :tags
-  self.enqueue_after_transaction_commit = true
+  sidekiq_options queue: "tags"
 
   # This many failed posts means something systemic, not scattered bad data.
   FAILURE_LIMIT = 100
 
-  def perform(*args)
-    antecedent = args[0]
-    consequent = args[1]
-    updater_id = args[2]
-    updater_ip_addr = args[3]
-
+  def perform(antecedent, consequent, updater_id, updater_ip_addr)
     resolved = nil
     stragglers = []
     failures = []
@@ -34,7 +28,7 @@ class TagBatchJob < ApplicationJob
     end
   ensure
     # In `ensure` so a job that dies or exhausts its retries still reindexes what it changed.
-    TagBatchFinalizeJob.perform_later(resolved, stragglers) if resolved
+    TagBatchFinalizeJob.perform_async(resolved, stragglers) if resolved
   end
 
   def migrate_posts(from, to, resolved = TagAlias.to_aliased([to]).first, stragglers = [], failures = [])

--- a/app/jobs/tag_batch_job.rb
+++ b/app/jobs/tag_batch_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TagBatchJob < ApplicationJob
+  include TransactionalEnqueue
   sidekiq_options queue: "tags"
 
   # This many failed posts means something systemic, not scattered bad data.

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class TagImplicationFinalizeJob < ApplicationJob
-  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
-
-  def self.lock_args(args)
-    [args[0]]
-  end
+  # Keyed on full args: an undo-finalize (id, name, true) must never dedup away
+  # against a queued approve-finalize (id, name) for the same implication — they
+  # differ only by the undo flag, and the survivor would skip reindexing the
+  # undo rows' posts.
+  sidekiq_options queue: "tags", lock: :until_executed, lock_ttl: 24.hours.to_i
 
   # Sidekiq args are positional JSON; keywords are not an option here.
   def perform(implication_id, reindex_tag_name, undo = false) # rubocop:disable Style/OptionalBooleanParameter

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class TagImplicationFinalizeJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)
     [args[0]]
   end
 
-  def perform(implication_id, reindex_tag_name, undo: false)
+  # Sidekiq args are positional JSON; keywords are not an option here.
+  def perform(implication_id, reindex_tag_name, undo = false) # rubocop:disable Style/OptionalBooleanParameter
     ti = TagImplication.find_by(id: implication_id)
     return unless ti
 

--- a/app/jobs/tag_implication_finalize_job.rb
+++ b/app/jobs/tag_implication_finalize_job.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class TagImplicationFinalizeJob < ApplicationJob
-  # Keyed on full args: an undo-finalize (id, name, true) must never dedup away
-  # against a queued approve-finalize (id, name) for the same implication — they
-  # differ only by the undo flag, and the survivor would skip reindexing the
-  # undo rows' posts.
+  # Keyed on full args: an undo-finalize (id, name, true) must not dedup against a
+  # queued approve-finalize (id, name), or the survivor skips the undo reindex.
   sidekiq_options queue: "tags", lock: :until_executed, lock_ttl: 24.hours.to_i
 
   # Sidekiq args are positional JSON; keywords are not an option here.

--- a/app/jobs/tag_implication_job.rb
+++ b/app/jobs/tag_implication_job.rb
@@ -1,16 +1,14 @@
 # frozen_string_literal: true
 
 class TagImplicationJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
-  self.enqueue_after_transaction_commit = true
+  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)
     [args[0]]
   end
 
-  def perform(*args)
-    ti = TagImplication.find(args[0])
-    ti.process!(update_topic: args[1])
+  def perform(implication_id, update_topic)
+    ti = TagImplication.find(implication_id)
+    ti.process!(update_topic: update_topic)
   end
 end

--- a/app/jobs/tag_implication_job.rb
+++ b/app/jobs/tag_implication_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TagImplicationJob < ApplicationJob
+  include TransactionalEnqueue
   sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)

--- a/app/jobs/tag_implication_undo_job.rb
+++ b/app/jobs/tag_implication_undo_job.rb
@@ -1,29 +1,25 @@
 # frozen_string_literal: true
 
 class TagImplicationUndoJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
-
-  # These conditions never self-heal, so retrying is pointless; tell the
-  # undoer what happened instead.
-  discard_on TagImplication::UndoError do |job, error|
-    implication_id, _update_topic, undoer_id = job.arguments
-    next if undoer_id.blank?
-
-    Dmail.create_automated(
-      to_id: undoer_id,
-      title: "Tag implication ##{implication_id} could not be undone",
-      body: "The undo of \"tag implication ##{implication_id}\":/tag_implications/#{implication_id} was rejected: #{error.message}",
-    )
-  end
+  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)
     [args[0]]
   end
 
-  def perform(*args)
-    ti = TagImplication.find(args[0])
-    undoer = User.find_by(id: args[2])
-    ti.process_undo!(update_topic: args[1], undoer: undoer)
+  def perform(implication_id, update_topic, undoer_id = nil)
+    ti = TagImplication.find(implication_id)
+    undoer = User.find_by(id: undoer_id)
+    ti.process_undo!(update_topic: update_topic, undoer: undoer)
+  rescue TagImplication::UndoError => e
+    # These conditions never self-heal, so retrying is pointless; tell the
+    # undoer what happened instead.
+    return if undoer_id.blank?
+
+    Dmail.create_automated(
+      to_id: undoer_id,
+      title: "Tag implication ##{implication_id} could not be undone",
+      body: "The undo of \"tag implication ##{implication_id}\":/tag_implications/#{implication_id} was rejected: #{e.message}",
+    )
   end
 end

--- a/app/jobs/tag_nuke_finalize_job.rb
+++ b/app/jobs/tag_nuke_finalize_job.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class TagNukeFinalizeJob < ApplicationJob
-  queue_as :tags
   # Keyed on full args: an enqueue carrying stragglers must never dedup away against a pending one.
-  # Currently inert either way — sidekiq-unique-jobs cannot see through the ActiveJob wrapper.
-  sidekiq_options lock: :until_executed
+  sidekiq_options queue: "tags", lock: :until_executed, lock_ttl: 24.hours.to_i
 
   def perform(tag_id, straggler_ids = [])
     # The tag is gone from every post by now, so the set only survives in the nuke's undo rows.

--- a/app/jobs/tag_nuke_job.rb
+++ b/app/jobs/tag_nuke_job.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TagNukeJob < ApplicationJob
+  include TransactionalEnqueue
   sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   # This many failed posts means something systemic, not scattered bad data.

--- a/app/jobs/tag_nuke_job.rb
+++ b/app/jobs/tag_nuke_job.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class TagNukeJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
-  self.enqueue_after_transaction_commit = true
+  sidekiq_options queue: "tags", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   # This many failed posts means something systemic, not scattered bad data.
   FAILURE_LIMIT = 100
@@ -12,11 +10,8 @@ class TagNukeJob < ApplicationJob
     [args[0]]
   end
 
-  def perform(*args)
-    tag_name = args[0]
+  def perform(tag_name, updater_id, updater_ip_addr)
     tag = Tag.find_by_normalized_name(tag_name)
-    updater_id = args[1]
-    updater_ip_addr = args[2]
     return if tag.nil?
 
     finalize_tag_id = tag.id
@@ -36,7 +31,7 @@ class TagNukeJob < ApplicationJob
     end
   ensure
     # A job that dies or exhausts its retries still reindexes what it changed, including stragglers.
-    TagNukeFinalizeJob.perform_later(finalize_tag_id, stragglers) if finalize_tag_id
+    TagNukeFinalizeJob.perform_async(finalize_tag_id, stragglers) if finalize_tag_id
   end
 
   def migrate_posts(tag_name, snapshot = nil, stragglers = [], failures = [])

--- a/app/jobs/tag_post_count_job.rb
+++ b/app/jobs/tag_post_count_job.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class TagPostCountJob < ApplicationJob
-  queue_as :tags
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+  # until_executing: a recount requested while one is running must not be
+  # dropped; the lock only dedupes queued duplicates.
+  sidekiq_options queue: "tags", lock: :until_executing, lock_args_method: :lock_args, lock_ttl: 1.hour.to_i
 
   def self.lock_args(args)
     [args[0]]
   end
 
-  def perform(*args)
-    tag = Tag.find_by(id: args[0])
+  def perform(tag_id)
+    tag = Tag.find_by(id: tag_id)
     return unless tag
 
     Tag.without_timeout do

--- a/app/jobs/tag_update_related_job.rb
+++ b/app/jobs/tag_update_related_job.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class TagUpdateRelatedJob < ApplicationJob
-  queue_as :tags
+  sidekiq_options queue: "tags"
 
-  def perform(*args)
-    tag = Tag.find(args[0])
+  def perform(tag_id)
+    tag = Tag.find(tag_id)
 
     tag.update_related
   end

--- a/app/jobs/takedown_job.rb
+++ b/app/jobs/takedown_job.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class TakedownJob < ApplicationJob
-  queue_as :high_prio
-  sidekiq_options lock: :until_executing, lock_args_method: :lock_args
+  sidekiq_options queue: "high_prio", lock: :until_executing, lock_args_method: :lock_args, lock_ttl: 1.hour.to_i
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/transfer_favorites_job.rb
+++ b/app/jobs/transfer_favorites_job.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class TransferFavoritesJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options lock: :until_executing
+  sidekiq_options queue: "low_prio", lock: :until_executing, lock_ttl: 1.hour.to_i
 
-  def perform(*args)
-    @post = Post.find_by(id: args[0])
-    @user = User.find_by(id: args[1])
+  def perform(post_id, user_id)
+    @post = Post.find_by(id: post_id)
+    @user = User.find_by(id: user_id)
     return unless @post && @user
 
     CurrentUser.scoped(@user) do

--- a/app/jobs/update_tag_category_job.rb
+++ b/app/jobs/update_tag_category_job.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class UpdateTagCategoryJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+  # until_executing: a category change while one update runs must not be
+  # dropped; the lock only dedupes queued duplicates.
+  sidekiq_options queue: "low_prio", lock: :until_executing, lock_args_method: :lock_args, lock_ttl: 1.hour.to_i
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/upload_delete_files_job.rb
+++ b/app/jobs/upload_delete_files_job.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class UploadDeleteFilesJob < ApplicationJob
-  queue_as :default
+  sidekiq_options queue: "default"
 
-  def perform(*args)
-    UploadService::Utils::delete_file(args[0], args[1], args[2])
+  def perform(md5, file_ext, upload_id)
+    UploadService::Utils.delete_file(md5, file_ext, upload_id)
   end
 end

--- a/app/jobs/user_feedback_mail_job.rb
+++ b/app/jobs/user_feedback_mail_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class UserFeedbackMailJob < ApplicationJob
+  sidekiq_options queue: "low_prio"
+
+  def perform(user_id, feedback_id)
+    user = User.find(user_id)
+    feedback = UserFeedback.find(feedback_id)
+    Maintenance::User::UserFeedbackMailer.feedback_notice(user, feedback).deliver_now
+  rescue ActiveRecord::RecordNotFound
+    # User or feedback deleted before the job ran; nothing to send.
+  end
+end

--- a/app/jobs/user_ip_address_backfill_job.rb
+++ b/app/jobs/user_ip_address_backfill_job.rb
@@ -6,7 +6,7 @@
 # contributions. If a run fails partway, clear user_ip_addresses and start over
 # (the table is fully reconstructible from these sources plus the live writes).
 class UserIpAddressBackfillJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   BATCH_SIZE = 100_000
 

--- a/app/jobs/user_ip_address_prune_job.rb
+++ b/app/jobs/user_ip_address_prune_job.rb
@@ -5,7 +5,7 @@
 # rows behind (the delete-and-re-register evasion pattern depends on them), so
 # the prune applies uniformly to active and deleted accounts.
 class UserIpAddressPruneJob < ApplicationJob
-  queue_as :low_prio
+  sidekiq_options queue: "low_prio"
 
   def perform
     UserIpAddress.without_timeout do

--- a/app/logical/bulk_update_request_importer.rb
+++ b/app/logical/bulk_update_request_importer.rb
@@ -232,10 +232,10 @@ class BulkUpdateRequestImporter
           tag_implication.reject!(update_topic: false)
 
         when :mass_update
-          TagBatchJob.perform_later(token[1], token[2], CurrentUser.id, CurrentUser.ip_addr)
+          TagBatchJob.perform_async(token[1], token[2], CurrentUser.id, CurrentUser.ip_addr)
 
         when :nuke_tag
-          TagNukeJob.perform_later(token[1], CurrentUser.id, CurrentUser.ip_addr)
+          TagNukeJob.perform_async(token[1], CurrentUser.id, CurrentUser.ip_addr)
 
         when :change_category
           tag = Tag.find_by(name: token[1])

--- a/app/logical/document_store/model.rb
+++ b/app/logical/document_store/model.rb
@@ -31,7 +31,7 @@ module DocumentStore
       return if Thread.current[:skip_post_index_update]
       return document_store.update_index refresh: "true" if Rails.env.test?
 
-      IndexUpdateJob.set(queue: queue).perform_later(self.class.to_s, id)
+      IndexUpdateJob.set(queue: queue).perform_async(self.class.to_s, id)
     end
   end
 

--- a/app/logical/tag_correction.rb
+++ b/app/logical/tag_correction.rb
@@ -34,7 +34,7 @@ class TagCorrection
   end
 
   def fix!
-    TagPostCountJob.perform_later(tag.id)
+    TagPostCountJob.perform_async(tag.id)
     tag.update_category_cache
   end
 end

--- a/app/logical/upload_service/utils.rb
+++ b/app/logical/upload_service/utils.rb
@@ -56,7 +56,7 @@ class UploadService
 
       # in case this upload never finishes processing, we need to delete the
       # distributed files in the future
-      UploadDeleteFilesJob.set(wait: 24.hours).perform_later(upload.md5, upload.file_ext, upload.id)
+      UploadDeleteFilesJob.perform_in(24.hours, upload.md5, upload.file_ext, upload.id)
     end
 
     def automatic_tags(upload, file)

--- a/app/logical/user_deletion.rb
+++ b/app/logical/user_deletion.rb
@@ -26,7 +26,7 @@ class UserDeletion
     clear_user_settings
     reset_password
     create_mod_action
-    FlushFavoritesJob.perform_later(user.id)
+    FlushFavoritesJob.perform_async(user.id)
   end
 
   private
@@ -60,7 +60,7 @@ class UserDeletion
       custom_style: "",
       level: [user.level, UserLevel::MEMBER].min, # Keep banned users banned
     )
-    AvatarCleanupJob.perform_later(user.id, force: true)
+    AvatarCleanupJob.perform_async(user.id, true)
   end
 
   def reset_password

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -349,10 +349,10 @@ class Comment < ApplicationRecord
   private
 
   def enqueue_automod_create_check
-    AutomodCheckJob.perform_later(id)
+    AutomodCheckJob.perform_async(id)
   end
 
   def enqueue_automod_update_check
-    AutomodCheckJob.perform_later(id)
+    AutomodCheckJob.perform_async(id)
   end
 end

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -310,7 +310,7 @@ class Pool < ApplicationRecord
   end
 
   def enqueue_destroy_cleanup
-    PostSetCleanupJob.perform_later(:pool, id)
+    PostSetCleanupJob.perform_async("pool", id)
   end
 
   def post_count

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -97,7 +97,7 @@ class Post < ApplicationRecord
 
     def delete_avatar_crops
       User.where(avatar_id: id).pluck(:id).each do |user_id|
-        AvatarCleanupJob.perform_later(user_id, force: true)
+        AvatarCleanupJob.perform_async(user_id, true)
         UserAvatarUrlCache.invalidate(user_id)
       end
     end
@@ -266,9 +266,9 @@ class Post < ApplicationRecord
 
     def generate_video_samples(later: false)
       if later
-        PostVideoConversionJob.set(wait: 1.minute).perform_later(id)
+        PostVideoConversionJob.perform_in(1.minute, id)
       else
-        PostVideoConversionJob.perform_later(id)
+        PostVideoConversionJob.perform_async(id)
       end
     end
 
@@ -295,7 +295,7 @@ class Post < ApplicationRecord
 
     def generate_image_samples(later: false)
       if later
-        PostImageSamplerJob.set(wait: 1.minute).perform_later(id)
+        PostImageSamplerJob.perform_in(1.minute, id)
       else
         ImageSampler.generate_post_images(self)
       end
@@ -1569,7 +1569,7 @@ class Post < ApplicationRecord
     end
 
     def give_favorites_to_parent
-      TransferFavoritesJob.perform_later(id, CurrentUser.id)
+      TransferFavoritesJob.perform_async(id, CurrentUser.id)
     end
 
     def parent_exists?
@@ -2046,14 +2046,14 @@ class Post < ApplicationRecord
     module ClassMethods
       def remove_iqdb(post_id)
         if IqdbProxy.enabled?
-          IqdbRemoveJob.perform_later(post_id)
+          IqdbRemoveJob.perform_async(post_id)
         end
       end
     end
 
     def update_iqdb_async
       if IqdbProxy.enabled? && has_preview?
-        IqdbUpdateJob.perform_later(id)
+        IqdbUpdateJob.perform_async(id)
       end
     end
 

--- a/app/models/post_set.rb
+++ b/app/models/post_set.rb
@@ -436,7 +436,7 @@ class PostSet < ApplicationRecord
       # Deferred to commit so the job cannot import pre-commit membership state
       # when called inside a transaction; runs immediately when none is open.
       ActiveRecord.after_all_transactions_commit do
-        ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_later("Post", slice) }
+        ids.each_slice(5_000) { |slice| BulkIndexUpdateJob.perform_async("Post", slice) }
       end
     end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -150,7 +150,7 @@ class Tag < ApplicationRecord
     end
 
     def update_category_post_counts
-      UpdateTagCategoryJob.perform_later(id)
+      UpdateTagCategoryJob.perform_async(id)
     end
 
     def update_category_cache
@@ -285,13 +285,13 @@ class Tag < ApplicationRecord
       self.related_tags_updated_at = Time.now
       save
 
-      TagPostCountJob.perform_later(id) if post_count > 20 && rand(post_count) <= 1
+      TagPostCountJob.perform_async(id) if post_count > 20 && rand(post_count) <= 1
     rescue ActiveRecord::StatementInvalid
     end
 
     def update_related_if_outdated
       if Cache.fetch("urt:#{name}").nil? && should_update_related?
-        TagUpdateRelatedJob.perform_later(id)
+        TagUpdateRelatedJob.perform_async(id)
         Cache.write("urt:#{name}", true, expires_in: 10.minutes) # mutex to prevent redundant updates
       end
     end

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -12,12 +12,12 @@ class TagAlias < TagRelationship
     def approve!(update_topic: true, approver: CurrentUser.user)
       CurrentUser.scoped(approver) do
         update(status: "queued", approver_id: approver.id)
-        TagAliasJob.perform_later(id, update_topic)
+        TagAliasJob.perform_async(id, update_topic)
       end
     end
 
     def undo!(undoer: CurrentUser.user, update_topic: true)
-      TagAliasUndoJob.perform_later(id, update_topic, undoer.id)
+      TagAliasUndoJob.perform_async(id, update_topic, undoer.id)
     end
   end
 
@@ -280,7 +280,7 @@ class TagAlias < TagRelationship
         tu.update!(applied: true)
       end
     end
-    TagAliasFinalizeJob.perform_later(id)
+    TagAliasFinalizeJob.perform_async(id)
   ensure
     Thread.current[:skip_post_index_update] = false
   end
@@ -395,7 +395,7 @@ class TagAlias < TagRelationship
         rename_artist
         forum_updater.update(approval_message(approver), "APPROVED") if update_topic
         update(status: "active", post_count: consequent_tag&.post_count || 0)
-        TagAliasFinalizeJob.perform_later(id)
+        TagAliasFinalizeJob.perform_async(id)
       end
     rescue Exception => e
       Rails.logger.error("[TA] #{e.message}\n#{e.backtrace}")
@@ -409,7 +409,7 @@ class TagAlias < TagRelationship
         forum_updater.update(failure_message(e), "FAILED") if update_topic
         update_columns(status: "error: #{e}")
       end
-      TagAliasFinalizeJob.perform_later(id)
+      TagAliasFinalizeJob.perform_async(id)
     end
   end
 

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -135,7 +135,7 @@ class TagImplication < TagRelationship
           update_descendant_names_for_parents
           forum_updater.update(approval_message(approver), "APPROVED") if update_topic
           update(status: "active")
-          TagImplicationFinalizeJob.perform_later(id, antecedent_name)
+          TagImplicationFinalizeJob.perform_async(id, antecedent_name)
         end
       rescue Exception => e
         if tries < 5 && !Rails.env.test?
@@ -211,11 +211,11 @@ class TagImplication < TagRelationship
     def approve!(approver: CurrentUser.user, update_topic: true)
       update(status: "queued", approver_id: approver.id)
       invalidate_cached_descendants
-      TagImplicationJob.perform_later(id, update_topic)
+      TagImplicationJob.perform_async(id, update_topic)
     end
 
     def undo!(undoer: CurrentUser.user, update_topic: true)
-      TagImplicationUndoJob.perform_later(id, update_topic, undoer.id)
+      TagImplicationUndoJob.perform_async(id, update_topic, undoer.id)
     end
 
     def reject!(update_topic: true)
@@ -326,7 +326,7 @@ class TagImplication < TagRelationship
           tu.update!(applied: true)
         end
       end
-      TagImplicationFinalizeJob.perform_later(id, antecedent_name, undo: true)
+      TagImplicationFinalizeJob.perform_async(id, antecedent_name, true)
     ensure
       Thread.current[:skip_post_index_update] = false
     end

--- a/app/models/takedown.rb
+++ b/app/models/takedown.rb
@@ -196,7 +196,7 @@ class Takedown < ApplicationRecord
     end
 
     def process!(approver, del_reason)
-      TakedownJob.perform_later(id, approver.id, del_reason)
+      TakedownJob.perform_async(id, approver.id, del_reason)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -444,7 +444,7 @@ class User < ApplicationRecord
       flag = User.flag_value_for("has_cropped_avatar")
       update_columns(bit_prefs: bit_prefs & ~flag)
 
-      AvatarCleanupJob.perform_later(id)
+      AvatarCleanupJob.perform_async(id)
     end
 
     def staff_cant_disable_dmail
@@ -1296,14 +1296,12 @@ class User < ApplicationRecord
   private
 
   def enqueue_automod_user_check
-    AutomodUserCheckJob.perform_later(id, check_username: true, check_profile: false)
+    AutomodUserCheckJob.perform_async(id, true, false)
   end
 
   def enqueue_automod_user_update_check
-    AutomodUserCheckJob.perform_later(
-      id,
-      check_username: saved_change_to_name?,
-      check_profile:  saved_change_to_profile_about? || saved_change_to_profile_artinfo?,
-    )
+    check_username = saved_change_to_name?
+    check_profile = saved_change_to_profile_about? || saved_change_to_profile_artinfo?
+    AutomodUserCheckJob.perform_async(id, check_username, check_profile)
   end
 end

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -111,7 +111,7 @@ class UserFeedback < ApplicationRecord
   end
 
   def create_email
-    Maintenance::User::UserFeedbackMailer.feedback_notice(user, self).deliver_later
+    UserFeedbackMailJob.perform_async(user_id, id)
   end
 
   def creator_is_moderator

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,9 +63,6 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
-  # Highlight code that enqueued background job in logs.
-  config.active_job.verbose_enqueue_logs = true
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -11,6 +11,9 @@ Sidekiq.logger.level = Logger::WARN if Rails.env.test?
 # Skipped in tests.
 unless Rails.env.test?
   require "sidekiq/transaction_aware_client"
+  # transactional_push! would register this for us; setting client_class per class does not,
+  # so strip it here or it rides along in every payload these jobs push to Redis.
+  Sidekiq::JobUtil::TRANSIENT_ATTRIBUTES << "client_class"
   Rails.application.config.to_prepare do
     [TagAliasJob, TagBatchJob, TagImplicationJob, TagNukeJob].each do |klass|
       klass.sidekiq_options(client_class: Sidekiq::TransactionAwareClient)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,20 +6,10 @@ require_relative "../../lib/sidekiq_capsules"
 
 Sidekiq.logger.level = Logger::WARN if Rails.env.test?
 
-# With ActiveJob, enqueue_after_transaction_commit defaulted to false; only these four jobs opted in.
-# Route just those through the transaction-aware client and leave every other job as is.
-# Skipped in tests.
-unless Rails.env.test?
-  require "sidekiq/transaction_aware_client"
-  # transactional_push! would register this for us; setting client_class per class does not,
-  # so strip it here or it rides along in every payload these jobs push to Redis.
-  Sidekiq::JobUtil::TRANSIENT_ATTRIBUTES << "client_class"
-  Rails.application.config.to_prepare do
-    [TagAliasJob, TagBatchJob, TagImplicationJob, TagNukeJob].each do |klass|
-      klass.sidekiq_options(client_class: Sidekiq::TransactionAwareClient)
-    end
-  end
-end
+# The four tag jobs defer enqueue to transaction commit via TransactionalEnqueue
+# (client_class: TransactionAwareClient). transactional_push! would strip client_class
+# for us; setting it per class does not, so do it here or the Class rides along in every payload.
+Sidekiq::JobUtil::TRANSIENT_ATTRIBUTES << "client_class"
 
 # Specs push through the real client middleware (even in fake mode); without
 # this, parallel workers would take real locks in the shared test Redis.

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,10 +6,17 @@ require_relative "../../lib/sidekiq_capsules"
 
 Sidekiq.logger.level = Logger::WARN if Rails.env.test?
 
-# Defer in-transaction enqueues to commit (and drop them on rollback), matching
-# ActiveJob's behavior before the native-Sidekiq migration. Not in tests:
-# transactional fixtures never commit, so every enqueue would vanish.
-Sidekiq.transactional_push! unless Rails.env.test?
+# With ActiveJob, enqueue_after_transaction_commit defaulted to false; only these four jobs opted in.
+# Route just those through the transaction-aware client and leave every other job as is.
+# Skipped in tests.
+unless Rails.env.test?
+  require "sidekiq/transaction_aware_client"
+  Rails.application.config.to_prepare do
+    [TagAliasJob, TagBatchJob, TagImplicationJob, TagNukeJob].each do |klass|
+      klass.sidekiq_options(client_class: Sidekiq::TransactionAwareClient)
+    end
+  end
+end
 
 # Specs push through the real client middleware (even in fake mode); without
 # this, parallel workers would take real locks in the shared test Redis.

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,6 +6,22 @@ require_relative "../../lib/sidekiq_capsules"
 
 Sidekiq.logger.level = Logger::WARN if Rails.env.test?
 
+# Defer in-transaction enqueues to commit (and drop them on rollback), matching
+# ActiveJob's behavior before the native-Sidekiq migration. Not in tests:
+# transactional fixtures never commit, so every enqueue would vanish.
+Sidekiq.transactional_push! unless Rails.env.test?
+
+# Specs push through the real client middleware (even in fake mode); without
+# this, parallel workers would take real locks in the shared test Redis.
+SidekiqUniqueJobs.config.enabled = false if Rails.env.test?
+
+# The reflection registry holds a single block per event; this is the only subscriber.
+SidekiqUniqueJobs.reflect do |on|
+  on.lock_failed do |item|
+    Rails.logger.warn("SidekiqUniqueJobs: dropped duplicate #{item['class']} args=#{item['args'].inspect} digest=#{item['lock_digest']}")
+  end
+end
+
 Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
   config.redis = { url: Danbooru.config.redis_url }
 
@@ -18,6 +34,8 @@ Sidekiq.configure_server do |config| # rubocop:disable Metrics/BlockLength
   end
 
   SidekiqUniqueJobs::Server.configure(config)
+
+  require_relative "../../lib/sidekiq_active_job_wrapper_shim"
 
   # Extra capsules with their own thread pools, capping per-queue concurrency
   # (e.g. concurrent video transcodes) without a dedicated host per queue.

--- a/db/fixes/124_regenerate_video_samples.rb
+++ b/db/fixes/124_regenerate_video_samples.rb
@@ -7,7 +7,7 @@ Post.without_timeout do
   Post.where("(file_ext = ? OR file_ext = ?)", "webm", "mp4").find_in_batches.with_index do |group, index|
     puts "Processing batch #{index} with #{group.size} posts"
     group.each do |post|
-      PostVideoConversionJob.perform_later(post.id)
+      PostVideoConversionJob.perform_async(post.id)
     end
   end
 end

--- a/db/fixes/127_2_regenerate_thumbnails.rb
+++ b/db/fixes/127_2_regenerate_thumbnails.rb
@@ -9,7 +9,7 @@ Post.without_timeout do
   Post.in_batches(load: true, order: :desc).each_with_index do |group, index|
     puts "batch #{index}"
     group.each do |post|
-      PostImageSamplerJob.perform_later(post.id)
+      PostImageSamplerJob.perform_async(post.id)
       sm.delete_crop_file(post.md5)
     end
   end

--- a/db/fixes/127_3_smart_regenerate.rb
+++ b/db/fixes/127_3_smart_regenerate.rb
@@ -29,7 +29,7 @@ Post.without_timeout do
       end
 
       scheduled += 1
-      PostImageSamplerJob.perform_later(post.id)
+      PostImageSamplerJob.perform_async(post.id)
       sm.delete_crop_file(post.md5)
     end
 

--- a/lib/sidekiq_active_job_wrapper_shim.rb
+++ b/lib/sidekiq_active_job_wrapper_shim.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# TEMPORARY deploy shim: payloads enqueued before the ActiveJob -> native Sidekiq
+# migration have class Sidekiq::ActiveJob::Wrapper and would fail to execute now
+# that the job classes are no longer ActiveJobs. Run them natively instead.
+# Remove once pre-migration payloads have drained from the queues, the scheduled
+# set (24h horizon), and the retry set (~21 day horizon).
+require "active_job/queue_adapters/sidekiq_adapter"
+
+module SidekiqActiveJobWrapperShim
+  def perform(job_data)
+    klass = job_data["job_class"].constantize
+    # e.g. ActionMailer::MailDeliveryJob is still a real ActiveJob.
+    return super if klass <= ActiveJob::Base
+
+    Sidekiq.logger.info do
+      "wrapper-shim: legacy payload for #{job_data['job_class']} jid=#{jid} enqueued_at=#{job_data['enqueued_at']}"
+    end
+    klass.new.perform(*ActiveJob::Arguments.deserialize(job_data["arguments"]))
+  end
+end
+
+Sidekiq::ActiveJob::Wrapper.prepend(SidekiqActiveJobWrapperShim)

--- a/lib/sidekiq_active_job_wrapper_shim.rb
+++ b/lib/sidekiq_active_job_wrapper_shim.rb
@@ -8,6 +8,18 @@
 require "active_job/queue_adapters/sidekiq_adapter"
 
 module SidekiqActiveJobWrapperShim
+  # These three jobs changed from keyword to positional parameters in the
+  # migration. Their legacy payloads deserialize the kwargs into a trailing
+  # symbol-keyed hash, which would otherwise reach perform as the wrong arity
+  # (AutomodUserCheckJob) or as a Hash where a boolean is expected. Translate
+  # each back into the new positional order; the option defaults cover legacy
+  # payloads that were enqueued without the keyword.
+  KWARG_REMAPS = {
+    "AutomodUserCheckJob" => ->(user_id, opts = {}) { [user_id, opts[:check_username], opts[:check_profile]] },
+    "AvatarCleanupJob" => ->(user_id, opts = {}) { [user_id, opts.fetch(:force, false)] },
+    "TagImplicationFinalizeJob" => ->(id, reindex_tag_name, opts = {}) { [id, reindex_tag_name, opts.fetch(:undo, false)] },
+  }.freeze
+
   def perform(job_data)
     klass = job_data["job_class"].constantize
     # e.g. ActionMailer::MailDeliveryJob is still a real ActiveJob.
@@ -16,7 +28,11 @@ module SidekiqActiveJobWrapperShim
     Sidekiq.logger.info do
       "wrapper-shim: legacy payload for #{job_data['job_class']} jid=#{jid} enqueued_at=#{job_data['enqueued_at']}"
     end
-    klass.new.perform(*ActiveJob::Arguments.deserialize(job_data["arguments"]))
+
+    args = ActiveJob::Arguments.deserialize(job_data["arguments"])
+    remap = KWARG_REMAPS[job_data["job_class"]]
+    args = remap.call(*args) if remap
+    klass.new.perform(*args)
   end
 end
 

--- a/spec/jobs/api_key_expiration_warning_job_spec.rb
+++ b/spec/jobs/api_key_expiration_warning_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ApiKeyExpirationWarningJob do
   include_context "as admin"
 
   def perform
-    described_class.perform_now
+    described_class.new.perform
   end
 
   describe "#perform" do

--- a/spec/jobs/asn_ranges_update_job_spec.rb
+++ b/spec/jobs/asn_ranges_update_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AsnRangesUpdateJob do
   describe "#perform" do
     it "runs the importer" do
       allow(AsnRangeImporter).to receive(:import!)
-      described_class.perform_now
+      described_class.new.perform
       expect(AsnRangeImporter).to have_received(:import!)
     end
   end

--- a/spec/jobs/automod_check_job_spec.rb
+++ b/spec/jobs/automod_check_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AutomodCheckJob do
   let(:comment) { create(:comment) }
 
   def perform(comment_id = comment.id)
-    described_class.perform_now(comment_id)
+    described_class.new.perform(comment_id)
   end
 
   describe "comment body checks" do

--- a/spec/jobs/automod_user_check_job_spec.rb
+++ b/spec/jobs/automod_user_check_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AutomodUserCheckJob do
   let(:user) { create(:user, name: "normaluser") }
 
   def perform(user_id = user.id, check_username: false, check_profile: false)
-    described_class.perform_now(user_id, check_username: check_username, check_profile: check_profile)
+    described_class.new.perform(user_id, check_username, check_profile)
   end
 
   describe "username checks" do

--- a/spec/jobs/avatar_cleanup_job_spec.rb
+++ b/spec/jobs/avatar_cleanup_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AvatarCleanupJob do
   end
 
   def perform(user_id = user.id)
-    described_class.perform_now(user_id)
+    described_class.new.perform(user_id)
   end
 
   describe "#perform" do

--- a/spec/jobs/avatar_crop_job_spec.rb
+++ b/spec/jobs/avatar_crop_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AvatarCropJob do
   end
 
   def perform(user_id: user.id, post_id: post.id, pos_x: 0, pos_y: 0, width: 256)
-    described_class.perform_now(user_id, post_id, pos_x, pos_y, width)
+    described_class.new.perform(user_id, post_id, pos_x, pos_y, width)
   end
 
   describe "#perform" do

--- a/spec/jobs/bulk_index_update_job_spec.rb
+++ b/spec/jobs/bulk_index_update_job_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe BulkIndexUpdateJob do
       posts = create_list(:post, 3)
       ids   = posts.map(&:id)
       allow(Post.document_store).to receive(:import)
-      job.perform_now("Post", ids)
+      job.new.perform("Post", ids)
       expect(Post.document_store).to have_received(:import).with(query: { id: ids })
     end
 
     it "does not raise when the id list is empty" do
       allow(Post.document_store).to receive(:import)
-      expect { job.perform_now("Post", []) }.not_to raise_error
+      expect { job.new.perform("Post", []) }.not_to raise_error
     end
   end
 end

--- a/spec/jobs/daily_prune_job_spec.rb
+++ b/spec/jobs/daily_prune_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe DailyPruneJob do
       allow(ExceptionLog).to receive(:prune!)
       allow(Post).to receive(:cleanup_stuck_favorite_transfer_flags!)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(TagAlias).to have_received(:update_cached_post_counts_for_all)
       expect(Tag).to have_received(:clean_up_negative_post_counts!)
@@ -27,7 +27,7 @@ RSpec.describe DailyPruneJob do
       old_upload = create(:upload, created_at: (Danbooru.config.upload_deletion_window + 1.day).ago)
       new_upload = create(:upload)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(Upload.exists?(old_upload.id)).to be(false)
       expect(Upload.exists?(new_upload.id)).to be(true)
@@ -37,7 +37,7 @@ RSpec.describe DailyPruneJob do
       allow(Setting).to receive(:disable_exception_prune?).and_return(true)
       allow(ExceptionLog).to receive(:prune!)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(ExceptionLog).not_to have_received(:prune!)
     end
@@ -48,7 +48,7 @@ RSpec.describe DailyPruneJob do
       allow(DanbooruLogger).to receive(:log)
       allow(Post).to receive(:cleanup_stuck_favorite_transfer_flags!)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(DanbooruLogger).to have_received(:log).with(error)
       expect(Post).to have_received(:cleanup_stuck_favorite_transfer_flags!)

--- a/spec/jobs/db_export_job_spec.rb
+++ b/spec/jobs/db_export_job_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DbExportJob do
   end
 
   def perform
-    described_class.perform_now
+    described_class.new.perform
   end
 
   def export_csv(name)

--- a/spec/jobs/discord_reports_job_spec.rb
+++ b/spec/jobs/discord_reports_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe DiscordReportsJob do
       allow(moderator).to receive(:run!)
       allow(aibur).to receive(:run!)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(janitor).to have_received(:run!)
       expect(moderator).to have_received(:run!)
@@ -33,7 +33,7 @@ RSpec.describe DiscordReportsJob do
       allow(aibur).to receive(:run!)
       allow(DanbooruLogger).to receive(:log)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(DanbooruLogger).to have_received(:log).with(error)
       expect(moderator).to have_received(:run!)

--- a/spec/jobs/flush_favorites_job_spec.rb
+++ b/spec/jobs/flush_favorites_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FlushFavoritesJob do
   include_context "as admin"
 
   def perform(user_id = CurrentUser.id)
-    described_class.perform_now(user_id)
+    described_class.new.perform(user_id)
   end
 
   # Creates a Favorite and keeps post.fav_count consistent.
@@ -33,7 +33,7 @@ RSpec.describe FlushFavoritesJob do
       end
 
       it "does not enqueue a BulkIndexUpdateJob" do
-        expect { perform }.not_to have_enqueued_job(BulkIndexUpdateJob)
+        expect { perform }.not_to enqueue_sidekiq_job(BulkIndexUpdateJob)
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe FlushFavoritesJob do
       end
 
       it "enqueues a BulkIndexUpdateJob" do
-        expect { perform }.to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
+        expect { perform }.to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", [post.id])
       end
     end
 
@@ -90,7 +90,7 @@ RSpec.describe FlushFavoritesJob do
       end
 
       it "enqueues a BulkIndexUpdateJob" do
-        expect { perform }.to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post_a.id, post_b.id, post_c.id])
+        expect { perform }.to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", [post_a.id, post_b.id, post_c.id])
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe FlushFavoritesJob do
       end
 
       it "enqueues a BulkIndexUpdateJob" do
-        expect { perform }.to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
+        expect { perform }.to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", [post.id])
       end
     end
   end

--- a/spec/jobs/forum_subscription_mail_job_spec.rb
+++ b/spec/jobs/forum_subscription_mail_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ForumSubscriptionMailJob do
     it "processes all forum subscriptions" do
       allow(ForumSubscription).to receive(:process_all!)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(ForumSubscription).to have_received(:process_all!)
     end

--- a/spec/jobs/hide_user_blips_job_spec.rb
+++ b/spec/jobs/hide_user_blips_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HideUserBlipsJob do
   let(:other_user)  { create(:user) }
 
   def perform(user_id = target_user.id)
-    described_class.perform_now(user_id, CurrentUser.id)
+    described_class.new.perform(user_id, CurrentUser.id)
   end
 
   describe "#perform" do

--- a/spec/jobs/hide_user_comments_job_spec.rb
+++ b/spec/jobs/hide_user_comments_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HideUserCommentsJob do
   let(:other_user)  { create(:user) }
 
   def perform(user_id = target_user.id)
-    described_class.perform_now(user_id, CurrentUser.id)
+    described_class.new.perform(user_id, CurrentUser.id)
   end
 
   describe "#perform" do

--- a/spec/jobs/hide_user_forum_posts_job_spec.rb
+++ b/spec/jobs/hide_user_forum_posts_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HideUserForumPostsJob do
   let(:other_user)  { create(:user) }
 
   def perform(user_id = target_user.id)
-    described_class.perform_now(user_id, CurrentUser.id)
+    described_class.new.perform(user_id, CurrentUser.id)
   end
 
   describe "#perform" do

--- a/spec/jobs/index_update_job_spec.rb
+++ b/spec/jobs/index_update_job_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe IndexUpdateJob do
       it "calls update_index on the document store" do
         allow(Post).to receive(:find).with(post.id).and_return(post)
         allow(post).to receive(:document_store).and_return(document_store)
-        described_class.perform_now("Post", post.id)
+        described_class.new.perform("Post", post.id)
         expect(document_store).to have_received(:update_index)
       end
     end
 
     context "when the record does not exist" do
       it "does not raise an error" do
-        expect { described_class.perform_now("Post", -1) }.not_to raise_error
+        expect { described_class.new.perform("Post", -1) }.not_to raise_error
       end
     end
   end

--- a/spec/jobs/iqdb_concurrency_reset_job_spec.rb
+++ b/spec/jobs/iqdb_concurrency_reset_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe IqdbConcurrencyResetJob do
       end
 
       it "deletes all matching keys" do
-        described_class.perform_now
+        described_class.new.perform
         expect(Cache.redis).to have_received(:del).with("iqdb:concurrent:e621", "iqdb:concurrent:e926")
         expect(Cache.redis).to have_received(:del).with("iqdb:concurrent:keys")
       end
@@ -25,7 +25,7 @@ RSpec.describe IqdbConcurrencyResetJob do
       end
 
       it "does not call DEL" do
-        described_class.perform_now
+        described_class.new.perform
         expect(Cache.redis).not_to have_received(:del)
       end
     end

--- a/spec/jobs/iqdb_remove_job_spec.rb
+++ b/spec/jobs/iqdb_remove_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IqdbRemoveJob do
   describe "#perform" do
     it "calls IqdbProxy.remove_post with the given post id" do
       allow(IqdbProxy).to receive(:remove_post)
-      described_class.perform_now(42)
+      described_class.new.perform(42)
       expect(IqdbProxy).to have_received(:remove_post).with(42)
     end
   end

--- a/spec/jobs/iqdb_update_job_spec.rb
+++ b/spec/jobs/iqdb_update_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe IqdbUpdateJob do
 
       it "calls IqdbProxy.update_post with the post" do
         allow(IqdbProxy).to receive(:update_post)
-        described_class.perform_now(post.id)
+        described_class.new.perform(post.id)
         expect(IqdbProxy).to have_received(:update_post).with(post)
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe IqdbUpdateJob do
     context "when the post does not exist" do
       it "does not call IqdbProxy.update_post" do
         allow(IqdbProxy).to receive(:update_post)
-        described_class.perform_now(-1)
+        described_class.new.perform(-1)
         expect(IqdbProxy).not_to have_received(:update_post)
       end
     end

--- a/spec/jobs/post_image_sampler_job_spec.rb
+++ b/spec/jobs/post_image_sampler_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PostImageSamplerJob do
 
     it "calls ImageSampler.generate_post_images with the post" do
       allow(ImageSampler).to receive(:generate_post_images)
-      described_class.perform_now(post.id)
+      described_class.new.perform(post.id)
       expect(ImageSampler).to have_received(:generate_post_images).with(post).at_least(:once)
     end
   end

--- a/spec/jobs/post_prune_job_spec.rb
+++ b/spec/jobs/post_prune_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PostPruneJob do
       allow(PostPruner).to receive(:new).and_return(pruner)
       allow(pruner).to receive(:prune!)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(pruner).to have_received(:prune!)
     end

--- a/spec/jobs/post_set_cleanup_job_spec.rb
+++ b/spec/jobs/post_set_cleanup_job_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe PostSetCleanupJob do
   include_context "as admin"
 
   def perform(type, obj_id)
-    described_class.perform_now(type, obj_id)
+    described_class.new.perform(type, obj_id)
   end
 
   describe "#perform" do
-    context "with type :pool" do
+    context "with type pool" do
       let(:pool_id) { 42 }
       let!(:post_in_pool) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id]) } }
       let!(:post_not_in_pool) { create(:post) }
@@ -23,12 +23,12 @@ RSpec.describe PostSetCleanupJob do
       end
 
       it "removes the pool id from the raw pool_ids column" do
-        perform(:pool, pool_id)
+        perform("pool", pool_id)
         expect(post_in_pool.reload[:pool_ids]).not_to include(pool_id)
       end
 
       it "does not modify posts that do not belong to the pool" do
-        perform(:pool, pool_id)
+        perform("pool", pool_id)
         expect(post_not_in_pool.reload[:pool_ids]).to eq([])
       end
 
@@ -37,7 +37,7 @@ RSpec.describe PostSetCleanupJob do
         let!(:post_in_both) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id, other_pool_id]) } }
 
         it "preserves the other pool ids" do
-          perform(:pool, pool_id)
+          perform("pool", pool_id)
           expect(post_in_both.reload[:pool_ids]).to eq([other_pool_id])
         end
       end
@@ -49,7 +49,7 @@ RSpec.describe PostSetCleanupJob do
         let!(:drifted_post) { create(:post).tap { |p| p.update_columns(pool_ids: [pool_id]) } }
 
         it "clears the stale membership anyway" do
-          perform(:pool, pool_id)
+          perform("pool", pool_id)
           expect(drifted_post.reload[:pool_ids]).to eq([])
         end
       end
@@ -63,11 +63,11 @@ RSpec.describe PostSetCleanupJob do
 
       it "enqueues a reindex for posts that carried the set token" do
         expect { perform(:set, set_id) }
-          .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post_in_set.id])
+          .to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", [post_in_set.id])
       end
 
       it "does not enqueue anything when no posts carry the token" do
-        expect { perform(:set, 999_999) }.not_to have_enqueued_job(BulkIndexUpdateJob)
+        expect { perform(:set, 999_999) }.not_to enqueue_sidekiq_job(BulkIndexUpdateJob)
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe PostSetCleanupJob do
 
     context "when no posts contain the pool" do
       it "does not raise an error" do
-        expect { perform(:pool, 999_999) }.not_to raise_error
+        expect { perform("pool", 999_999) }.not_to raise_error
       end
     end
   end

--- a/spec/jobs/post_set_posts_sync_job_spec.rb
+++ b/spec/jobs/post_set_posts_sync_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PostSetPostsSyncJob do
 
     context "when the set does not exist" do
       it "does not raise an error" do
-        expect { job.perform_now(-1) }.not_to raise_error
+        expect { job.new.perform(-1) }.not_to raise_error
       end
     end
 
@@ -29,8 +29,8 @@ RSpec.describe PostSetPostsSyncJob do
 
       it "enqueues a BulkIndexUpdateJob for them" do
         post_set.update_column(:post_ids, [post.id])
-        expect { job.perform_now(post_set.id) }
-          .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
+        expect { job.new.perform(post_set.id) }
+          .to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", [post.id])
       end
     end
 
@@ -41,16 +41,16 @@ RSpec.describe PostSetPostsSyncJob do
 
       it "enqueues a BulkIndexUpdateJob for it" do
         post_set.update_column(:post_ids, [])
-        expect { job.perform_now(post_set.id) }
-          .to have_enqueued_job(BulkIndexUpdateJob).with("Post", [post.id])
+        expect { job.new.perform(post_set.id) }
+          .to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", [post.id])
       end
     end
 
     context "when the set is empty and no posts carry its token" do
       it "does not enqueue a BulkIndexUpdateJob" do
         post_set.update_column(:post_ids, [])
-        expect { job.perform_now(post_set.id) }
-          .not_to have_enqueued_job(BulkIndexUpdateJob)
+        expect { job.new.perform(post_set.id) }
+          .not_to enqueue_sidekiq_job(BulkIndexUpdateJob)
       end
     end
   end

--- a/spec/jobs/post_video_conversion_job_spec.rb
+++ b/spec/jobs/post_video_conversion_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PostVideoConversionJob do
   end
 
   def perform(id = post.id)
-    described_class.perform_now(id)
+    described_class.new.perform(id)
   end
 
   def job_instance

--- a/spec/jobs/search_trend_aggregate_job_spec.rb
+++ b/spec/jobs/search_trend_aggregate_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe SearchTrendAggregateJob do
   def perform
-    described_class.perform_now
+    described_class.new.perform
   end
 
   let(:past_hour)    { 1.day.ago.utc.beginning_of_day + 12.hours }

--- a/spec/jobs/search_trend_cache_warm_job_spec.rb
+++ b/spec/jobs/search_trend_cache_warm_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SearchTrendCacheWarmJob do
   describe "#perform" do
     it "calls warm_rising_tags_cache! on SearchTrendHourly" do
       allow(SearchTrendHourly).to receive(:warm_rising_tags_cache!)
-      described_class.perform_now
+      described_class.new.perform
       expect(SearchTrendHourly).to have_received(:warm_rising_tags_cache!)
     end
   end

--- a/spec/jobs/search_trend_prune_job_spec.rb
+++ b/spec/jobs/search_trend_prune_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SearchTrendPruneJob do
     it "prunes hourly and daily search trend records" do
       allow(SearchTrendHourly).to receive(:prune!)
       allow(SearchTrend).to receive(:prune!)
-      described_class.perform_now
+      described_class.new.perform
       expect(SearchTrendHourly).to have_received(:prune!)
       expect(SearchTrend).to have_received(:prune!)
     end

--- a/spec/jobs/sitemap_generator_job_spec.rb
+++ b/spec/jobs/sitemap_generator_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SitemapGeneratorJob do
     before { allow(Post).to receive(:tag_match).and_return(Post.none) }
 
     it "generates the sitemap without error" do
-      expect { described_class.perform_now }.not_to raise_error
+      expect { described_class.new.perform }.not_to raise_error
     end
   end
 end

--- a/spec/jobs/stats_update_job_spec.rb
+++ b/spec/jobs/stats_update_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe StatsUpdateJob do
     it "updates the cached site statistics" do
       allow(StatsUpdater).to receive(:run!)
 
-      described_class.perform_now
+      described_class.new.perform
 
       expect(StatsUpdater).to have_received(:run!)
     end

--- a/spec/jobs/tag_alias_finalize_job_spec.rb
+++ b/spec/jobs/tag_alias_finalize_job_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe TagAliasFinalizeJob do
     end
 
     it "reindexes only the posts captured in the undo data" do
-      described_class.perform_now(ta.id)
+      described_class.new.perform(ta.id)
       expect(Post.document_store).to have_received(:import).with(query: { id: post_ids })
     end
 
     it "unions undo data across multiple tag_rel_undos and de-duplicates" do
       ta.tag_rel_undos.create!(undo_data: [103, 104])
-      described_class.perform_now(ta.id)
+      described_class.new.perform(ta.id)
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102, 103, 104] })
     end
 
@@ -40,24 +40,24 @@ RSpec.describe TagAliasFinalizeJob do
         "category_change" => nil,
         "artist_change" => nil,
       })
-      described_class.perform_now(ta.id)
+      described_class.new.perform(ta.id)
       expect(Post.document_store).to have_received(:import).with(query: { id: [201, 202] })
     end
 
     it "handles a mix of legacy and current undo data" do
       ta.tag_rel_undos.create!(undo_data: { "version" => 3, "kind" => "posts", "added" => { "103" => [], "301" => [ta.consequent_name] } })
-      described_class.perform_now(ta.id)
+      described_class.new.perform(ta.id)
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102, 103, 301] })
     end
 
     it "skips the bulk reindex when no posts were affected" do
       ta.tag_rel_undos.destroy_all
-      described_class.perform_now(ta.id)
+      described_class.new.perform(ta.id)
       expect(Post.document_store).not_to have_received(:import)
     end
 
     it "fixes post counts on both tags after reindexing" do
-      described_class.perform_now(ta.id)
+      described_class.new.perform(ta.id)
       expect(ta.antecedent_tag).to have_received(:fix_post_count)
       expect(ta.consequent_tag).to have_received(:fix_post_count)
     end
@@ -65,7 +65,7 @@ RSpec.describe TagAliasFinalizeJob do
     it "updates the post count of the tag alias after reindexing" do
       allow(ta).to receive(:update_columns).and_call_original
 
-      described_class.perform_now(ta.id)
+      described_class.new.perform(ta.id)
       expect(ta).to have_received(:update_columns).with(post_count: 42)
     end
   end

--- a/spec/jobs/tag_alias_job_spec.rb
+++ b/spec/jobs/tag_alias_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TagAliasJob do
     it "calls process! on the tag alias" do
       allow(TagAlias).to receive(:find).with(tag_alias.id).and_return(tag_alias)
       allow(tag_alias).to receive(:process!)
-      described_class.perform_now(tag_alias.id, false)
+      described_class.new.perform(tag_alias.id, false)
       expect(tag_alias).to have_received(:process!).with(update_topic: false)
     end
   end

--- a/spec/jobs/tag_alias_undo_job_spec.rb
+++ b/spec/jobs/tag_alias_undo_job_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe TagAliasUndoJob do
       undoer = create(:admin_user)
       allow(TagAlias).to receive(:find).with(tag_alias.id).and_return(tag_alias)
       allow(tag_alias).to receive(:process_undo!)
-      described_class.perform_now(tag_alias.id, false, undoer.id)
+      described_class.new.perform(tag_alias.id, false, undoer.id)
       expect(tag_alias).to have_received(:process_undo!).with(update_topic: false, undoer: undoer)
     end
 
     it "passes a nil undoer when none was recorded" do
       allow(TagAlias).to receive(:find).with(tag_alias.id).and_return(tag_alias)
       allow(tag_alias).to receive(:process_undo!)
-      described_class.perform_now(tag_alias.id, false)
+      described_class.new.perform(tag_alias.id, false)
       expect(tag_alias).to have_received(:process_undo!).with(update_topic: false, undoer: nil)
     end
 
@@ -28,7 +28,7 @@ RSpec.describe TagAliasUndoJob do
       allow(TagAlias).to receive(:find).with(tag_alias.id).and_return(tag_alias)
       allow(tag_alias).to receive(:process_undo!).and_raise(TagAlias::UndoError, "some permanent problem")
 
-      expect { described_class.perform_now(tag_alias.id, false, undoer.id) }
+      expect { described_class.new.perform(tag_alias.id, false, undoer.id) }
         .to change { Dmail.where(to_id: undoer.id, owner_id: undoer.id).count }.by(1)
 
       dmail = Dmail.where(to_id: undoer.id, owner_id: undoer.id).last
@@ -39,7 +39,7 @@ RSpec.describe TagAliasUndoJob do
       allow(TagAlias).to receive(:find).with(tag_alias.id).and_return(tag_alias)
       allow(tag_alias).to receive(:process_undo!).and_raise(TagAlias::UndoError, "some permanent problem")
 
-      expect { described_class.perform_now(tag_alias.id, false) }.not_to change(Dmail, :count)
+      expect { described_class.new.perform(tag_alias.id, false) }.not_to change(Dmail, :count)
     end
   end
 

--- a/spec/jobs/tag_batch_finalize_job_spec.rb
+++ b/spec/jobs/tag_batch_finalize_job_spec.rb
@@ -11,17 +11,17 @@ RSpec.describe TagBatchFinalizeJob do
 
   describe "#perform" do
     it "reindexes every post carrying the consequent" do
-      described_class.perform_now("new_tag")
+      described_class.new.perform("new_tag")
       expect(Post.document_store).to have_received(:import).with(query: tag_query)
     end
 
     it "also reindexes stragglers, which the consequent query cannot reach" do
-      described_class.perform_now("new_tag", [101, 102])
+      described_class.new.perform("new_tag", [101, 102])
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102] })
     end
 
     it "issues no id import when there are no stragglers" do
-      described_class.perform_now("new_tag", [])
+      described_class.new.perform("new_tag", [])
       expect(Post.document_store).not_to have_received(:import).with(query: hash_including(:id))
     end
   end

--- a/spec/jobs/tag_batch_job_spec.rb
+++ b/spec/jobs/tag_batch_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe TagBatchJob do
   include_context "as admin"
 
   def perform(antecedent = "old_tag", consequent = "new_tag")
-    described_class.perform_now(antecedent, consequent, CurrentUser.id, CurrentUser.ip_addr)
+    described_class.new.perform(antecedent, consequent, CurrentUser.id, CurrentUser.ip_addr)
   end
 
   describe "#perform" do
@@ -117,29 +117,29 @@ RSpec.describe TagBatchJob do
     let!(:post) { create(:post, tag_string: "old_tag other_tag") }
 
     it "enqueues the finalize job with the consequent and no stragglers" do
-      expect { perform }.to have_enqueued_job(TagBatchFinalizeJob).with("new_tag", [])
+      expect { perform }.to enqueue_sidekiq_job(TagBatchFinalizeJob).with("new_tag", [])
     end
 
     it "does not enqueue the finalize job when the arguments are rejected" do
       expect { perform("old_tag extra_tag", "new_tag") }.to raise_error(ApplicationJob::JobError)
-      expect(TagBatchFinalizeJob).not_to have_been_enqueued
+      expect(TagBatchFinalizeJob).not_to have_enqueued_sidekiq_job
     end
 
     it "still enqueues the finalize job when a post cannot be saved" do
       post.update_columns(rating: "x")
       expect { perform }.to raise_error(ApplicationJob::JobError)
-      expect(TagBatchFinalizeJob).to have_been_enqueued
+      expect(TagBatchFinalizeJob).to have_enqueued_sidekiq_job
     end
 
     it "resolves the consequent through an active alias" do
       create(:tag_alias, antecedent_name: "new_tag", consequent_name: "final_tag", status: "active")
-      expect { perform }.to have_enqueued_job(TagBatchFinalizeJob).with("final_tag", [])
+      expect { perform }.to enqueue_sidekiq_job(TagBatchFinalizeJob).with("final_tag", [])
       expect(post.reload.tag_array).to include("final_tag")
     end
 
     it "records posts the consequent did not survive on as stragglers" do
       post.update_columns(locked_tags: "-new_tag")
-      expect { perform }.to have_enqueued_job(TagBatchFinalizeJob).with("new_tag", [post.id])
+      expect { perform }.to enqueue_sidekiq_job(TagBatchFinalizeJob).with("new_tag", [post.id])
     end
 
     context "while migrating" do

--- a/spec/jobs/tag_implication_finalize_job_lock_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_lock_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# Real pushes to the test Redis through the client middleware, proving the lock
+# keys on full args: an approve-finalize and an undo-finalize for the same
+# implication differ only by the undo flag and must both survive, while two
+# identical approve-finalizes dedup. Private random queue + digest cleanup keep
+# it safe on the shared Redis DB 0.
+RSpec.describe TagImplicationFinalizeJob do
+  around do |example|
+    Sidekiq::Testing.disable! do
+      SidekiqUniqueJobs.config.enabled = true
+      example.run
+    ensure
+      SidekiqUniqueJobs.config.enabled = false
+    end
+  end
+
+  it "dedups identical finalizes but keeps approve and undo distinct" do
+    queue_name = "finlockspec_#{SecureRandom.hex(6)}"
+    id = SecureRandom.random_number(2**31)
+    name = "finlockspec_#{SecureRandom.hex(8)}"
+
+    approve1 = described_class.set(queue: queue_name).perform_async(id, name)
+    approve2 = described_class.set(queue: queue_name).perform_async(id, name)
+    undo = described_class.set(queue: queue_name).perform_async(id, name, true)
+
+    expect(approve1).to be_present
+    expect(approve2).to be_nil # identical approve-finalize deduped
+    expect(undo).to be_present # differs by the undo flag, must survive
+
+    queue = Sidekiq::Queue.new(queue_name)
+    expect(queue.map(&:args)).to contain_exactly([id, name], [id, name, true])
+  ensure
+    queue = Sidekiq::Queue.new(queue_name)
+    queue.each do |j|
+      digest = j.item["lock_digest"]
+      next unless digest
+
+      SidekiqUniqueJobs::Digests.new.delete_by_digest(digest)
+      SidekiqUniqueJobs::ExpiringDigests.new.delete_by_digest(digest)
+    end
+    queue.clear
+  end
+end

--- a/spec/jobs/tag_implication_finalize_job_spec.rb
+++ b/spec/jobs/tag_implication_finalize_job_spec.rb
@@ -17,20 +17,20 @@ RSpec.describe TagImplicationFinalizeJob do
     end
 
     it "bulk-reindexes posts matching the given tag name" do
-      described_class.perform_now(ti.id, ti.consequent_name)
+      described_class.new.perform(ti.id, ti.consequent_name)
       expect(Post.document_store).to have_received(:import).with(
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ti.consequent_name],
       )
     end
 
     it "fixes post counts on both tags after reindexing" do
-      described_class.perform_now(ti.id, ti.consequent_name)
+      described_class.new.perform(ti.id, ti.consequent_name)
       expect(ti.antecedent_tag).to have_received(:fix_post_count)
       expect(ti.consequent_tag).to have_received(:fix_post_count)
     end
 
     it "uses antecedent_name as the reindex target when called for an undo" do
-      described_class.perform_now(ti.id, ti.antecedent_name)
+      described_class.new.perform(ti.id, ti.antecedent_name)
       expect(Post.document_store).to have_received(:import).with(
         query: ["string_to_array(tag_string, ' ') @> ARRAY[?]::text[]", ti.antecedent_name],
       )
@@ -40,7 +40,7 @@ RSpec.describe TagImplicationFinalizeJob do
       ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "101" => ["species_b"] } })
       ti.tag_rel_undos.create!(undo_data: { "102" => "char_a species_b" })
 
-      described_class.perform_now(ti.id, ti.antecedent_name, undo: true)
+      described_class.new.perform(ti.id, ti.antecedent_name, true)
 
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102] })
     end
@@ -48,13 +48,13 @@ RSpec.describe TagImplicationFinalizeJob do
     it "does not reindex by id on the approval path even when undo rows exist" do
       ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => { "101" => ["species_b"] } })
 
-      described_class.perform_now(ti.id, ti.consequent_name)
+      described_class.new.perform(ti.id, ti.consequent_name)
 
       expect(Post.document_store).not_to have_received(:import).with(query: hash_including(:id))
     end
 
     it "does not reindex by id when no undo rows exist" do
-      described_class.perform_now(ti.id, ti.antecedent_name, undo: true)
+      described_class.new.perform(ti.id, ti.antecedent_name, true)
       expect(Post.document_store).not_to have_received(:import).with(query: hash_including(:id))
     end
   end

--- a/spec/jobs/tag_implication_job_spec.rb
+++ b/spec/jobs/tag_implication_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TagImplicationJob do
     it "calls process! on the tag implication" do
       allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
       allow(tag_implication).to receive(:process!)
-      described_class.perform_now(tag_implication.id, false)
+      described_class.new.perform(tag_implication.id, false)
       expect(tag_implication).to have_received(:process!).with(update_topic: false)
     end
   end

--- a/spec/jobs/tag_implication_undo_job_spec.rb
+++ b/spec/jobs/tag_implication_undo_job_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe TagImplicationUndoJob do
       undoer = create(:admin_user)
       allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
       allow(tag_implication).to receive(:process_undo!)
-      described_class.perform_now(tag_implication.id, false, undoer.id)
+      described_class.new.perform(tag_implication.id, false, undoer.id)
       expect(tag_implication).to have_received(:process_undo!).with(update_topic: false, undoer: undoer)
     end
 
     it "passes a nil undoer when none was recorded" do
       allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
       allow(tag_implication).to receive(:process_undo!)
-      described_class.perform_now(tag_implication.id, false)
+      described_class.new.perform(tag_implication.id, false)
       expect(tag_implication).to have_received(:process_undo!).with(update_topic: false, undoer: nil)
     end
 
@@ -28,7 +28,7 @@ RSpec.describe TagImplicationUndoJob do
       allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
       allow(tag_implication).to receive(:process_undo!).and_raise(TagImplication::UndoError, "some permanent problem")
 
-      expect { described_class.perform_now(tag_implication.id, false, undoer.id) }
+      expect { described_class.new.perform(tag_implication.id, false, undoer.id) }
         .to change { Dmail.where(to_id: undoer.id, owner_id: undoer.id).count }.by(1)
 
       dmail = Dmail.where(to_id: undoer.id, owner_id: undoer.id).last
@@ -39,7 +39,7 @@ RSpec.describe TagImplicationUndoJob do
       allow(TagImplication).to receive(:find).with(tag_implication.id).and_return(tag_implication)
       allow(tag_implication).to receive(:process_undo!).and_raise(TagImplication::UndoError, "some permanent problem")
 
-      expect { described_class.perform_now(tag_implication.id, false) }.not_to change(Dmail, :count)
+      expect { described_class.new.perform(tag_implication.id, false) }.not_to change(Dmail, :count)
     end
   end
 

--- a/spec/jobs/tag_nuke_finalize_job_spec.rb
+++ b/spec/jobs/tag_nuke_finalize_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TagNukeFinalizeJob do
       TagRelUndo.create!(tag_rel: tag, undo_data: [101, 102])
       TagRelUndo.create!(tag_rel: tag, undo_data: [102, 103])
 
-      described_class.perform_now(tag.id)
+      described_class.new.perform(tag.id)
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102, 103] })
     end
 
@@ -22,24 +22,24 @@ RSpec.describe TagNukeFinalizeJob do
       TagRelUndo.create!(tag_rel: tag, undo_data: [101])
       TagRelUndo.create!(tag_rel: tag, undo_data: [999], applied: true)
 
-      described_class.perform_now(tag.id)
+      described_class.new.perform(tag.id)
       expect(Post.document_store).to have_received(:import).with(query: { id: [101] })
     end
 
     it "does not import when the tag has no unapplied undo rows" do
-      described_class.perform_now(tag.id)
+      described_class.new.perform(tag.id)
       expect(Post.document_store).not_to have_received(:import)
     end
 
     it "unions straggler ids with the undo row ids" do
       TagRelUndo.create!(tag_rel: tag, undo_data: [101, 102])
 
-      described_class.perform_now(tag.id, [102, 103])
+      described_class.new.perform(tag.id, [102, 103])
       expect(Post.document_store).to have_received(:import).with(query: { id: [101, 102, 103] })
     end
 
     it "imports stragglers even when no undo rows exist" do
-      described_class.perform_now(tag.id, [101])
+      described_class.new.perform(tag.id, [101])
       expect(Post.document_store).to have_received(:import).with(query: { id: [101] })
     end
   end

--- a/spec/jobs/tag_nuke_job_lock_spec.rb
+++ b/spec/jobs/tag_nuke_job_lock_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# End-to-end proof that sidekiq-unique-jobs dedups native payloads: real pushes
+# to the test Redis through the real client middleware. The Redis instance is
+# shared with parallel workers and (in dev setups) a live Sidekiq worker, so the
+# pushes go to a private random queue nobody consumes, and the cleanup only
+# touches that queue and this example's own digests.
+RSpec.describe TagNukeJob do
+  around do |example|
+    Sidekiq::Testing.disable! do
+      SidekiqUniqueJobs.config.enabled = true
+      example.run
+    ensure
+      SidekiqUniqueJobs.config.enabled = false
+    end
+  end
+
+  it "drops a duplicate enqueue for the same tag but accepts a different tag" do
+    queue_name = "lockspec_#{SecureRandom.hex(6)}"
+    tag_a = "lockspec_#{SecureRandom.hex(8)}"
+    tag_b = "lockspec_#{SecureRandom.hex(8)}"
+
+    jid1 = described_class.set(queue: queue_name).perform_async(tag_a, 1, "127.0.0.1")
+    jid2 = described_class.set(queue: queue_name).perform_async(tag_a, 2, "127.0.0.1") # same lock_args -> [tag_a]
+    jid3 = described_class.set(queue: queue_name).perform_async(tag_b, 1, "127.0.0.1")
+
+    expect(jid1).to be_present
+    expect(jid2).to be_nil
+    expect(jid3).to be_present
+
+    queue = Sidekiq::Queue.new(queue_name)
+    expect(queue.map { |j| j.args[0] }).to contain_exactly(tag_a, tag_b)
+  ensure
+    queue = Sidekiq::Queue.new(queue_name)
+    queue.each do |j|
+      digest = j.item["lock_digest"]
+      next unless digest
+
+      SidekiqUniqueJobs::Digests.new.delete_by_digest(digest)
+      SidekiqUniqueJobs::ExpiringDigests.new.delete_by_digest(digest)
+    end
+    queue.clear
+  end
+end

--- a/spec/jobs/tag_nuke_job_spec.rb
+++ b/spec/jobs/tag_nuke_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TagNukeJob do
   let!(:tag) { create(:tag, name: tag_name) }
 
   def perform(name = tag_name, updater_id = CurrentUser.id, ip = "127.0.0.1")
-    described_class.perform_now(name, updater_id, ip)
+    described_class.new.perform(name, updater_id, ip)
   end
 
   describe "#perform" do
@@ -119,18 +119,18 @@ RSpec.describe TagNukeJob do
     let!(:tagged_post) { create(:post, tag_string: "#{tag_name} extra_tag") }
 
     it "enqueues the finalize job with the tag id" do
-      expect { perform }.to have_enqueued_job(TagNukeFinalizeJob).with(tag.id, [])
+      expect { perform }.to enqueue_sidekiq_job(TagNukeFinalizeJob).with(tag.id, [])
     end
 
     it "does not enqueue the finalize job when the tag does not resolve" do
       perform("nonexistent_tag")
-      expect(TagNukeFinalizeJob).not_to have_been_enqueued
+      expect(TagNukeFinalizeJob).not_to have_enqueued_sidekiq_job
     end
 
     it "still enqueues the finalize job when a post cannot be saved" do
       tagged_post.update_columns(rating: "x")
       expect { perform }.to raise_error(ApplicationJob::JobError)
-      expect(TagNukeFinalizeJob).to have_been_enqueued
+      expect(TagNukeFinalizeJob).to have_enqueued_sidekiq_job
     end
 
     it "records the undo row even when a post cannot be saved" do
@@ -219,7 +219,7 @@ RSpec.describe TagNukeJob do
       end
 
       it "passes the stragglers to the finalize job" do
-        expect { job.perform(tag_name, CurrentUser.id, "127.0.0.1") }.to have_enqueued_job(TagNukeFinalizeJob).with(tag.id, [tagged_post.id])
+        expect { job.perform(tag_name, CurrentUser.id, "127.0.0.1") }.to enqueue_sidekiq_job(TagNukeFinalizeJob).with(tag.id, [tagged_post.id])
       end
     end
   end

--- a/spec/jobs/tag_post_count_job_spec.rb
+++ b/spec/jobs/tag_post_count_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TagPostCountJob do
     it "calls fix_post_count on the tag" do
       allow(Tag).to receive(:find_by).with(id: tag.id).and_return(tag)
       allow(tag).to receive(:fix_post_count)
-      described_class.perform_now(tag.id)
+      described_class.new.perform(tag.id)
       expect(tag).to have_received(:fix_post_count)
     end
   end

--- a/spec/jobs/tag_update_related_job_spec.rb
+++ b/spec/jobs/tag_update_related_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TagUpdateRelatedJob do
     it "calls update_related on the tag" do
       allow(Tag).to receive(:find).with(tag.id).and_return(tag)
       allow(tag).to receive(:update_related)
-      described_class.perform_now(tag.id)
+      described_class.new.perform(tag.id)
       expect(tag).to have_received(:update_related)
     end
   end

--- a/spec/jobs/takedown_job_spec.rb
+++ b/spec/jobs/takedown_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe TakedownJob do
   let(:approver) { create(:admin_user) }
 
   def perform(takedown, reason = "copyright infringement")
-    described_class.perform_now(takedown.id, approver.id, reason)
+    described_class.new.perform(takedown.id, approver.id, reason)
   end
 
   describe "#perform" do

--- a/spec/jobs/transfer_favorites_job_spec.rb
+++ b/spec/jobs/transfer_favorites_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TransferFavoritesJob do
   let(:child_post)  { create(:post, parent_id: parent_post.id) }
 
   def perform(post_id = child_post.id, user_id = CurrentUser.id)
-    described_class.perform_now(post_id, user_id)
+    described_class.new.perform(post_id, user_id)
   end
 
   # Creates a Favorite and keeps post.fav_count consistent.

--- a/spec/jobs/update_tag_category_job_spec.rb
+++ b/spec/jobs/update_tag_category_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UpdateTagCategoryJob do
     it "calls update_category_post_counts! on the tag" do
       allow(Tag).to receive(:find).with(tag.id).and_return(tag)
       allow(tag).to receive(:update_category_post_counts!)
-      described_class.perform_now(tag.id)
+      described_class.new.perform(tag.id)
       expect(tag).to have_received(:update_category_post_counts!)
     end
   end

--- a/spec/jobs/upload_delete_files_job_spec.rb
+++ b/spec/jobs/upload_delete_files_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UploadDeleteFilesJob do
   describe "#perform" do
     it "delegates to UploadService::Utils.delete_file" do
       allow(UploadService::Utils).to receive(:delete_file)
-      described_class.perform_now("abc123", "jpg", nil)
+      described_class.new.perform("abc123", "jpg", nil)
       expect(UploadService::Utils).to have_received(:delete_file).with("abc123", "jpg", nil)
     end
   end

--- a/spec/jobs/user_feedback_mail_job_spec.rb
+++ b/spec/jobs/user_feedback_mail_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserFeedbackMailJob do
+  include_context "as admin"
+
+  def perform(user_id, feedback_id)
+    described_class.new.perform(user_id, feedback_id)
+  end
+
+  describe "#perform" do
+    let(:feedback) { create(:user_feedback) }
+
+    it "sends one feedback notice email to the user" do
+      expect { perform(feedback.user_id, feedback.id) }
+        .to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.last.to).to include(feedback.user.email)
+    end
+
+    it "does nothing when the user no longer exists" do
+      expect { perform(-1, feedback.id) }
+        .not_to(change { ActionMailer::Base.deliveries.count })
+    end
+
+    it "does nothing when the feedback no longer exists" do
+      expect { perform(feedback.user_id, -1) }
+        .not_to(change { ActionMailer::Base.deliveries.count })
+    end
+  end
+end

--- a/spec/jobs/user_ip_address_backfill_job_spec.rb
+++ b/spec/jobs/user_ip_address_backfill_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UserIpAddressBackfillJob do
       create(:comment, post: post)
     end
 
-    described_class.perform_now
+    described_class.new.perform
     row = UserIpAddress.find_by(user_id: user.id, ip_addr: "203.0.113.10")
     expect(row).to be_present
     expect(row.hit_count).to eq(2)
@@ -36,20 +36,20 @@ RSpec.describe UserIpAddressBackfillJob do
     # Sanity: the split really did create both mailbox copies.
     expect(Dmail.where(from_id: user.id).count).to eq(2)
 
-    described_class.perform_now
+    described_class.new.perform
     row = UserIpAddress.find_by(user_id: user.id, ip_addr: "203.0.113.20")
     expect(row.hit_count).to eq(1)
   end
 
   it "excludes loopback addresses" do
     create(:user, last_ip_addr: "127.0.0.1", last_logged_in_at: 1.day.ago)
-    described_class.perform_now
+    described_class.new.perform
     expect(UserIpAddress.where(ip_addr: "127.0.0.1")).to be_empty
   end
 
   it "ignores rows outside the retention window" do
     create(:user, last_ip_addr: "203.0.113.30", last_logged_in_at: 3.years.ago)
-    described_class.perform_now
+    described_class.new.perform
     expect(UserIpAddress.find_by(ip_addr: "203.0.113.30")).to be_nil
   end
 end

--- a/spec/jobs/user_ip_address_prune_job_spec.rb
+++ b/spec/jobs/user_ip_address_prune_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UserIpAddressPruneJob do
     fresh = create(:user_ip_address, user: user, ip_addr: "203.0.113.2",
                                      last_seen_at: 1.day.ago, first_seen_at: 1.day.ago)
 
-    expect { described_class.perform_now }.to change(UserIpAddress, :count).by(-1)
+    expect { described_class.new.perform }.to change(UserIpAddress, :count).by(-1)
     expect(UserIpAddress.exists?(fresh.id)).to be(true)
     expect(UserIpAddress.exists?(stale.id)).to be(false)
   end
@@ -23,6 +23,6 @@ RSpec.describe UserIpAddressPruneJob do
     old = create(:user_ip_address, user: user, ip_addr: "203.0.113.3",
                                    last_seen_at: 60.days.ago, first_seen_at: 60.days.ago)
 
-    expect { described_class.perform_now }.to change { UserIpAddress.exists?(old.id) }.from(true).to(false)
+    expect { described_class.new.perform }.to change { UserIpAddress.exists?(old.id) }.from(true).to(false)
   end
 end

--- a/spec/lib/sidekiq_active_job_wrapper_shim_spec.rb
+++ b/spec/lib/sidekiq_active_job_wrapper_shim_spec.rb
@@ -41,6 +41,29 @@ RSpec.describe SidekiqActiveJobWrapperShim do
     expect(instance).to have_received(:perform).with(:pool, 42)
   end
 
+  it "remaps a legacy keyword payload for a job that is now positional" do
+    instance = instance_double(AutomodUserCheckJob)
+    allow(AutomodUserCheckJob).to receive(:new).and_return(instance)
+    allow(instance).to receive(:perform)
+
+    # Serialized shape of perform_later(5, check_username: true, check_profile: false).
+    kwargs = { "check_username" => true, "check_profile" => false, "_aj_ruby2_keywords" => %w[check_username check_profile] }
+    Sidekiq::ActiveJob::Wrapper.new.perform(wrapper_job_data("AutomodUserCheckJob", [5, kwargs]))
+
+    expect(instance).to have_received(:perform).with(5, true, false)
+  end
+
+  it "defaults the option when a legacy payload omitted the keyword" do
+    instance = instance_double(TagImplicationFinalizeJob)
+    allow(TagImplicationFinalizeJob).to receive(:new).and_return(instance)
+    allow(instance).to receive(:perform)
+
+    # perform_later(7, "some_tag") — the undo: keyword was never supplied.
+    Sidekiq::ActiveJob::Wrapper.new.perform(wrapper_job_data("TagImplicationFinalizeJob", [7, "some_tag"]))
+
+    expect(instance).to have_received(:perform).with(7, "some_tag", false)
+  end
+
   it "delegates payloads for classes that are still ActiveJobs" do
     # Deliberately a raw ActiveJob: ApplicationJob is a native Sidekiq job now.
     stub_const("ShimSpecActiveJob", Class.new(ActiveJob::Base)) # rubocop:disable Rails/ApplicationJob

--- a/spec/lib/sidekiq_active_job_wrapper_shim_spec.rb
+++ b/spec/lib/sidekiq_active_job_wrapper_shim_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require Rails.root.join("lib/sidekiq_active_job_wrapper_shim")
+
+RSpec.describe SidekiqActiveJobWrapperShim do
+  def wrapper_job_data(job_class, arguments)
+    {
+      "job_class" => job_class,
+      "job_id" => SecureRandom.uuid,
+      "provider_job_id" => nil,
+      "queue_name" => "default",
+      "priority" => nil,
+      "arguments" => arguments,
+      "executions" => 0,
+      "exception_executions" => {},
+      "locale" => "en",
+      "timezone" => "UTC",
+      "enqueued_at" => Time.current.utc.iso8601(9),
+    }
+  end
+
+  it "executes legacy payloads for migrated jobs natively" do
+    instance = instance_double(IqdbRemoveJob)
+    allow(IqdbRemoveJob).to receive(:new).and_return(instance)
+    allow(instance).to receive(:perform)
+
+    Sidekiq::ActiveJob::Wrapper.new.perform(wrapper_job_data("IqdbRemoveJob", [123]))
+
+    expect(instance).to have_received(:perform).with(123)
+  end
+
+  it "revives ActiveJob-serialized symbol arguments" do
+    instance = instance_double(PostSetCleanupJob)
+    allow(PostSetCleanupJob).to receive(:new).and_return(instance)
+    allow(instance).to receive(:perform)
+
+    symbol_arg = { "_aj_serialized" => "ActiveJob::Serializers::SymbolSerializer", "value" => "pool" }
+    Sidekiq::ActiveJob::Wrapper.new.perform(wrapper_job_data("PostSetCleanupJob", [symbol_arg, 42]))
+
+    expect(instance).to have_received(:perform).with(:pool, 42)
+  end
+
+  it "delegates payloads for classes that are still ActiveJobs" do
+    # Deliberately a raw ActiveJob: ApplicationJob is a native Sidekiq job now.
+    stub_const("ShimSpecActiveJob", Class.new(ActiveJob::Base)) # rubocop:disable Rails/ApplicationJob
+    allow(ActiveJob::Base).to receive(:execute)
+
+    Sidekiq::ActiveJob::Wrapper.new.perform(wrapper_job_data("ShimSpecActiveJob", []))
+
+    expect(ActiveJob::Base).to have_received(:execute).with(hash_including("job_class" => "ShimSpecActiveJob"))
+  end
+end

--- a/spec/logical/bulk_update_request_importer_spec.rb
+++ b/spec/logical/bulk_update_request_importer_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe BulkUpdateRequestImporter do
     BulkUpdateRequestImporter.new(script, forum_id, CurrentUser.id, CurrentUser.ip_addr)
   end
 
+  # Production defers in-transaction enqueues via Sidekiq.transactional_push!,
+  # which is off in tests (transactional fixtures never commit). Opt back in for
+  # examples that assert a rollback discards the enqueue. The client_class must
+  # go on the job classes themselves: they captured default_job_options at load.
+  def with_transactional_push(*job_classes)
+    require "sidekiq/transaction_aware_client"
+    job_classes.each { |klass| klass.sidekiq_options client_class: Sidekiq::TransactionAwareClient }
+    yield
+  ensure
+    job_classes.each { |klass| klass.sidekiq_options_hash = klass.get_sidekiq_options.except("client_class") }
+  end
+
   # ---------------------------------------------------------------------------
   # .tokenize
   # ---------------------------------------------------------------------------
@@ -508,7 +520,7 @@ RSpec.describe BulkUpdateRequestImporter do
 
       it "enqueues a TagAliasJob" do
         expect { importer("alias proc_ca_ant -> proc_ca_con").process!(approver) }
-          .to have_enqueued_job(TagAliasJob)
+          .to enqueue_sidekiq_job(TagAliasJob)
       end
 
       context "when a pending alias already exists for the pair" do
@@ -521,7 +533,7 @@ RSpec.describe BulkUpdateRequestImporter do
 
         it "enqueues a TagAliasJob for the reused alias" do
           expect { importer("alias proc_ca_reuse_ant -> proc_ca_reuse_con").process!(approver) }
-            .to have_enqueued_job(TagAliasJob)
+            .to enqueue_sidekiq_job(TagAliasJob)
         end
       end
 
@@ -563,7 +575,7 @@ RSpec.describe BulkUpdateRequestImporter do
 
       it "enqueues a TagImplicationJob" do
         expect { importer("implicate proc_ci_ant -> proc_ci_con").process!(approver) }
-          .to have_enqueued_job(TagImplicationJob)
+          .to enqueue_sidekiq_job(TagImplicationJob)
       end
 
       context "when a pending implication already exists for the pair" do
@@ -635,26 +647,30 @@ RSpec.describe BulkUpdateRequestImporter do
     describe "mass_update" do
       it "enqueues a TagBatchJob with the source and destination tag names" do
         expect { importer("update proc_mu_src -> proc_mu_dst").process!(approver) }
-          .to have_enqueued_job(TagBatchJob).with("proc_mu_src", "proc_mu_dst", anything, anything)
+          .to enqueue_sidekiq_job(TagBatchJob).with("proc_mu_src", "proc_mu_dst", anything, anything)
       end
 
       it "does not enqueue a TagBatchJob when a later line rolls the transaction back" do
         script = "update proc_mu_rb_src -> proc_mu_rb_dst\nunalias proc_mu_rb_missing_ant -> proc_mu_rb_missing_con"
-        expect { importer(script).process!(approver) }.to raise_error(BulkUpdateRequestImporter::Error)
-        expect(TagBatchJob).not_to have_been_enqueued
+        with_transactional_push(TagBatchJob) do
+          expect { importer(script).process!(approver) }.to raise_error(BulkUpdateRequestImporter::Error)
+        end
+        expect(TagBatchJob).not_to have_enqueued_sidekiq_job
       end
     end
 
     describe "nuke_tag" do
       it "enqueues a TagNukeJob with the tag name" do
         expect { importer("nuke proc_nuke_target").process!(approver) }
-          .to have_enqueued_job(TagNukeJob).with("proc_nuke_target", anything, anything)
+          .to enqueue_sidekiq_job(TagNukeJob).with("proc_nuke_target", anything, anything)
       end
 
       it "does not enqueue a TagNukeJob when a later line rolls the transaction back" do
         script = "nuke proc_nuke_rb_target\nunalias proc_nuke_rb_missing_ant -> proc_nuke_rb_missing_con"
-        expect { importer(script).process!(approver) }.to raise_error(BulkUpdateRequestImporter::Error)
-        expect(TagNukeJob).not_to have_been_enqueued
+        with_transactional_push(TagNukeJob) do
+          expect { importer(script).process!(approver) }.to raise_error(BulkUpdateRequestImporter::Error)
+        end
+        expect(TagNukeJob).not_to have_enqueued_sidekiq_job
       end
     end
 

--- a/spec/logical/upload_service/utils_spec.rb
+++ b/spec/logical/upload_service/utils_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe UploadService::Utils do
       end
 
       it "enqueues UploadDeleteFilesJob" do
-        expect { described_class.process_file(upload, file) }.to have_enqueued_job(UploadDeleteFilesJob)
+        expect { described_class.process_file(upload, file) }.to enqueue_sidekiq_job(UploadDeleteFilesJob)
       end
     end
 

--- a/spec/logical/upload_service_spec.rb
+++ b/spec/logical/upload_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe UploadService do
       end
 
       it "enqueues UploadDeleteFilesJob" do
-        expect { service.start! }.to have_enqueued_job(UploadDeleteFilesJob)
+        expect { service.start! }.to enqueue_sidekiq_job(UploadDeleteFilesJob)
       end
 
       it "defaults tag_string to 'tagme' when not provided" do

--- a/spec/logical/user_deletion_spec.rb
+++ b/spec/logical/user_deletion_spec.rb
@@ -61,11 +61,11 @@ RSpec.describe UserDeletion do
       end
 
       it "enqueues FlushFavoritesJob with the user's id" do
-        expect { deletion.delete! }.to have_enqueued_job(FlushFavoritesJob).with(user.id)
+        expect { deletion.delete! }.to enqueue_sidekiq_job(FlushFavoritesJob).with(user.id)
       end
 
-      it "enqueues AvatarCleanupJob with force: true" do
-        expect { deletion.delete! }.to have_enqueued_job(AvatarCleanupJob).with(user.id, force: true)
+      it "enqueues AvatarCleanupJob with force" do
+        expect { deletion.delete! }.to enqueue_sidekiq_job(AvatarCleanupJob).with(user.id, true)
       end
     end
 
@@ -103,7 +103,7 @@ RSpec.describe UserDeletion do
       end
 
       it "enqueues FlushFavoritesJob" do
-        expect { deletion.delete! }.to have_enqueued_job(FlushFavoritesJob).with(user.id)
+        expect { deletion.delete! }.to enqueue_sidekiq_job(FlushFavoritesJob).with(user.id)
       end
     end
 

--- a/spec/models/bulk_update_request/approval_methods_spec.rb
+++ b/spec/models/bulk_update_request/approval_methods_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe BulkUpdateRequest do
     end
 
     it "enqueues a TagAliasJob" do
-      expect { bur.approve!(approver) }.to have_enqueued_job(TagAliasJob)
+      expect { bur.approve!(approver) }.to enqueue_sidekiq_job(TagAliasJob)
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.describe BulkUpdateRequest do
     end
 
     it "enqueues a TagImplicationJob" do
-      expect { bur.approve!(approver) }.to have_enqueued_job(TagImplicationJob)
+      expect { bur.approve!(approver) }.to enqueue_sidekiq_job(TagImplicationJob)
     end
   end
 

--- a/spec/models/pool/destroy_spec.rb
+++ b/spec/models/pool/destroy_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Pool, "#destroy" do
     pool = create(:pool)
 
     expect { pool.destroy }
-      .to have_enqueued_job(PostSetCleanupJob).with(:pool, pool.id)
+      .to enqueue_sidekiq_job(PostSetCleanupJob).with("pool", pool.id)
   end
 
   it "clears the members' pool_ids once the cleanup job runs" do
@@ -19,7 +19,7 @@ RSpec.describe Pool, "#destroy" do
     expect(post.reload[:pool_ids]).to eq([pool.id])
 
     pool.destroy
-    PostSetCleanupJob.perform_now(:pool, pool.id)
+    PostSetCleanupJob.new.perform("pool", pool.id)
 
     expect(post.reload[:pool_ids]).to eq([])
   end

--- a/spec/models/post/file_methods_spec.rb
+++ b/spec/models/post/file_methods_spec.rb
@@ -228,13 +228,13 @@ RSpec.describe Post do
       it "enqueues PostVideoConversionJob immediately when later is false" do
         post = create(:post, file_ext: "webm")
         expect { post.generate_video_samples(later: false) }
-          .to have_enqueued_job(PostVideoConversionJob)
+          .to enqueue_sidekiq_job(PostVideoConversionJob)
       end
 
       it "enqueues PostVideoConversionJob with a delay when later is true" do
         post = create(:post, file_ext: "webm")
         expect { post.generate_video_samples(later: true) }
-          .to have_enqueued_job(PostVideoConversionJob)
+          .to enqueue_sidekiq_job(PostVideoConversionJob)
       end
     end
 

--- a/spec/models/post/parent_methods_spec.rb
+++ b/spec/models/post/parent_methods_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Post do
       it "enqueues a TransferFavoritesJob" do
         parent = create(:post)
         child  = create(:post, parent: parent)
-        expect { child.give_favorites_to_parent }.to have_enqueued_job(TransferFavoritesJob)
+        expect { child.give_favorites_to_parent }.to enqueue_sidekiq_job(TransferFavoritesJob)
       end
     end
 

--- a/spec/models/post_set/write_methods_spec.rb
+++ b/spec/models/post_set/write_methods_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PostSet do
       posts = create_list(:post, 2)
 
       expect { set.add(posts.map(&:id)) }
-        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
+        .to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe PostSet do
       set.update_columns(post_ids: posts.map(&:id), post_count: posts.size)
 
       expect { set.remove(posts.map(&:id)) }
-        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
+        .to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
     end
   end
 
@@ -62,12 +62,12 @@ RSpec.describe PostSet do
       set.reload
 
       expect { set.destroy }
-        .to have_enqueued_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
+        .to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", posts.map(&:id))
     end
 
     it "enqueues nothing for an empty set" do
       set # create before the expectation block
-      expect { set.destroy }.not_to have_enqueued_job(BulkIndexUpdateJob)
+      expect { set.destroy }.not_to enqueue_sidekiq_job(BulkIndexUpdateJob)
     end
   end
 end

--- a/spec/models/tag_alias/instance_methods_spec.rb
+++ b/spec/models/tag_alias/instance_methods_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe TagAlias do
       create_posts_chunk(ta)
 
       expect { ta.update_posts_undo }
-        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
+        .to enqueue_sidekiq_job(TagAliasFinalizeJob).with(ta.id)
     end
   end
 

--- a/spec/models/tag_alias/process_methods_spec.rb
+++ b/spec/models/tag_alias/process_methods_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TagAlias do
       ta.update_columns(status: "queued", approver_id: create(:admin_user).id)
 
       expect { ta.process!(update_topic: false) }
-        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
+        .to enqueue_sidekiq_job(TagAliasFinalizeJob).with(ta.id)
     end
 
     it "enqueues TagAliasFinalizeJob even when processing fails so partially-modified posts get reindexed" do
@@ -43,7 +43,7 @@ RSpec.describe TagAlias do
       allow(ta).to receive(:update_posts).and_raise(RuntimeError, "simulated failure")
 
       expect { ta.process!(update_topic: false) }
-        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
+        .to enqueue_sidekiq_job(TagAliasFinalizeJob).with(ta.id)
       expect(ta.reload.status).to start_with("error:")
     end
 
@@ -191,7 +191,7 @@ RSpec.describe TagAlias do
       ta = create_undoable_alias
 
       expect { ta.process_undo!(update_topic: false) }
-        .to have_enqueued_job(TagAliasFinalizeJob).with(ta.id)
+        .to enqueue_sidekiq_job(TagAliasFinalizeJob).with(ta.id)
     end
 
     it "removes tags the consequent's implications added during processing" do
@@ -272,7 +272,7 @@ RSpec.describe TagAlias do
     it "enqueues TagAliasUndoJob with the undoing user" do
       ta = create(:active_tag_alias)
 
-      expect { ta.undo! }.to have_enqueued_job(TagAliasUndoJob).with(ta.id, true, CurrentUser.user.id)
+      expect { ta.undo! }.to enqueue_sidekiq_job(TagAliasUndoJob).with(ta.id, true, CurrentUser.user.id)
     end
   end
 end

--- a/spec/models/tag_implication/approval_methods_spec.rb
+++ b/spec/models/tag_implication/approval_methods_spec.rb
@@ -20,20 +20,20 @@ RSpec.describe TagImplication do
 
     it "changes status to queued" do
       expect { ti.approve!(update_topic: false) }
-        .to have_enqueued_job(TagImplicationJob)
+        .to enqueue_sidekiq_job(TagImplicationJob)
         .and(change { ti.reload.status }.to("queued"))
     end
 
     it "sets approver_id to the given approver" do
       approver = create(:admin_user)
       expect { ti.approve!(approver: approver, update_topic: false) }
-        .to have_enqueued_job(TagImplicationJob)
+        .to enqueue_sidekiq_job(TagImplicationJob)
         .and(change { ti.reload.approver_id }.to(approver.id))
     end
 
     it "enqueues TagImplicationJob with the implication id and update_topic flag" do
       expect { ti.approve!(update_topic: false) }
-        .to have_enqueued_job(TagImplicationJob).with(ti.id, false)
+        .to enqueue_sidekiq_job(TagImplicationJob).with(ti.id, false)
     end
 
     it "calls invalidate_cached_descendants" do
@@ -81,7 +81,7 @@ RSpec.describe TagImplication do
       )
 
       expect { ti.process!(update_topic: false) }
-        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name)
+        .to enqueue_sidekiq_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name)
     end
   end
 
@@ -392,7 +392,7 @@ RSpec.describe TagImplication do
       ti.tag_rel_undos.create!(undo_data: { "version" => 2, "kind" => "posts", "added" => {} })
 
       expect { ti.update_posts_undo }
-        .to have_enqueued_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name, undo: true)
+        .to enqueue_sidekiq_job(TagImplicationFinalizeJob).with(ti.id, ti.antecedent_name, true)
     end
   end
 
@@ -403,7 +403,7 @@ RSpec.describe TagImplication do
     it "enqueues TagImplicationUndoJob with the undoing user" do
       ti = create(:active_tag_implication)
 
-      expect { ti.undo! }.to have_enqueued_job(TagImplicationUndoJob).with(ti.id, true, CurrentUser.user.id)
+      expect { ti.undo! }.to enqueue_sidekiq_job(TagImplicationUndoJob).with(ti.id, true, CurrentUser.user.id)
     end
   end
 

--- a/spec/models/takedown/process_methods_spec.rb
+++ b/spec/models/takedown/process_methods_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Takedown do
 
     it "enqueues a TakedownJob with the takedown id and approver id" do
       expect { takedown.process!(approver, "takedown reason") }
-        .to have_enqueued_job(TakedownJob)
+        .to enqueue_sidekiq_job(TakedownJob)
         .with(takedown.id, approver.id, "takedown reason")
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,8 +43,13 @@ require_relative "../config/environment"
 
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"
+require "rspec-sidekiq" # sets Sidekiq.testing!(:fake) and clears the in-memory queues before each example
 require "factory_bot_rails"
 require "view_component/test_helpers"
+
+RSpec::Sidekiq.configure do |config|
+  config.warn_when_jobs_not_processed_by_sidekiq = false
+end
 
 # Ensures that the test database schema matches the current schema file.
 begin
@@ -67,10 +72,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.filter_rails_from_backtrace!
   config.infer_spec_type_from_file_location!
-
-  config.before do
-    ActiveJob::Base.queue_adapter = :test
-  end
 
   # rails-settings-cached caches all settings in Rails.cache. With transactional fixtures,
   # after_commit never fires, so the cache is never cleared after a test that writes a setting.

--- a/spec/requests/maintenance/user/avatars_controller_spec.rb
+++ b/spec/requests/maintenance/user/avatars_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Maintenance::User::AvatarsController do
         it "enqueues an AvatarCropJob with the correct arguments" do
           expect do
             patch maintenance_user_avatar_path, params: valid_params
-          end.to have_enqueued_job(AvatarCropJob).with(user.id, post.id, 0, 0, 256)
+          end.to enqueue_sidekiq_job(AvatarCropJob).with(user.id, post.id, 0, 0, 256)
         end
 
         it "redirects to the user's profile" do

--- a/spec/requests/post_sets_controller_spec.rb
+++ b/spec/requests/post_sets_controller_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe PostSetsController do
         expect do
           post update_posts_post_set_path(private_set),
                params: { post_set: { post_ids_string: posts.map(&:id).join(" ") } }
-        end.to have_enqueued_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
+        end.to enqueue_sidekiq_job(BulkIndexUpdateJob).with("Post", match_array(posts.map(&:id)))
         expect(private_set.reload.post_ids).to match_array(posts.map(&:id))
       end
     end

--- a/spec/requests/search_trends_controller_spec.rb
+++ b/spec/requests/search_trends_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe SearchTrendsController do
       it "returns json" do
         hour = 2.hours.ago.utc
         SearchTrendHourly.bulk_increment!([{ tag: "fox", hour: hour }])
-        SearchTrendAggregateJob.perform_now
+        SearchTrendAggregateJob.new.perform
         get search_trends_path(format: :json, day: hour.to_date.to_s)
         expect(response).to have_http_status(:success)
         json = response.parsed_body

--- a/spec/requests/staff/user_cleanups_controller_spec.rb
+++ b/spec/requests/staff/user_cleanups_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe Staff::UserCleanupsController do
     it "enqueues HideUserCommentsJob" do
       expect do
         post hide_comments_staff_user_cleanup_path(target)
-      end.to have_enqueued_job(HideUserCommentsJob).with(target.id, moderator.id)
+      end.to enqueue_sidekiq_job(HideUserCommentsJob).with(target.id, moderator.id)
     end
 
     it "logs a user_comments_hide ModAction" do
@@ -173,7 +173,7 @@ RSpec.describe Staff::UserCleanupsController do
     it "enqueues HideUserForumPostsJob" do
       expect do
         post hide_forum_posts_staff_user_cleanup_path(target)
-      end.to have_enqueued_job(HideUserForumPostsJob).with(target.id, moderator.id)
+      end.to enqueue_sidekiq_job(HideUserForumPostsJob).with(target.id, moderator.id)
     end
 
     it "logs a user_forum_posts_hide ModAction" do
@@ -204,7 +204,7 @@ RSpec.describe Staff::UserCleanupsController do
     it "enqueues HideUserBlipsJob" do
       expect do
         post hide_blips_staff_user_cleanup_path(target)
-      end.to have_enqueued_job(HideUserBlipsJob).with(target.id, moderator.id)
+      end.to enqueue_sidekiq_job(HideUserBlipsJob).with(target.id, moderator.id)
     end
 
     it "logs a user_blips_delete ModAction" do

--- a/spec/requests/tag_aliases_controller_spec.rb
+++ b/spec/requests/tag_aliases_controller_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe TagAliasesController do
 
       it "enqueues TagAliasUndoJob attributed to the admin" do
         expect { post undo_tag_alias_path(undoable_alias) }
-          .to have_enqueued_job(TagAliasUndoJob).with(undoable_alias.id, true, admin.id)
+          .to enqueue_sidekiq_job(TagAliasUndoJob).with(undoable_alias.id, true, admin.id)
       end
 
       it "redirects to the tag alias page" do
@@ -336,7 +336,7 @@ RSpec.describe TagAliasesController do
 
       it "returns 403 and enqueues no job" do
         expect { post undo_tag_alias_path(active_alias) }
-          .not_to have_enqueued_job(TagAliasUndoJob)
+          .not_to enqueue_sidekiq_job(TagAliasUndoJob)
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/requests/tag_corrections_controller_spec.rb
+++ b/spec/requests/tag_corrections_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe TagCorrectionsController do
         it "enqueues TagPostCountJob" do
           expect do
             post tag_correction_path(tag_id: tag.id), params: { commit: "Fix" }
-          end.to have_enqueued_job(TagPostCountJob)
+          end.to enqueue_sidekiq_job(TagPostCountJob)
         end
 
         it "redirects to the tag search page with a notice" do

--- a/spec/requests/tag_implications_controller_spec.rb
+++ b/spec/requests/tag_implications_controller_spec.rb
@@ -239,13 +239,13 @@ RSpec.describe TagImplicationsController do
 
       it "enqueues TagImplicationUndoJob attributed to the admin and redirects to show" do
         expect { post undo_tag_implication_path(undoable_implication) }
-          .to have_enqueued_job(TagImplicationUndoJob).with(undoable_implication.id, true, admin.id)
+          .to enqueue_sidekiq_job(TagImplicationUndoJob).with(undoable_implication.id, true, admin.id)
         expect(response).to redirect_to(tag_implication_path(undoable_implication))
       end
 
       it "returns 403 and enqueues no job when the implication is not undoable" do
         expect { post undo_tag_implication_path(active_implication) }
-          .not_to have_enqueued_job(TagImplicationUndoJob)
+          .not_to enqueue_sidekiq_job(TagImplicationUndoJob)
         expect(response).to have_http_status(:forbidden)
       end
     end

--- a/spec/requests/takedowns_controller_spec.rb
+++ b/spec/requests/takedowns_controller_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe TakedownsController do
 
       it "enqueues a TakedownJob when process_takedown is truthy" do
         patch takedown_path(takedown), params: update_params.merge(process_takedown: "1", delete_reason: "DMCA")
-        expect(TakedownJob).to have_been_enqueued
+        expect(TakedownJob).to have_enqueued_sidekiq_job
       end
     end
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -673,7 +673,7 @@ RSpec.describe UsersController do
 
       it "enqueues FlushFavoritesJob, logs a ModAction, and redirects" do
         expect { post flush_favorites_user_path(user) }
-          .to have_enqueued_job(FlushFavoritesJob).with(user.id)
+          .to enqueue_sidekiq_job(FlushFavoritesJob).with(user.id)
           .and change(ModAction, :count).by(1)
         expect(ModAction.last[:values]).to include("user_id" => user.id)
         expect(response).to redirect_to(user_path(user))


### PR DESCRIPTION
All jobs were ActiveJob subclasses, so sidekiq-unique-jobs saw a `Sidekiq::ActiveJob::Wrapper` payload carrying a per-enqueue job_id and computed a unique lock digest every time. Every `sidekiq_options lock:` was a silent no-op (e.g. concurrent same-tag nukes were never prevented).

Rather than patch the gem to see through the wrapper, drop the wrapper:
ApplicationJob now includes Sidekiq::Job directly and all 48 jobs are native.

The app used almost none of ActiveJob's features, so the surface is small.

- Removed `retry_on Deadlocked`
  A held until_executed lock would silently drop the AJ retry; Sidekiq's native retry replaces it.
- Transaction parity via `Sidekiq.transactional_push!`
- Lock fixes, now that locks work
  Flipped video/sampler/tag-count/tag-category to `until_executing` (mid-run re-triggers must not be dropped); add `lock_ttl` backstops to every locked job; log dropped duplicates (lock_failed).
- New native UserFeedbackMailJob replaces the lone `deliver_later`.
- Temporary `lib/sidekiq_active_job_wrapper_shim.rb` runs legacy wrapper payloads still queued/scheduled/retrying at cutover; remove after drain.
- Tests: rspec-sidekiq (fake mode) replaces the ActiveJob test adapter; disabled `sidekiq-unique-jobs` in test so shared-Redis specs don't collide.