### PR TITLE
[TagPreview] Fix stale tag-preview badges by not mutating the cache

### DIFF
--- a/app/javascript/src/js/pages/uploads/new/tag_preview.vue
+++ b/app/javascript/src/js/pages/uploads/new/tag_preview.vue
@@ -37,7 +37,8 @@ export default {
       for (const input of this.tagsArray) {
         const tag = this.tagCache[input];
         if (tag) {
-          result.push(tag);
+          // Copy so the duplicate/impliedBy flags below never write through to the cache.
+          result.push({ ...tag });
 
           if (tag.implies && Array.isArray(tag.implies)) {
             for (const implication of tag.implies) {

--- a/app/javascript/test/components/uploads/tag_preview.test.ts
+++ b/app/javascript/test/components/uploads/tag_preview.test.ts
@@ -79,6 +79,20 @@ describe("uploads/tag_preview", () => {
     expect(w.find(".tag-preview-tag .invalid").exists()).toBe(true);
   });
 
+  it("clears the duplicate badge when the colliding tag is removed (no cache mutation)", async () => {
+    stubFetch([
+      { id: 1, name: "wolf", post_count: 5, category: 0 },
+      { id: 2, name: "wolves", post_count: 3, category: 0, alias: "wolf" }, // resolves to "wolf"
+    ]);
+    const w = make("wolf wolves");
+    await settle();
+    expect(w.findAll(".tag-preview-tag .duplicate").length).toBeGreaterThan(0);
+
+    await w.setProps({ tags: "wolves" }); // drop the collision; "wolves" is already cached
+    await settle();
+    expect(w.find(".tag-preview-tag .duplicate").exists()).toBe(false);
+  });
+
   it("marks a tag implied by another as implied", async () => {
     stubFetch([
       { id: 1, name: "foo", post_count: 5, category: 0, implies: ["bar"] },


### PR DESCRIPTION
tag_preview's tagRecords computed pushed cached tag objects by reference and then set duplicate/impliedBy on them, so those flags were never cleared and persisted across recomputes.