### PR TITLE
[Uploads] Sequence the whitelist lookup so stale responses can't win

### DIFF
--- a/app/javascript/src/js/pages/uploads/new/file_input.vue
+++ b/app/javascript/src/js/pages/uploads/new/file_input.vue
@@ -83,6 +83,8 @@ export default {
         domain: "",
         oldDomain: "",
       },
+      // Sequencing token so out-of-order whitelist responses can't show a stale verdict.
+      whitelistRequestId: 0,
       uploader: {
         dragging: false,
       },
@@ -181,6 +183,7 @@ export default {
     },
     updatePreviewURL() {
       if (this.uploadURL.length === 0 || this.$refs["post_file"]?.files?.[0]) {
+        this.whitelistRequestId++; // invalidate any in-flight lookup
         this.disableFileUpload = false;
         this.whitelist.oldDomain = "";
         this.clearWhitelistWarning();
@@ -193,8 +196,12 @@ export default {
       catch { domain = ""; }
 
       if (domain && domain !== this.whitelist.oldDomain) {
-        // Non-blocking: the synchronous preview tail below must run regardless.
+        // Non-blocking (the synchronous preview tail below must run regardless) and
+        // latest-wins: a newer URL change supersedes this lookup so a slow, out-of-order
+        // response can't overwrite the current verdict.
+        const requestId = ++this.whitelistRequestId;
         HTTP.getJSON("/upload_whitelists/is_allowed.json", { url: this.uploadURL }).then(data => {
+          if (requestId !== this.whitelistRequestId) return;
           if (data.domain) {
             this.whitelistWarning(data.is_allowed, data.domain, data.reason);
             if (!data.is_allowed) {
@@ -203,6 +210,7 @@ export default {
           }
         }).catch(() => {});
       } else if (!domain) {
+        this.whitelistRequestId++; // invalidate any in-flight lookup
         this.clearWhitelistWarning();
         this.setEmptyThumb();
       }

--- a/app/javascript/test/components/uploads/file_input.test.ts
+++ b/app/javascript/test/components/uploads/file_input.test.ts
@@ -75,6 +75,26 @@ describe("uploads/file_input — direct URL checks", () => {
     expect(warning.isVisible()).toBe(true);
     expect(warning.text()).toContain("permitted");
   });
+
+  it("ignores a stale whitelist response when the URL has since changed (latest wins)", async () => {
+    // Defer each lookup so responses can be resolved out of order.
+    const resolvers: ((v: unknown) => void)[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((() => new Promise((resolve) => { resolvers.push(resolve); })) as any);
+    const w = await mountFileInput();
+
+    await urlInput(w).setValue("https://first.com/a.png");  // resolvers[0]
+    await urlInput(w).setValue("https://second.com/b.png"); // resolvers[1]
+
+    // Newer lookup resolves first, then the stale older one.
+    resolvers[1](jsonResponse({ domain: "second.com", is_allowed: true }));
+    await flushPromises();
+    resolvers[0](jsonResponse({ domain: "first.com", is_allowed: false }));
+    await flushPromises();
+
+    const warning = w.find("#whitelist-warning");
+    expect(warning.text()).toContain("second.com");
+    expect(warning.text()).not.toContain("first.com");
+  });
 });
 
 describe("uploads/file_input — file size", () => {


### PR DESCRIPTION
Rapid URL edits fired overlapping `/upload_whitelists/is_allowed` lookups whose responses could arrive out of order, leaving a warning for the wrong domain. Add a request token so only the latest lookup applies, and invalidate pending lookups when the URL is cleared or replaced by a file.