### PR TITLE
[misc] Added .env-backed ability for custom hosts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -58,6 +58,9 @@
 # When running behind an SSL-terminating reverse proxy, you may want to set this to true
 # RAILS_ASSUME_SSL=true
 
+# Optional hostname to allow in development when accessing through a reverse proxy.
+# RAILS_HOST=e621.example.com
+
 # discord: Starts the discord integration to join users to a discord server.
 #          The application must have its OAuth2 redirect URI set to ${JOINER_BASE_URL}/callback.
 #          You also need to fill out all the JOINER_* environment variables below.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,6 +80,12 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   config.hosts << "e621ng.local"
 
+  # Keep machine-specific/custom development hosts in environment configuration
+  # instead of editing this tracked file and accidentally including them in commits.
+  if ENV["RAILS_HOST"].present?
+    config.hosts << ENV["RAILS_HOST"]
+  end
+
   # Allow access from GitHub Codespaces, if applicable
   if ENV["CODESPACES"].present? && ENV.fetch("CODESPACES", "false") == "true"
     codespace_name = ENV.key?("CODESPACE_NAME") ? Regexp.escape(ENV["CODESPACE_NAME"]) : ".*"


### PR DESCRIPTION
Comment in `development.rb` says it all, allows contributors to add their custom domain to `.env` without the risk of dirtying a commit.

Personally a huge life-saver, I don't add the relevant files, I just commit all affected files and hope for the best.