### PR TITLE
[DbExports] Add eris export

### DIFF
--- a/app/jobs/db_export_job.rb
+++ b/app/jobs/db_export_job.rb
@@ -13,33 +13,47 @@ class DbExportJob < ApplicationJob
   EXPORTS = {
     "artists" => {
       query: read_export_sql("artists"),
+      connection: nil,
     },
     "bulk_update_requests" => {
       query: read_export_sql("bulk_update_requests"),
+      connection: nil,
+    },
+    "eris" => {
+      query: read_export_sql("eris"),
+      connection: "eris",
     },
     "pools" => {
       query: read_export_sql("pools"),
+      connection: nil,
     },
     "post_replacements" => {
       query: read_export_sql("post_replacements"),
+      connection: nil,
     },
     "post_versions" => {
       query: read_export_sql("post_versions"),
+      connection: nil,
     },
     "posts" => {
       query: read_export_sql("posts"),
+      connection: nil,
     },
     "tag_aliases" => {
       query: read_export_sql("tag_aliases"),
+      connection: nil,
     },
     "tag_implications" => {
       query: read_export_sql("tag_implications"),
+      connection: nil,
     },
     "tags" => {
       query: read_export_sql("tags"),
+      connection: nil,
     },
     "wiki_pages" => {
       query: read_export_sql("wiki_pages"),
+      connection: nil,
     },
   }.freeze
 
@@ -53,11 +67,35 @@ class DbExportJob < ApplicationJob
 
   private
 
+  def with_connection(name)
+    raise(LocalJumpError, "block required") unless block_given?
+    case name
+    when nil
+      conn = ActiveRecord::Base.connection.raw_connection
+      conn.exec("SET statement_timeout = 0")
+      begin
+        yield(conn)
+      ensure
+        conn&.exec("RESET statement_timeout")
+      end
+    else
+      config = ActiveRecord::Base.configurations.configs_for(env_name: name).first&.configuration_hash
+      raise(ArgumentError, "unknown connection: #{name}") if config.blank?
+      conn = PG.connect(host: config[:host], port: config[:port], user: config[:username], password: config[:password], dbname: config[:database])
+      conn.exec("SET statement_timeout = 0")
+      begin
+        yield(conn)
+      ensure
+        conn&.close
+      end
+    end
+  end
+
   def generate_export(name, config)
     Rails.logger.info("DbExportJob: Generating #{name} export")
 
     file = Tempfile.new(["#{name}-export", ".csv.gz"], binmode: true)
-    write_csv_gz(config[:query].call, file)
+    with_connection(config[:connection]) { |conn| write_csv_gz(conn, config[:query].call, file) }
     file.rewind
 
     checksum = Digest::SHA256.file(file.path).hexdigest
@@ -72,17 +110,14 @@ class DbExportJob < ApplicationJob
     file&.close!
   end
 
-  def write_csv_gz(query, file)
+  def write_csv_gz(conn, query, file)
     gz = Zlib::GzipWriter.new(file)
-    conn = ActiveRecord::Base.connection.raw_connection
-    conn.exec("SET statement_timeout = 0")
     conn.copy_data("COPY (#{query}) TO STDOUT WITH CSV HEADER") do
       while (row = conn.get_copy_data)
         gz.write(row)
       end
     end
   ensure
-    conn&.exec("RESET statement_timeout")
     gz&.finish
   end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,6 +11,13 @@ development:
   host: postgres
   pool: 5
 
+eris:
+  <<: *default
+  database: eris
+  password: <%= ENV["ERIS_DB_PASSWORD"] %>
+  host: <%= ENV.fetch("ERIS_DB_HOST", "postgres") %>
+  port: <%= ENV.fetch("ERIS_DB_PORT", "5432") %>
+
 test:
   <<: *default
   database: e621_test<%= ENV["TEST_ENV_NUMBER"] %>

--- a/db/exports/eris.sql
+++ b/db/exports/eris.sql
@@ -1,0 +1,8 @@
+SELECT images.post_id,
+       images.avglf1,
+       images.avglf2,
+       images.avglf3,
+       images.sig,
+       images.updated_at
+FROM images
+ORDER BY images.post_id


### PR DESCRIPTION
As per the request of https://e621.net/forum_topics/61561, adds an export for the eris service. I Chose to name it eris since that's the name of the new service, but can definitely name it iqdb if we're sticking with that name when public facing.

Added the eris database to database.yml, with `ERIS_DB_HOST`, `ERIS_DB_PORT`, and `ERIS_DB_PASSWORD` env variables
Only includes the images table since that seems the most relevant.

Not sure what to really do about testing since the database is managed externally and we have no way to make a copy or really even insert rows beyond manual queries.