### PR TITLE
[DB] Update change_seq tracking & add tests

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,6 +14,16 @@ class Post < ApplicationRecord
   # Smaller favours fresher posts; larger lets posts stay hot longer.
   HOTNESS_TIME_DIVISOR = 432_000.0
 
+  # Columns the posts_trigger_change_seq() DB trigger does not bump change_seq for.
+  # Every posts column must appear either in the trigger (db/migrate/*_update_posts_trigger_change_seq.rb) or here
+  # ChangeSeqSpec fails otherwise, so a newly added column can't silently go uncategorized.
+  CHANGE_SEQ_IGNORED = [
+    :id, :created_at, :updated_at, :change_seq, :uploader_ip_addr, :has_children, # not relevant
+    :up_score, :down_score, :score, :hotness, :fav_count, :comment_count, :tag_count, *TagCategory::CATEGORIES.map { |n| :"tag_count_#{n}" }, # transient counters
+    :file_ext, :file_size, :image_width, :image_height, :duration, # handled by md5
+    :last_comment_bumped_at, :last_commented_at, :is_comment_disabled, :is_comment_locked, # comments
+  ].freeze
+
   # Replaced by pool_ids for pools; sets keep no post-side state (queried via
   # post_sets.post_ids). Dropped in a follow-up migration after the rollback window.
   self.ignored_columns += %w[pool_string]
@@ -2091,6 +2101,24 @@ class Post < ApplicationRecord
     end
   end
 
+  module ChangeSeqMethods
+    # Reads the columns the live posts_trigger_change_seq() trigger checks, straight from
+    # Postgres, so this can't drift out of sync with the migration that defines it.
+    # @return [Array<Symbol>] the posts columns the trigger currently compares
+    def change_seq_tracked_columns
+      source = connection.select_one("SELECT prosrc FROM pg_proc WHERE proname = $1", nil, ["posts_trigger_change_seq"])&.[]("prosrc")
+
+      return [] if source.nil?
+      source.scan(/NEW\.(\w+) IS DISTINCT FROM OLD\.\1\b/).flatten.map(&:to_sym)
+    end
+
+    # Columns tracked by neither the trigger nor CHANGE_SEQ_IGNORED - should always be empty.
+    # @return [Array<Symbol>] posts columns nobody has categorized yet
+    def change_seq_untracked_columns
+      column_names.map(&:to_sym) - change_seq_tracked_columns - CHANGE_SEQ_IGNORED
+    end
+  end
+
   module ValidationMethods
     def fix_bg_color
       if bg_color.blank?
@@ -2201,6 +2229,7 @@ class Post < ApplicationRecord
   include IqdbMethods
   include ValidationMethods
   include PostEventMethods
+  extend ChangeSeqMethods
   include Danbooru::HasBitFlags
   include DocumentStore::Model
   include PostIndex

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ Bundler.require(*Rails.groups)
 require_relative "danbooru_default_config"
 require_relative "danbooru_local_config"
 require_relative "../lib/middleware/parameter_sanitizer"
+require_relative "../lib/migration_helpers"
 
 module Danbooru
   class Application < Rails::Application

--- a/db/migrate/20260907205015_update_posts_trigger_change_seq.rb
+++ b/db/migrate/20260907205015_update_posts_trigger_change_seq.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# posts_trigger_change_seq() previously compared columns with `!=`, which is NULL-unsafe:
+# a column changing into or out of NULL makes the whole OR-chain evaluate to NULL, so the IF
+# is skipped and change_seq silently fails to bump. It had also drifted from the posts table -
+# missing several columns added since, including uploader_id (reassigned on replacement
+# approval), locked_tags, bg_color, video_samples and pool_ids, which all carry real,
+# API-visible post content.
+#
+# Rebuilt from scratch with IS DISTINCT FROM and the current column list, via
+# MigrationHelpers#update_change_seq (lib/migration_helpers.rb) so future column
+# additions/removals can use `update_change_seq(add: ...)`/`(remove: ...)` instead of
+# rewriting this list. See Post::CHANGE_SEQ_IGNORED for which posts columns are
+# deliberately left out, and why - ChangeSeqSpec fails the build if a column is in neither
+# place, or in both.
+class UpdatePostsTriggerChangeSeq < ActiveRecord::Migration[8.1]
+  TRACKED_COLUMNS = %w[
+    source md5 rating
+    is_note_locked is_rating_locked is_status_locked
+    is_pending is_flagged is_deleted
+    uploader_id approver_id parent_id
+    tag_string locked_tags description bg_color
+    last_noted_at has_active_children bit_flags
+    video_samples pool_ids
+  ].freeze
+
+  def up
+    update_change_seq(TRACKED_COLUMNS)
+  end
+
+  # Not reversible via update_change_seq: the old function compared with `!=`, which
+  # update_change_seq intentionally cannot produce. Restored verbatim instead.
+  def down
+    execute(<<~SQL) # rubocop:disable Rails/SquishedSQLHeredocs
+      CREATE OR REPLACE FUNCTION public.posts_trigger_change_seq() RETURNS trigger
+          LANGUAGE plpgsql
+      AS $$
+      BEGIN
+        IF NEW.tag_string != OLD.tag_string OR NEW.parent_id != OLD.parent_id OR NEW.source != OLD.source OR NEW.approver_id != OLD.approver_id OR NEW.rating != OLD.rating OR NEW.description != OLD.description OR NEW.md5 != OLD.md5 OR NEW.is_deleted != OLD.is_deleted OR NEW.is_pending != OLD.is_pending OR NEW.is_flagged != OLD.is_flagged OR NEW.is_rating_locked != OLD.is_rating_locked OR NEW.is_status_locked != OLD.is_status_locked OR NEW.is_note_locked != OLD.is_note_locked OR NEW.bit_flags != OLD.bit_flags OR NEW.has_active_children != OLD.has_active_children OR NEW.last_noted_at != OLD.last_noted_at
+        THEN
+          NEW.change_seq = nextval('public.posts_change_seq_seq');
+        END IF;
+        RETURN NEW;
+      END;
+      $$;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -31,11 +31,31 @@ CREATE FUNCTION public.posts_trigger_change_seq() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
 BEGIN
-  IF NEW.tag_string != OLD.tag_string OR NEW.parent_id != OLD.parent_id OR NEW.source != OLD.source OR NEW.approver_id != OLD.approver_id OR NEW.rating != OLD.rating OR NEW.description != OLD.description OR NEW.md5 != OLD.md5 OR NEW.is_deleted != OLD.is_deleted OR NEW.is_pending != OLD.is_pending OR NEW.is_flagged != OLD.is_flagged OR NEW.is_rating_locked != OLD.is_rating_locked OR NEW.is_status_locked != OLD.is_status_locked OR NEW.is_note_locked != OLD.is_note_locked OR NEW.bit_flags != OLD.bit_flags OR NEW.has_active_children != OLD.has_active_children OR NEW.last_noted_at != OLD.last_noted_at
-  THEN
-     NEW.change_seq = nextval('public.posts_change_seq_seq');
-  END IF;
-  RETURN NEW;
+    IF NEW.source IS DISTINCT FROM OLD.source
+        OR NEW.md5 IS DISTINCT FROM OLD.md5
+        OR NEW.rating IS DISTINCT FROM OLD.rating
+        OR NEW.is_note_locked IS DISTINCT FROM OLD.is_note_locked
+        OR NEW.is_rating_locked IS DISTINCT FROM OLD.is_rating_locked
+        OR NEW.is_status_locked IS DISTINCT FROM OLD.is_status_locked
+        OR NEW.is_pending IS DISTINCT FROM OLD.is_pending
+        OR NEW.is_flagged IS DISTINCT FROM OLD.is_flagged
+        OR NEW.is_deleted IS DISTINCT FROM OLD.is_deleted
+        OR NEW.uploader_id IS DISTINCT FROM OLD.uploader_id
+        OR NEW.approver_id IS DISTINCT FROM OLD.approver_id
+        OR NEW.parent_id IS DISTINCT FROM OLD.parent_id
+        OR NEW.tag_string IS DISTINCT FROM OLD.tag_string
+        OR NEW.locked_tags IS DISTINCT FROM OLD.locked_tags
+        OR NEW.description IS DISTINCT FROM OLD.description
+        OR NEW.bg_color IS DISTINCT FROM OLD.bg_color
+        OR NEW.last_noted_at IS DISTINCT FROM OLD.last_noted_at
+        OR NEW.has_active_children IS DISTINCT FROM OLD.has_active_children
+        OR NEW.bit_flags IS DISTINCT FROM OLD.bit_flags
+        OR NEW.video_samples IS DISTINCT FROM OLD.video_samples
+        OR NEW.pool_ids IS DISTINCT FROM OLD.pool_ids
+    THEN
+        NEW.change_seq = nextval('public.posts_change_seq_seq');
+    END IF;
+    RETURN NEW;
 END;
 $$;
 
@@ -6423,6 +6443,7 @@ ALTER TABLE ONLY public.oauth_access_tokens
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260907205015'),
 ('20260827214903'),
 ('20260824220908'),
 ('20260819154314'),

--- a/lib/migration_helpers.rb
+++ b/lib/migration_helpers.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Shared helpers available to every migration (included into ActiveRecord::Migration -
+# see config/application.rb). Keep additions here generic and reusable; a one-off schema
+# change should just use `execute`/`change_column`/etc. directly in its own migration.
+module MigrationHelpers
+  # Reads the columns the live posts_trigger_change_seq() trigger currently checks, so a
+  # migration can add or remove one without retyping the rest of the list.
+  # @return [Array<String>] the posts columns the trigger currently compares
+  def existing_change_seq_columns
+    source = connection.select_one("SELECT prosrc FROM pg_proc WHERE proname = $1", nil, ["posts_trigger_change_seq"])&.[]("prosrc")
+
+    return [] if source.nil?
+    source.scan(/NEW\.(\w+) IS DISTINCT FROM OLD\.\1\b/).flatten
+  end
+
+  # @param columns [Array<String, Symbol>, nil] the exact set of columns to track; defaults
+  #   to whatever posts_trigger_change_seq() currently tracks (see #existing_change_seq_columns)
+  # @param add [Array<String, Symbol>] columns to add to `columns`
+  # @param remove [Array<String, Symbol>] columns to drop from `columns`
+  # @return [String] SQL that recreates posts_trigger_change_seq() with the resulting column set
+  def update_change_seq_sql(columns = nil, add: [], remove: [])
+    columns = (columns || existing_change_seq_columns).map(&:to_s)
+    columns = (columns | Array(add).map(&:to_s)) - Array(remove).map(&:to_s)
+    conditions = columns.map { |column| "NEW.#{column} IS DISTINCT FROM OLD.#{column}" }.join("\n        OR ")
+
+    <<~SQL # rubocop:disable Rails/SquishedSQLHeredocs
+      CREATE OR REPLACE FUNCTION public.posts_trigger_change_seq() RETURNS trigger
+          LANGUAGE plpgsql
+      AS $$
+      BEGIN
+          IF #{conditions}
+          THEN
+              NEW.change_seq = nextval('public.posts_change_seq_seq');
+          END IF;
+          RETURN NEW;
+      END;
+      $$;
+    SQL
+  end
+
+  # Recreates posts_trigger_change_seq(), tracking `columns` (or, if omitted, whatever the
+  # live function already tracks) plus `add` and minus `remove`.
+  #
+  # With `add`/`remove`, this is reversible on its own - the down direction just swaps them.
+  # Passing an explicit `columns` list instead is a one-off rewrite, and not reversible.
+  # @param columns [Array<String, Symbol>, nil] the exact set of columns to track; defaults
+  #   to whatever posts_trigger_change_seq() currently tracks (see #existing_change_seq_columns)
+  # @param add [Array<String, Symbol>] columns to add to `columns`
+  # @param remove [Array<String, Symbol>] columns to drop from `columns`
+  # @return [void]
+  def update_change_seq(columns = nil, add: [], remove: [])
+    if add.blank? && remove.blank?
+      execute(update_change_seq_sql(columns, add: [], remove: []))
+    else
+      reversible do |dir|
+        dir.up   { execute(update_change_seq_sql(columns, add: add, remove: remove)) }
+        dir.down { execute(update_change_seq_sql(columns, add: remove, remove: add)) }
+      end
+    end
+  end
+end
+
+ActiveRecord::Migration.include(MigrationHelpers)

--- a/spec/models/post/change_seq_spec.rb
+++ b/spec/models/post/change_seq_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Post do
+  include_context "as admin"
+
+  describe "ChangeSeqMethods" do
+    describe ".change_seq_untracked_columns" do
+      it "is empty" do
+        # A column showing up here means it was added to the posts table without anyone
+        # deciding whether it should bump change_seq - see Post::CHANGE_SEQ_IGNORED.
+        expect(Post.change_seq_untracked_columns).to be_empty
+      end
+    end
+
+    describe "CHANGE_SEQ_IGNORED" do
+      it "does not overlap with the trigger's tracked columns" do
+        # A column in both places means the trigger and CHANGE_SEQ_IGNORED disagree about
+        # whether it should bump change_seq.
+        expect(Post.change_seq_tracked_columns & Post::CHANGE_SEQ_IGNORED).to be_empty
+      end
+    end
+
+    describe "the posts_trigger_change_seq() database trigger" do
+      subject(:post) { create(:post) }
+
+      # update_column issues a plain SQL UPDATE without running validations or callbacks,
+      # so these specs exercise the trigger itself rather than the model's business logic
+      # around each column.
+      def distinct_value_for(column)
+        col = Post.columns_hash[column.to_s]
+        current = post.read_attribute(column)
+
+        return(current == "s" ? "e" : "s") if column == :rating
+        return Array(current) + [rand(1..1_000_000)] if col.array?
+
+        case col.type
+        when :boolean  then !current
+        when :integer  then current.to_i + 1
+        when :datetime then 1.minute.from_now.change(usec: 0)
+        when :jsonb    then { "changed" => SecureRandom.hex(4) }
+        else "#{current}_#{SecureRandom.hex(4)}"
+        end
+      end
+
+      Post.change_seq_tracked_columns.sort.each do |column|
+        it "bumps change_seq when #{column} changes" do
+          old_value = post.read_attribute(column)
+          old_seq = post.change_seq
+
+          post.update_column(column, distinct_value_for(column))
+          post.reload
+
+          expect(post.read_attribute(column)).not_to eq(old_value)
+          expect(post.change_seq).not_to eq(old_seq)
+        end
+      end
+
+      it "does not bump change_seq when only an ignored column changes" do
+        old_seq = post.change_seq
+
+        post.update_column(:fav_count, post.fav_count + 1)
+        post.reload
+
+        expect(post.change_seq).to eq(old_seq)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pr updates the `posts_trigger_change_seq` database trigger which updates the `posts.change_seq` column in line with the newly added columns, and adds tests to ensure it does not get out of sync again. This also formats the function for better reading, and switches from `!=` to `IS DISTINCT FROM` for null safety.
Added:
- uploader_id
- locked_tags
- bg_color
- video_samples
- pool_ids

Ignored:
- id, created_at, updated_at, change_seq, uploader_ip_addr, has_children (not relevant)
- up_score, down_score, score, hotness, fav_count, comment_count, tag_count, tag_count_* (transient counters)
- file_ext, file_size, image_width, image_height, duration (handled by md5)
- last_comment_bumped_at, last_commented_at, is_comment_disabled, is_comment_locked (comments)


Documentation was added with claude, but the actual code and concept are from GayFurCity/GayFurCity@3e6a8abd5c867b111f34ff7467b2576715f7e64b