### PR TITLE
[Uploads] Submit an empty source when "No available source" is checked

### DIFF
--- a/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
+++ b/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
@@ -5,7 +5,7 @@
   <div class="input">
     <label>
       Additional Source
-      <sources :maxSources="1" :showErrors="showErrors" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event" @noSource="noSource = $event" v-model:sources="sources"></sources>
+      <sources :maxSources="1" :showErrors="showErrors" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event" v-model:noSource="noSource" v-model:sources="sources"></sources>
     </label>
     <span class="hint">The submission page the replacement file came from</span>
   </div>

--- a/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
+++ b/app/javascript/src/js/pages/post_replacements/new/replacement_uploader.vue
@@ -5,7 +5,7 @@
   <div class="input">
     <label>
       Additional Source
-      <sources :maxSources="1" :showErrors="showErrors" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event" v-model:sources="sources"></sources>
+      <sources :maxSources="1" :showErrors="showErrors" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event" @noSource="noSource = $event" v-model:sources="sources"></sources>
     </label>
     <span class="hint">The submission page the replacement file came from</span>
   </div>
@@ -65,6 +65,7 @@ export default {
         isVideo: false,
       },
       sources: [""],
+      noSource: false,
       uploadValue: "",
       reason: "",
       errorMessage: undefined,
@@ -107,7 +108,7 @@ export default {
       } else {
         formData.append("post_replacement[replacement_file]", this.uploadValue);
       }
-      formData.append("post_replacement[source]", this.sources[0]);
+      formData.append("post_replacement[source]", this.noSource ? "" : this.sources[0]);
       formData.append("post_replacement[reason]", this.reason);
       formData.append("post_replacement[as_pending]", this.uploadAsPending);
 

--- a/app/javascript/src/js/pages/uploads/new/sources.vue
+++ b/app/javascript/src/js/pages/uploads/new/sources.vue
@@ -134,7 +134,7 @@
         immediate: true,
         handler() {
           this.$emit("missingSourceWarning", this.missingSourceWarning);
-        }  
+        }
       },
       nonUrlSourceWarning: {
         immediate: true,

--- a/app/javascript/src/js/pages/uploads/new/sources.vue
+++ b/app/javascript/src/js/pages/uploads/new/sources.vue
@@ -7,7 +7,7 @@
   </div>
   <div class="upload-source-more">
     <label class="section-label upload-source-none">
-      <input type="checkbox" id="no_source" v-model="noSource"/>
+      <input type="checkbox" id="no_source" :checked="noSource" @change="$emit('update:noSource', $event.target.checked)"/>
       No available source.
     </label>
     <button @click="addSource" v-if="sources.length < maxSources && !noSource" class="upload-source-add">Add another source</button>
@@ -34,13 +34,8 @@
     components: {
       "file-source": fileSource,
     },
-    props: ["showErrors", "sources", "maxSources"],
-    data() {
-      return {
-        noSource: false,
-      };
-    },
-    emits: ["missingSourceWarning", "nonUrlSourceWarning", "update:sources", "noSource"],
+    props: ["showErrors", "sources", "maxSources", "noSource"],
+    emits: ["missingSourceWarning", "nonUrlSourceWarning", "update:sources", "update:noSource"],
     methods: {
       // The list is owned by the parent (v-model:sources). Every mutation builds a
       // new array and emits it; the prop is never written in place.
@@ -140,13 +135,6 @@
         immediate: true,
         handler() {
           this.$emit("nonUrlSourceWarning", this.nonUrlSourceWarning);
-        }
-      },
-      // Surface the checkbox so the parent can omit the source at submit time.
-      noSource: {
-        immediate: true,
-        handler() {
-          this.$emit("noSource", this.noSource);
         }
       },
     },

--- a/app/javascript/src/js/pages/uploads/new/sources.vue
+++ b/app/javascript/src/js/pages/uploads/new/sources.vue
@@ -40,7 +40,7 @@
         noSource: false,
       };
     },
-    emits: ["missingSourceWarning", "nonUrlSourceWarning", "update:sources"],
+    emits: ["missingSourceWarning", "nonUrlSourceWarning", "update:sources", "noSource"],
     methods: {
       // The list is owned by the parent (v-model:sources). Every mutation builds a
       // new array and emits it; the prop is never written in place.
@@ -140,7 +140,14 @@
         immediate: true,
         handler() {
           this.$emit("nonUrlSourceWarning", this.nonUrlSourceWarning);
-        }  
+        }
+      },
+      // Surface the checkbox so the parent can omit the source at submit time.
+      noSource: {
+        immediate: true,
+        handler() {
+          this.$emit("noSource", this.noSource);
+        }
       },
     },
   }

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -20,7 +20,7 @@
                     </div>
                 </div>
                 <div class="col2">
-                    <sources :maxSources="10" :showErrors="showErrors" v-model:sources="sources" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event" @noSource="noSource = $event"></sources>
+                    <sources :maxSources="10" :showErrors="showErrors" v-model:sources="sources" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event" v-model:noSource="noSource"></sources>
                 </div>
             </div>
             <template v-if="!compactMode">

--- a/app/javascript/src/js/pages/uploads/new/uploader.vue
+++ b/app/javascript/src/js/pages/uploads/new/uploader.vue
@@ -20,7 +20,7 @@
                     </div>
                 </div>
                 <div class="col2">
-                    <sources :maxSources="10" :showErrors="showErrors" v-model:sources="sources" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event"></sources>
+                    <sources :maxSources="10" :showErrors="showErrors" v-model:sources="sources" @missingSourceWarning="missingSourceWarning = $event" @nonUrlSourceWarning="nonUrlSourceWarning = $event" @noSource="noSource = $event"></sources>
                 </div>
             </div>
             <template v-if="!compactMode">
@@ -275,6 +275,7 @@
 
         missingSourceWarning: false,
         nonUrlSourceWarning: false,
+        noSource: false,
         sources: [''],
         compactMode: UploadData.compactMode,
 
@@ -417,7 +418,7 @@
         }
         data.append('upload[tag_string]', this.tags);
         data.append('upload[rating]', this.rating);
-        data.append('upload[source]', this.sources.join('\n'));
+        data.append('upload[source]', this.noSource ? '' : this.sources.join('\n'));
         data.append('upload[description]', this.description);
         data.append('upload[parent_id]', this.parentID);
         if (this.allowLockedTags)

--- a/app/javascript/test/components/uploads/sources.test.ts
+++ b/app/javascript/test/components/uploads/sources.test.ts
@@ -57,6 +57,14 @@ describe("uploads/sources", () => {
       expect(wrapper.find(".upload-source-list").exists()).toBe(false);
     });
 
+    it("emits the no-source flag when the checkbox toggles", async () => {
+      const { wrapper } = make();
+      await wrapper.find("#no_source").setValue(true);
+      expect(lastEmitted(wrapper, "noSource")).toBe(true);
+      await wrapper.find("#no_source").setValue(false);
+      expect(lastEmitted(wrapper, "noSource")).toBe(false);
+    });
+
     it("shows the warning box only when showErrors is set", async () => {
       const shown = make().wrapper;
       expect(shown.findAll(".source_warning")[0].isVisible()).toBe(true);

--- a/app/javascript/test/components/uploads/sources.test.ts
+++ b/app/javascript/test/components/uploads/sources.test.ts
@@ -11,13 +11,15 @@ afterEach(() => {
 // fresh array and never mutates the prop. The harness feeds those emits back into
 // props (as the real parent's `v-model:sources` does), so downstream computeds and
 // re-renders react; the list contract itself is asserted via the emitted array.
-function make (overrides: { sources?: string[], maxSources?: number, showErrors?: boolean } = {}) {
+function make (overrides: { sources?: string[], maxSources?: number, showErrors?: boolean, noSource?: boolean } = {}) {
   const wrapper: VueWrapper = mount(Sources, {
     props: {
       "sources": overrides.sources ?? [""],
       "maxSources": overrides.maxSources ?? 10,
       "showErrors": overrides.showErrors ?? true,
+      "noSource": overrides.noSource ?? false,
       "onUpdate:sources": (v: string[]) => wrapper.setProps({ sources: v }),
+      "onUpdate:noSource": (v: boolean) => wrapper.setProps({ noSource: v }),
     },
     attachTo: document.body,
   });
@@ -53,16 +55,19 @@ describe("uploads/sources", () => {
     it("is suppressed by the no-source checkbox, which also hides the source list", async () => {
       const { wrapper } = make();
       await wrapper.find("#no_source").setValue(true);
+      await flushPromises();
       expect(lastEmitted(wrapper, "missingSourceWarning")).toBe(false);
       expect(wrapper.find(".upload-source-list").exists()).toBe(false);
     });
 
-    it("emits the no-source flag when the checkbox toggles", async () => {
+    it("emits the no-source flag (v-model) when the checkbox toggles", async () => {
       const { wrapper } = make();
       await wrapper.find("#no_source").setValue(true);
-      expect(lastEmitted(wrapper, "noSource")).toBe(true);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:noSource")).toBe(true);
       await wrapper.find("#no_source").setValue(false);
-      expect(lastEmitted(wrapper, "noSource")).toBe(false);
+      await flushPromises();
+      expect(lastEmitted(wrapper, "update:noSource")).toBe(false);
     });
 
     it("shows the warning box only when showErrors is set", async () => {
@@ -107,6 +112,7 @@ describe("uploads/sources", () => {
       const { wrapper } = make({ sources: ["not a url"] });
       expect(lastEmitted(wrapper, "nonUrlSourceWarning")).toBe(true);
       await wrapper.find("#no_source").setValue(true);
+      await flushPromises();
       expect(lastEmitted(wrapper, "nonUrlSourceWarning")).toBe(false);
     });
   });

--- a/app/javascript/test/components/uploads/uploader.submit.test.ts
+++ b/app/javascript/test/components/uploads/uploader.submit.test.ts
@@ -93,6 +93,17 @@ describe("uploads/uploader — submit payload", () => {
     expect(data.get("upload[parent_id]")).toBe("12345");
   });
 
+  it("submits an empty source when 'no available source' is checked", async () => {
+    const mounted = await mountUploader();
+    (mounted.wrapper.vm as any).sources = ["https://example.com/typed"];
+    await nextTick();
+    await fillValidForm(mounted.wrapper); // checks #no_source
+    await clickSubmit(mounted.wrapper);
+
+    const data = mounted.fetchSpy.mock.calls.at(-1)![1].body as FormData;
+    expect(data.get("upload[source]")).toBe("");
+  });
+
   it("omits privileged fields for a regular member", async () => {
     const { data } = await submitAndCapture();
     expect(data.get("upload[locked_tags]")).toBeNull();


### PR DESCRIPTION
The no-source checkbox lived only inside `sources.vue`, so a typed source was still submitted when the box was ticked.
Surface the flag to the parent (like the existing warning emits) and gate the submit source on it in both the uploader and the replacement uploader.

Typed values are preserved, so unticking restores them.