### PR TITLE
[Uploads] Key source rows by stable id, not index

### DIFF
--- a/app/javascript/src/js/pages/uploads/new/file_source.vue
+++ b/app/javascript/src/js/pages/uploads/new/file_source.vue
@@ -4,7 +4,6 @@
           type="text"
           size="50"
           placeholder="Ex: https://example.com/artist/post/12345"
-          ref="inputEl"
           v-model="realValue"
           @keyup.enter="fadd"
           @keyup.up="focusPrev"
@@ -35,12 +34,6 @@
       }
     },
     methods: {
-      // Focus the input element for this source row
-      focus() {
-        if (this.$refs && this.$refs.inputEl) {
-          this.$refs.inputEl.focus();
-        }
-      },
       fadd() { this.$emit("fadd") },
       remove() { this.$emit("delete"); },
       paste($event) { this.$emit("madd", $event); },

--- a/app/javascript/src/js/pages/uploads/new/sources.vue
+++ b/app/javascript/src/js/pages/uploads/new/sources.vue
@@ -97,6 +97,9 @@
         next.splice(index, urls.length, ...urls);
         this.rowIds.splice(index, urls.length, ...urls.map(() => this.nextRowId++));
         this.$emit("update:sources", next);
+
+        // Focus the last pasted row.
+        this.$nextTick(() => this.focusRow(index + urls.length - 1));
       },
       navigate($event) {
         let targetIndex = $event;

--- a/app/javascript/src/js/pages/uploads/new/sources.vue
+++ b/app/javascript/src/js/pages/uploads/new/sources.vue
@@ -22,7 +22,7 @@
       @fadd="addSource(i + 1)"
       @madd="pasteSource($event, i)"
       @navigate="navigate($event)"
-      :key="i"
+      :key="rowIds[i]"
       ref="fileSources"
     ></file-source>
   </div>
@@ -36,6 +36,11 @@
     },
     props: ["showErrors", "sources", "maxSources", "noSource"],
     emits: ["missingSourceWarning", "nonUrlSourceWarning", "update:sources", "update:noSource"],
+    data() {
+      // Stable per-row ids so Vue keys rows by identity (not index), preserving a
+      // row's DOM node — and its focus/caret — across a splice/reorder.
+      return { rowIds: [], nextRowId: 0 };
+    },
     methods: {
       // The list is owned by the parent (v-model:sources). Every mutation builds a
       // new array and emits it; the prop is never written in place.
@@ -47,8 +52,11 @@
       removeSource(i) {
         const next = this.sources.slice();
         next.splice(i, 1);
-        if (next.length === 0)
+        this.rowIds.splice(i, 1);
+        if (next.length === 0) {
           next.push("");
+          this.rowIds.push(this.nextRowId++);
+        }
         this.$emit("update:sources", next);
       },
       addSource(i) {
@@ -59,9 +67,11 @@
         // Insert a new source at the requested index (e.g. after current row)
         if (typeof i === "number" && i >= 0 && i <= next.length) {
           next.splice(i, 0, "");
+          this.rowIds.splice(i, 0, this.nextRowId++);
           targetIndex = i;
         } else {
           next.push("");
+          this.rowIds.push(this.nextRowId++);
           targetIndex = next.length - 1;
         }
         this.$emit("update:sources", next);
@@ -90,6 +100,7 @@
         // Insert the pasted URLs starting at the current index
         const next = this.sources.slice();
         next.splice(index, urls.length, ...urls);
+        this.rowIds.splice(index, urls.length, ...urls.map(() => this.nextRowId++));
         this.$emit("update:sources", next);
       },
       navigate($event) {
@@ -125,6 +136,16 @@
       },
     },
     watch: {
+      // Seed on mount and reconcile length when the parent replaces the list
+      // wholesale (query-param import). The structural mutators keep rowIds in
+      // lockstep, so those changes land here as no-ops.
+      sources: {
+        immediate: true,
+        handler() {
+          while (this.rowIds.length < this.sources.length) this.rowIds.push(this.nextRowId++);
+          if (this.rowIds.length > this.sources.length) this.rowIds.splice(this.sources.length);
+        }
+      },
       missingSourceWarning: {
         immediate: true,
         handler() {

--- a/app/javascript/src/js/pages/uploads/new/sources.vue
+++ b/app/javascript/src/js/pages/uploads/new/sources.vue
@@ -12,7 +12,7 @@
     </label>
     <button @click="addSource" v-if="sources.length < maxSources && !noSource" class="upload-source-add">Add another source</button>
   </div>
-  <div class="upload-source-list" v-if="!noSource">
+  <div class="upload-source-list" v-if="!noSource" ref="sourceList">
     <file-source
       :index="i"
       :model-value="sources[i]"
@@ -23,7 +23,6 @@
       @madd="pasteSource($event, i)"
       @navigate="navigate($event)"
       :key="rowIds[i]"
-      ref="fileSources"
     ></file-source>
   </div>
 </template>
@@ -77,11 +76,7 @@
         this.$emit("update:sources", next);
 
         // Focus the newly created source after the parent round-trips the array back.
-        this.$nextTick(() => {
-          const refs = this.$refs.fileSources;
-          if (refs && refs[targetIndex])
-            refs[targetIndex].focus();
-        });
+        this.$nextTick(() => this.focusRow(targetIndex));
       },
       pasteSource(event, index) {
         if (!event.clipboardData) return;
@@ -108,8 +103,14 @@
         if (targetIndex >= this.sources.length) targetIndex = 0;
         else if (targetIndex < 0) targetIndex = this.sources.length - 1;
 
-        const refs = this.$refs.fileSources;
-        if (refs[targetIndex]) refs[targetIndex].focus();
+        this.focusRow(targetIndex);
+      },
+      // Focus the row input at a VISUAL position. Query the DOM (ordered) rather
+      // than $refs — a v-for ref array isn't guaranteed to match DOM order after
+      // a keyed insert/move.
+      focusRow(index) {
+        const inputs = this.$refs.sourceList?.querySelectorAll(".upload-source-row input");
+        if (inputs && inputs[index]) inputs[index].focus();
       },
     },
     computed: {

--- a/app/javascript/test/components/uploads/sources.test.ts
+++ b/app/javascript/test/components/uploads/sources.test.ts
@@ -210,6 +210,15 @@ describe("uploads/sources", () => {
       expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://keep", "https://a", "https://b"]);
     });
 
+    it("focuses the last pasted row after a multi-line paste", async () => {
+      const { wrapper } = make({ sources: ["https://keep", ""] });
+      await paste(wrapper, 1, "https://a\nhttps://b\nhttps://c"); // → ["https://keep", a, b, c]
+      await flushPromises();
+      const rows = rowInputs(wrapper);
+      expect(document.activeElement).toBe(rows[rows.length - 1].element);
+      expect((rows[rows.length - 1].element as HTMLInputElement).value).toBe("https://c");
+    });
+
     it("leaves single-line pastes to vanilla input behaviour (no emit)", async () => {
       const { wrapper } = make();
       await paste(wrapper, 0, "https://only-one");

--- a/app/javascript/test/components/uploads/sources.test.ts
+++ b/app/javascript/test/components/uploads/sources.test.ts
@@ -159,6 +159,17 @@ describe("uploads/sources", () => {
       await flushPromises();
       expect(lastEmitted(wrapper, "update:sources")).toEqual([""]);
     });
+
+    it("preserves a surviving row's DOM node across a removal (stable keys)", async () => {
+      const { wrapper } = make({ sources: ["https://a", "https://b", "https://c"] });
+      const bNode = rowInputs(wrapper)[1].element; // the "b" input
+      await wrapper.findAll(".upload-source-row button")[0].trigger("click"); // remove row a
+      await flushPromises();
+      // b is now index 0; with stable keys it is the SAME node (index keys would
+      // rebind the position-0 node to "b" instead of moving b's node up).
+      expect(rowInputs(wrapper)[0].element).toBe(bNode);
+      expect((rowInputs(wrapper)[0].element as HTMLInputElement).value).toBe("https://b");
+    });
   });
 
   describe("pasting", () => {

--- a/app/javascript/test/components/uploads/sources.test.ts
+++ b/app/javascript/test/components/uploads/sources.test.ts
@@ -143,6 +143,16 @@ describe("uploads/sources", () => {
       await flushPromises();
       expect(lastEmitted(wrapper, "update:sources")).toEqual(["https://a", "", "https://b"]);
     });
+
+    it("focuses the newly inserted row on Enter, not a shifted one", async () => {
+      const { wrapper } = make({ sources: ["https://a", "https://b", "https://c"] });
+      rowInputs(wrapper)[0].element.focus();
+      await rowInputs(wrapper)[0].trigger("keyup.enter"); // insert an empty row after row 0
+      await flushPromises();
+      // The new empty row is at index 1; focus must land there (not the shifted-down old rows).
+      expect(document.activeElement).toBe(rowInputs(wrapper)[1].element);
+      expect((rowInputs(wrapper)[1].element as HTMLInputElement).value).toBe("");
+    });
   });
 
   describe("removing sources", () => {


### PR DESCRIPTION
`sources.vue` keyed <file-source> rows by array index over a spliced list, so removing/inserting a middle row rebound DOM nodes to different logical rows – jumping a focused input or caret.
Track a per-row id internally and key on it; the parent's string[] contract is unchanged.