### PR TITLE
[Artists] Reindex all tagged posts on `linked_user_id` change

### DIFF
--- a/app/jobs/artist_reindex_job.rb
+++ b/app/jobs/artist_reindex_job.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class ArtistReindexJob < ApplicationJob
-  queue_as :low_prio
-  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
-  self.enqueue_after_transaction_commit = true
+  include TransactionalEnqueue
+  sidekiq_options queue: "low_prio", lock: :until_executed, lock_args_method: :lock_args, lock_ttl: 24.hours.to_i
 
   def self.lock_args(args)
     [args[0]]

--- a/app/jobs/artist_reindex_job.rb
+++ b/app/jobs/artist_reindex_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ArtistReindexJob < ApplicationJob
+  queue_as :low_prio
+  sidekiq_options lock: :until_executed, lock_args_method: :lock_args
+  self.enqueue_after_transaction_commit = true
+
+  def self.lock_args(args)
+    [args[0]]
+  end
+
+  def perform(artist_name)
+    Post.without_timeout do
+      Post.sql_raw_tag_match(artist_name).find_each { |post| post.update_index(queue: :low_prio) }
+    end
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -580,6 +580,6 @@ class Artist < ApplicationRecord
   end
 
   def update_posts_index
-    Post.tag_match_system(name).each(&:update_index)
+    Post.sql_raw_tag_match(name).find_each(&:update_index)
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -22,7 +22,7 @@ class Artist < ApplicationRecord
   after_save :update_wiki
   after_save :propagate_locked, if: :should_propagate_locked
   after_save :clear_url_string_changed
-  after_save :update_posts_index, if: :saved_change_to_linked_user_id?
+  after_commit :update_posts_index, if: :saved_change_to_linked_user_id?
 
   has_many :members, class_name: "Artist", foreign_key: "group_name", primary_key: "name"
   has_many :urls, dependent: :destroy, class_name: "ArtistUrl", autosave: true
@@ -580,6 +580,6 @@ class Artist < ApplicationRecord
   end
 
   def update_posts_index
-    Post.sql_raw_tag_match(name).find_each(&:update_index)
+    ArtistReindexJob.perform_later(name)
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -580,6 +580,6 @@ class Artist < ApplicationRecord
   end
 
   def update_posts_index
-    ArtistReindexJob.perform_later(name)
+    ArtistReindexJob.perform_async(name)
   end
 end

--- a/spec/jobs/artist_reindex_job_spec.rb
+++ b/spec/jobs/artist_reindex_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ArtistReindexJob do
+  include_context "as admin"
+
+  let(:artist_name) { "reindex_artist" }
+  let!(:tagged)   { create(:post, tag_string: "#{artist_name} extra") }
+  let!(:untagged) { create(:post, tag_string: "unrelated") }
+
+  it "reindexes every post tagged with the artist name" do
+    reindexed = []
+    allow_any_instance_of(Post).to receive(:update_index) { |post, **| reindexed << post.id } # rubocop:disable RSpec/AnyInstance
+    described_class.perform_now(artist_name)
+    expect(reindexed).to include(tagged.id)
+    expect(reindexed).not_to include(untagged.id)
+  end
+
+  it "returns without error when no posts match" do
+    expect { described_class.perform_now("no_such_artist") }.not_to raise_error
+  end
+end

--- a/spec/jobs/artist_reindex_job_spec.rb
+++ b/spec/jobs/artist_reindex_job_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe ArtistReindexJob do
   it "reindexes every post tagged with the artist name" do
     reindexed = []
     allow_any_instance_of(Post).to receive(:update_index) { |post, **| reindexed << post.id } # rubocop:disable RSpec/AnyInstance
-    described_class.perform_now(artist_name)
+    described_class.new.perform(artist_name)
     expect(reindexed).to include(tagged.id)
     expect(reindexed).not_to include(untagged.id)
   end
 
   it "returns without error when no posts match" do
-    expect { described_class.perform_now("no_such_artist") }.not_to raise_error
+    expect { described_class.new.perform("no_such_artist") }.not_to raise_error
   end
 end

--- a/spec/models/artist/reindex_spec.rb
+++ b/spec/models/artist/reindex_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# --------------------------------------------------------------------------- #
+#                         Artist Post Reindexing                              #
+# --------------------------------------------------------------------------- #
+
+RSpec.describe Artist do
+  include_context "as admin"
+
+  describe "#update_posts_index" do
+    it "enqueues a reindex when a user is linked" do
+      artist = create(:artist)
+      linked = create(:user)
+      expect do
+        artist.update!(linked_user_id: linked.id)
+      end.to enqueue_sidekiq_job(ArtistReindexJob).with(artist.name)
+    end
+
+    it "enqueues a reindex when a linked user is removed" do
+      linked = create(:user)
+      artist = create(:artist, linked_user_id: linked.id)
+      expect do
+        artist.update!(linked_user_id: nil)
+      end.to enqueue_sidekiq_job(ArtistReindexJob).with(artist.name)
+    end
+
+    it "does NOT enqueue a reindex when linked_user_id is unchanged" do
+      artist = create(:artist)
+      expect do
+        artist.update!(name: "#{artist.name}_renamed")
+      end.not_to enqueue_sidekiq_job(ArtistReindexJob)
+    end
+  end
+end


### PR DESCRIPTION
`update_posts_index` used `tag_match_system(name).each`, an OpenSearch query with no size set.
It defaulted to 10 hits ordered `id desc`, so only an artist's 10 newest posts had their artverified flag refreshed.

Switched to `sql_raw_tag_match(name).find_each` to reindex every matching post, matching Tag/TagAlias/TagImplication.

Existing posts are unaffected, and require reindexing.
```Ruby
Artist.where.not(linked_user_id: nil).find_each do |a|
  Post.sql_raw_tag_match(a.name).find_each(&:update_index)
end
```