### PR TITLE
[Uploads] Rework the uploader to use a tag-source registry

### DIFF
--- a/app/javascript/src/js/pages/uploads/new/artist_source.vue
+++ b/app/javascript/src/js/pages/uploads/new/artist_source.vue
@@ -20,6 +20,9 @@
   export default {
     components: { 'artist-tag-input': artistTagInput },
     inject: ['tagRegistry'],
+    props: {
+      order: { type: Number, default: 0 },
+    },
     data() {
       return { model: '', verifiedArtistTags: UploadData.verifiedArtistTags };
     },
@@ -42,6 +45,7 @@
     mounted() {
       this.descriptor = {
         role: 'artist',
+        order: this.order,
         currentTags: () => this.currentTags(),
         addTags: tags => this.addTags(tags),
         removeTag: tag => this.removeTag(tag),

--- a/app/javascript/src/js/pages/uploads/new/artist_source.vue
+++ b/app/javascript/src/js/pages/uploads/new/artist_source.vue
@@ -1,0 +1,55 @@
+<template>
+  <div>
+    <artist-tag-input :modelValue="model" @update:modelValue="model = $event"></artist-tag-input>
+    <div v-if="verifiedArtistTags.length" class="upload-artist-tags">
+      <div>Linked artist tags:</div>
+      <button v-for="name in verifiedArtistTags" :key="name" type="button" class="toggle-button"
+              @click="toggle(name)">{{ name }}</button>
+    </div>
+  </div>
+</template>
+
+<script>
+  import artistTagInput from './artist_tag_input.vue';
+  import * as TagField from './tag_field.js';
+  import UploadData from "@/models/UploadData";
+
+  // The artist field as a self-registering tag source. Wraps the (untouched)
+  // artist_tag_input and renders the linked-artist buttons declaratively,
+  // replacing the old imperative initVerifiedArtistButtons() DOM fossil.
+  export default {
+    components: { 'artist-tag-input': artistTagInput },
+    inject: ['tagRegistry'],
+    data() {
+      return { model: '', verifiedArtistTags: UploadData.verifiedArtistTags };
+    },
+    methods: {
+      currentTags() {
+        return TagField.splitTags(this.model);
+      },
+      addTags(tags) {
+        this.model = TagField.addTags(this.model, tags);
+      },
+      removeTag(tag) {
+        this.model = TagField.removeTag(this.model, tag);
+      },
+      toggle(name) {
+        this.model = TagField.splitTags(this.model).includes(name)
+          ? TagField.removeTag(this.model, name)
+          : TagField.addTags(this.model, [name]);
+      },
+    },
+    mounted() {
+      this.descriptor = {
+        role: 'artist',
+        currentTags: () => this.currentTags(),
+        addTags: tags => this.addTags(tags),
+        removeTag: tag => this.removeTag(tag),
+      };
+      this.tagRegistry.register(this.descriptor);
+    },
+    beforeUnmount() {
+      this.tagRegistry.unregister(this.descriptor);
+    },
+  };
+</script>

--- a/app/javascript/src/js/pages/uploads/new/checkbox_source.vue
+++ b/app/javascript/src/js/pages/uploads/new/checkbox_source.vue
@@ -1,0 +1,133 @@
+<template>
+  <template v-for="(group, gi) in renderGroups" :key="gi">
+    <hr v-if="gi > 0">
+    <div class="flex-wrap">
+      <image-checkbox :check="check" :checks="selected" v-for="check in group"
+                      @set="setCheck" :key="check.name"></image-checkbox>
+    </div>
+  </template>
+</template>
+
+<script>
+  import checkbox from './checkbox.vue';
+
+  const sex_names = {
+    male: 'Male',
+    female: 'Female',
+    andromorph: 'Andromorph',
+    gynomorph: 'Gynomorph',
+    herm: 'Hermaphrodite',
+    maleherm: 'Male-Herm',
+    ambiguous_gender: 'Ambiguous'
+  };
+
+  const sex_checks = Object.entries(sex_names).map(([tag, name]) => ({ name, tag }));
+
+  const sex_tag_keys = Object.keys(sex_names);
+  const all_pairing_pairs = [];
+  for (let i = 0; i < sex_tag_keys.length; i++) {
+    for (let j = i; j < sex_tag_keys.length; j++) {
+      all_pairing_pairs.push({ tagA: sex_tag_keys[i], tagB: sex_tag_keys[j] });
+    }
+  }
+  const pairing_tag_name = tag => tag === 'ambiguous_gender' ? 'ambiguous' : tag;
+  const all_pairing_tag_set = new Set(all_pairing_pairs.map(p => pairing_tag_name(p.tagA) + "/" + pairing_tag_name(p.tagB)));
+
+  const char_count_checks = [
+    {name: 'Solo'},
+    {name: 'Duo'},
+    {name: 'Trio'},
+    {name: 'Group'},
+    {name: 'Zero Pictured'}];
+
+  const body_type_checks = [
+    {name: 'Anthro'},
+    {name: 'Feral'},
+    {name: 'Humanoid'},
+    {name: 'Human'},
+    {name: 'Taur'}];
+
+  export default {
+    components: { 'image-checkbox': checkbox },
+    inject: ['tagRegistry'],
+    // "characters" = sex + count + sex-pairings; "body" = body types.
+    props: { kind: { type: String, required: true } },
+    data() {
+      return { selected: {} };
+    },
+    computed: {
+      pairing() {
+        return this.kind === 'characters';
+      },
+      baseGroups() {
+        return this.kind === 'characters' ? [sex_checks, char_count_checks] : [body_type_checks];
+      },
+      filteredPairings() {
+        if (!this.pairing) return [];
+        const selected = this.selected;
+        return all_pairing_pairs
+          .filter(p => selected[p.tagA] && selected[p.tagB])
+          .map(p => ({
+            name: sex_names[p.tagA] + "/" + sex_names[p.tagB],
+            tag: pairing_tag_name(p.tagA) + "/" + pairing_tag_name(p.tagB),
+          }));
+      },
+      renderGroups() {
+        return this.pairing ? [...this.baseGroups, this.filteredPairings] : this.baseGroups;
+      },
+    },
+    methods: {
+      setCheck(tag, value) {
+        this.selected[tag] = value;
+        if (!value && this.pairing) {
+          for (const p of all_pairing_pairs) {
+            if (p.tagA === tag || p.tagB === tag)
+              this.selected[pairing_tag_name(p.tagA) + "/" + pairing_tag_name(p.tagB)] = false;
+          }
+        }
+      },
+      // TagSource: the checked tags, with pairing tags only when both sexes remain selected.
+      currentTags() {
+        const self = this;
+        const validPairingTags = new Set(this.filteredPairings.map(p => p.tag));
+        return Object.keys(this.selected).filter(function (x) {
+          if (!self.selected[x]) return false;
+          if (all_pairing_tag_set.has(x)) return validPairingTags.has(x);
+          return true;
+        });
+      },
+      ownsTag(tag) {
+        return typeof this.allChecks[tag] !== "undefined";
+      },
+      addTags(tags) {
+        for (const tag of tags) this.setCheck(tag, true);
+      },
+      removeTag(tag) {
+        this.setCheck(tag, false);
+      },
+    },
+    created() {
+      // Static ownership lookup for this instance's checkbox tags (non-reactive).
+      const allChecks = {};
+      const add = function (check) {
+        if (typeof check['tag'] !== "undefined") allChecks[check.tag] = true;
+        else allChecks[check.name.toLowerCase().replace(' ', '_')] = true;
+      };
+      this.baseGroups.forEach(group => group.forEach(add));
+      if (this.pairing) all_pairing_tag_set.forEach(tag => { allChecks[tag] = true; });
+      this.allChecks = allChecks;
+    },
+    mounted() {
+      this.descriptor = {
+        ownsTag: tag => this.ownsTag(tag),
+        currentTags: () => this.currentTags(),
+        addTags: tags => this.addTags(tags),
+        removeTag: tag => this.removeTag(tag),
+      };
+      this.tagRegistry.register(this.descriptor);
+    },
+    beforeUnmount() {
+      this.tagRegistry.unregister(this.descriptor);
+    },
+  };
+</script>

--- a/app/javascript/src/js/pages/uploads/new/checkbox_source.vue
+++ b/app/javascript/src/js/pages/uploads/new/checkbox_source.vue
@@ -51,7 +51,10 @@
     components: { 'image-checkbox': checkbox },
     inject: ['tagRegistry'],
     // "characters" = sex + count + sex-pairings; "body" = body types.
-    props: { kind: { type: String, required: true } },
+    props: {
+      kind: { type: String, required: true },
+      order: { type: Number, default: 0 },
+    },
     data() {
       return { selected: {} };
     },
@@ -119,6 +122,7 @@
     },
     mounted() {
       this.descriptor = {
+        order: this.order,
         ownsTag: tag => this.ownsTag(tag),
         currentTags: () => this.currentTags(),
         addTags: tags => this.addTags(tags),

--- a/app/javascript/src/js/pages/uploads/new/tag_field.js
+++ b/app/javascript/src/js/pages/uploads/new/tag_field.js
@@ -1,0 +1,23 @@
+// Shared helpers for the free-text tag sources (the "Other Tags" sink, the
+// per-category textareas, and the artist field). A field's value is a
+// space-separated string; its contribution is the clean token list.
+
+export function splitTags (value) {
+  return (value || "").trim().split(/\s+/).filter(Boolean);
+}
+
+// Append tags (deduped) and keep the trailing space the inputs rely on.
+export function addTags (value, tags) {
+  const existing = splitTags(value);
+  for (const tag of tags) if (!existing.includes(tag)) existing.push(tag);
+  return existing.join(" ") + " ";
+}
+
+// Remove a tag; returns the value unchanged when the tag is absent.
+export function removeTag (value, tag) {
+  const tags = splitTags(value);
+  const idx = tags.indexOf(tag);
+  if (idx === -1) return value;
+  tags.splice(idx, 1);
+  return tags.join(" ") + " ";
+}

--- a/app/javascript/src/js/pages/uploads/new/tag_textarea.vue
+++ b/app/javascript/src/js/pages/uploads/new/tag_textarea.vue
@@ -4,6 +4,8 @@
 </template>
 
 <script>
+  import * as TagField from './tag_field.js';
+
   // A role-tagged free-text tag source (character / species / content). Registers
   // with the coordinator; contributes its tokens and accepts role-routed imports.
   export default {
@@ -18,20 +20,13 @@
     },
     methods: {
       currentTags() {
-        return this.model.trim().split(/\s+/).filter(Boolean);
+        return TagField.splitTags(this.model);
       },
       addTags(tags) {
-        const existing = this.model ? this.model.trim().split(/\s+/).filter(Boolean) : [];
-        for (const tag of tags) if (!existing.includes(tag)) existing.push(tag);
-        // Trailing space kept deliberately (vue chokes without it on some inputs).
-        this.model = existing.join(" ") + " ";
+        this.model = TagField.addTags(this.model, tags);
       },
       removeTag(tag) {
-        const tags = this.model ? this.model.trim().split(/\s+/).filter(Boolean) : [];
-        const idx = tags.indexOf(tag);
-        if (idx === -1) return;
-        tags.splice(idx, 1);
-        this.model = tags.join(" ") + " ";
+        this.model = TagField.removeTag(this.model, tag);
       },
     },
     mounted() {

--- a/app/javascript/src/js/pages/uploads/new/tag_textarea.vue
+++ b/app/javascript/src/js/pages/uploads/new/tag_textarea.vue
@@ -14,6 +14,7 @@
       role: { type: String, required: true },
       fieldId: { type: String, default: '' },
       placeholder: { type: String, default: '' },
+      order: { type: Number, default: 0 },
     },
     data() {
       return { model: '' };
@@ -32,6 +33,7 @@
     mounted() {
       this.descriptor = {
         role: this.role,
+        order: this.order,
         currentTags: () => this.currentTags(),
         addTags: tags => this.addTags(tags),
         removeTag: tag => this.removeTag(tag),

--- a/app/javascript/src/js/pages/uploads/new/tag_textarea.vue
+++ b/app/javascript/src/js/pages/uploads/new/tag_textarea.vue
@@ -1,0 +1,50 @@
+<template>
+  <textarea class="tag-textarea" rows="2" v-model="model" :id="fieldId"
+            :placeholder="placeholder" data-autocomplete="tag-edit"></textarea>
+</template>
+
+<script>
+  // A role-tagged free-text tag source (character / species / content). Registers
+  // with the coordinator; contributes its tokens and accepts role-routed imports.
+  export default {
+    inject: ['tagRegistry'],
+    props: {
+      role: { type: String, required: true },
+      fieldId: { type: String, default: '' },
+      placeholder: { type: String, default: '' },
+    },
+    data() {
+      return { model: '' };
+    },
+    methods: {
+      currentTags() {
+        return this.model.trim().split(/\s+/).filter(Boolean);
+      },
+      addTags(tags) {
+        const existing = this.model ? this.model.trim().split(/\s+/).filter(Boolean) : [];
+        for (const tag of tags) if (!existing.includes(tag)) existing.push(tag);
+        // Trailing space kept deliberately (vue chokes without it on some inputs).
+        this.model = existing.join(" ") + " ";
+      },
+      removeTag(tag) {
+        const tags = this.model ? this.model.trim().split(/\s+/).filter(Boolean) : [];
+        const idx = tags.indexOf(tag);
+        if (idx === -1) return;
+        tags.splice(idx, 1);
+        this.model = tags.join(" ") + " ";
+      },
+    },
+    mounted() {
+      this.descriptor = {
+        role: this.role,
+        currentTags: () => this.currentTags(),
+        addTags: tags => this.addTags(tags),
+        removeTag: tag => this.removeTag(tag),
+      };
+      this.tagRegistry.register(this.descriptor);
+    },
+    beforeUnmount() {
+      this.tagRegistry.unregister(this.descriptor);
+    },
+  };
+</script>

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -33,7 +33,7 @@
                         <div>Please don't use <a href="/wiki_pages/anonymous_artist">anonymous_artist</a> or <a href="/wiki_pages/unknown_artist">unknown_artist</a> tags unless they fall under those definitions on the wiki.</div>
                     </div>
                     <div class="col2">
-                        <artist-tag-input v-model="tagEntries.artist" />
+                        <artist-source></artist-source>
                     </div>
                 </div>
                 <div class="flex-grid border-bottom">
@@ -122,7 +122,7 @@
                         You must provide at least <b>{{4 - tagCount}}</b> more tags. Tags in other sections count
                         towards this total.
                     </div>
-                    <textarea class="tag-textarea" id="post_tags" v-model="tagEntries.other" rows="5"
+                    <textarea class="tag-textarea" id="post_tags" v-model="otherTags" rows="5"
                               placeholder="Ex: standing orange_fur white_shirt outside smile 4_toes etc."
                               ref="otherTags" data-autocomplete="tag-edit"></textarea>
                     <tag-preview :tags="tags" />
@@ -224,7 +224,8 @@
   import filePreview from './file_preview.vue';
   import fileInput from './file_input.vue';
   import parentPostInput from './parent_post_input.vue';
-  import artistTagInput from './artist_tag_input.vue';
+  import artistSource from './artist_source.vue';
+  import * as TagField from './tag_field.js';
   import Autocomplete from "@/components/autocomplete";
   import DTextFormatter from "@/components/DTextFormatter.ts";
   import CurrentUser from "@/models/CurrentUser";
@@ -251,7 +252,7 @@
       'file-preview': filePreview,
       'file-input': fileInput,
       'parent-post-input': parentPostInput,
-      'artist-tag-input': artistTagInput,
+      'artist-source': artistSource,
     },
     provide() {
       return {
@@ -282,12 +283,9 @@
 
         // Tag sources register here; `tags` aggregates their contributions.
         registry: { sources: [] },
-        // Artist + free-text ("other") remain inline on the root — the sink is
-        // always present, and the verified-artist DOM fossil writes tagEntries.artist.
-        tagEntries: {
-          artist: "",
-          other: "",
-        },
+        // The free-text "Other Tags" field is the always-present sink (inline on
+        // the root so findRelated can reach its textarea via $refs.otherTags).
+        otherTags: "",
 
         allowLockedTags: CurrentUser.is.admin,
         lockedTags: '',
@@ -310,25 +308,15 @@
       };
     },
     created() {
-      // The free-text "Other Tags" field is the always-present sink.
+      // The free-text "Other Tags" field is the always-present sink. Every other
+      // source (artist, checkboxes, textareas) is a self-registering child.
       this.sinkDescriptor = {
         isSink: true,
-        currentTags: () => this.fieldCurrentTags('other'),
-        addTags: tags => this.fieldAddTags('other', tags),
-        removeTag: tag => this.fieldRemoveTag('other', tag),
+        currentTags: () => TagField.splitTags(this.otherTags),
+        addTags: tags => { this.otherTags = TagField.addTags(this.otherTags, tags); },
+        removeTag: tag => { this.otherTags = TagField.removeTag(this.otherTags, tag); },
       };
       this.registerSource(this.sinkDescriptor);
-
-      // The artist field is a source only when its input is on screen (normal mode).
-      if (!this.compactMode) {
-        this.artistDescriptor = {
-          role: 'artist',
-          currentTags: () => this.fieldCurrentTags('artist'),
-          addTags: tags => this.fieldAddTags('artist', tags),
-          removeTag: tag => this.fieldRemoveTag('artist', tag),
-        };
-        this.registerSource(this.artistDescriptor);
-      }
     },
     mounted() {
       const self = this;
@@ -381,8 +369,6 @@
       if(this.allowUploadAsPending)
         fillFieldBool("uploadAsPending", "upload_as_pending")
 
-      this.initVerifiedArtistButtons();
-
       Autocomplete.initialize_autocomplete('tag-edit');
       new DTextFormatter($(".dtext-formatter.pending"));
     },
@@ -403,22 +389,6 @@
       routeByRole(role) {
         return this.registry.sources.find(s => s.role === role)
           || this.registry.sources.find(s => s.isSink);
-      },
-      // Inline sink/artist source helpers over tagEntries fields.
-      fieldCurrentTags(field) {
-        return this.tagEntries[field].trim().split(/\s+/).filter(Boolean);
-      },
-      fieldAddTags(field, tags) {
-        const existing = this.tagEntries[field] ? this.tagEntries[field].trim().split(/\s+/).filter(Boolean) : [];
-        for (const tag of tags) if (!existing.includes(tag)) existing.push(tag);
-        this.tagEntries[field] = existing.join(" ") + " ";
-      },
-      fieldRemoveTag(field, tag) {
-        const tags = this.tagEntries[field] ? this.tagEntries[field].trim().split(/\s+/).filter(Boolean) : [];
-        const idx = tags.indexOf(tag);
-        if (idx === -1) return;
-        tags.splice(idx, 1);
-        this.tagEntries[field] = tags.join(" ") + " ";
       },
       submit() {
         this.showErrors = true;
@@ -570,36 +540,6 @@
         }).always(function () {
           self.loadingRelated = false;
         });
-      },
-
-      initVerifiedArtistButtons () {
-        if (UploadData.verifiedArtistTags.length == 0) return;
-
-        // Compact uploader
-        const artistTextBox = document.querySelector("#post_artist");
-        if (artistTextBox === null) return;
-
-        const artistTextBoxParent = artistTextBox.parentElement;
-        const buttonRow = document.createElement("div");
-        buttonRow.classList.add("upload-artist-tags");
-
-        const hint = document.createElement("div");
-        hint.innerHTML = "Linked artist tags:";
-        buttonRow.appendChild(hint);
-
-        for (const artistName of UploadData.verifiedArtistTags) {
-          const newButton = document.createElement("button");
-          newButton.classList.add("toggle-button");
-          newButton.innerHTML = artistName;
-          newButton.onclick = () => {
-            let val = (this.tagEntries.artist ?? "").trim().split(" ").filter(n => n);
-            if (val.includes(artistName)) val = val.filter(n => n !== artistName);
-            else val.push(artistName);
-            this.tagEntries.artist = val.join(" ") + " ";
-          };
-          buttonRow.appendChild(newButton);
-        }
-        artistTextBoxParent.appendChild(buttonRow);
       },
     },
     computed: {

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -215,6 +215,7 @@
 </template>
 
 <script>
+  import { markRaw } from "vue";
   import ToastManager from "@/utility/Toast";
   import sources from './sources.vue';
   import checkboxSource from './checkbox_source.vue';
@@ -374,8 +375,11 @@
     },
     methods: {
       // ===== Tag-source coordinator =====
+      // markRaw keeps descriptors out of the reactive proxy so `unregisterSource`
+      // can match them by identity (a proxied element would never === the raw
+      // object the child holds, and the filter would remove nothing).
       registerSource(descriptor) {
-        this.registry.sources.push(descriptor);
+        this.registry.sources.push(markRaw(descriptor));
       },
       unregisterSource(descriptor) {
         this.registry.sources = this.registry.sources.filter(s => s !== descriptor);

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -33,7 +33,7 @@
                         <div>Please don't use <a href="/wiki_pages/anonymous_artist">anonymous_artist</a> or <a href="/wiki_pages/unknown_artist">unknown_artist</a> tags unless they fall under those definitions on the wiki.</div>
                     </div>
                     <div class="col2">
-                        <artist-source></artist-source>
+                        <artist-source :order="2"></artist-source>
                     </div>
                 </div>
                 <div class="flex-grid border-bottom">
@@ -48,8 +48,8 @@
                         </a></div>
                     </div>
                     <div class="col2">
-                        <checkbox-source kind="characters"></checkbox-source>
-                        <tag-textarea role="character" field-id="post_character"
+                        <checkbox-source kind="characters" :order="0"></checkbox-source>
+                        <tag-textarea role="character" field-id="post_character" :order="3"
                                       placeholder="Ex: character_name"></tag-textarea>
                     </div>
                 </div>
@@ -59,8 +59,8 @@
                         <div>One listed body type per visible character, listed options are mutually exclusive.</div>
                     </div>
                     <div class="col2">
-                        <checkbox-source kind="body"></checkbox-source>
-                        <tag-textarea role="species" field-id="post_species"
+                        <checkbox-source kind="body" :order="0"></checkbox-source>
+                        <tag-textarea role="species" field-id="post_species" :order="4"
                                       placeholder="Ex: bear dragon hyena rat newt etc."></tag-textarea>
                     </div>
                 </div>
@@ -74,7 +74,7 @@
                         </div>
                     </div>
                     <div class="col2">
-                        <tag-textarea role="content" field-id="post_content"
+                        <tag-textarea role="content" field-id="post_content" :order="5"
                                       placeholder="Ex: young gore scat watersports diaper my_little_pony vore not_furry rape hyper etc."></tag-textarea>
                     </div>
                 </div>
@@ -313,6 +313,7 @@
       // source (artist, checkboxes, textareas) is a self-registering child.
       this.sinkDescriptor = {
         isSink: true,
+        order: 1, // checkboxes (0) then other (1) then artist/character/species/content
         currentTags: () => TagField.splitTags(this.otherTags),
         addTags: tags => { this.otherTags = TagField.addTags(this.otherTags, tags); },
         removeTag: tag => { this.otherTags = TagField.removeTag(this.otherTags, tag); },
@@ -547,10 +548,12 @@
       },
     },
     computed: {
-      // Aggregate every registered source. Serialization matches the old computed
-      // exactly (first-comma replace + whitespace collapse); no cross-source dedupe.
+      // Aggregate every registered source, in declared `order` (not registration
+      // order) so the preview matches the pre-registry sequence. Serialization is
+      // identical (first-comma replace + whitespace collapse); no cross-source dedupe.
       tags() {
-        return this.registry.sources
+        return [...this.registry.sources]
+          .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
           .flatMap(s => s.currentTags())
           .join(' ').replace(',', ' ').trim().replace(/ +/g, ' ');
       },

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -25,7 +25,7 @@
                     <sources :maxSources="10" :showErrors="showErrors" v-model:sources="sources" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event"></sources>
                 </div>
             </div>
-            <template v-if="normalMode">
+            <template v-if="!compactMode">
                 <div class="flex-grid border-bottom">
                     <div class="col">
                         <label class="section-label" for="names">Artists and Contributors</label>
@@ -48,26 +48,9 @@
                         </a></div>
                     </div>
                     <div class="col2">
-                        <div class="flex-wrap">
-                            <image-checkbox :check="check" :checks="checkboxes.selected" v-for="check in checkboxes.sex"
-                                            @set="setCheck"
-                                            :key="check.name"></image-checkbox>
-                        </div>
-                        <hr>
-                        <div class="flex-wrap">
-                            <image-checkbox :check="check" :checks="checkboxes.selected"
-                                            v-for="check in checkboxes.count" @set="setCheck"
-                                            :key="check.name"></image-checkbox>
-                        </div>
-                        <hr>
-                        <div class="flex-wrap">
-                            <image-checkbox :check="check" :checks="checkboxes.selected"
-                                            v-for="check in filteredPairings" @set="setCheck"
-                                            :key="check.name"></image-checkbox>
-                        </div>
-                        <textarea class="tag-textarea" rows="2" v-model="tagEntries.character" id="post_character"
-                                  placeholder="Ex: character_name"
-                                  data-autocomplete="tag-edit"></textarea>
+                        <checkbox-source kind="characters"></checkbox-source>
+                        <tag-textarea role="character" field-id="post_character"
+                                      placeholder="Ex: character_name"></tag-textarea>
                     </div>
                 </div>
                 <div class="flex-grid border-bottom">
@@ -76,14 +59,9 @@
                         <div>One listed body type per visible character, listed options are mutually exclusive.</div>
                     </div>
                     <div class="col2">
-                        <div class="flex-wrap">
-                            <image-checkbox :check="check" :checks="checkboxes.selected"
-                                            v-for="check in checkboxes.body" @set="setCheck"
-                                            :key="check.name"></image-checkbox>
-                        </div>
-                        <textarea class="tag-textarea" rows="2" v-model="tagEntries.species" id="post_species"
-                                  placeholder="Ex: bear dragon hyena rat newt etc."
-                                  data-autocomplete="tag-edit"></textarea>
+                        <checkbox-source kind="body"></checkbox-source>
+                        <tag-textarea role="species" field-id="post_species"
+                                      placeholder="Ex: bear dragon hyena rat newt etc."></tag-textarea>
                     </div>
                 </div>
                 <div class="flex-grid border-bottom">
@@ -96,9 +74,8 @@
                         </div>
                     </div>
                     <div class="col2">
-          <textarea class="tag-textarea" v-model="tagEntries.content" id="post_content" rows="2"
-                    data-autocomplete="tag-edit"
-                    placeholder="Ex: young gore scat watersports diaper my_little_pony vore not_furry rape hyper etc."></textarea>
+                        <tag-textarea role="content" field-id="post_content"
+                                      placeholder="Ex: young gore scat watersports diaper my_little_pony vore not_furry rape hyper etc."></tag-textarea>
                     </div>
                 </div>
             </template>
@@ -240,7 +217,8 @@
 <script>
   import ToastManager from "@/utility/Toast";
   import sources from './sources.vue';
-  import checkbox from './checkbox.vue';
+  import checkboxSource from './checkbox_source.vue';
+  import tagTextarea from './tag_textarea.vue';
   import relatedTags from './related.vue';
   import tagPreview from './tag_preview.vue';
   import filePreview from './file_preview.vue';
@@ -251,42 +229,6 @@
   import DTextFormatter from "@/components/DTextFormatter.ts";
   import CurrentUser from "@/models/CurrentUser";
   import UploadData from "@/models/UploadData";
-
-  const sex_names = {
-    male: 'Male',
-    female: 'Female',
-    andromorph: 'Andromorph',
-    gynomorph: 'Gynomorph',
-    herm: 'Hermaphrodite',
-    maleherm: 'Male-Herm',
-    ambiguous_gender: 'Ambiguous'
-  };
-
-  const sex_checks = Object.entries(sex_names).map(([tag, name]) => ({ name, tag }));
-
-  const sex_tag_keys = Object.keys(sex_names);
-  const all_pairing_pairs = [];
-  for (let i = 0; i < sex_tag_keys.length; i++) {
-    for (let j = i; j < sex_tag_keys.length; j++) {
-      all_pairing_pairs.push({ tagA: sex_tag_keys[i], tagB: sex_tag_keys[j] });
-    }
-  }
-  const pairing_tag_name = tag => tag === 'ambiguous_gender' ? 'ambiguous' : tag;
-  const all_pairing_tag_set = new Set(all_pairing_pairs.map(p => pairing_tag_name(p.tagA) + "/" + pairing_tag_name(p.tagB)));
-
-  const char_count_checks = [
-    {name: 'Solo'},
-    {name: 'Duo'},
-    {name: 'Trio'},
-    {name: 'Group'},
-    {name: 'Zero Pictured'}];
-
-  const body_type_checks = [
-    {name: 'Anthro'},
-    {name: 'Feral'},
-    {name: 'Humanoid'},
-    {name: 'Human'},
-    {name: 'Taur'}];
 
   function tagSorter(a, b) {
     return a.name > b.name ? 1 : -1;
@@ -302,7 +244,8 @@
   export default {
     components: {
       'sources': sources,
-      'image-checkbox': checkbox,
+      'checkbox-source': checkboxSource,
+      'tag-textarea': tagTextarea,
       'related-tags': relatedTags,
       'tag-preview': tagPreview,
       'file-preview': filePreview,
@@ -310,21 +253,15 @@
       'parent-post-input': parentPostInput,
       'artist-tag-input': artistTagInput,
     },
-    data() {
-      const allChecks = {};
-      const addChecks = function (check) {
-        if (typeof check['tag'] !== "undefined") {
-          allChecks[check.tag] = true;
-          return
-        }
-        allChecks[check.name.toLowerCase().replace(' ', '_')] = true;
+    provide() {
+      return {
+        tagRegistry: {
+          register: this.registerSource,
+          unregister: this.unregisterSource,
+        },
       };
-      sex_checks.forEach(addChecks);
-      all_pairing_tag_set.forEach(tag => { allChecks[tag] = true; });
-      char_count_checks.forEach(addChecks);
-      body_type_checks.forEach(addChecks);
-
-
+    },
+    data() {
       return {
         safe: UploadData.safeSite,
         showErrors: false,
@@ -341,23 +278,15 @@
         missingSourceWarning: false,
         nonUrlSourceWarning: false,
         sources: [''],
-        normalMode: !UploadData.compactMode,
+        compactMode: UploadData.compactMode,
 
-        checkboxes: {
-          sex: sex_checks,
-          count: char_count_checks,
-          body: body_type_checks,
-          selected: {},
-          all: allChecks
-        },
+        // Tag sources register here; `tags` aggregates their contributions.
+        registry: { sources: [] },
+        // Artist + free-text ("other") remain inline on the root — the sink is
+        // always present, and the verified-artist DOM fossil writes tagEntries.artist.
         tagEntries: {
-          // These had a bizarre naming pattern
-          // Old names are listed below VVV
-          artist: "",     // character: '',
-          character: "",  // sex: '',
-          species: "",    // bodyType: '',
-          content: "",    // theme: '',
-          other: "",      // other: '',
+          artist: "",
+          other: "",
         },
 
         allowLockedTags: CurrentUser.is.admin,
@@ -380,6 +309,27 @@
         duplicateId: 0,
       };
     },
+    created() {
+      // The free-text "Other Tags" field is the always-present sink.
+      this.sinkDescriptor = {
+        isSink: true,
+        currentTags: () => this.fieldCurrentTags('other'),
+        addTags: tags => this.fieldAddTags('other', tags),
+        removeTag: tag => this.fieldRemoveTag('other', tag),
+      };
+      this.registerSource(this.sinkDescriptor);
+
+      // The artist field is a source only when its input is on screen (normal mode).
+      if (!this.compactMode) {
+        this.artistDescriptor = {
+          role: 'artist',
+          currentTags: () => this.fieldCurrentTags('artist'),
+          addTags: tags => this.fieldAddTags('artist', tags),
+          removeTag: tag => this.fieldRemoveTag('artist', tag),
+        };
+        this.registerSource(this.artistDescriptor);
+      }
+    },
     mounted() {
       const self = this;
       window.onbeforeunload = unloadWarning.bind(self);
@@ -395,28 +345,17 @@
         }
       };
 
-      // Import tags from query parameters
+      // Import tags from query parameters. Routing handles mode: params whose
+      // role source isn't mounted (compact) fall through to the sink.
       const fillTags = function() {
         const queryList = ["tags-artist", "tags-character", "tags-species", "tags-content"];
 
         if(params.has("tags"))
           self.importTags(params.get("tags"), "other");
 
-        if(self.normalMode) {
-          for(const name of queryList) {
-            if(!params.has(name)) continue;
-            self.importTags(params.get(name), name.replace("tags-", ""));
-          }
-        } else {
-          // No other inputs in advanced mode, so we can avoid
-          // recalculating duplicates every time in importTags
-          const tags = [];
-          for(const name of queryList) {
-            if(!params.has(name)) continue;
-            tags.push(params.get(name));
-          }
-          if(tags.length > 0)
-            self.importTags(tags.join(" "), "other");
+        for(const name of queryList) {
+          if(!params.has(name)) continue;
+          self.importTags(params.get(name), name.replace("tags-", ""));
         }
       };
 
@@ -448,14 +387,38 @@
       new DTextFormatter($(".dtext-formatter.pending"));
     },
     methods: {
-      setCheck(tag, value) {
-        this.checkboxes.selected[tag] = value;
-        if (!value) {
-          for (const p of all_pairing_pairs) {
-            if (p.tagA === tag || p.tagB === tag)
-              this.checkboxes.selected[pairing_tag_name(p.tagA) + "/" + pairing_tag_name(p.tagB)] = false;
-          }
-        }
+      // ===== Tag-source coordinator =====
+      registerSource(descriptor) {
+        this.registry.sources.push(descriptor);
+      },
+      unregisterSource(descriptor) {
+        this.registry.sources = this.registry.sources.filter(s => s !== descriptor);
+      },
+      // Inbound routing: by value (a source that owns the tag) then the sink.
+      route(tag) {
+        return this.registry.sources.find(s => s.ownsTag && s.ownsTag(tag))
+          || this.registry.sources.find(s => s.isSink);
+      },
+      // Inbound routing by role (query import), falling back to the sink.
+      routeByRole(role) {
+        return this.registry.sources.find(s => s.role === role)
+          || this.registry.sources.find(s => s.isSink);
+      },
+      // Inline sink/artist source helpers over tagEntries fields.
+      fieldCurrentTags(field) {
+        return this.tagEntries[field].trim().split(/\s+/).filter(Boolean);
+      },
+      fieldAddTags(field, tags) {
+        const existing = this.tagEntries[field] ? this.tagEntries[field].trim().split(/\s+/).filter(Boolean) : [];
+        for (const tag of tags) if (!existing.includes(tag)) existing.push(tag);
+        this.tagEntries[field] = existing.join(" ") + " ";
+      },
+      fieldRemoveTag(field, tag) {
+        const tags = this.tagEntries[field] ? this.tagEntries[field].trim().split(/\s+/).filter(Boolean) : [];
+        const idx = tags.indexOf(tag);
+        if (idx === -1) return;
+        tags.splice(idx, 1);
+        this.tagEntries[field] = tags.join(" ") + " ";
       },
       submit() {
         this.showErrors = true;
@@ -539,47 +502,32 @@
           }
         });
       },
+      // Related-tag toggle: route the tag to its owning source, else the sink.
       pushTag(tag, add) {
-        const isCheck = typeof this.checkboxes.all[tag] !== "undefined";
-        // In advanced mode we need to push these into the tags area because there are no checkboxes or other
-        // tag fields so we can't see them otherwise.
-        if (isCheck && this.normalMode) {
-          this.setCheck(tag, add);
-          return;
-        }
-        const tags = this.tagEntries.other ? this.tagEntries.other.trim().split(' ') : [];
-        const tagIdx = tags.indexOf(tag);
-        if (add) {
-          if (tagIdx === -1)
-            tags.push(tag);
-        } else {
-          if (tagIdx === -1)
-            return;
-          tags.splice(tagIdx, 1);
-        }
-        this.tagEntries.other = tags.join(' ') + ' ';
+        const source = this.route(tag);
+        if (!source) return;
+        if (add) source.addTags([tag]);
+        else source.removeTag(tag);
       },
 
       /**
-       * Used to import tags from the query parameters
+       * Import tags from a query parameter into the given role's field.
        * @param {string} tags Raw tag string
-       * @param {string} input Which of the tagEntries the tags should be added to
+       * @param {string} role Target role ("other" for the sink, "artist"/"character"/…)
        */
-      importTags(tags, input) {
-        const tagsA = (tags + "").trim().split(" ").filter(n => n);
+      importTags(tags, role) {
+        const incoming = (tags + "").trim().split(" ").filter(n => n);
+        const deduped = [];
+        for (const tag of incoming) if (!deduped.includes(tag)) deduped.push(tag);
 
-        // Dedupe
-        let tagsB = this.normalMode ? [] : (this.tagEntries.other || "").trim().split(" ");
-        tagsA.forEach((tag) => {
-          if(tagsB.indexOf(tag) >= 0) return;
-          // In advanced mode, checkboxes are not available
-          if(this.normalMode && typeof this.checkboxes.all[tag] !== "undefined")
-            this.setCheck(tag, true);
-          tagsB.push(tag);
-        });
-
-        // Without a space at the end, vue panics
-        this.tagEntries[this.normalMode ? input : "other"] = tagsB.join(" ") + " ";
+        // Value-route: a checkbox-owned tag flips its checkbox (in either param).
+        for (const tag of deduped) {
+          const owner = this.registry.sources.find(s => s.ownsTag && s.ownsTag(tag));
+          if (owner) owner.addTags([tag]);
+        }
+        // Textual home: the role's field, or the sink if that source isn't mounted.
+        const target = this.routeByRole(role);
+        if (target) target.addTags(deduped);
       },
       findRelated(categoryId) {
         const self = this;
@@ -655,27 +603,12 @@
       },
     },
     computed: {
-      filteredPairings() {
-        const selected = this.checkboxes.selected;
-        return all_pairing_pairs
-          .filter(p => selected[p.tagA] && selected[p.tagB])
-          .map(p => ({
-            name: sex_names[p.tagA] + "/" + sex_names[p.tagB],
-            tag: pairing_tag_name(p.tagA) + "/" + pairing_tag_name(p.tagB),
-          }));
-      },
+      // Aggregate every registered source. Serialization matches the old computed
+      // exactly (first-comma replace + whitespace collapse); no cross-source dedupe.
       tags() {
-        const self = this;
-        if (!this.normalMode)
-          return this.tagEntries.other;
-        const validPairingTags = new Set(this.filteredPairings.map(p => p.tag));
-        const checked = Object.keys(this.checkboxes.selected).filter(function (x) {
-          if (!self.checkboxes.selected[x]) return false;
-          if (all_pairing_tag_set.has(x)) return validPairingTags.has(x);
-          return true;
-        });
-        return checked.concat([this.tagEntries.other, this.tagEntries.artist, this.tagEntries.character,
-          this.tagEntries.species, this.tagEntries.content]).join(' ').replace(',', ' ').trim().replace(/ +/g, ' ');
+        return this.registry.sources
+          .flatMap(s => s.currentTags())
+          .join(' ').replace(',', ' ').trim().replace(/ +/g, ' ');
       },
       tagsArray() {
         return this.tags.toLowerCase().split(' ');

--- a/app/javascript/test/components/uploads/artist_tag_input.test.ts
+++ b/app/javascript/test/components/uploads/artist_tag_input.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import ArtistTagInput from "@/pages/uploads/new/artist_tag_input.vue";
+
+const wrappers: VueWrapper[] = [];
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  for (const w of wrappers.splice(0)) w.unmount();
+  vi.useRealTimers();
+});
+
+// Route fetch responses by URL. `tags` is the /tags.json result, `aliases` the /tag_aliases.json result.
+function stubFetch (tags: any[], aliases: any[] = []) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation((url: any) => {
+    const body = String(url).includes("/tag_aliases.json") ? aliases : tags;
+    return Promise.resolve({ ok: true, json: async () => body } as Response);
+  });
+}
+
+function make (modelValue = "") {
+  const wrapper = mount(ArtistTagInput, { props: { modelValue } });
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+async function checkAfter (w: VueWrapper, value: string) {
+  await w.setProps({ modelValue: value });
+  await vi.advanceTimersByTimeAsync(1000); // debounce
+  await flushPromises();
+  await flushPromises(); // second fetch hop (aliases), if any
+}
+
+const notices = (w: VueWrapper) => w.findAll(".artist-tag-notice");
+const lastEmit = (w: VueWrapper) => w.emitted("update:modelValue")?.at(-1)?.[0];
+
+describe("uploads/artist_tag_input", () => {
+  it("emits typed input immediately", async () => {
+    const w = make();
+    await w.find("textarea").setValue("picasso");
+    expect(lastEmit(w)).toBe("picasso");
+  });
+
+  it("offers to make an unknown tag into an artist tag", async () => {
+    stubFetch([], []); // not found + no alias
+    const w = make();
+    await checkAfter(w, "newartist");
+    expect(notices(w)).toHaveLength(1);
+    expect(notices(w)[0].attributes("data-type")).toBe("make_artist");
+    expect(notices(w)[0].text()).toContain("newartist");
+  });
+
+  it("warns that a populated general tag is the wrong category", async () => {
+    stubFetch([{ name: "tree", category: 0, post_count: 500 }]);
+    const w = make();
+    await checkAfter(w, "tree");
+    expect(notices(w)[0].attributes("data-type")).toBe("wrong");
+    expect(notices(w)[0].text()).toContain("populated general tag");
+  });
+
+  it("says nothing when the tag is already an artist tag", async () => {
+    stubFetch([{ name: "picasso", category: 1, post_count: 100 }]);
+    const w = make();
+    await checkAfter(w, "picasso");
+    expect(notices(w)).toHaveLength(0);
+  });
+
+  it("names the wrong category for a non-general tag", async () => {
+    stubFetch([{ name: "pikachu", category: 4, post_count: 100 }]);
+    const w = make();
+    await checkAfter(w, "pikachu");
+    expect(notices(w)[0].text()).toContain("character");
+  });
+
+  it("prefixes with artist: when 'make artist' is clicked", async () => {
+    stubFetch([], []);
+    const w = make();
+    await checkAfter(w, "newartist");
+    await notices(w)[0].find("a").trigger("click");
+    expect(lastEmit(w)).toBe("artist:newartist ");
+  });
+
+  it("removes a wrong-category tag when its notice is clicked", async () => {
+    stubFetch([{ name: "tree", category: 0, post_count: 500 }]);
+    const w = make();
+    await checkAfter(w, "tree");
+    await notices(w)[0].find("a").trigger("click");
+    expect(lastEmit(w)).toBe(" "); // removing the only tag leaves the trailing-space artifact
+  });
+
+  it("ignores tags already carrying an artist:/art: prefix", async () => {
+    const fetchSpy = stubFetch([]);
+    const w = make();
+    await checkAfter(w, "artist:picasso art:monet");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(notices(w)).toHaveLength(0);
+  });
+});

--- a/app/javascript/test/components/uploads/file_input.test.ts
+++ b/app/javascript/test/components/uploads/file_input.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import $ from "jquery";
+import { setSiteData } from "../../helpers";
+
+const wrappers: VueWrapper[] = [];
+
+beforeEach(() => {
+  // jsdom lacks createObjectURL; file selection calls it.
+  (URL as any).createObjectURL = vi.fn(() => "blob:mock");
+});
+afterEach(() => {
+  for (const w of wrappers.splice(0)) w.unmount();
+});
+
+async function mountFileInput (opts: { maxFileSize?: number, maxFileSizes?: Record<string, number> } = {}) {
+  setSiteData("site-settings", {
+    Posts: { max_file_size: opts.maxFileSize ?? 100, max_file_sizes: opts.maxFileSizes ?? {} },
+  });
+  vi.resetModules();
+  const FileInput = (await import("@/pages/uploads/new/file_input.vue")).default;
+  const wrapper = mount(FileInput, { attachTo: document.body });
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+const urlInput = (w: VueWrapper) => w.find("input[placeholder='Paste image URL']");
+const lastEmit = (w: VueWrapper, name: string) => w.emitted(name)?.at(-1)?.[0];
+
+async function selectFile (w: VueWrapper, file: File) {
+  const input = w.find("#file-input");
+  Object.defineProperty(input.element, "files", { value: [file], configurable: true });
+  await input.trigger("change");
+}
+
+describe("uploads/file_input — direct URL checks", () => {
+  it.each([
+    ["https://a.furaffinity.net/1/x.jpg", "Thumbnail URL"],
+    ["https://pbs.twimg.com/media/AbC123.jpg", "Sample URL"],
+  ])("flags %s as a problem", async (url, reason) => {
+    vi.spyOn($, "getJSON").mockReturnValue(undefined as any);
+    const w = await mountFileInput();
+    await urlInput(w).setValue(url);
+    const box = w.find(".linkinput-wrapper .background-red");
+    expect(box.exists()).toBe(true);
+    expect(box.text()).toContain(reason);
+    expect(lastEmit(w, "invalidUploadValueChanged")).toBe(true);
+  });
+
+  it("accepts a plain image URL and emits a preview", async () => {
+    vi.spyOn($, "getJSON").mockReturnValue(undefined as any);
+    const w = await mountFileInput();
+    await urlInput(w).setValue("https://example.com/art.png");
+    expect(w.find(".linkinput-wrapper .background-red").exists()).toBe(false);
+    expect(lastEmit(w, "uploadValueChanged")).toBe("https://example.com/art.png");
+    expect(lastEmit(w, "previewChanged")).toEqual({ url: "https://example.com/art.png", isVideo: false });
+  });
+
+  it("shows the whitelist verdict returned by the server", async () => {
+    vi.spyOn($, "getJSON").mockImplementation(((_url: string, _params: unknown, cb: (d: unknown) => void) => {
+      cb({ domain: "example.com", is_allowed: true });
+      return undefined;
+    }) as any);
+    const w = await mountFileInput();
+    await urlInput(w).setValue("https://example.com/art.png");
+    const warning = w.find("#whitelist-warning");
+    expect(warning.isVisible()).toBe(true);
+    expect(warning.text()).toContain("permitted");
+  });
+});
+
+describe("uploads/file_input — file size", () => {
+  it("rejects a file larger than the per-extension limit", async () => {
+    const w = await mountFileInput({ maxFileSizes: { png: 10 } });
+    await selectFile(w, new File([new ArrayBuffer(200)], "big.png", { type: "image/png" }));
+    expect(w.find(".fileinput-wrapper .background-red").text()).toContain("too large");
+    expect(lastEmit(w, "invalidUploadValueChanged")).toBe(true);
+    expect(lastEmit(w, "uploadValueChanged")).toBeInstanceOf(File);
+  });
+
+  it("falls back to the global limit when the extension is unmapped", async () => {
+    const w = await mountFileInput({ maxFileSize: 100, maxFileSizes: {} });
+    await selectFile(w, new File([new ArrayBuffer(200)], "big.png", { type: "image/png" }));
+    expect(w.find(".fileinput-wrapper .background-red").exists()).toBe(true);
+  });
+
+  it("accepts a file within the limit", async () => {
+    const w = await mountFileInput({ maxFileSizes: { png: 1000 } });
+    await selectFile(w, new File([new ArrayBuffer(200)], "ok.png", { type: "image/png" }));
+    expect(w.find(".fileinput-wrapper .background-red").exists()).toBe(false);
+    expect(lastEmit(w, "previewChanged")).toEqual({ url: "blob:mock", isVideo: false });
+  });
+});

--- a/app/javascript/test/components/uploads/file_preview.test.ts
+++ b/app/javascript/test/components/uploads/file_preview.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import FilePreview from "@/pages/uploads/new/file_preview.vue";
+
+const wrappers: VueWrapper[] = [];
+afterEach(() => {
+  for (const w of wrappers.splice(0)) w.unmount();
+});
+
+function make (data: { url: string, isVideo: boolean }) {
+  const wrapper = mount(FilePreview, { props: { classes: "", data } });
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+// jsdom never decodes media, so stub the natural dimensions then fire the load event.
+async function loadImage (w: VueWrapper, width: number, height: number) {
+  const img = w.find("img").element as HTMLImageElement;
+  Object.defineProperty(img, "naturalWidth", { value: width, configurable: true });
+  Object.defineProperty(img, "naturalHeight", { value: height, configurable: true });
+  await w.find("img").trigger("load");
+}
+
+const THUMB_NONE = "data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==";
+
+describe("uploads/file_preview", () => {
+  it("shows the placeholder thumbnail when there is no url", () => {
+    const w = make({ url: "", isVideo: false });
+    expect(w.find("img").attributes("src")).toBe(THUMB_NONE);
+    expect(w.find(".upload_preview_dims").text()).toBe("");
+  });
+
+  it("reports dimensions once the image loads", async () => {
+    const w = make({ url: "http://example.com/a.png", isVideo: false });
+    await loadImage(w, 800, 600);
+    expect(w.find(".upload_preview_dims").text()).toBe("800×600");
+    expect(w.find(".background-red").isVisible()).toBe(false);
+  });
+
+  it("warns when a dimension exceeds 15000px", async () => {
+    const w = make({ url: "http://example.com/huge.png", isVideo: false });
+    await loadImage(w, 16000, 100);
+    expect(w.find(".background-red").isVisible()).toBe(true);
+    expect(w.find(".background-red").text()).toContain("15,000px");
+  });
+
+  it("resets dimensions when the source changes", async () => {
+    const w = make({ url: "http://example.com/a.png", isVideo: false });
+    await loadImage(w, 800, 600);
+    await w.setProps({ data: { url: "http://example.com/b.png", isVideo: false } });
+    expect(w.find(".upload_preview_dims").text()).toBe("");
+  });
+
+  it("shows the failure notice when the preview errors", async () => {
+    const w = make({ url: "http://example.com/broken.png", isVideo: false });
+    await w.find("img").trigger("error");
+    expect(w.find(".preview-fail").exists()).toBe(true);
+    expect(w.find("img").exists()).toBe(false);
+  });
+
+  it("renders a video element for video data", () => {
+    const w = make({ url: "http://example.com/a.webm", isVideo: true });
+    expect(w.find("video").exists()).toBe(true);
+    expect(w.find("img").exists()).toBe(false);
+  });
+});

--- a/app/javascript/test/components/uploads/mountUploader.ts
+++ b/app/javascript/test/components/uploads/mountUploader.ts
@@ -1,0 +1,129 @@
+import { mount, VueWrapper } from "@vue/test-utils";
+import { vi } from "vitest";
+import $ from "jquery";
+import { setSiteData } from "../../helpers";
+
+// IMPORTANT: `vi.mock` is file-scoped and hoisted, so it cannot live in this helper.
+// Every test file that mounts the uploader must include this header block itself,
+// BEFORE any imports:
+//
+//   vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+//   vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+//   vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+//
+// The helper only performs the runtime setup (blob seeding, URL, network spies,
+// navigation stub) and the fresh dynamic import + mount.
+
+export interface UploadTag {
+  name: string;
+  count: number;
+  category_id: number;
+}
+
+export interface MountUploaderOptions {
+  // CurrentUser (#site-user) permission flags
+  admin?: boolean; // → allowLockedTags
+  privileged?: boolean; // → allowRatingLock
+  uploadFree?: boolean; // → allowUploadAsPending
+  // UploadData (#upload-data)
+  compactMode?: boolean; // normalMode = !compactMode
+  safeSite?: boolean; // hides the e/q rating buttons
+  uploadTags?: UploadTag[];
+  recentTags?: UploadTag[];
+  verifiedArtistTags?: string[];
+  // Settings.Posts (#site-settings) — consumed by file_input
+  maxFileSize?: number;
+  maxFileSizes?: Record<string, number>;
+  // mounted() reads window.location.search for its query-param import
+  search?: string;
+}
+
+export interface MountedUploader {
+  wrapper: VueWrapper;
+  ajax: ReturnType<typeof vi.spyOn>;
+  getJSON: ReturnType<typeof vi.spyOn>;
+  fetchSpy: ReturnType<typeof vi.spyOn>;
+  locationAssign: ReturnType<typeof vi.fn>;
+  restore: () => void;
+}
+
+const wrappers: VueWrapper[] = [];
+/** Call in each test file's afterEach to tear down mounted uploaders. */
+export function unmountAll (): void {
+  for (const wrapper of wrappers.splice(0)) wrapper.unmount();
+}
+
+// jqXHR-ish chainable so `$.getJSON(...).always(cb)` and friends don't throw
+// when the spy is left inert (individual tests override to drive callbacks).
+function chainable (): any {
+  const stub: any = {
+    done: () => stub,
+    fail: () => stub,
+    always: (cb?: () => void) => {
+      cb?.();
+      return stub;
+    },
+  };
+  return stub;
+}
+
+export async function mountUploader (opts: MountUploaderOptions = {}): Promise<MountedUploader> {
+  // 1. Seed the singleton blobs BEFORE importing the component (singletons memoize
+  //    at first import; setup.ts's vi.resetModules() gives a fresh read each test).
+  setSiteData("site-user", {
+    id: 1,
+    name: "tester",
+    level: 20,
+    level_string: "Member",
+    is: { member: true, admin: !!opts.admin, privileged: !!opts.privileged },
+    can: { upload_free: !!opts.uploadFree, approve_posts: false },
+  });
+  setSiteData("upload-data", {
+    safe_site: !!opts.safeSite,
+    compact_mode: !!opts.compactMode,
+    verified_artist_tags: opts.verifiedArtistTags ?? [],
+    upload_tags: opts.uploadTags ?? [],
+    recent_tags: opts.recentTags ?? [],
+  });
+  setSiteData("site-settings", {
+    Posts: {
+      max_file_size: opts.maxFileSize ?? 1048576,
+      max_file_sizes: opts.maxFileSizes ?? {},
+    },
+  });
+
+  // Disable the tag-preview auto-fetch so its 1s debounce can't fire a stray
+  // $.ajax after the component unmounts. (LStorage serializes booleans as JSON.)
+  window.localStorage.setItem("e6.posts.tagpreview", "false");
+
+  // 2. + 4. Replace window.location wholesale with a URL-based stand-in. This
+  //    controls the query string mounted() reads AND stubs .assign (jsdom's real
+  //    location.assign is non-configurable and throws "Not implemented: navigation").
+  const originalLocation = window.location;
+  const locationAssign = vi.fn();
+  const fakeLocation: any = new URL("http://localhost/uploads/new" + (opts.search ?? ""));
+  fakeLocation.assign = locationAssign;
+  Object.defineProperty(window, "location", { configurable: true, writable: true, value: fakeLocation });
+
+  // 3. Inert-by-default network spies. jQuery === $ (same singleton the app calls).
+  const ajax = vi.spyOn($, "ajax").mockReturnValue(chainable());
+  const getJSON = vi.spyOn($, "getJSON").mockReturnValue(chainable());
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue({ ok: true, status: 200, json: async () => ([]) } as unknown as Response);
+
+  // 5. Reset the module cache so the singletons (CurrentUser/UploadData/Settings)
+  //    re-read the freshly-seeded blobs — even on a second mount within one test.
+  //    (The $/fetch spies are on stable globals and survive the reset.)
+  vi.resetModules();
+  const Uploader = (await import("@/pages/uploads/new/uploader.vue")).default;
+  const wrapper = mount(Uploader, { attachTo: document.body });
+  wrappers.push(wrapper);
+
+  const restore = () => {
+    wrapper.unmount();
+    Object.defineProperty(window, "location", { configurable: true, writable: true, value: originalLocation });
+  };
+
+  return { wrapper, ajax, getJSON, fetchSpy, locationAssign, restore };
+}

--- a/app/javascript/test/components/uploads/parent_post_input.test.ts
+++ b/app/javascript/test/components/uploads/parent_post_input.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import ParentPostInput from "@/pages/uploads/new/parent_post_input.vue";
+
+const wrappers: VueWrapper[] = [];
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  for (const w of wrappers.splice(0)) w.unmount();
+  vi.useRealTimers();
+});
+
+function make () {
+  const wrapper = mount(ParentPostInput, { props: { modelValue: "" } });
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+function fetchOk (post: unknown) {
+  return { ok: true, status: 200, json: async () => ({ post }) };
+}
+
+async function type (w: VueWrapper, v: string) {
+  await w.find("input").setValue(v);
+  await vi.advanceTimersByTimeAsync(500); // debounce
+  await flushPromises();
+}
+
+const error = (w: VueWrapper) => w.find(".upload-parent-error");
+
+describe("uploads/parent_post_input", () => {
+  it("emits the trimmed value immediately on input", async () => {
+    const w = make();
+    await w.find("input").setValue("  55  ");
+    expect(w.emitted("update:modelValue")!.at(-1)).toEqual(["55"]);
+  });
+
+  it.each([["0"], ["-1"], ["1.5"], ["abc"]])("rejects %s as a non-positive-integer without fetching", async (bad) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const w = make();
+    await type(w, bad);
+    expect(error(w).exists()).toBe(true);
+    expect(error(w).text()).toContain("positive integer");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches and shows a preview for a valid id", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      fetchOk({ id: 123, preview: { url: "/data/preview/123.jpg" } }) as unknown as Response,
+    );
+    const w = make();
+    await type(w, "123");
+    expect(globalThis.fetch).toHaveBeenCalledWith("/posts/123.json");
+    const img = w.find(".upload-parent-preview img");
+    expect(img.exists()).toBe(true);
+    expect(img.attributes("src")).toBe("/data/preview/123.jpg");
+  });
+
+  it("reports a 404 as not found", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: false, status: 404 } as unknown as Response);
+    const w = make();
+    await type(w, "999");
+    expect(error(w).text()).toContain("not found");
+  });
+
+  it("reports a post with no preview as unavailable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(fetchOk({ id: 7, preview: { url: null } }) as unknown as Response);
+    const w = make();
+    await type(w, "7");
+    expect(error(w).text()).toContain("unavailable");
+  });
+});

--- a/app/javascript/test/components/uploads/related.test.ts
+++ b/app/javascript/test/components/uploads/related.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mount, VueWrapper } from "@vue/test-utils";
+import Related from "@/pages/uploads/new/related.vue";
+
+const wrappers: VueWrapper[] = [];
+afterEach(() => {
+  for (const w of wrappers.splice(0)) w.unmount();
+  delete (window as any).uploaderSettings;
+});
+
+function make (props: Record<string, unknown> = {}) {
+  const wrapper = mount(Related, {
+    props: { tags: [], related: [], loading: false, ...props },
+  });
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+const titles = (w: VueWrapper) => w.findAll(".related-title").map((t) => t.text());
+const itemText = (w: VueWrapper) => w.findAll(".related-item a").map((a) => a.text());
+
+describe("uploads/related", () => {
+  it("renders Quick Tags and Recent groups from props, recent sorted by name", async () => {
+    const w = make({
+      uploadedTags: [{ name: "fav", category_id: 0 }],
+      recentTags: [{ name: "zzz", category_id: 0 }, { name: "aaa", category_id: 0 }],
+    });
+    expect(titles(w)).toEqual(["Quick Tags", "Recent"]);
+    // Recent is sorted; Quick Tags keeps its given order.
+    expect(itemText(w)).toEqual(["fav", "aaa", "zzz"]);
+  });
+
+  it("falls back to window.uploaderSettings when the props are absent", async () => {
+    (window as any).uploaderSettings = { uploadTags: [{ name: "legacy", category_id: 0 }], recentTags: [] };
+    const w = make(); // no uploadedTags/recentTags props
+    expect(titles(w)).toContain("Quick Tags");
+    expect(itemText(w)).toContain("legacy");
+  });
+
+  it("renders server-provided related groups", () => {
+    const w = make({ related: [{ title: "Related: artist", tags: [{ name: "picasso", category_id: 1 }] }] });
+    expect(titles(w)).toContain("Related: artist");
+    expect(itemText(w)).toContain("picasso");
+  });
+
+  it("shows a loading placeholder group while loading", () => {
+    const w = make({ loading: true });
+    expect(titles(w)).toContain("Loading Related Tags");
+  });
+
+  it("splits a group into rows of 15", () => {
+    const tags = Array.from({ length: 20 }, (_, i) => ({ name: `t${i}`, category_id: 0 }));
+    const w = make({ related: [{ title: "Big", tags }] });
+    expect(w.findAll(".related-section .related-items").length).toBe(2);
+  });
+
+  it("marks active tags and applies the category class", () => {
+    const w = make({
+      tags: ["picasso"],
+      related: [{ title: "Related: artist", tags: [{ name: "picasso", category_id: 1 }, { name: "monet", category_id: 1 }] }],
+    });
+    const picasso = w.findAll(".related-item a").find((a) => a.text() === "picasso")!;
+    expect(picasso.classes()).toContain("tag-active");
+    expect(picasso.classes()).toContain("tag-type-1");
+    expect(w.findAll(".related-item a").find((a) => a.text() === "monet")!.classes()).not.toContain("tag-active");
+  });
+
+  it("emits tag-active with the toggled state on click", async () => {
+    const w = make({
+      tags: ["picasso"],
+      related: [{ title: "Related: artist", tags: [{ name: "picasso", category_id: 1 }, { name: "monet", category_id: 1 }] }],
+    });
+    await w.findAll(".related-item a").find((a) => a.text() === "monet")!.trigger("click");
+    expect(w.emitted("tag-active")!.at(-1)).toEqual(["monet", true]); // not active → add
+
+    await w.findAll(".related-item a").find((a) => a.text() === "picasso")!.trigger("click");
+    expect(w.emitted("tag-active")!.at(-1)).toEqual(["picasso", false]); // active → remove
+  });
+});

--- a/app/javascript/test/components/uploads/tag_preview.test.ts
+++ b/app/javascript/test/components/uploads/tag_preview.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import $ from "jquery";
+import TagPreview from "@/pages/uploads/new/tag_preview.vue";
+
+const wrappers: VueWrapper[] = [];
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  for (const w of wrappers.splice(0)) w.unmount();
+  vi.useRealTimers();
+});
+
+// $.ajax POST /tags/preview.json → immediately invoke success with the given rows.
+function stubAjax (response: any[]) {
+  return vi.spyOn($, "ajax").mockImplementation(((_url: string, opts: any) => {
+    opts.success(response);
+    return undefined;
+  }) as any);
+}
+
+function make (tags: string) {
+  const wrapper = mount(TagPreview, { props: { tags } });
+  wrappers.push(wrapper);
+  return wrapper;
+}
+
+async function settle () {
+  await vi.advanceTimersByTimeAsync(1000); // debounce
+  await flushPromises();
+}
+
+describe("uploads/tag_preview", () => {
+  it("requests preview data for the current tags (enabled by default)", async () => {
+    const ajax = stubAjax([{ name: "foo", post_count: 5, category: 0 }]);
+    make("foo");
+    await settle();
+    expect(ajax).toHaveBeenCalledWith("/tags/preview.json", expect.objectContaining({
+      method: "POST",
+      data: { tags: "foo" },
+    }));
+    expect(wrappers[0].findAll(".tag-preview-tag").length).toBeGreaterThan(0);
+  });
+
+  it("only fetches tags missing from the cache", async () => {
+    const ajax = stubAjax([{ name: "foo", post_count: 5, category: 0 }]);
+    const w = make("foo");
+    await settle();
+
+    ajax.mockClear();
+    await w.setProps({ tags: "foo bar" });
+    await settle();
+    expect(ajax).toHaveBeenCalledWith("/tags/preview.json", expect.objectContaining({ data: { tags: "bar" } }));
+  });
+
+  it("persists the enabled flag and hides the preview when toggled off", async () => {
+    stubAjax([{ name: "foo", post_count: 5, category: 0 }]);
+    const w = make("foo");
+    await settle();
+
+    const toggle = () => w.findAll("a").find((a) => a.text().includes("tag preview"))!;
+    expect(toggle().text()).toContain("Hide");
+
+    await toggle().trigger("click");
+    expect(window.localStorage.getItem("e6.posts.tagpreview")).toBe("false");
+    expect(w.find(".tag-preview").exists()).toBe(false);
+    expect(toggle().text()).toContain("Show");
+  });
+
+  it("marks a tag implied by another as implied", async () => {
+    stubAjax([
+      { id: 1, name: "foo", post_count: 5, category: 0, implies: ["bar"] },
+      { id: 2, name: "bar", post_count: 9, category: 0 },
+    ]);
+    const w = make("foo");
+    await settle();
+    expect(w.find(".tag-preview-tag .implied").exists()).toBe(true);
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.guards.test.ts
+++ b/app/javascript/test/components/uploads/uploader.guards.test.ts
@@ -1,0 +1,78 @@
+import { vi } from "vitest";
+
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { VueWrapper } from "@vue/test-utils";
+import { mountUploader, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+const submitButton = (w: VueWrapper) => w.find("button[accesskey='s']");
+const clickSubmit = (w: VueWrapper) => submitButton(w).trigger("click");
+
+describe("uploads/uploader — validation guards", () => {
+  it("hides every error box until a submit is attempted (showErrors gating)", async () => {
+    const { wrapper } = await mountUploader();
+    // background-red boxes exist in the DOM but are v-show:false / v-if absent.
+    for (const box of wrapper.findAll(".box-section.background-red"))
+      expect(box.isVisible()).toBe(false);
+    // The button itself is NOT disabled before a submit attempt.
+    expect(submitButton(wrapper).attributes("disabled")).toBeUndefined();
+  });
+
+  it("surfaces the requirement boxes and disables submit after a failed attempt", async () => {
+    const { wrapper } = await mountUploader();
+    await clickSubmit(wrapper);
+    expect(wrapper.findAll(".box-section.background-red").some((b) => b.isVisible())).toBe(true);
+    expect(submitButton(wrapper).attributes("disabled")).toBeDefined();
+  });
+
+  it("counts down the 'more tags' requirement and clears it at four", async () => {
+    const { wrapper } = await mountUploader();
+    await clickSubmit(wrapper);
+    const tagBox = () => wrapper.findAll(".box-section.background-red").find((b) => b.text().includes("more tags"));
+
+    await wrapper.find("#post_tags").setValue("a b");
+    expect(tagBox()!.isVisible()).toBe(true);
+    expect(tagBox()!.text()).toContain("2");
+
+    await wrapper.find("#post_tags").setValue("a b c d");
+    expect(tagBox()?.isVisible() ?? false).toBe(false);
+  });
+
+  it("requires a rating", async () => {
+    const { wrapper } = await mountUploader();
+    await clickSubmit(wrapper);
+    const ratingBox = () => wrapper.findAll(".box-section.background-red").find((b) => b.text().includes("appropriate rating"));
+    expect(ratingBox()).toBeTruthy();
+
+    await wrapper.find(".rating-s").trigger("click");
+    expect(ratingBox()).toBeUndefined();
+  });
+
+  it("lets a fully-satisfied form submit (preventUpload clears)", async () => {
+    const { wrapper, ajax } = await mountUploader();
+    await wrapper.find("#post_tags").setValue("a b c d");
+    await wrapper.find(".rating-s").trigger("click");
+    await wrapper.find("#no_source").setValue(true); // suppresses the missing-source warning
+    await clickSubmit(wrapper);
+    // Reached the network layer → all guards passed.
+    expect(ajax).toHaveBeenCalledWith("/uploads.json", expect.anything());
+  });
+
+  describe("beforeunload warning", () => {
+    it("does not warn on a pristine form", async () => {
+      await mountUploader();
+      expect((window.onbeforeunload as () => unknown)()).toBeUndefined();
+    });
+
+    it("warns once the form has tags", async () => {
+      const { wrapper } = await mountUploader();
+      await wrapper.find("#post_tags").setValue("wolf");
+      expect((window.onbeforeunload as () => unknown)()).toBe(true);
+    });
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.queryImport.test.ts
+++ b/app/javascript/test/components/uploads/uploader.queryImport.test.ts
@@ -11,12 +11,30 @@ import { mountUploader, unmountAll } from "./mountUploader";
 afterEach(unmountAll);
 
 const value = (w: VueWrapper, selector: string) => (w.find(selector).element as HTMLInputElement | HTMLTextAreaElement).value;
+const tagsOf = (w: VueWrapper) => w.findComponent(".tag-preview-area").props("tags") as string;
+const checkActive = (w: VueWrapper, label: string) => w.findAll("button.toggle-button").find((b) => b.text() === label)?.classes().includes("active") ?? false;
 
 describe("uploads/uploader — query-param import", () => {
   it("imports free-form tags into Other Tags (with the trailing-space quirk)", async () => {
     const { wrapper } = await mountUploader({ search: "?tags=a+a+b" });
     // Deduped, and a trailing space is appended ("or vue panics").
     expect(value(wrapper, "#post_tags")).toBe("a b ");
+  });
+
+  it("activates the matching checkbox when an imported tag owns one (normal mode)", async () => {
+    const { wrapper } = await mountUploader({ search: "?tags=male+solo+standing" });
+    // Route-by-value: checkbox-owned tags flip their checkbox on...
+    expect(checkActive(wrapper, "Male")).toBe(true);
+    expect(checkActive(wrapper, "Solo")).toBe(true);
+    // ...and every imported tag still ends up in the assembled tag string.
+    const tags = tagsOf(wrapper).split(" ");
+    expect(tags).toEqual(expect.arrayContaining(["male", "solo", "standing"]));
+  });
+
+  it("folds a checkbox-owned tag into Other Tags in compact mode (no checkboxes exist)", async () => {
+    const { wrapper } = await mountUploader({ compactMode: true, search: "?tags=male" });
+    expect(wrapper.findAll("button.toggle-button").some((b) => b.text() === "Male")).toBe(false);
+    expect(value(wrapper, "#post_tags")).toContain("male");
   });
 
   it("routes per-category tag params to their fields in normal mode", async () => {

--- a/app/javascript/test/components/uploads/uploader.queryImport.test.ts
+++ b/app/javascript/test/components/uploads/uploader.queryImport.test.ts
@@ -1,0 +1,82 @@
+import { vi } from "vitest";
+
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { VueWrapper } from "@vue/test-utils";
+import { mountUploader, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+const value = (w: VueWrapper, selector: string) => (w.find(selector).element as HTMLInputElement | HTMLTextAreaElement).value;
+
+describe("uploads/uploader — query-param import", () => {
+  it("imports free-form tags into Other Tags (with the trailing-space quirk)", async () => {
+    const { wrapper } = await mountUploader({ search: "?tags=a+a+b" });
+    // Deduped, and a trailing space is appended ("or vue panics").
+    expect(value(wrapper, "#post_tags")).toBe("a b ");
+  });
+
+  it("routes per-category tag params to their fields in normal mode", async () => {
+    const { wrapper } = await mountUploader({
+      search: "?tags-artist=picasso&tags-character=pikachu&tags-species=rodent&tags-content=young",
+    });
+    expect(value(wrapper, "#post_artist")).toContain("picasso");
+    expect(value(wrapper, "#post_character")).toContain("pikachu");
+    expect(value(wrapper, "#post_species")).toContain("rodent");
+    expect(value(wrapper, "#post_content")).toContain("young");
+  });
+
+  it("folds every tag param into Other Tags in compact mode", async () => {
+    const { wrapper } = await mountUploader({
+      compactMode: true,
+      search: "?tags-artist=picasso&tags-character=pikachu",
+    });
+    const other = value(wrapper, "#post_tags");
+    expect(other).toContain("picasso");
+    expect(other).toContain("pikachu");
+  });
+
+  it("imports a valid rating and ignores an invalid one", async () => {
+    const explicit = (await mountUploader({ search: "?rating=Explicit" })).wrapper;
+    expect(explicit.find(".rating-e").classes()).toContain("active");
+
+    const bogus = (await mountUploader({ search: "?rating=z" })).wrapper;
+    expect(bogus.find(".rating-e").classes()).not.toContain("active");
+    expect(bogus.find(".rating-s").classes()).not.toContain("active");
+  });
+
+  it("imports parent, description, and comma-split sources", async () => {
+    const { wrapper } = await mountUploader({
+      search: "?parent=12345&description=hello+there&sources=https://a,https://b",
+    });
+    expect(value(wrapper, "input[placeholder='Ex. 12345']")).toBe("12345");
+    expect(value(wrapper, "#post_description")).toBe("hello there");
+    const sourceInputs = wrapper.findAll(".upload-source-row input");
+    expect(sourceInputs.map((i) => (i.element as HTMLInputElement).value)).toEqual(["https://a", "https://b"]);
+  });
+
+  describe("permission-gated params", () => {
+    it("applies rating_locked / locked_tags / upload_as_pending only when allowed", async () => {
+      const { wrapper } = await mountUploader({
+        admin: true,
+        privileged: true,
+        uploadFree: true,
+        search: "?rating_locked=true&locked_tags=secret&upload_as_pending=true",
+      });
+      expect(value(wrapper, "input[data-autocomplete='tag-query']")).toBe("secret");
+      // rating-lock + as-pending checkboxes are both checked
+      const checked = wrapper.findAll("input[type='checkbox']").filter((c) => (c.element as HTMLInputElement).checked);
+      expect(checked.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("ignores gated params for a regular member (fields absent)", async () => {
+      const { wrapper } = await mountUploader({
+        search: "?rating_locked=true&locked_tags=secret&upload_as_pending=true",
+      });
+      expect(wrapper.find("input[data-autocomplete='tag-query']").exists()).toBe(false);
+    });
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.registry.test.ts
+++ b/app/javascript/test/components/uploads/uploader.registry.test.ts
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mountUploader, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+// No source unmounts mid-session through the UI today, so this guards the
+// coordinator mechanism directly: descriptors are stored raw (markRaw), so
+// unregisterSource can match them by identity. Without markRaw the reactive
+// proxy wrapping the pushed descriptor would never === the raw object the
+// child holds, and the filter would remove nothing.
+describe("uploads/uploader — source registry", () => {
+  it("unregisterSource actually removes the descriptor", async () => {
+    const { wrapper } = await mountUploader();
+    const vm = wrapper.vm as any;
+
+    const before = vm.registry.sources.length;
+    expect(before).toBeGreaterThan(0);
+
+    // The sink is an inline descriptor the root holds a raw reference to.
+    vm.unregisterSource(vm.sinkDescriptor);
+
+    expect(vm.registry.sources.length).toBe(before - 1);
+    expect(vm.registry.sources.includes(vm.sinkDescriptor)).toBe(false);
+  });
+
+  it("re-registering after unregister restores the count (no proxy identity drift)", async () => {
+    const { wrapper } = await mountUploader();
+    const vm = wrapper.vm as any;
+
+    const original = vm.registry.sources.length;
+    vm.unregisterSource(vm.sinkDescriptor);
+    vm.registerSource(vm.sinkDescriptor);
+    expect(vm.registry.sources.length).toBe(original);
+
+    vm.unregisterSource(vm.sinkDescriptor);
+    expect(vm.registry.sources.length).toBe(original - 1);
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.related.test.ts
+++ b/app/javascript/test/components/uploads/uploader.related.test.ts
@@ -1,0 +1,84 @@
+import { vi } from "vitest";
+
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { VueWrapper } from "@vue/test-utils";
+import { mountUploader, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+// The "Related:" bar links, in order: Tags, Artists, Contributors, Copyrights, Characters, Species, Metatags.
+const relatedLink = (w: VueWrapper, label: string) => w.findAll(".related-tag-functions a").find((a) => a.text() === label)!;
+
+function stubRelated (getJSON: any, data: Record<string, { name: string, category_id: number }[]>) {
+  getJSON.mockImplementation((_url: string, _params: unknown, cb: (d: unknown) => void) => {
+    cb(data);
+    return { always: (fn: () => void) => fn() };
+  });
+}
+
+const relatedItem = (w: VueWrapper, name: string) => w.findAll(".related-item a").find((a) => a.text() === name);
+
+describe("uploads/uploader — related tags", () => {
+  it("queries the endpoint with the current tags and category id", async () => {
+    const { wrapper, getJSON } = await mountUploader();
+    await wrapper.find("#post_tags").setValue("wolf outside");
+    stubRelated(getJSON, {});
+    await relatedLink(wrapper, "Artists").trigger("click");
+    expect(getJSON).toHaveBeenCalledWith(
+      "/related_tag/bulk.json",
+      { query: "wolf outside", category_id: 1 },
+      expect.any(Function),
+    );
+  });
+
+  it("renders returned groups, sorted by tag name", async () => {
+    const { wrapper, getJSON } = await mountUploader();
+    await wrapper.find("#post_tags").setValue("seed");
+    stubRelated(getJSON, { artist: [{ name: "zed", category_id: 1 }, { name: "abe", category_id: 1 }] });
+    await relatedLink(wrapper, "Tags").trigger("click");
+
+    expect(wrapper.find(".related-title").text()).toBe("Related: artist");
+    const items = wrapper.findAll(".related-item a").map((a) => a.text());
+    expect(items).toEqual(["abe", "zed"]);
+  });
+
+  it("toggles the panel off when the same category is clicked twice", async () => {
+    const { wrapper, getJSON } = await mountUploader();
+    await wrapper.find("#post_tags").setValue("seed");
+    stubRelated(getJSON, { artist: [{ name: "abe", category_id: 1 }] });
+    await relatedLink(wrapper, "Artists").trigger("click");
+    expect(wrapper.find(".related-section").exists()).toBe(true);
+
+    await relatedLink(wrapper, "Artists").trigger("click");
+    expect(wrapper.find(".related-section").exists()).toBe(false);
+  });
+
+  describe("pushTag routing (via clicking a related tag)", () => {
+    it("appends a non-checkbox tag to Other Tags", async () => {
+      const { wrapper, getJSON } = await mountUploader();
+      await wrapper.find("#post_tags").setValue("seed");
+      stubRelated(getJSON, { related: [{ name: "foobar", category_id: 0 }] });
+      await relatedLink(wrapper, "Tags").trigger("click");
+
+      await relatedItem(wrapper, "foobar")!.trigger("click");
+      expect((wrapper.find("#post_tags").element as HTMLTextAreaElement).value).toContain("foobar");
+    });
+
+    it("toggles the matching checkbox for a checkbox tag instead", async () => {
+      const { wrapper, getJSON } = await mountUploader();
+      await wrapper.find("#post_tags").setValue("seed");
+      stubRelated(getJSON, { related: [{ name: "male", category_id: 0 }] });
+      await relatedLink(wrapper, "Tags").trigger("click");
+
+      await relatedItem(wrapper, "male")!.trigger("click");
+      const maleButton = wrapper.findAll("button.toggle-button").find((b) => b.text() === "Male")!;
+      expect(maleButton.classes()).toContain("active");
+      // Routed to the checkbox, not appended as free text.
+      expect((wrapper.find("#post_tags").element as HTMLTextAreaElement).value).not.toContain("male");
+    });
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.smoke.test.ts
+++ b/app/javascript/test/components/uploads/uploader.smoke.test.ts
@@ -1,0 +1,46 @@
+import { vi } from "vitest";
+
+// vi.mock is file-scoped + hoisted — every uploader test file needs this header.
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import { mountUploader, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+describe("uploads/uploader — mount smoke", () => {
+  it("mounts the full tree without throwing", async () => {
+    const { wrapper } = await mountUploader();
+    expect(wrapper.find(".flex-grid-outer").exists()).toBe(true);
+    expect(wrapper.find("button[accesskey='s']").text()).toBe("Upload");
+  });
+
+  it("runs mounted(): wires autocomplete and constructs the DText editor", async () => {
+    await mountUploader();
+    // Resolve the mocked modules the component actually used (post-reset instance).
+    const Autocomplete = (await import("@/components/autocomplete")).default;
+    const DTextFormatter = (await import("@/components/DTextFormatter.ts")).default;
+    expect(Autocomplete.initialize_autocomplete).toHaveBeenCalledWith("tag-edit");
+    expect(DTextFormatter).toHaveBeenCalled();
+  });
+
+  it("renders normal mode by default and compact mode when requested", async () => {
+    const normal = (await mountUploader()).wrapper;
+    // Artists/Characters sections only exist in normal mode.
+    expect(normal.find("#post_artist").exists()).toBe(true);
+
+    const compact = (await mountUploader({ compactMode: true })).wrapper;
+    expect(compact.find("#post_artist").exists()).toBe(false);
+  });
+
+  it("seeds the rating buttons per safe mode", async () => {
+    const normal = (await mountUploader()).wrapper;
+    expect(normal.find(".rating-e").exists()).toBe(true);
+
+    const safe = (await mountUploader({ safeSite: true })).wrapper;
+    expect(safe.find(".rating-e").exists()).toBe(false);
+    expect(safe.find(".rating-s").exists()).toBe(true);
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.submit.test.ts
+++ b/app/javascript/test/components/uploads/uploader.submit.test.ts
@@ -1,0 +1,163 @@
+import { vi } from "vitest";
+
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import { nextTick } from "vue";
+import type { VueWrapper } from "@vue/test-utils";
+import { mountUploader, MountUploaderOptions, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+// Fill the form so preventUpload clears and submit() reaches the network layer.
+async function fillValidForm (wrapper: VueWrapper): Promise<void> {
+  await wrapper.find("#post_tags").setValue("a b c d");
+  await wrapper.find(".rating-s").trigger("click");
+  await wrapper.find("#no_source").setValue(true); // suppresses the missing-source warning
+}
+
+// Capture the jQuery.ajax options (payload + success/error callbacks). This tiny
+// helper is the ONLY §4-fragile seam: when submit() moves to fetch, only this swaps.
+async function submitAndCapture (opts: MountUploaderOptions = {}) {
+  const mounted = await mountUploader(opts);
+  await fillValidForm(mounted.wrapper);
+  await mounted.wrapper.find("button[accesskey='s']").trigger("click");
+  const call = mounted.ajax.mock.calls[0];
+  expect(call?.[0]).toBe("/uploads.json");
+  const options = call[1] as any;
+  return { ...mounted, data: options.data as FormData, success: options.success, error: options.error };
+}
+
+// jqXHR stand-in for the error branches.
+function xhr (init: { headers?: Record<string, string>, status?: number, responseJSON?: any } = {}) {
+  const headers = Object.fromEntries(Object.entries(init.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    status: init.status ?? 500,
+    statusText: "",
+    responseText: init.responseJSON ? JSON.stringify(init.responseJSON) : "",
+    responseJSON: init.responseJSON,
+    getResponseHeader: (name: string) => headers[name.toLowerCase()] ?? null,
+  };
+}
+
+function errorBox (wrapper: VueWrapper, needle: string) {
+  return wrapper.findAll(".box-section.background-red").find((b) => b.text().includes(needle));
+}
+
+describe("uploads/uploader — submit payload", () => {
+  it("sends a direct URL (string upload value) rather than a file", async () => {
+    const { data } = await submitAndCapture();
+    expect(data.get("upload[direct_url]")).toBe("");
+    expect(data.get("upload[file]")).toBeNull();
+  });
+
+  it("sends the file when the upload value is a File", async () => {
+    const mounted = await mountUploader();
+    (mounted.wrapper.vm as any).uploadValue = new File(["x"], "art.png", { type: "image/png" });
+    await fillValidForm(mounted.wrapper);
+    await mounted.wrapper.find("button[accesskey='s']").trigger("click");
+    const data = mounted.ajax.mock.calls[0][1].data as FormData;
+    expect(data.get("upload[file]")).toBeInstanceOf(File);
+    expect(data.get("upload[direct_url]")).toBeNull();
+  });
+
+  it("includes the core fields", async () => {
+    const mounted = await mountUploader();
+    await mounted.wrapper.find("#post_tags").setValue("a b c d");
+    await mounted.wrapper.find(".rating-e").trigger("click");
+    await mounted.wrapper.find("#post_description").setValue("a description");
+    (mounted.wrapper.vm as any).sources = ["https://example.com/a", "https://example.com/b"];
+    (mounted.wrapper.vm as any).parentID = "12345";
+    await nextTick();
+    await mounted.wrapper.find("button[accesskey='s']").trigger("click");
+
+    const data = mounted.ajax.mock.calls[0][1].data as FormData;
+    expect(data.get("upload[tag_string]")).toBe("a b c d");
+    expect(data.get("upload[rating]")).toBe("e");
+    expect(data.get("upload[source]")).toBe("https://example.com/a\nhttps://example.com/b");
+    expect(data.get("upload[description]")).toBe("a description");
+    expect(data.get("upload[parent_id]")).toBe("12345");
+  });
+
+  it("omits privileged fields for a regular member", async () => {
+    const { data } = await submitAndCapture();
+    expect(data.get("upload[locked_tags]")).toBeNull();
+    expect(data.get("upload[locked_rating]")).toBeNull();
+    expect(data.get("upload[as_pending]")).toBeNull();
+  });
+
+  it("includes privileged fields when the user is allowed", async () => {
+    const { data } = await submitAndCapture({ admin: true, privileged: true, uploadFree: true });
+    expect(data.get("upload[locked_tags]")).not.toBeNull();
+    expect(data.get("upload[locked_rating]")).not.toBeNull();
+    expect(data.get("upload[as_pending]")).not.toBeNull();
+  });
+});
+
+describe("uploads/uploader — submit outcomes", () => {
+  it("navigates and toasts on success", async () => {
+    const { wrapper, success, locationAssign } = await submitAndCapture();
+    const Toast = (await import("@/utility/Toast")).default;
+    success({ location: "/posts/999" });
+    await nextTick();
+    expect(Toast.notice).toHaveBeenCalledWith("Post uploaded successfully.");
+    expect(locationAssign).toHaveBeenCalledWith("/posts/999");
+    // beforeunload guard released.
+    expect((window.onbeforeunload as () => unknown)()).toBeUndefined();
+    void wrapper;
+  });
+
+  it("reports a Cloudflare challenge", async () => {
+    const { wrapper, error } = await submitAndCapture();
+    error(xhr({ headers: { "cf-mitigated": "challenge" }, status: 403 }), "error", "");
+    await nextTick();
+    expect(errorBox(wrapper, "security challenge")?.isVisible()).toBe(true);
+  });
+
+  it("reports a Cloudflare 403", async () => {
+    const { wrapper, error } = await submitAndCapture();
+    error(xhr({ headers: { server: "cloudflare" }, status: 403 }), "error", "");
+    await nextTick();
+    expect(errorBox(wrapper, "Cloudflare (403)")?.isVisible()).toBe(true);
+  });
+
+  it("flags a duplicate with a link to the existing post", async () => {
+    const { wrapper, error } = await submitAndCapture();
+    error(xhr({ status: 409, responseJSON: { reason: "duplicate", post_id: 42, message: "Already uploaded." } }), "error", "");
+    await nextTick();
+    expect(wrapper.find("a[href='/posts/42']").exists()).toBe(true);
+    expect(errorBox(wrapper, "Already uploaded.")?.isVisible()).toBe(true);
+  });
+
+  it("shows the server message for an invalid upload", async () => {
+    const { wrapper, error } = await submitAndCapture();
+    error(xhr({ status: 422, responseJSON: { reason: "invalid", message: "Bad tags." } }), "error", "");
+    await nextTick();
+    expect(errorBox(wrapper, "Bad tags.")?.isVisible()).toBe(true);
+  });
+
+  it("prefixes a bare message with 'Error:'", async () => {
+    const { wrapper, error } = await submitAndCapture();
+    error(xhr({ status: 500, responseJSON: { message: "Something broke." } }), "error", "");
+    await nextTick();
+    expect(errorBox(wrapper, "Error: Something broke.")?.isVisible()).toBe(true);
+  });
+
+  it("falls back to reason when there is no message", async () => {
+    const { wrapper, error } = await submitAndCapture();
+    error(xhr({ status: 500, responseJSON: { reason: "server_error" } }), "error", "");
+    await nextTick();
+    expect(errorBox(wrapper, "Error: server_error")?.isVisible()).toBe(true);
+  });
+
+  it("falls back to textStatus/errorThrown when there is no JSON", async () => {
+    const { wrapper, error } = await submitAndCapture();
+    error(xhr({ status: 500 }), "timeout", "Timeout");
+    await nextTick();
+    const box = errorBox(wrapper, "timeout");
+    expect(box?.isVisible()).toBe(true);
+    expect(box?.text()).toContain("Timeout");
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.submit.test.ts
+++ b/app/javascript/test/components/uploads/uploader.submit.test.ts
@@ -4,10 +4,18 @@ vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete
 vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
 vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { nextTick } from "vue";
 import type { VueWrapper } from "@vue/test-utils";
 import { mountUploader, MountUploaderOptions, unmountAll } from "./mountUploader";
+
+// submit()'s error handler logs verbosely on every branch (status, headers, the
+// caught JSON-parse error). That output is expected here; silence it so the run
+// stays quiet. Restored by setup.ts's vi.restoreAllMocks() afterEach.
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
 
 afterEach(unmountAll);
 

--- a/app/javascript/test/components/uploads/uploader.tags.test.ts
+++ b/app/javascript/test/components/uploads/uploader.tags.test.ts
@@ -96,6 +96,17 @@ describe("uploads/uploader — tag assembly", () => {
     });
   });
 
+  describe("source ordering", () => {
+    // Checkbox (button) tags precede free-text "Other Tags", matching the layout
+    // (buttons sit above the input) and the pre-registry order.
+    it("emits checkbox tags before Other Tags regardless of entry order", async () => {
+      const { wrapper } = await mountUploader();
+      await wrapper.find("#post_tags").setValue("mammal");
+      await checkButton(wrapper, "Male").trigger("click");
+      expect(tagsOf(wrapper)).toBe("male mammal");
+    });
+  });
+
   describe("whitespace / comma sanitisation (as-is)", () => {
     it("collapses runs of whitespace to single spaces and trims", async () => {
       const { wrapper } = await mountUploader();

--- a/app/javascript/test/components/uploads/uploader.tags.test.ts
+++ b/app/javascript/test/components/uploads/uploader.tags.test.ts
@@ -1,0 +1,123 @@
+import { vi } from "vitest";
+
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { VueWrapper } from "@vue/test-utils";
+import { mountUploader, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+// The assembled tag string is observed where it actually leaves the component:
+// the prop handed to <tag-preview> (located by its root class, so it survives the
+// §2 registry refactor and the per-test module reset).
+function tagsOf (wrapper: VueWrapper): string {
+  return wrapper.findComponent(".tag-preview-area").props("tags") as string;
+}
+
+function checkButton (wrapper: VueWrapper, label: string) {
+  const button = wrapper.findAll("button.toggle-button").find((b) => b.text() === label);
+  if (!button) throw new Error(`No checkbox button labelled "${label}"`);
+  return button;
+}
+
+describe("uploads/uploader — tag assembly", () => {
+  it("is empty on a fresh form", async () => {
+    const { wrapper } = await mountUploader();
+    expect(tagsOf(wrapper)).toBe("");
+  });
+
+  it("includes free-text tags typed into Other Tags", async () => {
+    const { wrapper } = await mountUploader();
+    await wrapper.find("#post_tags").setValue("standing outside smile");
+    expect(tagsOf(wrapper)).toContain("standing");
+    expect(tagsOf(wrapper)).toContain("outside");
+  });
+
+  it("merges tags from the per-category textareas", async () => {
+    const { wrapper } = await mountUploader();
+    await wrapper.find("#post_character").setValue("pikachu");
+    await wrapper.find("#post_species").setValue("rodent");
+    await wrapper.find("#post_content").setValue("young");
+    const tags = tagsOf(wrapper).split(" ");
+    expect(tags).toContain("pikachu");
+    expect(tags).toContain("rodent");
+    expect(tags).toContain("young");
+  });
+
+  it("adds a checkbox tag when its button is toggled", async () => {
+    const { wrapper } = await mountUploader();
+    await checkButton(wrapper, "Male").trigger("click");
+    await checkButton(wrapper, "Solo").trigger("click");
+    const tags = tagsOf(wrapper).split(" ");
+    expect(tags).toContain("male");
+    expect(tags).toContain("solo");
+  });
+
+  it("derives a checkbox tag name by lowercasing and underscoring the label", async () => {
+    const { wrapper } = await mountUploader();
+    await checkButton(wrapper, "Zero Pictured").trigger("click");
+    expect(tagsOf(wrapper).split(" ")).toContain("zero_pictured");
+  });
+
+  describe("sex pairings", () => {
+    it("offers a pairing only once BOTH constituent sexes are selected", async () => {
+      const { wrapper } = await mountUploader();
+      expect(wrapper.findAll("button.toggle-button").some((b) => b.text() === "Male/Female")).toBe(false);
+
+      await checkButton(wrapper, "Male").trigger("click");
+      expect(wrapper.findAll("button.toggle-button").some((b) => b.text() === "Male/Female")).toBe(false);
+
+      await checkButton(wrapper, "Female").trigger("click");
+      expect(wrapper.findAll("button.toggle-button").some((b) => b.text() === "Male/Female")).toBe(true);
+    });
+
+    it("adds the pairing tag when its checkbox is selected", async () => {
+      const { wrapper } = await mountUploader();
+      await checkButton(wrapper, "Male").trigger("click");
+      await checkButton(wrapper, "Female").trigger("click");
+      await checkButton(wrapper, "Male/Female").trigger("click");
+      expect(tagsOf(wrapper).split(" ")).toContain("male/female");
+    });
+
+    it("cascades: deselecting a sex clears its pairings from the tag string and UI", async () => {
+      const { wrapper } = await mountUploader();
+      await checkButton(wrapper, "Male").trigger("click");
+      await checkButton(wrapper, "Female").trigger("click");
+      await checkButton(wrapper, "Male/Female").trigger("click");
+      expect(tagsOf(wrapper).split(" ")).toContain("male/female");
+
+      await checkButton(wrapper, "Female").trigger("click");
+      expect(tagsOf(wrapper).split(" ")).not.toContain("male/female");
+      expect(tagsOf(wrapper).split(" ")).not.toContain("female");
+      expect(wrapper.findAll("button.toggle-button").some((b) => b.text() === "Male/Female")).toBe(false);
+    });
+  });
+
+  describe("whitespace / comma sanitisation (as-is)", () => {
+    it("collapses runs of whitespace to single spaces and trims", async () => {
+      const { wrapper } = await mountUploader();
+      await wrapper.find("#post_tags").setValue("  a    b   c  ");
+      expect(tagsOf(wrapper)).toBe("a b c");
+    });
+
+    // Pins the current .replace(',', ' ') behaviour: only the FIRST comma is
+    // replaced. This is a known quirk — characterised, not endorsed.
+    it("replaces only the first comma with a space", async () => {
+      const { wrapper } = await mountUploader();
+      await wrapper.find("#post_tags").setValue("a,b,c");
+      expect(tagsOf(wrapper)).toBe("a b,c");
+    });
+  });
+
+  describe("compact mode", () => {
+    it("returns only the Other Tags field (no checkboxes/per-category inputs)", async () => {
+      const { wrapper } = await mountUploader({ compactMode: true });
+      expect(wrapper.find("#post_character").exists()).toBe(false);
+      await wrapper.find("#post_tags").setValue("solo male");
+      expect(tagsOf(wrapper)).toBe("solo male");
+    });
+  });
+});

--- a/app/javascript/test/components/uploads/uploader.verifiedArtists.test.ts
+++ b/app/javascript/test/components/uploads/uploader.verifiedArtists.test.ts
@@ -1,0 +1,45 @@
+import { vi } from "vitest";
+
+vi.mock("@/components/autocomplete", () => ({ default: { initialize_autocomplete: vi.fn() } }));
+vi.mock("@/components/DTextFormatter.ts", () => ({ default: vi.fn() }));
+vi.mock("@/utility/Toast", () => ({ default: { notice: vi.fn(), alert: vi.fn() } }));
+
+import { afterEach, describe, expect, it } from "vitest";
+import { nextTick } from "vue";
+import type { VueWrapper } from "@vue/test-utils";
+import { mountUploader, unmountAll } from "./mountUploader";
+
+afterEach(unmountAll);
+
+const artistField = (w: VueWrapper) => (w.find("#post_artist").element as HTMLTextAreaElement);
+const linkedButton = (w: VueWrapper, name: string) => w.findAll(".upload-artist-tags button").find((b) => b.text() === name)!;
+
+describe("uploads/uploader — verified artist buttons", () => {
+  it("renders one button per linked artist in normal mode", async () => {
+    const { wrapper } = await mountUploader({ verifiedArtistTags: ["artist_a", "artist_b"] });
+    expect(wrapper.find(".upload-artist-tags").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Linked artist tags:");
+    expect(wrapper.findAll(".upload-artist-tags button").map((b) => b.text())).toEqual(["artist_a", "artist_b"]);
+  });
+
+  it("toggles the artist tag in and out of the artist field on click", async () => {
+    const { wrapper } = await mountUploader({ verifiedArtistTags: ["artist_a"] });
+    await linkedButton(wrapper, "artist_a").trigger("click");
+    await nextTick();
+    expect(artistField(wrapper).value).toContain("artist_a");
+
+    await linkedButton(wrapper, "artist_a").trigger("click");
+    await nextTick();
+    expect(artistField(wrapper).value).not.toContain("artist_a");
+  });
+
+  it("renders nothing when the user has no linked artists", async () => {
+    const { wrapper } = await mountUploader({ verifiedArtistTags: [] });
+    expect(wrapper.find(".upload-artist-tags").exists()).toBe(false);
+  });
+
+  it("renders nothing in compact mode (no #post_artist to attach to)", async () => {
+    const { wrapper } = await mountUploader({ compactMode: true, verifiedArtistTags: ["artist_a"] });
+    expect(wrapper.find(".upload-artist-tags").exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
Previously, `normalMode` was threaded through everything.
Now, it just controls whether components render. Ones that don't render simply don't get registered.