### PR TITLE
[Uploads] Stop sources.vue mutating its v-model prop

### DIFF
--- a/app/javascript/src/js/pages/uploads/new/sources.vue
+++ b/app/javascript/src/js/pages/uploads/new/sources.vue
@@ -17,7 +17,8 @@
       :maxSources="maxSources"
       :last="i === (sources.length-1)"
       :index="i"
-      v-model="sources[i]"
+      :model-value="sources[i]"
+      @update:model-value="updateSource(i, $event)"
       v-for="s, i in sources"
       @delete="removeSource(i)"
       @add="addSource"
@@ -42,30 +43,41 @@
         noSource: false,
       };
     },
-    emits: ["missingSourceWarning", "nonUrlSourceWarning"],
+    emits: ["missingSourceWarning", "nonUrlSourceWarning", "update:sources"],
     methods: {
+      // The list is owned by the parent (v-model:sources). Every mutation builds a
+      // new array and emits it; the prop is never written in place.
+      updateSource(i, value) {
+        const next = this.sources.slice();
+        next[i] = value;
+        this.$emit("update:sources", next);
+      },
       removeSource(i) {
-        this.sources.splice(i, 1);
-        if (this.sources.length === 0)
-          this.sources.push("");
+        const next = this.sources.slice();
+        next.splice(i, 1);
+        if (next.length === 0)
+          next.push("");
+        this.$emit("update:sources", next);
       },
       addSource(i) {
         if (this.sources.length >= this.maxSources) return;
 
+        const next = this.sources.slice();
         let targetIndex;
         // Insert a new source at the requested index (e.g. after current row)
-        if (typeof i === "number" && i >= 0 && i <= this.sources.length) {
-          this.sources.splice(i, 0, "");
+        if (typeof i === "number" && i >= 0 && i <= next.length) {
+          next.splice(i, 0, "");
           targetIndex = i;
         } else {
-          this.sources.push("");
-          targetIndex = this.sources.length - 1;
+          next.push("");
+          targetIndex = next.length - 1;
         }
+        this.$emit("update:sources", next);
 
-        // Focus the newly created source after DOM updates
+        // Focus the newly created source after the parent round-trips the array back.
         this.$nextTick(() => {
           const refs = this.$refs.fileSources;
-          if (refs[targetIndex])
+          if (refs && refs[targetIndex])
             refs[targetIndex].focus();
         });
       },
@@ -84,7 +96,9 @@
           urls.splice(this.maxSources - index);
 
         // Insert the pasted URLs starting at the current index
-        this.sources.splice(index, urls.length, ...urls);
+        const next = this.sources.slice();
+        next.splice(index, urls.length, ...urls);
+        this.$emit("update:sources", next);
       },
       navigate($event) {
         let targetIndex = $event;

--- a/app/javascript/test/components/uploads/sources.test.ts
+++ b/app/javascript/test/components/uploads/sources.test.ts
@@ -1,6 +1,5 @@
-import { mount, VueWrapper } from "@vue/test-utils";
+import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
 import { afterEach, describe, expect, it } from "vitest";
-import { nextTick, reactive } from "vue";
 import Sources from "@/pages/uploads/new/sources.vue";
 
 const wrappers: VueWrapper[] = [];
@@ -8,17 +7,22 @@ afterEach(() => {
   for (const wrapper of wrappers.splice(0)) wrapper.unmount();
 });
 
-// The real parent passes a reactive data() array that the component mutates
-// in place; a plain array would not track splices.
+// The component is a well-behaved v-model child: it emits `update:sources` with a
+// fresh array and never mutates the prop. The harness feeds those emits back into
+// props (as the real parent's `v-model:sources` does), so downstream computeds and
+// re-renders react; the list contract itself is asserted via the emitted array.
 function make (overrides: { sources?: string[], maxSources?: number, showErrors?: boolean } = {}) {
-  const props = {
-    sources: reactive(overrides.sources ?? [""]),
-    maxSources: overrides.maxSources ?? 10,
-    showErrors: overrides.showErrors ?? true,
-  };
-  const wrapper = mount(Sources, { props, attachTo: document.body });
+  const wrapper: VueWrapper = mount(Sources, {
+    props: {
+      "sources": overrides.sources ?? [""],
+      "maxSources": overrides.maxSources ?? 10,
+      "showErrors": overrides.showErrors ?? true,
+      "onUpdate:sources": (v: string[]) => wrapper.setProps({ sources: v }),
+    },
+    attachTo: document.body,
+  });
   wrappers.push(wrapper);
-  return { wrapper, sources: props.sources };
+  return { wrapper };
 }
 
 function lastEmitted (wrapper: VueWrapper, name: string): unknown {
@@ -41,6 +45,8 @@ describe("uploads/sources", () => {
     it("emits false once a source is entered", async () => {
       const { wrapper } = make();
       await rowInputs(wrapper)[0].setValue("https://example.com/post/1");
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://example.com/post/1"]);
       expect(lastEmitted(wrapper, "missingSourceWarning")).toBe(false);
     });
 
@@ -98,11 +104,11 @@ describe("uploads/sources", () => {
   });
 
   describe("adding sources", () => {
-    it("appends an empty source and focuses it", async () => {
-      const { wrapper, sources } = make();
+    it("emits an appended empty source and focuses it", async () => {
+      const { wrapper } = make();
       await wrapper.find(".upload-source-add").trigger("click");
-      await nextTick();
-      expect(sources).toEqual(["", ""]);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual(["", ""]);
       expect(document.activeElement).toBe(rowInputs(wrapper)[1].element);
     });
 
@@ -118,23 +124,26 @@ describe("uploads/sources", () => {
     });
 
     it("inserts after the current row on Enter", async () => {
-      const { wrapper, sources } = make({ sources: ["https://a", "https://b"] });
+      const { wrapper } = make({ sources: ["https://a", "https://b"] });
       await rowInputs(wrapper)[0].trigger("keyup.enter");
-      expect(sources).toEqual(["https://a", "", "https://b"]);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://a", "", "https://b"]);
     });
   });
 
   describe("removing sources", () => {
     it("removes the clicked row", async () => {
-      const { wrapper, sources } = make({ sources: ["https://a", "https://b"] });
+      const { wrapper } = make({ sources: ["https://a", "https://b"] });
       await wrapper.findAll(".upload-source-row button")[0].trigger("click");
-      expect(sources).toEqual(["https://b"]);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://b"]);
     });
 
     it("refills with a single empty source when the last row is removed", async () => {
-      const { wrapper, sources } = make({ sources: ["https://a"] });
+      const { wrapper } = make({ sources: ["https://a"] });
       await wrapper.find(".upload-source-row button").trigger("click");
-      expect(sources).toEqual([""]);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual([""]);
     });
   });
 
@@ -146,27 +155,31 @@ describe("uploads/sources", () => {
     }
 
     it("splits multi-line pastes into one source per line, trimming blanks", async () => {
-      const { wrapper, sources } = make();
+      const { wrapper } = make();
       await paste(wrapper, 0, "https://a\n  https://b  \n\nhttps://c");
-      expect(sources).toEqual(["https://a", "https://b", "https://c"]);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://a", "https://b", "https://c"]);
     });
 
     it("caps multi-line pastes at maxSources", async () => {
-      const { wrapper, sources } = make({ maxSources: 2 });
+      const { wrapper } = make({ maxSources: 2 });
       await paste(wrapper, 0, "https://a\nhttps://b\nhttps://c");
-      expect(sources).toEqual(["https://a", "https://b"]);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://a", "https://b"]);
     });
 
     it("replaces entries starting at the pasted row", async () => {
-      const { wrapper, sources } = make({ sources: ["https://keep", "https://old"] });
+      const { wrapper } = make({ sources: ["https://keep", "https://old"] });
       await paste(wrapper, 1, "https://a\nhttps://b");
-      expect(sources).toEqual(["https://keep", "https://a", "https://b"]);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://keep", "https://a", "https://b"]);
     });
 
-    it("leaves single-line pastes to vanilla input behaviour", async () => {
-      const { wrapper, sources } = make();
+    it("leaves single-line pastes to vanilla input behaviour (no emit)", async () => {
+      const { wrapper } = make();
       await paste(wrapper, 0, "https://only-one");
-      expect(sources).toEqual([""]);
+      await flushPromises();
+      expect(wrapper.emitted("update:sources")).toBeUndefined();
     });
   });
 
@@ -183,9 +196,10 @@ describe("uploads/sources", () => {
     });
   });
 
-  it("writes typed values back into the sources array", async () => {
-    const { wrapper, sources } = make();
+  it("emits typed values back through update:sources", async () => {
+    const { wrapper } = make();
     await rowInputs(wrapper)[0].setValue("https://example.com/typed");
-    expect(sources[0]).toBe("https://example.com/typed");
+    await flushPromises();
+    expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://example.com/typed"]);
   });
 });


### PR DESCRIPTION
`sources.vue` mutated the `sources` prop array in place, relying on shared references instead of the v-model contract.
Emit `update:sources` with a fresh array from every mutation instead; both parents already own the list by reassignment, so no parent changes are needed.